### PR TITLE
Problems with boost mixing with hipcc, removing boost

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -29,7 +29,7 @@ if( BUILD_CLIENTS_DEPENDENCY_LAPACK )
 endif( )
 
 set( CLIENTS_CMAKE_ARGS
-	-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+	-DCMAKE_TOOLCHAIN_FILE=${DEVICE_TOOLCHAIN_FILE}
 	-DBUILD_64=${BUILD_64}
 	)
 
@@ -81,7 +81,7 @@ if( BUILD_CLIENTS_TESTS )
   	)
 
   ExternalProject_Add( tests
-    DEPENDS boost googletest lapack
+    DEPENDS googletest lapack
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/tests
     BINARY_DIR tests-build
     CMAKE_ARGS ${TESTS_CMAKE_ARGS}

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -119,12 +119,13 @@ endif( )
 target_compile_definitions( rocblas-test PRIVATE GTEST_USE_OWN_TR1_TUPLE=1 )
 target_include_directories( rocblas-test
   PRIVATE
-		$<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
+#		$<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
 		$<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
 )
 
-target_link_libraries( rocblas-test rocblas ${GTEST_LIBRARIES} ${Boost_LIBRARIES} )
+#target_link_libraries( rocblas-test rocblas ${GTEST_LIBRARIES} ${Boost_LIBRARIES} )
+target_link_libraries( rocblas-test rocblas ${GTEST_LIBRARIES} )
 
 # Ubuntu systems need to explicitely link to pthreads lib because of --as-needed
 # https://github.com/google/googletest/issues/391#issuecomment-125645879

--- a/clients/tests/main.cpp
+++ b/clients/tests/main.cpp
@@ -9,32 +9,35 @@
 #include <iostream>
 #include <cblas.h>
 #include <gtest/gtest.h>
-#include <boost/program_options.hpp>
+// #include <boost/program_options.hpp>
 
-namespace po = boost::program_options;
+#include "hip_runtime.h"
+#include "rocblas.h"
+
+// namespace po = boost::program_options;
 
 int main( int argc, char* argv[] )
 {
-	// Declare the supported options.
-	po::options_description desc( "rocblas-test command line options" );
-	desc.add_options()
-		( "help,h",		"print help message" )
-		;
-
-	//	Parse the command line options, ignore unrecognized options and collect them into a vector of strings
-	po::variables_map vm;
-	po::parsed_options parsed = po::command_line_parser( argc, argv ).options( desc ).allow_unregistered( ).run( );
-	po::store( parsed, vm );
-	po::notify( vm );
-	std::vector< std::string > to_pass_further = po::collect_unrecognized( parsed.options, po::include_positional );
-
-	std::cout << std::endl;
-
-	if( vm.count( "help" ) )
-	{
-		std::cout << desc << std::endl;
-		return 0;
-	}
+	// // Declare the supported options.
+	// po::options_description desc( "rocblas-test command line options" );
+	// desc.add_options()
+	// 	( "help,h",		"print help message" )
+	// 	;
+	//
+	// //	Parse the command line options, ignore unrecognized options and collect them into a vector of strings
+	// po::variables_map vm;
+	// po::parsed_options parsed = po::command_line_parser( argc, argv ).options( desc ).allow_unregistered( ).run( );
+	// po::store( parsed, vm );
+	// po::notify( vm );
+	// std::vector< std::string > to_pass_further = po::collect_unrecognized( parsed.options, po::include_positional );
+	//
+	// std::cout << std::endl;
+	//
+	// if( vm.count( "help" ) )
+	// {
+	// 	std::cout << desc << std::endl;
+	// 	return 0;
+	// }
 
 	::testing::InitGoogleTest( &argc, argv );
 


### PR DESCRIPTION
Summary of proposed changes:
-  Compiling and linking boost with hipcc is causing problems for now, remove dependency

Removing the Boost dependency from our unit tester for now until
we can understand the problems mixing boost with hipcc
