### PR TITLE
Don't install the python performance scripts

### DIFF
--- a/clients/benchmarks/perf_script/CMakeLists.txt
+++ b/clients/benchmarks/perf_script/CMakeLists.txt
@@ -3,21 +3,15 @@
 #
 # ########################################################################
 
+set(GRAPHING_SCRIPTS measurePerformance.py
+    plotPerformance.py
+    blasPerformanceTesting.py
+    errorHandler.py
+    performanceUtility.py
+    README.txt
+  )
 
-set(GRAPHING_SCRIPTS 	measurePerformance.py 
-						plotPerformance.py 
-						blasPerformanceTesting.py 
-						errorHandler.py 
-						performanceUtility.py
-                        README.txt
-						)
-foreach(SCRIPT ${GRAPHING_SCRIPTS}) 
-#Copy a file to another location.
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT} ${CMAKE_CURRENT_BINARY_DIR}/${SCRIPT} @ONLY)
-endforeach()
-
-if( WIN32 )
-		install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )
-else ( )
-		install( FILES ${GRAPHING_SCRIPTS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR} )
-endif( )
+foreach( SCRIPT ${GRAPHING_SCRIPTS} )
+  #Copy a file to another location.
+  configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT} ${CMAKE_CURRENT_BINARY_DIR}/${SCRIPT} @ONLY )
+endforeach( )


### PR DESCRIPTION
Summary of proposed changes:
-  Clients should eventually install in a separate .deb package

