### PR TITLE
Adding new targets to super-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,25 +21,15 @@ endif()
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake /opt/rocm/hip/cmake )
 
-# Temp fix, there is a problem building our test program using googletest with gcc
-# Change compiler default to clang
-if( NOT DEFINED CMAKE_CXX_COMPILER AND NOT DEFINED ENV{CXX} )
-  set( CMAKE_CXX_COMPILER clang++ )
-endif( )
-
-if( NOT DEFINED CMAKE_C_COMPILER AND NOT DEFINED ENV{CC} )
-  set( CMAKE_C_COMPILER clang )
-endif( )
-
 # The superbuild does not build anything itself, all compiling is done in external projects
 project( rocblas-superbuild NONE )
 
 # Default ON settings so cmake builds library and samples
 option( BUILD_LIBRARY "Build rocBLAS library" ON )
+option( BUILD_WITH_TENSILE "Building rocBLAS with Tensile or not" ON)
+
 option( BUILD_CLIENTS "Build rocBLAS clients" ON )
 option( BUILD_CLIENTS_SAMPLES "Build rocBLAS client samples" ON )
-
-option( BUILD_WITH_TENSILE "Building rocBLAS with Tensile or not" ON)
 
 # which benchmark solution schedule
 set( Tensile_ROOT "" CACHE STRING "Local path of Tensile.")
@@ -54,13 +44,10 @@ if ( BUILD_WITH_TENSILE )
 endif()
 
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
-option( BUILD_SHARED_LIBS "Build rocBLAS as a shared library" OFF )
+option( BUILD_SHARED_LIBS "Build rocBLAS as a shared library" ON )
 
 set( HIP_ROOT /opt/rocm/hip CACHE PATH "Specify hip installation dir")
 set( BOOST_ROOT /opt/boost  CACHE PATH "Specify boost installation dir")
-
-# set( rocblas_INSTALL_DIR ${CMAKE_INSTALL_PREFIX} )
-set( rocblas_INSTALL_DIR "${PROJECT_BINARY_DIR}/package" )
 
 # Default behavior is to NOT install library, but clients may overload
 set( rocblas_INSTALL_COMMAND INSTALL_COMMAND ${CMAKE_COMMAND} -E echo_append )
@@ -117,9 +104,7 @@ if( BUILD_LIBRARY )
     -DCMAKE_PREFIX_PATH=${LIBRARY_PREFIX_PATH}
     -DCMAKE_MODULE_PATH=${LIBRARY_MODULE_PATH}
     -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-    -DCMAKE_CXX_COMPILER=${DEVICE_CXX_COMPILER}
     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}${LIBRARY_CXX_FLAGS}
-    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DBUILD_WITH_TENSILE=${BUILD_WITH_TENSILE}
     -DTensile_LOGIC=${Tensile_LOGIC}
     -DTensile_MERGE_FILES=${Tensile_MERGE_FILES}
@@ -127,6 +112,21 @@ if( BUILD_LIBRARY )
     -DTensile_PRINT_DEBUG=${Tensile_PRINT_DEBUG}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
   )
+
+  # The library uses the c++ compiler to compile device code
+  if( DEFINED DEVICE_CXX_COMPILER )
+    message( STATUS "DEVICE_CXX_COMPILER: ${DEVICE_CXX_COMPILER} " )
+    list( APPEND LIBRARY_CMAKE_ARGS -DCMAKE_CXX_COMPILER=${DEVICE_CXX_COMPILER} )
+  endif( )
+
+  # Normalize the different ways of specifying a c compiler through -DCMAKE_C_COMPILER
+  if( DEFINED CMAKE_C_COMPILER )
+    message( STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}" )
+    list( APPEND LIBRARY_CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} )
+  elseif( DEFINED ENV{CC} )
+    message( STATUS "ENV{CC}: $ENV{CC} " )
+    list( APPEND LIBRARY_CMAKE_ARGS -DCMAKE_C_COMPILER=$ENV{CC} )
+  endif( )
 
   if( DEFINED CPACK_PACKAGING_INSTALL_PREFIX )
     list( APPEND LIBRARY_CMAKE_ARGS -DCPACK_PACKAGING_INSTALL_PREFIX=${CPACK_PACKAGING_INSTALL_PREFIX} )
@@ -165,6 +165,13 @@ if( BUILD_CLIENTS )
     list( APPEND CMAKE_PREFIX_PATH ${install_dir} )
   endif( )
 
+  # If the c++ compiler used to compile the clients is hipcc/hcc, make sure to specify the desired targets
+  if( (CMAKE_CXX_COMPILER MATCHES "hipcc$") OR (CMAKE_CXX_COMPILER MATCHES "hcc$") )
+    set( CLIENT_CXX_FLAGS " --amdgpu-target=gfx803 --amdgpu-target=gfx900" CACHE STRING "hcc specific compiler flags for rocblas clients" )
+  else( )
+    set( CLIENT_CXX_FLAGS "" CACHE STRING "hcc specific compiler flags for rocblas clients" )
+  endif( )
+
   # WARNING: do not surround CMAKE_PREFIX_PATH with quotes, it breaks
   # Replace all occurances of ; with ^^, which we elect to use a path seperator
   string(REGEX REPLACE ";" "^^" CLIENT_PREFIX_PATH "${CMAKE_PREFIX_PATH}" )
@@ -173,10 +180,8 @@ if( BUILD_CLIENTS )
   # Default arguments that get passed down into all external projects
   set( CLIENTS_CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DDEVICE_CXX_COMPILER=${DEVICE_CXX_COMPILER}
-    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}${CLIENT_CXX_FLAGS}
     -DCMAKE_PREFIX_PATH=${CLIENT_PREFIX_PATH}
     -DCMAKE_MODULE_PATH=${CLIENT_MODULE_PATH}
     -DBUILD_CLIENTS_SAMPLES=${BUILD_CLIENTS_SAMPLES}
@@ -185,8 +190,25 @@ if( BUILD_CLIENTS )
     -DBUILD_WITH_TENSILE=${BUILD_WITH_TENSILE}
     -DDEVICE_CXX_COMPILER=${DEVICE_CXX_COMPILER}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-
   )
+
+  # Normalize the different ways of specifying a c++ compiler through -DCMAKE_CXX_COMPILER
+  if( DEFINED CMAKE_CXX_COMPILER )
+    message( STATUS "CMAKE_CXX_COMPILER[clients]: ${CMAKE_CXX_COMPILER} " )
+    list( APPEND CLIENTS_CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} )
+  elseif( DEFINED ENV{CXX} )
+    message( STATUS "ENV{CXX}: $ENV{CXX} " )
+    list( APPEND CLIENTS_CMAKE_ARGS -DCMAKE_CXX_COMPILER=$ENV{CXX} )
+  endif( )
+
+  # Normalize the different ways of specifying a c compiler through -DCMAKE_C_COMPILER
+  if( DEFINED CMAKE_C_COMPILER )
+    message( STATUS "CMAKE_C_COMPILER[clients]: ${CMAKE_C_COMPILER}" )
+    list( APPEND CLIENTS_CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} )
+  elseif( DEFINED ENV{CC} )
+    message( STATUS "ENV{CC}: $ENV{CC} " )
+    list( APPEND CLIENTS_CMAKE_ARGS -DCMAKE_C_COMPILER=$ENV{CC} )
+  endif( )
 
   # Clients are set up as an external project to take advantage of specifying toolchain files.
   # We want cmake to go through it's usual discovery process
@@ -200,3 +222,26 @@ if( BUILD_CLIENTS )
     INSTALL_COMMAND ""
   )
 endif( )
+
+# POLICY CMP0037 - "Target names should not be reserved and should match a validity pattern"
+# target names like 'install' should be OK at the superbuild level
+if( POLICY CMP0037 )
+  cmake_policy( SET CMP0037 OLD )
+endif( )
+
+add_custom_target( install
+  COMMAND ${CMAKE_COMMAND} --build . --target install
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/library-build"
+  DEPENDS rocblas
+  COMMENT "super-build installing rocblas"
+  VERBATIM
+)
+
+add_custom_target( package
+  COMMAND ${CMAKE_COMMAND} --build . --target package
+  COMMAND ${CMAKE_COMMAND} -E copy *.deb *.rpm ..
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/library-build"
+  DEPENDS rocblas
+  COMMENT "super-build packaging rocblas"
+#  VERBATIM  // non-intuitively, VERBATIM breaks the cmake -E copy
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ node('rocm-1.6 && fiji')
         {
           stage("configure clang release") {
               sh """#!/usr/bin/env bash
-                cmake -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_PREFIX_PATH=/opt/boost/clang -DBUILD_SHARED_LIBS=ON -DBUILD_LIBRARY=ON -DBUILD_WITH_TENSILE=ON \
+                cmake -DCMAKE_CXX_COMPILER=clang++-3.8 -DCMAKE_C_COMPILER=clang-3.8 -DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_PREFIX_PATH=/opt/boost/clang -DBUILD_SHARED_LIBS=ON -DBUILD_LIBRARY=ON -DBUILD_WITH_TENSILE=ON \
                 -DBUILD_CLIENTS=ON -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm/rocblas ${scm_dir}
                 """
           }

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -40,11 +40,6 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS )
   endif( )
 endif()
 
-# if( DEFINED HIP_ROOT )
-#   list( APPEND CMAKE_MODULE_PATH ${HIP_ROOT}/cmake )
-# #  list( APPEND CMAKE_PREFIX_PATH ${HIP_ROOT} )
-# endif( )
-
 # WARNING: do not surround CMAKE_PREFIX_PATH with quotes, it breaks
 # Replace all occurances of ; with ^^, which we elect to use a path seperator
 string(REGEX REPLACE ";" "^^" CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}" )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -35,7 +35,8 @@ include( build-version )
 project_version( NAME rocblas LANGUAGES CXX )
 
 message( STATUS "rocblas_VERSION= ${rocblas_VERSION}" )
-message( STATUS "CMAKE_BUILD_TYPE= ${CMAKE_BUILD_TYPE}" )
+message( STATUS "\t==>CMAKE_BUILD_TYPE= ${CMAKE_BUILD_TYPE}" )
+message( STATUS "\t==>CMAKE_INSTALL_PREFIX link: " ${CMAKE_INSTALL_PREFIX} )
 
 # This is incremented when the ABI to the library changes
 set( rocblas_SOVERSION 1 )


### PR DESCRIPTION
Summary of proposed changes:
-  The super-build has targets like 'install' & 'package'
-  Allow clients to be compiled with hipcc/hcc with target architecture
flags to align with changes in compiler

