### PR TITLE
correct rocblas_dot for inc<0

### DIFF
--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -251,11 +251,29 @@ TEST_P(blas1_gtest, dot_float)
         if( arg.N < 0 ){
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if( arg.incx < 0){
+        else 
+        {
+            ASSERT_EQ(status, rocblas_status_success) << "incorrect return status";
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dot_double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments arg = setup_blas1_arguments( GetParam() );
+    rocblas_status status = testing_dot<double>( arg );
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != rocblas_status_success){
+        if( arg.N < 0 ){
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if( arg.incy < 0){
-            EXPECT_EQ(rocblas_status_invalid_size, status);
+        else 
+        {
+            ASSERT_EQ(status, rocblas_status_success) << "incorrect return status";
         }
     }
 }

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -229,11 +229,6 @@ rocblas_dot_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    if (incx < 0)
-        return rocblas_status_invalid_size;
-    else if (incy < 0)
-        return rocblas_status_invalid_size;
-
     rocblas_int blocks = (n-1)/ NB_X + 1;
 
     rocblas_status status;


### PR DESCRIPTION
rocblas_dot was returning rocblas_status_success when incx<0 || incy<0, and tests were not catching the error.
Remove the return for incx<0 || incy<0. rocblas_dot gives correct behavior for incx<0||incy<0, so no change is needed other than to remove the incorrect return. Also change tests to catch this error.

