### PR TITLE
add error message for cmake3.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,19 +28,24 @@ find_package( ROCM CONFIG QUIET PATHS /opt/rocm )
 if( NOT ROCM_FOUND )
   set( rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download" )
   file( DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-      ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip SHOW_PROGRESS)
+      ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
+
+  list(GET status 0 status_code)
+  list(GET status 1 status_string)
+
+  if(NOT status_code EQUAL 0)
+    message(FATAL_ERROR "error: downloading
+    'https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
+    status_code: ${status_code}
+    status_string: ${status_string}
+    log: ${log}
+    ")
+  endif()
+
+  message(STATUS "downloading... done") 
 
   execute_process( COMMAND ${CMAKE_COMMAND} -E tar xzvf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
     WORKING_DIRECTORY ${PROJECT_EXTERN_DIR} )
-
-  if( NOT EXISTS ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag})
-      message("************************************************************************")
-      message("***ERROR*** Failed to create ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}")
-      message("***ERROR*** try to use cmake 3.5.1 not cmake 3.5.2")
-      message("***ERROR*** try command    PATH=/usr/bin:$PATH ./install.sh -idc")
-      execute_process( COMMAND ${CMAKE_COMMAND} cmake --version)
-      message("************************************************************************")
-  endif()
 
   find_package( ROCM REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
 endif( )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,19 @@ find_package( ROCM CONFIG QUIET PATHS /opt/rocm )
 if( NOT ROCM_FOUND )
   set( rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download" )
   file( DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-    ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip )
+      ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip SHOW_PROGRESS)
 
-  execute_process( COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+  execute_process( COMMAND ${CMAKE_COMMAND} -E tar xzvf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
     WORKING_DIRECTORY ${PROJECT_EXTERN_DIR} )
+
+  if( NOT EXISTS ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag})
+      message("************************************************************************")
+      message("***ERROR*** Failed to create ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}")
+      message("***ERROR*** try to use cmake 3.5.1 not cmake 3.5.2")
+      message("***ERROR*** try command    PATH=/usr/bin:$PATH ./install.sh -idc")
+      execute_process( COMMAND ${CMAKE_COMMAND} cmake --version)
+      message("************************************************************************")
+  endif()
 
   find_package( ROCM REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
 endif( )


### PR DESCRIPTION
rocBLAS build fails if cmake 3.5.2 is used. It passes if cmake 3.5.1 is used. 

Add descriptive error message that will help users avoid the build fail with cmake 3.5.2.
