### PR TITLE
correct geam API move beta before B

### DIFF
--- a/clients/common/rocblas_template_specialization.cpp
+++ b/clients/common/rocblas_template_specialization.cpp
@@ -544,10 +544,10 @@
         rocblas_int m, rocblas_int n,
         const float *alpha,
         const float *A, rocblas_int lda,
-        const float *B, rocblas_int ldb,
         const float *beta,
+        const float *B, rocblas_int ldb,
         float *C, rocblas_int ldc){
-        return rocblas_sgeam(handle, transA, transB, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+        return rocblas_sgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
     }
 
     template<>
@@ -556,10 +556,10 @@
         rocblas_int m, rocblas_int n,
         const double *alpha,
         const double *A, rocblas_int lda,
-        const double *B, rocblas_int ldb,
         const double *beta,
+        const double *B, rocblas_int ldb,
         double *C, rocblas_int ldc){
-        return rocblas_dgeam(handle, transA, transB, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+        return rocblas_dgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
     }
 
 

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -126,8 +126,8 @@
         rocblas_int m, rocblas_int n,
         const T *alpha,
         const T *A, rocblas_int lda,
-        const T *B, rocblas_int ldb,
         const T *beta,
+        const T *B, rocblas_int ldb,
         T *C, rocblas_int ldc);
 
     template<typename T>

--- a/clients/include/testing_geam.hpp
+++ b/clients/include/testing_geam.hpp
@@ -79,8 +79,8 @@ void testing_geam_bad_arg()
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA_null, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: A is nullptr");
     }
@@ -89,8 +89,8 @@ void testing_geam_bad_arg()
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB_null, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB_null, ldb,
+                    dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: B is nullptr");
     }
@@ -99,8 +99,8 @@ void testing_geam_bad_arg()
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC_null, ldc);
+                    &h_beta, dB, ldb,
+                    dC_null, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: C is nullptr");
     }
@@ -109,8 +109,8 @@ void testing_geam_bad_arg()
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     h_alpha_null, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: h_alpha is nullptr");
     }
@@ -119,8 +119,8 @@ void testing_geam_bad_arg()
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    h_beta_null, dC, ldc);
+                    h_beta_null, dB, ldb,
+                    dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: h_beta is nullptr");
     }
@@ -129,8 +129,8 @@ void testing_geam_bad_arg()
         status = rocblas_geam<T>(handle_null, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
 
         verify_rocblas_status_invalid_handle(status);
     }
@@ -213,8 +213,8 @@ rocblas_status testing_geam(Arguments argus)
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
 
         geam_arg_check(status, M, N, lda, ldb, ldc);
 
@@ -239,8 +239,8 @@ rocblas_status testing_geam(Arguments argus)
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: A or B or C is nullptr");
 
@@ -257,8 +257,8 @@ rocblas_status testing_geam(Arguments argus)
         status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
 
         verify_rocblas_status_invalid_handle(status);
 
@@ -301,8 +301,8 @@ rocblas_status testing_geam(Arguments argus)
         status_h = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
 
         CHECK_HIP_ERROR(hipMemcpy(hC_h.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
@@ -311,8 +311,8 @@ rocblas_status testing_geam(Arguments argus)
         status_d = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     d_alpha, dA, lda,
-                    dB, ldb,
-                    d_beta, dC, ldc);
+                    d_beta, dB, ldb,
+                    dC, ldc);
 
         CHECK_HIP_ERROR(hipMemcpy(hC_d.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
@@ -373,8 +373,8 @@ rocblas_status testing_geam(Arguments argus)
             status_h = rocblas_geam<T>(handle, transA, transB,
                         M, N,
                         &h_alpha, dA, lda,
-                        dB, ldb,
-                        &h_beta, dC_in_place, ldc);
+                        &h_beta, dB, ldb,
+                        dC_in_place, ldc);
 
             if (lda != ldc || transA != rocblas_operation_none)
             {
@@ -428,8 +428,8 @@ rocblas_status testing_geam(Arguments argus)
             status_h = rocblas_geam<T>(handle, transA, transB,
                         M, N,
                         &h_alpha, dA, lda,
-                        dB, ldb,
-                        &h_beta, dC_in_place, ldc);
+                        &h_beta, dB, ldb,
+                        dC_in_place, ldc);
 
             if (ldb != ldc || transB != rocblas_operation_none)
             {
@@ -489,8 +489,8 @@ rocblas_status testing_geam(Arguments argus)
             status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
         }
 
         gpu_time_used = get_time_us();   // in microseconds
@@ -499,8 +499,8 @@ rocblas_status testing_geam(Arguments argus)
             status = rocblas_geam<T>(handle, transA, transB,
                     M, N,
                     &h_alpha, dA, lda,
-                    dB, ldb,
-                    &h_beta, dC, ldc);
+                    &h_beta, dB, ldb,
+                    dC, ldc);
         }
         gpu_time_used = get_time_us() - gpu_time_used;
         rocblas_gflops = geam_gflop_count<T> (M, N) * number_hot_calls / gpu_time_used * 1e6;

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1207,12 +1207,12 @@ rocblas_zgemm_strided_batched(
     lda       rocblas_int
               specifies the leading dimension of A.
     @param[in]
+    beta      specifies the scalar beta.
+    @param[in]
     B         pointer storing matrix B on the GPU.
     @param[in]
     ldb       rocblas_int
               specifies the leading dimension of B.
-    @param[in]
-    beta      specifies the scalar beta.
     @param[in, out]
     C         pointer storing matrix C on the GPU.
     @param[in]
@@ -1228,8 +1228,8 @@ rocblas_sgeam(
     rocblas_int m, rocblas_int n,
     const float *alpha,
     const float *A, rocblas_int lda,
-    const float *B, rocblas_int ldb,
     const float *beta,
+    const float *B, rocblas_int ldb,
           float *C, rocblas_int ldc);
 
 ROCBLAS_EXPORT rocblas_status
@@ -1239,8 +1239,8 @@ rocblas_dgeam(
     rocblas_int m, rocblas_int n,
     const double *alpha,
     const double *A, rocblas_int lda,
-    const double *B, rocblas_int ldb,
     const double *beta,
+    const double *B, rocblas_int ldb,
           double *C, rocblas_int ldc);
 
 

--- a/library/src/blas3/geam_device.h
+++ b/library/src/blas3/geam_device.h
@@ -10,8 +10,8 @@ geam_device(
     rocblas_int m, rocblas_int n,
     T alpha,
     const T * __restrict__ A, rocblas_int lda,
-    const T * __restrict__ B, rocblas_int ldb,
     T beta,
+    const T * __restrict__ B, rocblas_int ldb,
           T *              C, rocblas_int ldc)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -92,8 +92,8 @@ geam_1D_device(
     rocblas_int size,
     T alpha,
     const T * __restrict__ A,
-    const T * __restrict__ B,
     T beta,
+    const T * __restrict__ B,
           T *              C)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -144,8 +144,8 @@ geam_inplace_device(
     rocblas_operation transB,
     rocblas_int m, rocblas_int n,
     T alpha,
-    const T * __restrict__ B, rocblas_int ldb,
     T beta,
+    const T * __restrict__ B, rocblas_int ldb,
           T *              C, rocblas_int ldc)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;


### PR DESCRIPTION
Correct geam API to move beta before B. Incorrect API is:

rocblas_status rocblas_Xgeam(handle, transA, transB, m, n, alpha, A, lda, B, ldb, beta, C, ldc)

Correct API is:

rocblas_status rocblas_Xgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
