### PR TITLE
gemm rocblas_pointer_mode_device

### DIFF
--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -213,8 +213,8 @@ rocblas_status testing_gemm(Arguments argus)
     rocblas_int ldb = argus.ldb;
     rocblas_int ldc = argus.ldc;
 
-    T alpha = argus.alpha;
-    T beta = argus.beta;
+    T h_alpha = argus.alpha;
+    T h_beta = argus.beta;
 
     rocblas_int safe_size = 100;
 
@@ -248,7 +248,7 @@ rocblas_status testing_gemm(Arguments argus)
             return rocblas_status_memory_error;
         }
 
-        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
+        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
 
         gemm_arg_check(status, M, N, K, lda, ldb, ldc);
 
@@ -263,10 +263,14 @@ rocblas_status testing_gemm(Arguments argus)
     auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
     auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
     auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
+    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
+    auto d_beta_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
     T* dA = (T*) dA_managed.get();
     T* dB = (T*) dB_managed.get();
     T* dC = (T*) dC_managed.get();
-    if (!dA || !dB || !dC)
+    T* d_alpha = (T*) d_alpha_managed.get();
+    T* d_beta  = (T*) d_beta_managed.get();
+    if (!dA || !dB || !dC || !d_alpha || !d_beta)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
@@ -275,47 +279,65 @@ rocblas_status testing_gemm(Arguments argus)
     //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> hB(size_B);
-    vector<T> hC(size_C);
-    vector<T> hC_copy(size_C);
+    vector<T> hC_1(size_C);
+    vector<T> hC_2(size_C);
+    vector<T> hC_gold(size_C);
 
     //Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, A_row, A_col, lda);
     rocblas_init<T>(hB, B_row, B_col, ldb);
-    rocblas_init<T>(hC, M, N, ldc);
+    rocblas_init<T>(hC_1, M, N, ldc);
 
-    hC_copy = hC;
+    hC_2 = hC_1;
+    hC_gold = hC_1;
 
     //copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
     {
-        // ROCBLAS
-        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc));
+        // ROCBLAS rocblas_pointer_mode_host
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        //copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
+
+        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+
+        // ROCBLAS rocblas_pointer_mode_device
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_2.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
+
+        CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+
+        CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
+
+        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
 
-        cblas_gemm<T>(transA, transB, M, N, K, alpha, hA.data(), lda, hB.data(), ldb, beta, hC_copy.data(), ldc);
+        cblas_gemm<T>(transA, transB, M, N, K, h_alpha, hA.data(), lda, hB.data(), ldb, h_beta, hC_gold.data(), ldc);
 
         cpu_time_used = get_time_us() - cpu_time_used;
         cblas_gflops = gemm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
 
         #ifndef NDEBUG
-        print_matrix(hC_copy, hC, min(M,3), min(N,3), ldc);
+        print_matrix(hC_gold, hC, min(M,3), min(N,3), ldc);
         #endif
 
         //enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N, ldc, hC_copy.data(), hC.data());
+            unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_1.data());
+            unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_2.data());
         }
 
         //if enable norm check, norm check is invasive
@@ -323,7 +345,8 @@ rocblas_status testing_gemm(Arguments argus)
         //in compilation time
         if(argus.norm_check)
         {
-            rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_copy.data(), hC.data());
+            rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
+            rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_2.data());
         }
     }
 
@@ -332,15 +355,17 @@ rocblas_status testing_gemm(Arguments argus)
         int number_cold_calls = 2;
         int number_hot_calls = 10;
 
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
         for (int i = 0; i < number_cold_calls; i++)
         {
-            rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
+            rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
         }
 
         gpu_time_used = get_time_us();   // in microseconds
         for (int i = 0; i < number_hot_calls; i++)
         {
-            rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
+            rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
         }
         gpu_time_used = get_time_us() - gpu_time_used;
         rocblas_gflops = gemm_gflop_count<T> (M, N, K) * number_hot_calls / gpu_time_used * 1e6;
@@ -362,7 +387,6 @@ rocblas_status testing_gemm(Arguments argus)
 
         cout << endl;
     }
-
     return status;
 }
 
@@ -404,7 +428,7 @@ rocblas_status range_testing_gemm(Arguments argus)
     vector<T> hA(size_A);
     vector<T> hB(size_B);
     vector<T> hC(size_C);
-    vector<T> hC_copy(size_C);
+    vector<T> hC_gold(size_C);
 
     rocblas_status status;
 
@@ -430,8 +454,8 @@ rocblas_status range_testing_gemm(Arguments argus)
     rocblas_init<T>(hB, end, end, end);
     rocblas_init<T>(hC, end, end, end);
 
-    //copy vector is easy in STL; hz = hx: save a copy in hC_copy which will be output of CPU BLAS
-    hC_copy = hC;
+    //copy vector is easy in STL; hz = hx: save a copy in hC_gold which will be output of CPU BLAS
+    hC_gold = hC;
 
     //copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*end*end,  hipMemcpyHostToDevice));
@@ -459,7 +483,7 @@ rocblas_status range_testing_gemm(Arguments argus)
         cout << "Benchmarking M:" << (int)size << ", N:"<< (int) size <<", K:" << (int)size << endl ;
 
         //make sure CPU and GPU routines see the same input
-        hC = hC_copy;
+        hC = hC_gold;
         CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*size*size,      hipMemcpyHostToDevice));
 
         /* =====================================================================
@@ -493,7 +517,7 @@ rocblas_status range_testing_gemm(Arguments argus)
                          transA, transB, size, size, size,
                          alpha, hA.data(), size,
                          hB.data(), size,
-                         beta, hC_copy.data(), size);
+                         beta, hC_gold.data(), size);
 
 
             cpu_time_used = get_time_us() - cpu_time_used;
@@ -504,7 +528,7 @@ rocblas_status range_testing_gemm(Arguments argus)
             //any typeinfo(T) will not work here, because template deduction is matched in compilation time
             if(argus.norm_check) 
             {
-                rocblas_error = norm_check_general<T>('F', size, size, size, hC_copy.data(), hC.data());
+                rocblas_error = norm_check_general<T>('F', size, size, size, hC_gold.data(), hC.data());
             }
 
         }// end of if unit/norm check

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -27,8 +27,8 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     rocblas_int N = argus.N;
     rocblas_int K = argus.K;
 
-    T alpha = argus.alpha;
-    T beta = argus.beta;
+    T h_alpha = argus.alpha;
+    T h_beta = argus.beta;
 
     rocblas_int lda = argus.lda;
     rocblas_int ldb = argus.ldb;
@@ -71,9 +71,9 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
 
         status = rocblas_gemm_strided_batched<T>(handle, transA, transB,
                     M, N, K,
-                    &alpha, dA, lda, bsa,
+                    &h_alpha, dA, lda, bsa,
                     dB, ldb, bsb,
-                    &beta, dC, ldc, bsc, batch_count);
+                    &h_beta, dC, ldc, bsc, batch_count);
 
         gemm_strided_batched_arg_check(status, M, N, K, lda, ldb, ldc, batch_count);
 
@@ -93,10 +93,14 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
     auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
     auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
+    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
+    auto d_beta_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
     T* dA = (T*) dA_managed.get();
     T* dB = (T*) dB_managed.get();
     T* dC = (T*) dC_managed.get();
-    if ((!dA && (size_A != 0)) || (!dB && (size_B != 0)) || (!dC && (size_C != 0)))
+    T* d_alpha = (T*) d_alpha_managed.get();
+    T* d_beta  = (T*) d_beta_managed.get();
+    if ((!dA && (size_A != 0)) || (!dB && (size_B != 0)) || (!dC && (size_C != 0)) || !d_alpha || !d_beta)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
@@ -105,32 +109,51 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hA(size_A);
     vector<T> hB(size_B);
-    vector<T> hC(size_C);
+    vector<T> hC_1(size_C);
+    vector<T> hC_2(size_C);
     vector<T> hC_gold(size_C);
 
     //Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, A_row, A_col * batch_count, lda);
     rocblas_init<T>(hB, B_row, B_col * batch_count, ldb);
-    rocblas_init<T>(hC, M, N * batch_count, ldc);
-    hC_gold = hC;
+    rocblas_init<T>(hC_1, M, N * batch_count, ldc);
+    hC_2 = hC_1;
+    hC_gold = hC_1;
 
     //copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T)*size_B,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*size_C,  hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
     {
-        // ROCBLAS
+        // ROCBLAS rocblas_pointer_mode_host
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T)*size_C,  hipMemcpyHostToDevice));
+
         CHECK_ROCBLAS_ERROR(rocblas_gemm_strided_batched<T>(handle, transA, transB,
                     M, N, K,
-                    &alpha, dA, lda, bsa,
+                    &h_alpha, dA, lda, bsa,
                     dB, ldb, bsb,
-                    &beta, dC, ldc, bsc, batch_count));
+                    &h_beta, dC, ldc, bsc, batch_count));
 
-        //copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T)*size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T)*size_C, hipMemcpyDeviceToHost));
+
+        // ROCBLAS rocblas_pointer_mode_device
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_2.data(), sizeof(T)*size_C,  hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
+
+        CHECK_ROCBLAS_ERROR(rocblas_gemm_strided_batched<T>(handle, transA, transB,
+                    M, N, K,
+                    d_alpha, dA, lda, bsa,
+                    dB, ldb, bsb,
+                    d_beta, dC, ldc, bsc, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T)*size_C, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -138,9 +161,9 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
         {
             cblas_gemm<T>(
                      transA, transB, M, N, K,
-                     alpha, hA.data() + bsa * i, lda,
+                     h_alpha, hA.data() + bsa * i, lda,
                      hB.data() + bsb * i, ldb,
-                     beta, hC_gold.data() + bsc * i, ldc);
+                     h_beta, hC_gold.data() + bsc * i, ldc);
         }
         cpu_time_used = get_time_us() - cpu_time_used;
         cblas_gflops = gemm_gflop_count<T>(M, N, K) * batch_count / cpu_time_used * 1e6;
@@ -149,26 +172,30 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N*batch_count, lda, hC_gold.data(), hC.data());
+            unit_check_general<T>(M, N*batch_count, lda, hC_gold.data(), hC_1.data());
+            unit_check_general<T>(M, N*batch_count, lda, hC_gold.data(), hC_2.data());
         }
 
         //if enable norm check, norm check is invasive
         //any typeinfo(T) will not work here, because template deduction is matched in compilation time
         if(argus.norm_check)
         {
-            rocblas_error = norm_check_general<T>('F', M, N*batch_count, lda, hC_gold.data(), hC.data());
+            rocblas_error = norm_check_general<T>('F', M, N*batch_count, lda, hC_gold.data(), hC_1.data());
+            rocblas_error = norm_check_general<T>('F', M, N*batch_count, lda, hC_gold.data(), hC_2.data());
         }
     }
 
     if(argus.timing)
     {
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
         gpu_time_used = get_time_us();  // in microseconds
 
         rocblas_gemm_strided_batched<T>(handle, transA, transB,
                     M, N, K,
-                    &alpha, dA, lda, bsa,
+                    &h_alpha, dA, lda, bsa,
                     dB, ldb, bsb,
-                    &beta, dC, ldc, bsc, batch_count);
+                    &h_beta, dC, ldc, bsc, batch_count);
 
         gpu_time_used = get_time_us() - gpu_time_used;
         rocblas_gflops = gemm_gflop_count<T> (M, N, K) * batch_count / gpu_time_used * 1e6;


### PR DESCRIPTION
add rocblas_pointer_mode_device to gemm, gemm_strided_batched and trsm.

This is done by copying alpha and beta from device to host. TODO: change to add gemm and gemm_strided_batched kernels that handle rocblas_pointer_mode_device
