### PR TITLE
add gemm NaN and bad-arg tests

### DIFF
--- a/clients/common/arg_check.cpp
+++ b/clients/common/arg_check.cpp
@@ -263,3 +263,26 @@ void verify_rocblas_status_success(rocblas_status status, const char* message)
     }
 }
 
+template<>
+void verify_not_nan(float arg)
+{
+#ifdef GOOGLE_TEST
+    ASSERT_EQ(arg, arg);
+#endif
+    if(arg != arg)
+    {
+        std::cout << "ERROR: argument is NaN" << std::endl;
+    }
+}
+
+template<>
+void verify_not_nan(double arg)
+{
+#ifdef GOOGLE_TEST
+    ASSERT_EQ(arg, arg);
+#endif
+    if(arg != arg)
+    {
+        std::cout << "ERROR: argument is NaN" << std::endl;
+    }
+}

--- a/clients/gtest/gemm_gtest.cpp
+++ b/clients/gtest/gemm_gtest.cpp
@@ -134,6 +134,15 @@ class gemm_gtest: public :: TestWithParam <gemm_tuple>
         virtual void TearDown(){}
 };
 
+TEST(rocblas_blas3, gemm_float_bad_arg)
+{
+    testing_gemm_bad_arg<float>();
+}
+
+TEST(rocblas_blas3, gemm_float_NaN_test)
+{
+    testing_gemm_NaN<float>();
+}
 
 TEST_P(gemm_gtest, gemm_gtest_float)
 {

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -151,7 +151,7 @@ class gemv_gtest: public :: TestWithParam <gemv_tuple>
         virtual void TearDown(){}
 };
 
-TEST(blas2_gtest, gemv_float_bad_arg)
+TEST(rocblas_blas2, gemv_float_bad_arg)
 {
     testing_gemv_bad_arg<float>();
 }

--- a/clients/include/arg_check.h
+++ b/clients/include/arg_check.h
@@ -59,4 +59,7 @@
 
     void verify_rocblas_status_success(rocblas_status status, const char* message);
 
+    template<typename T>
+    void verify_not_nan(T arg);
+
 #endif

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -19,106 +19,129 @@
 #include "flops.h"
 #include <typeinfo>
 
-
 using namespace std;
 
 /* ============================================================================================ */
-
 template<typename T>
-void testing_gemm_NaN()
+void testing_gemm_NaN(Arguments argus)
 {
-    const rocblas_int M = 100;
-    const rocblas_int N = 100;
-    const rocblas_int K = 100;
+    rocblas_int M = argus.M;
+    rocblas_int N = argus.N;
+    rocblas_int K = argus.K;
 
-    const rocblas_int lda = 100;
-    const rocblas_int ldb = 100;
-    const rocblas_int ldc = 100;
+    rocblas_int lda = argus.lda;
+    rocblas_int ldb = argus.ldb;
+    rocblas_int ldc = argus.ldc;
 
-    T alpha;
-    T beta;
+    rocblas_operation transA = char2rocblas_operation(argus.transA_option);
+    rocblas_operation transB = char2rocblas_operation(argus.transB_option);
 
-    const rocblas_operation transA = rocblas_operation_none;
-    const rocblas_operation transB = rocblas_operation_none;
-
-    rocblas_handle handle;
     T *dA, *dB, *dC;
 
+    rocblas_int  A_size, B_size, C_size, A_row, A_col, B_row, B_col;
+    T alpha = argus.alpha;
+    T beta = argus.beta;
+
+    rocblas_handle handle;
     rocblas_status status;
     status = rocblas_create_handle(&handle);
     verify_rocblas_status_success(status,"ERROR: rocblas_create_handle");
 
-    if(status != rocblas_status_success) {
+    if(status != rocblas_status_success) 
+    {
         rocblas_destroy_handle(handle);
         return;
     }
+    if(transA == rocblas_operation_none)
+    {
+        A_row =  M; A_col = K;
+    }
+    else
+    {
+        A_row = K; A_col = M;
+    }
 
-    rocblas_int A_size = M * lda;
-    rocblas_int B_size = K * ldb;
-    rocblas_int C_size = M * ldc;
+    if(transB == rocblas_operation_none)
+    {
+        B_row =  K; B_col = N;
+    }
+    else
+    {
+        B_row = N; B_col = K;
+    }
 
+    A_size = lda * A_col; B_size = ldb * B_col; C_size = ldc * N;
+
+    //check here to prevent undefined memory allocation error
+    if( M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M )
+    {
+        // bad arguments are tested in other tests
+        return;
+    }
+    else if (nullptr == dA || nullptr == dB || nullptr == dC )
+    {
+        verify_rocblas_status_invalid_pointer(rocblas_status_success, "ERROR: A or B or C is nullptr");
+        return;
+    }
+    else if (nullptr == handle )
+    {
+        verify_rocblas_status_invalid_handle(rocblas_status_success);
+        return;
+    }
+
+    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory.
     vector<T> hA(A_size);
     vector<T> hB(B_size);
     vector<T> hC(C_size);
-
-    for (int i = 0; i < A_size; i++) hA[i] = 1.0;
-    for (int i = 0; i < B_size; i++) hB[i] = 1.0;
-    for (int i = 0; i < C_size; i++) hC[i] = std::numeric_limits<T>::quiet_NaN();
 
     //allocate memory on device
     CHECK_HIP_ERROR(hipMalloc(&dA, A_size * sizeof(T)));
     CHECK_HIP_ERROR(hipMalloc(&dB, B_size * sizeof(T)));
     CHECK_HIP_ERROR(hipMalloc(&dC, C_size * sizeof(T)));
 
+    //Initial Data on CPU
+    for (int i = 0; i < A_size; i++) hA[i] = 1.0;
+    for (int i = 0; i < B_size; i++) hB[i] = 1.0;
+    for (int i = 0; i < C_size; i++) hC[i] = 1.0;
+
+    for (int i = 0; i < N; i++) 
+    {
+        for (int j = 0; j < M; j++)
+        {
+            hC[j + i*ldc] = std::numeric_limits<T>::quiet_NaN();
+        }
+    }
+
     //copy data from CPU to device, does not work for lda != A_row
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T)*B_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
 
-    {
-        alpha = 1.2;
-        beta = 0.0;
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
 
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*C_size, hipMemcpyHostToDevice));
-
-        status = rocblas_gemm<T>(handle, transA, transB,
+    //library interface
+    status = rocblas_gemm<T>(handle, transA, transB,
                     M, N, K,
                     &alpha, dA, lda,
                     dB, ldb,
                     &beta, dC, ldc);
 
-        verify_rocblas_status_success(status,"ERROR: rocblas_gemm");
+    verify_rocblas_status_success(status,"ERROR: rocblas_gemm");
 
-        CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T)*C_size, hipMemcpyDeviceToHost));
+    //copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-        for (int i = 0; i < C_size; i++)
-        {
-            verify_not_nan(hC[i]);
-            if(hC[i] != hC[i]) break;
-        }
-    }
+    for (int i = 0; i < N; i++) 
     {
-        alpha = 0.0;
-        beta = 0.0;
-
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*C_size, hipMemcpyHostToDevice));
-
-        status = rocblas_gemm<T>(handle, transA, transB,
-                    M, N, K,
-                    &alpha, dA, lda,
-                    dB, ldb,
-                    &beta, dC, ldc);
-
-        verify_rocblas_status_success(status,"ERROR: rocblas_gemm");
-
-        CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T)*C_size, hipMemcpyDeviceToHost));
-
-        for (int i = 0; i < C_size; i++)
+        for (int j = 0; j < M; j++)
         {
-            verify_not_nan(hC[i]);
-            if(hC[i] != hC[i]) break;
+            verify_not_nan(hC[j + i*ldc]);
+            if(hC[j + i*ldc] != hC[j + i*ldc]) goto finish_nested_loops;
         }
     }
+    finish_nested_loops:
 
     CHECK_HIP_ERROR(hipFree(dA));
     CHECK_HIP_ERROR(hipFree(dB));
@@ -152,7 +175,8 @@ void testing_gemm_bad_arg()
     status = rocblas_create_handle(&handle);
     verify_rocblas_status_success(status,"ERROR: rocblas_create_handle");
 
-    if(status != rocblas_status_success) {
+    if(status != rocblas_status_success) 
+    {
         rocblas_destroy_handle(handle);
         return;
     }
@@ -280,30 +304,33 @@ rocblas_status testing_gemm(Arguments argus)
     status = rocblas_create_handle(&handle);
     verify_rocblas_status_success(status,"ERROR: rocblas_create_handle");
 
-    if(status != rocblas_status_success) {
+    if(status != rocblas_status_success) 
+    {
         rocblas_destroy_handle(handle);
         return status;
     }
-
-    if(transA == rocblas_operation_none){
+    if(transA == rocblas_operation_none)
+    {
         A_row =  M; A_col = K;
     }
-    else{
+    else
+    {
         A_row = K; A_col = M;
     }
-
-    if(transB == rocblas_operation_none){
+    if(transB == rocblas_operation_none)
+    {
         B_row =  K; B_col = N;
     }
-    else{
+    else
+    {
         B_row = N; B_col = K;
     }
 
     A_size = lda * A_col; B_size = ldb * B_col; C_size = ldc * N;
 
     //check here to prevent undefined memory allocation error
-    if( M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M ){
-
+    if( M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M )
+    {
         CHECK_HIP_ERROR(hipMalloc(&dA, 100 * sizeof(T))); // 100 is arbitary
         CHECK_HIP_ERROR(hipMalloc(&dB, 100 * sizeof(T)));
         CHECK_HIP_ERROR(hipMalloc(&dC, 100 * sizeof(T)));
@@ -343,7 +370,7 @@ rocblas_status testing_gemm(Arguments argus)
         return status;
     }
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(A_size);
     vector<T> hB(B_size);
     vector<T> hC(C_size);
@@ -360,13 +387,12 @@ rocblas_status testing_gemm(Arguments argus)
     rocblas_init<T>(hB, B_row, B_col, ldb);
     rocblas_init<T>(hC, M, N, ldc);
 
-    //copy vector is easy in STL; hz = hx: save a copy in hC_copy which will be output of CPU BLAS
     hC_copy = hC;
 
     //copy data from CPU to device, does not work for lda != A_row
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*lda*A_col,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T)*ldb*B_col,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*ldc*N,      hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
 
     /* =====================================================================
          ROCBLAS
@@ -388,30 +414,31 @@ rocblas_status testing_gemm(Arguments argus)
     }
 
     //copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T)*ldc*N,      hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-
-    if(argus.unit_check || argus.norm_check){
+    if(argus.unit_check || argus.norm_check)
+    {
 
      /* =====================================================================
                  CPU BLAS
      =================================================================== */
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us();
         }
-
-        if(status != rocblas_status_invalid_size){//only valid size compare with cblas
+        if(status != rocblas_status_invalid_size) //only valid size compare with cblas
+        {
             cblas_gemm<T>(
                      transA, transB, M, N, K,
                      alpha, hA.data(), lda,
                      hB.data(), ldb,
                      beta, hC_copy.data(), ldc);
         }
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us() - cpu_time_used;
             cblas_gflops = gemm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
         }
-
 
         #ifndef NDEBUG
         print_matrix(hC_copy, hC, min(M,3), min(N,3), ldc);
@@ -419,13 +446,15 @@ rocblas_status testing_gemm(Arguments argus)
 
         //enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if(argus.unit_check){
+        if(argus.unit_check)
+        {
             unit_check_general<T>(M, N, ldc, hC_copy.data(), hC.data());
         }
 
         //if enable norm check, norm check is invasive
         //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-        if(argus.norm_check){
+        if(argus.norm_check)
+        {
             rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_copy.data(), hC.data());
         }
 
@@ -434,7 +463,8 @@ rocblas_status testing_gemm(Arguments argus)
     if(argus.timing){
         //only norm_check return an norm error, unit check won't return anything,
             cout << "Shape, M, N, K, lda, ldb, ldc, rocblas-Gflops (us) ";
-            if(argus.norm_check){
+            if(argus.norm_check)
+            {
                 cout << "CPU-Gflops(us), norm-error" ;
             }
             cout << endl;
@@ -442,7 +472,8 @@ rocblas_status testing_gemm(Arguments argus)
             cout << argus.transA_option << argus.transB_option << ',' << M <<','<< N <<',' << K <<',' << lda <<','<< ldb <<','
                  << ldc <<',' << rocblas_gflops << " (" << gpu_time_used << "), ";
 
-            if(argus.norm_check){
+            if(argus.norm_check)
+            {
                 cout << cblas_gflops << " (" << cpu_time_used << "), ";
                 cout << rocblas_error;
             }
@@ -467,7 +498,6 @@ Intended for long time running
 template<typename T>
 rocblas_status range_testing_gemm(Arguments argus)
 {
-
     rocblas_int start = argus.start;
     rocblas_int step = argus.step;
     rocblas_int end = argus.end;
@@ -485,11 +515,11 @@ rocblas_status range_testing_gemm(Arguments argus)
     T rocblas_error = 0.0;
 
     //argument sanity check, quick return if input parameters are invalid before allocating invalid memory
-    if( start < 0 || end < 0 || step < 0 || end < start ){
+    if( start < 0 || end < 0 || step < 0 || end < start )
+    {
         cout << "Invalid matrix dimension input, will return" << endl;
         return rocblas_status_invalid_size;
     }
-
 
     A_size = B_size = C_size = end * end;
 
@@ -506,7 +536,8 @@ rocblas_status range_testing_gemm(Arguments argus)
     status = rocblas_create_handle(&handle);
     verify_rocblas_status_success(status,"ERROR: rocblas_create_handle");
 
-    if(status != rocblas_status_success) {
+    if(status != rocblas_status_success) 
+    {
         rocblas_destroy_handle(handle);
         return status;
     }
@@ -538,16 +569,18 @@ rocblas_status range_testing_gemm(Arguments argus)
 
     ofstream myfile;
     myfile.open(filename);
-    if (myfile.is_open()){
+    if (myfile.is_open())
+    {
         myfile << "M, N, K, lda, ldb, ldc, rocblas-Gflops (us) ";
-        if(argus.norm_check){
+        if(argus.norm_check)
+        {
             myfile << "CPU-Gflops(us), norm-error" ;
         }
         myfile << endl;
     }
 
-    for(rocblas_int size = start; size <= end; size += step){
-
+    for(rocblas_int size = start; size <= end; size += step)
+    {
         cout << "Benchmarking M:" << (int)size << ", N:"<< (int) size <<", K:" << (int)size << endl ;
 
         //make sure CPU and GPU routines see the same input
@@ -573,8 +606,8 @@ rocblas_status range_testing_gemm(Arguments argus)
         //copy output from device to CPU
         hipMemcpy(hC.data(), dC, sizeof(T)*size*size,      hipMemcpyDeviceToHost);
 
-        if(argus.norm_check){
-
+        if(argus.norm_check)
+        {
              /* =====================================================================
                          CPU BLAS
              =================================================================== */
@@ -594,17 +627,20 @@ rocblas_status range_testing_gemm(Arguments argus)
 
             //if enable norm check, norm check is invasive
             //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-            if(argus.norm_check) {
+            if(argus.norm_check) 
+            {
                 rocblas_error = norm_check_general<T>('F', size, size, size, hC_copy.data(), hC.data());
             }
 
         }// end of if unit/norm check
 
-        if (myfile.is_open()){
+        if (myfile.is_open())
+        {
         //only norm_check return an norm error, unit check won't return anything, only return the real part, imag part does not make sense
             myfile << size <<','<< size <<',' << size <<',' << size <<','<< size <<',' << size <<',' << rocblas_gflops << "(" << gpu_time_used << "),";
 
-            if(argus.norm_check){
+            if(argus.norm_check)
+            {
                 myfile << cblas_gflops << "(" << cpu_time_used << "),";
                 //cout << rocblas_error;
             }
@@ -629,12 +665,14 @@ rocblas_status benchmark_gemm(Arguments argus)
 {
     //if negative, fall back to specific matrix size testing
     //otherwise, range testing. only norm check is enabled in range_test
-    if(argus.start < 0 || argus.end < 0 || argus.step < 0){
+    if(argus.start < 0 || argus.end < 0 || argus.step < 0)
+    {
         cout << "Specific matrix size testing: output will be displayed on terminal" << endl;
         cout << endl;
         return testing_gemm<T>(argus);
     }
-    else{
+    else
+    {
         argus.timing = 1; //timing is enabled
         cout << "Range matrix size testing: output will be benchmark_xgemm_(transpose)_(begin)to(end)_(step).csv ..." << endl;
         cout << endl;

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -123,6 +123,8 @@ rocblas_gemv_template(rocblas_handle handle,
         return rocblas_status_invalid_pointer;
     else if (nullptr == y)
         return rocblas_status_invalid_pointer;
+    else if (nullptr == beta)
+        return rocblas_status_invalid_pointer;
     else if(nullptr == handle)
         return rocblas_status_invalid_handle;
 


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
-  when gemm parameter beta == 0 matrix C must be set to 0, not multiplied by zero. 
-  This prevents propagation of NaN when beta == 0.
-  A test is added to verify that C is set to zero when beta == 0
-  gemm tests are also added to verify correct behavior when A, B, C, alpha, beta = nullptr
