### PR TITLE
adding clang-format style and scripts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+AccessModifierOffset: 0
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+# SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.githooks/install
+++ b/.githooks/install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(git rev-parse --git-dir)
+cd hooks
+
+echo "Installing hooks..." 
+ln -s ../../.githooks/pre-commit pre-commit
+echo "Done!"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# This pre-commit hook checks if any versions of clang-format
+# are installed, and if so, uses the installed version to format
+# the staged changes.
+
+base=clang-format-3.8
+format=""
+
+# Redirect output to stderr.
+exec 1>&2
+
+ # check if clang-format is installed
+type "$base" >/dev/null 2>&1 && format="$base"
+
+# no versions of clang-format are installed
+if [ -z "$format" ]
+then
+    echo "$base is not installed. Pre-commit hook will not be executed."
+    exit 0
+fi
+
+# Do everything from top - level
+cd $(git rev-parse --show-toplevel)
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# do the formatting
+for file in $(git diff-index --cached --name-only $against | grep -E '\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$')
+do
+    if [ -e "$file" ]
+    then
+        echo "$format $file"
+        "$format" -i -style=file "$file"
+    fi
+done
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,20 +170,6 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
           """
       }
 
-    stage('Clang Format') {
-        sh '''
-            find . -iname \'*.h\' \
-                -o -iname \'*.hpp\' \
-                -o -iname \'*.cpp\' \
-                -o -iname \'*.h.in\' \
-                -o -iname \'*.hpp.in\' \
-                -o -iname \'*.cpp.in\' \
-                -o -iname \'*.cl\' \
-            | grep -v 'build/' \
-            | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'
-        '''
-    }
-
     stage( "Test ${compiler_args.compiler_name} ${compiler_args.build_config}" )
     {
       withEnv(["LD_LIBRARY_PATH=/opt/rocm/lib"])
@@ -225,6 +211,20 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
         archiveArtifacts artifacts: "${docker_context}/*.deb", fingerprint: true
         archiveArtifacts artifacts: "${docker_context}/*.rpm", fingerprint: true
       }
+    }
+
+    stage('Clang Format') {
+        sh '''
+            find . -iname \'*.h\' \
+                -o -iname \'*.hpp\' \
+                -o -iname \'*.cpp\' \
+                -o -iname \'*.h.in\' \
+                -o -iname \'*.hpp.in\' \
+                -o -iname \'*.cpp.in\' \
+                -o -iname \'*.cl\' \
+            | grep -v 'build/' \
+            | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'
+        '''
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,6 +170,20 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
           """
       }
 
+    stage('Clang Format') {
+        sh '''
+            find . -iname \'*.h\' \
+                -o -iname \'*.hpp\' \
+                -o -iname \'*.cpp\' \
+                -o -iname \'*.h.in\' \
+                -o -iname \'*.hpp.in\' \
+                -o -iname \'*.cpp.in\' \
+                -o -iname \'*.cl\' \
+            | grep -v 'build/' \
+            | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'
+        '''
+    }
+
     stage( "Test ${compiler_args.compiler_name} ${compiler_args.build_config}" )
     {
       withEnv(["LD_LIBRARY_PATH=/opt/rocm/lib"])

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -25,19 +25,19 @@
 #include "testing_set_get_vector.hpp"
 #include "testing_set_get_matrix.hpp"
 #if BUILD_WITH_TENSILE
-    #include "testing_gemm.hpp"
-    #include "testing_gemm_strided_batched.hpp"
-    #include "testing_trsm.hpp"
+#include "testing_gemm.hpp"
+#include "testing_gemm_strided_batched.hpp"
+#include "testing_trsm.hpp"
 #endif
 
 namespace po = boost::program_options;
 
-
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     Arguments argus;
-    argus.unit_check = 0;//disable unit_check in client benchmark, it is only used in gtest unit test
-    argus.timing = 1; //enable timing check,otherwise no performance data collected
+    argus.unit_check =
+        0;            // disable unit_check in client benchmark, it is only used in gtest unit test
+    argus.timing = 1; // enable timing check,otherwise no performance data collected
 
     std::string function;
     char precision;
@@ -45,187 +45,248 @@ int main(int argc, char *argv[])
     rocblas_int device_id;
     vector<rocblas_int> range = {-1, -1, -1};
 
-    po::options_description desc( "rocblas client command line options" );
-    desc.add_options()
-        ( "help,h", "produces this help message" )
-        (   "range", po::value< vector<rocblas_int> >( &range )->multitoken(), "Range matrix size testing: BLAS-3 benchmarking only. Accept three positive integers. Usage: ""--range start end step"". e.g ""--range 100 1000 200"". Diabled if not specified. If enabled, user specified m,n,k will be nullified")
-        ( "sizem,m", po::value<rocblas_int>( &argus.M )->default_value(128), "Specific matrix size testing: sizem is only applicable to BLAS-2 & BLAS-3: the number of rows." )
-        ( "sizen,n", po::value<rocblas_int>( &argus.N )->default_value(128), "Specific matrix/vector size testing: BLAS-1: the length of the vector. BLAS-2 & BLAS-3: the number of columns" )
-        ( "sizek,k", po::value<rocblas_int>( &argus.K )->default_value(128), "Specific matrix size testing:sizek is only applicable to BLAS-3: the number of columns in A & C  and rows in B." )
-        ( "lda", po::value<rocblas_int>( &argus.lda )->default_value(128), "Specific leading dimension of matrix A, is only applicable to BLAS-2 & BLAS-3: the number of rows." )
-        ( "ldb", po::value<rocblas_int>( &argus.ldb )->default_value(128), "Specific leading dimension of matrix B, is only applicable to BLAS-2 & BLAS-3: the number of rows." )
-        ( "ldc", po::value<rocblas_int>( &argus.ldc )->default_value(128), "Specific leading dimension of matrix C, is only applicable to BLAS-2 & BLAS-3: the number of rows." )
-        ( "alpha",   po::value<double>( &argus.alpha)->default_value(1.0), "specifies the scalar alpha" )
-        ( "beta",    po::value<double>( &argus.beta )->default_value(0.0), "specifies the scalar beta" )
-        ( "function,f", po::value<std::string>( &function )->default_value("gemv"), "BLAS function to test. Options: gemv, ger, trsm, trmm, symv, syrk, syr2k" )
-        ( "precision,r", po::value<char>( &precision )->default_value('s'), "Options: h,s,d,c,z" )
-        ( "transposeA", po::value<char>( &argus.transA_option )->default_value('N'), "N = no transpose, T = transpose, C = conjugate transpose" )
-        ( "transposeB", po::value<char>( &argus.transB_option )->default_value('N'), "N = no transpose, T = transpose, C = conjugate transpose" )
-        ( "side", po::value<char>( &argus.side_option )->default_value('L'), "L = left, R = right. Only applicable to certain routines" )
-        ( "uplo", po::value<char>( &argus.uplo_option )->default_value('U'), "U = upper, L = lower. Only applicable to certain routines" )    // xsymv xsyrk xsyr2k xtrsm xtrmm
-        ( "diag", po::value<char>( &argus.diag_option )->default_value('N'), "U = unit diagonal, N = non unit diagonal. Only applicable to certain routines" ) // xtrsm xtrmm
-        ( "batch", po::value<rocblas_int>( &argus.batch_count )->default_value(10), "Number of matrices. Only applicable to batched routines" ) // xtrsm xtrmm
-        ( "verify,v", po::value<rocblas_int>(&argus.norm_check)->default_value(0), "Validate GPU results with CPU? 0 = No, 1 = Yes (default: No)")
-        ( "device", po::value<rocblas_int>(&device_id)->default_value(0), "Set default device to be used for subsequent program runs")
-        ;
-
+    po::options_description desc("rocblas client command line options");
+    desc.add_options()("help,h", "produces this help message")(
+        "range",
+        po::value<vector<rocblas_int>>(&range)->multitoken(),
+        "Range matrix size testing: BLAS-3 benchmarking only. Accept three positive integers. "
+        "Usage: "
+        "--range start end step"
+        ". e.g "
+        "--range 100 1000 200"
+        ". Diabled if not specified. If enabled, user specified m,n,k will be nullified")(
+        "sizem,m",
+        po::value<rocblas_int>(&argus.M)->default_value(128),
+        "Specific matrix size testing: sizem is only applicable to BLAS-2 & BLAS-3: the number of "
+        "rows.")("sizen,n",
+                 po::value<rocblas_int>(&argus.N)->default_value(128),
+                 "Specific matrix/vector size testing: BLAS-1: the length of the vector. BLAS-2 & "
+                 "BLAS-3: the number of columns")(
+        "sizek,k",
+        po::value<rocblas_int>(&argus.K)->default_value(128),
+        "Specific matrix size testing:sizek is only applicable to BLAS-3: the number of columns in "
+        "A & C  and rows in B.")("lda",
+                                 po::value<rocblas_int>(&argus.lda)->default_value(128),
+                                 "Specific leading dimension of matrix A, is only applicable to "
+                                 "BLAS-2 & BLAS-3: the number of rows.")(
+        "ldb",
+        po::value<rocblas_int>(&argus.ldb)->default_value(128),
+        "Specific leading dimension of matrix B, is only applicable to BLAS-2 & BLAS-3: the number "
+        "of rows.")("ldc",
+                    po::value<rocblas_int>(&argus.ldc)->default_value(128),
+                    "Specific leading dimension of matrix C, is only applicable to BLAS-2 & "
+                    "BLAS-3: the number of rows.")(
+        "alpha", po::value<double>(&argus.alpha)->default_value(1.0), "specifies the scalar alpha")(
+        "beta", po::value<double>(&argus.beta)->default_value(0.0), "specifies the scalar beta")(
+        "function,f",
+        po::value<std::string>(&function)->default_value("gemv"),
+        "BLAS function to test. Options: gemv, ger, trsm, trmm, symv, syrk, syr2k")(
+        "precision,r", po::value<char>(&precision)->default_value('s'), "Options: h,s,d,c,z")(
+        "transposeA",
+        po::value<char>(&argus.transA_option)->default_value('N'),
+        "N = no transpose, T = transpose, C = conjugate transpose")(
+        "transposeB",
+        po::value<char>(&argus.transB_option)->default_value('N'),
+        "N = no transpose, T = transpose, C = conjugate transpose")(
+        "side",
+        po::value<char>(&argus.side_option)->default_value('L'),
+        "L = left, R = right. Only applicable to certain routines")(
+        "uplo",
+        po::value<char>(&argus.uplo_option)->default_value('U'),
+        "U = upper, L = lower. Only applicable to certain routines") // xsymv xsyrk xsyr2k xtrsm
+                                                                     // xtrmm
+        ("diag",
+         po::value<char>(&argus.diag_option)->default_value('N'),
+         "U = unit diagonal, N = non unit diagonal. Only applicable to certain routines") // xtrsm
+                                                                                          // xtrmm
+        ("batch",
+         po::value<rocblas_int>(&argus.batch_count)->default_value(10),
+         "Number of matrices. Only applicable to batched routines") // xtrsm xtrmm
+        ("verify,v",
+         po::value<rocblas_int>(&argus.norm_check)->default_value(0),
+         "Validate GPU results with CPU? 0 = No, 1 = Yes (default: No)")(
+            "device",
+            po::value<rocblas_int>(&device_id)->default_value(0),
+            "Set default device to be used for subsequent program runs");
 
     po::variables_map vm;
-    po::store( po::parse_command_line( argc, argv, desc ), vm );
-    po::notify( vm );
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
 
-
-    if( vm.count( "help" ) ){
+    if(vm.count("help"))
+    {
         std::cout << desc << std::endl;
         return 0;
     }
 
-    if( precision != 'h' && precision != 's' && precision != 'd' && precision != 'c' && precision != 'z' ){
+    if(precision != 'h' && precision != 's' && precision != 'd' && precision != 'c' &&
+       precision != 'z')
+    {
         std::cerr << "Invalid value for --precision" << std::endl;
         return -1;
     }
 
-
-    //Device Query
+    // Device Query
     rocblas_int device_count = query_device_property();
 
-    if(device_count <= device_id){
+    if(device_count <= device_id)
+    {
         printf("Error: invalid device ID. There may not be such device ID. Will exit \n");
         return -1;
     }
-    else{
+    else
+    {
         set_device(device_id);
     }
-    /* ============================================================================================ */
-    if( argus.M < 0 || argus.N < 0 || argus.K < 0 ){
+    /* ============================================================================================
+     */
+    if(argus.M < 0 || argus.N < 0 || argus.K < 0)
+    {
         printf("Invalide matrix dimension\n");
     }
 
+    argus.start = range[0];
+    argus.step  = range[1];
+    argus.end   = range[2];
 
-    argus.start = range[0]; argus.step = range[1]; argus.end = range[2];
-
-
-    if (function == "asum"){
-        if (precision == 's')
-            testing_asum<float, float>( argus );
-        else if (precision == 'd')
-            testing_asum<double, double>( argus );
+    if(function == "asum")
+    {
+        if(precision == 's')
+            testing_asum<float, float>(argus);
+        else if(precision == 'd')
+            testing_asum<double, double>(argus);
     }
-    else if (function == "axpy"){
-        if (precision == 'h')
-            testing_axpy<rocblas_half>( argus );
-        else if (precision == 's')
-            testing_axpy<float>( argus );
-        else if (precision == 'd')
-            testing_axpy<double>( argus );
+    else if(function == "axpy")
+    {
+        if(precision == 'h')
+            testing_axpy<rocblas_half>(argus);
+        else if(precision == 's')
+            testing_axpy<float>(argus);
+        else if(precision == 'd')
+            testing_axpy<double>(argus);
     }
-    else if (function == "copy"){
-        if (precision == 's')
-            testing_copy<float>( argus );
-        else if (precision == 'd')
-            testing_copy<double>( argus );
+    else if(function == "copy")
+    {
+        if(precision == 's')
+            testing_copy<float>(argus);
+        else if(precision == 'd')
+            testing_copy<double>(argus);
     }
-    else if (function == "dot"){
-        if (precision == 's')
-            testing_dot<float>( argus );
-        else if (precision == 'd')
-            testing_dot<double>( argus );
+    else if(function == "dot")
+    {
+        if(precision == 's')
+            testing_dot<float>(argus);
+        else if(precision == 'd')
+            testing_dot<double>(argus);
     }
-    else if (function == "iamax"){
-        if (precision == 's')
-            testing_iamax<float>( argus );
-        else if (precision == 'd')
-            testing_iamax<double>( argus );
+    else if(function == "iamax")
+    {
+        if(precision == 's')
+            testing_iamax<float>(argus);
+        else if(precision == 'd')
+            testing_iamax<double>(argus);
     }
-    else if (function == "nrm2"){
-        if (precision == 's')
-            testing_nrm2<float, float>( argus );
-        else if (precision == 'd')
-            testing_nrm2<double, double>( argus );
+    else if(function == "nrm2")
+    {
+        if(precision == 's')
+            testing_nrm2<float, float>(argus);
+        else if(precision == 'd')
+            testing_nrm2<double, double>(argus);
     }
-    else if (function == "scal"){
-        if (precision == 's')
-            testing_scal<float>( argus );
-        else if (precision == 'd')
-            testing_scal<double>( argus );
+    else if(function == "scal")
+    {
+        if(precision == 's')
+            testing_scal<float>(argus);
+        else if(precision == 'd')
+            testing_scal<double>(argus);
     }
-    else if (function == "gemv"){
-        if (precision == 's')
-            testing_gemv<float>( argus );
-        else if (precision == 'd')
-            testing_gemv<double>( argus );
+    else if(function == "gemv")
+    {
+        if(precision == 's')
+            testing_gemv<float>(argus);
+        else if(precision == 'd')
+            testing_gemv<double>(argus);
     }
-    else if (function == "ger"){
-        if (precision == 's')
-            testing_ger<float>( argus );
-        else if (precision == 'd')
-            testing_ger<double>( argus );
+    else if(function == "ger")
+    {
+        if(precision == 's')
+            testing_ger<float>(argus);
+        else if(precision == 'd')
+            testing_ger<double>(argus);
     }
-    else if (function == "trtri"){
-        if (precision == 's')
-            testing_trtri<float>( argus );
-        else if (precision == 'd')
-            testing_trtri<double>( argus );
+    else if(function == "trtri")
+    {
+        if(precision == 's')
+            testing_trtri<float>(argus);
+        else if(precision == 'd')
+            testing_trtri<double>(argus);
     }
-    else if (function == "trtri_batched"){
-        if (precision == 's')
-            testing_trtri_batched<float>( argus );
-        else if (precision == 'd')
-            testing_trtri_batched<double>( argus );
+    else if(function == "trtri_batched")
+    {
+        if(precision == 's')
+            testing_trtri_batched<float>(argus);
+        else if(precision == 'd')
+            testing_trtri_batched<double>(argus);
     }
-    else if (function == "geam"){
-        if (precision == 's')
-            testing_geam<float>( argus );
-        else if (precision == 'd')
-            testing_geam<double>( argus );
+    else if(function == "geam")
+    {
+        if(precision == 's')
+            testing_geam<float>(argus);
+        else if(precision == 'd')
+            testing_geam<double>(argus);
     }
-    else if (function == "set_get_vector"){
-        if (precision == 's')
-            testing_set_get_vector<float>( argus );
-        else if (precision == 'd')
-            testing_set_get_vector<double>( argus );
+    else if(function == "set_get_vector")
+    {
+        if(precision == 's')
+            testing_set_get_vector<float>(argus);
+        else if(precision == 'd')
+            testing_set_get_vector<double>(argus);
     }
-    else if (function == "set_get_matrix"){
-        if (precision == 's')
-            testing_set_get_matrix<float>( argus );
-        else if (precision == 'd')
-            testing_set_get_matrix<double>( argus );
+    else if(function == "set_get_matrix")
+    {
+        if(precision == 's')
+            testing_set_get_matrix<float>(argus);
+        else if(precision == 'd')
+            testing_set_get_matrix<double>(argus);
     }
 #if BUILD_WITH_TENSILE
-    else if (function == "gemm"){
+    else if(function == "gemm")
+    {
 
-        //adjust dimension for GEMM routines
+        // adjust dimension for GEMM routines
         argus.transA_option == 'N' ? argus.lda = argus.M : argus.lda = argus.K;
         argus.transB_option == 'N' ? argus.ldb = argus.K : argus.ldb = argus.N;
-        argus.ldc = argus.M;
+        argus.ldc                                                    = argus.M;
 
-        if (precision == 's')
-            testing_gemm<float>( argus );
-        else if (precision == 'd')
-            testing_gemm<double>( argus );
+        if(precision == 's')
+            testing_gemm<float>(argus);
+        else if(precision == 'd')
+            testing_gemm<double>(argus);
     }
-    else if (function == "gemm_strided_batched"){
-        //adjust dimension for GEMM routines
+    else if(function == "gemm_strided_batched")
+    {
+        // adjust dimension for GEMM routines
         argus.transA_option == 'N' ? argus.lda = argus.M : argus.lda = argus.K;
         argus.transB_option == 'N' ? argus.ldb = argus.K : argus.ldb = argus.N;
-        argus.ldc = argus.M;
-        if (precision == 's')
-            testing_gemm_strided_batched<float>( argus );
-        else if (precision == 'd')
-            testing_gemm_strided_batched<double>( argus );
+        argus.ldc                                                    = argus.M;
+        if(precision == 's')
+            testing_gemm_strided_batched<float>(argus);
+        else if(precision == 'd')
+            testing_gemm_strided_batched<double>(argus);
     }
-    else if (function == "trsm"){
-        if (precision == 's')
-            testing_trsm<float>( argus );
-        else if (precision == 'd')
-            testing_trsm<double>( argus );
+    else if(function == "trsm")
+    {
+        if(precision == 's')
+            testing_trsm<float>(argus);
+        else if(precision == 'd')
+            testing_trsm<double>(argus);
     }
 #endif
-    else{
+    else
+    {
         printf("Invalid value for --function \n");
         return -1;
     }
-
 
     return 0;
 }

--- a/clients/common/arg_check.cpp
+++ b/clients/common/arg_check.cpp
@@ -7,57 +7,70 @@
 #include "rocblas.h"
 #include "arg_check.h"
 
-#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK) {\
-    hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != hipSuccess) { \
-        fprintf(stderr, "hip error code: %d at %s:%d\n",  TMP_STATUS_FOR_CHECK,__FILE__, __LINE__); \
-} }
+#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
+    {                                                             \
+        hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != hipSuccess)                    \
+        {                                                         \
+            fprintf(stderr,                                       \
+                    "hip error code: %d at %s:%d\n",              \
+                    TMP_STATUS_FOR_CHECK,                         \
+                    __FILE__,                                     \
+                    __LINE__);                                    \
+        }                                                         \
+    }
 
+/* ========================================Gtest Arg Check
+ * ===================================================== */
 
-/* ========================================Gtest Arg Check ===================================================== */
+/*! \brief Template: checks if arguments are valid
+*/
 
-
-    /*! \brief Template: checks if arguments are valid
-    */
-
-
-void set_get_matrix_arg_check(rocblas_status status, rocblas_int rows, rocblas_int cols, 
-    rocblas_int lda, rocblas_int ldb, rocblas_int ldc)
+void set_get_matrix_arg_check(rocblas_status status,
+                              rocblas_int rows,
+                              rocblas_int cols,
+                              rocblas_int lda,
+                              rocblas_int ldb,
+                              rocblas_int ldc)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_size);
-    #else
-    if (status != rocblas_status_invalid_size)
+#else
+    if(status != rocblas_status_invalid_size)
     {
         std::cerr << "rocBLAS TEST ERROR in arguments rows, cols, lda, ldb, ldc: ";
         std::cerr << rows << ',' << cols << ',' << lda << ',' << ldb << ',' << ldc << std::endl;
     }
-    #endif
+#endif
 }
 
-void set_get_vector_arg_check(rocblas_status status, rocblas_int M, rocblas_int incx, 
-    rocblas_int incy, rocblas_int incd)
+void set_get_vector_arg_check(
+    rocblas_status status, rocblas_int M, rocblas_int incx, rocblas_int incy, rocblas_int incd)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_size);
-    #else
-    if (status != rocblas_status_invalid_size)
+#else
+    if(status != rocblas_status_invalid_size)
     {
         std::cerr << "rocBLAS TEST ERROR in arguments M, incx, incy, incd: ";
         std::cerr << M << ',' << incx << ',' << incy << ',' << incd << std::endl;
     }
-    #endif
+#endif
 }
 
-void gemv_ger_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int lda, 
-    rocblas_int incx, rocblas_int incy)
+void gemv_ger_arg_check(rocblas_status status,
+                        rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int lda,
+                        rocblas_int incx,
+                        rocblas_int incy)
 {
-    #ifdef GOOGLE_TEST
-    if (M < 0 || N < 0 || lda < M || lda < 1 || 0 == incx || 0 == incy)
+#ifdef GOOGLE_TEST
+    if(M < 0 || N < 0 || lda < M || lda < 1 || 0 == incx || 0 == incy)
     {
         ASSERT_EQ(status, rocblas_status_invalid_size);
     }
-    else if (0 == M || 0 == N)
+    else if(0 == M || 0 == N)
     {
         ASSERT_EQ(status, rocblas_status_success);
     }
@@ -65,44 +78,58 @@ void gemv_ger_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, roc
     {
         EXPECT_TRUE(false) << "error in gemv_ger_arg_check";
     }
-    #else
-    if (M < 0 || N < 0 || lda < M || lda < 1 || 0 == incx || 0 == incy)
+#else
+    if(M < 0 || N < 0 || lda < M || lda < 1 || 0 == incx || 0 == incy)
     {
-        if (status != rocblas_status_invalid_size)
+        if(status != rocblas_status_invalid_size)
         {
-            std::cerr << "rocBLAS TEST ERROR: (M < 0 || N < 0 || lda < M || lda < 1 || 0 == incx || 0 == incy) " << std::endl;
-            std::cerr << "rocBLAS TEST ERROR: and (status != rocblas_status_invalid_size)" << std::endl;
-	        std::cerr << "rocBLAS TEST ERROR: status = " << status << std::endl;
+            std::cerr << "rocBLAS TEST ERROR: (M < 0 || N < 0 || lda < M || lda < 1 || 0 == incx "
+                         "|| 0 == incy) "
+                      << std::endl;
+            std::cerr << "rocBLAS TEST ERROR: and (status != rocblas_status_invalid_size)"
+                      << std::endl;
+            std::cerr << "rocBLAS TEST ERROR: status = " << status << std::endl;
         }
     }
-    else if (0 == M || 0 == N)
+    else if(0 == M || 0 == N)
     {
-        if (status != rocblas_status_success)
+        if(status != rocblas_status_success)
         {
             std::cerr << "rocBLAS TEST ERROR: (0 == M || 0 == N)" << std::endl;
             std::cerr << "rocBLAS TEST ERROR: and (status != rocblas_status_success)" << std::endl;
-	        std::cerr << "rocBLAS TEST ERROR: status = " << status << std::endl;
+            std::cerr << "rocBLAS TEST ERROR: status = " << status << std::endl;
         }
     }
-    #endif
+#endif
 }
 
-void gemm_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int K, 
-    rocblas_int lda, rocblas_int ldb, rocblas_int ldc)
+void gemm_arg_check(rocblas_status status,
+                    rocblas_int M,
+                    rocblas_int N,
+                    rocblas_int K,
+                    rocblas_int lda,
+                    rocblas_int ldb,
+                    rocblas_int ldc)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_size);
-    #else
+#else
     std::cerr << "rocBLAS TEST ERROR in arguments M, N, K, lda, ldb, ldc: ";
     std::cerr << M << ',' << N << ',' << K << ',' << lda << ',' << ldb << ',' << ldc << std::endl;
-    #endif
+#endif
 }
 
-void gemm_strided_batched_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int K, 
-    rocblas_int lda, rocblas_int ldb, rocblas_int ldc, rocblas_int batch_count)
+void gemm_strided_batched_arg_check(rocblas_status status,
+                                    rocblas_int M,
+                                    rocblas_int N,
+                                    rocblas_int K,
+                                    rocblas_int lda,
+                                    rocblas_int ldb,
+                                    rocblas_int ldc,
+                                    rocblas_int batch_count)
 {
-    #ifdef GOOGLE_TEST
-    if (M == 0 || N == 0 || K == 0 || batch_count == 0)
+#ifdef GOOGLE_TEST
+    if(M == 0 || N == 0 || K == 0 || batch_count == 0)
     {
         ASSERT_EQ(status, rocblas_status_success);
     }
@@ -110,17 +137,22 @@ void gemm_strided_batched_arg_check(rocblas_status status, rocblas_int M, rocbla
     {
         ASSERT_EQ(status, rocblas_status_invalid_size);
     }
-    #else
+#else
     std::cerr << "rocBLAS TEST ERROR in arguments M, N, K, lda, ldb, ldc, batch_count: ";
-    std::cerr << M << ',' << N << ',' << K << ',' << lda << ',' << ldb << ',' << ldc << batch_count << std::endl;
-    #endif
+    std::cerr << M << ',' << N << ',' << K << ',' << lda << ',' << ldb << ',' << ldc << batch_count
+              << std::endl;
+#endif
 }
 
-void geam_arg_check(rocblas_status status, rocblas_int M, rocblas_int N,
-    rocblas_int lda, rocblas_int ldb, rocblas_int ldc)
+void geam_arg_check(rocblas_status status,
+                    rocblas_int M,
+                    rocblas_int N,
+                    rocblas_int lda,
+                    rocblas_int ldb,
+                    rocblas_int ldc)
 {
-    #ifdef GOOGLE_TEST
-    if (M == 0 || N == 0)
+#ifdef GOOGLE_TEST
+    if(M == 0 || N == 0)
     {
         ASSERT_EQ(status, rocblas_status_success);
     }
@@ -128,237 +160,243 @@ void geam_arg_check(rocblas_status status, rocblas_int M, rocblas_int N,
     {
         ASSERT_EQ(status, rocblas_status_invalid_size);
     }
-    #else
+#else
     std::cerr << "rocBLAS TEST ERROR in arguments M, N, lda, ldb, ldc: ";
     std::cerr << M << ',' << N << ',' << lda << ',' << ldb << ',' << ldc << std::endl;
-    #endif
+#endif
 }
 
-void trsm_arg_check(rocblas_status status, rocblas_int M, rocblas_int N,
-    rocblas_int lda, rocblas_int ldb)
+void trsm_arg_check(
+    rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int ldb)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_size);
-    #else
+#else
     std::cerr << "rocBLAS TEST ERROR in arguments M, N, lda, ldb: ";
     std::cerr << M << ',' << N << ',' << lda << ',' << ldb << std::endl;
-    #endif
+#endif
 }
 
-void symv_arg_check(rocblas_status status, rocblas_int N, rocblas_int lda, rocblas_int incx, rocblas_int incy)
+void symv_arg_check(
+    rocblas_status status, rocblas_int N, rocblas_int lda, rocblas_int incx, rocblas_int incy)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_size);
-    #else
+#else
     std::cerr << "rocBLAS TEST ERROR in arguments N, lda, incx, incy: ";
     std::cerr << N << ',' << lda << ',' << incx << ',' << incy << std::endl;
-    #endif
+#endif
 }
 
 void iamax_arg_check(rocblas_status status, rocblas_int* d_rocblas_result)
 {
     rocblas_int h_rocblas_result;
-    if( rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device )
+    if(rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device)
     {
-        PRINT_IF_HIP_ERROR(hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(rocblas_int), hipMemcpyDeviceToHost));
+        PRINT_IF_HIP_ERROR(hipMemcpy(
+            &h_rocblas_result, d_rocblas_result, sizeof(rocblas_int), hipMemcpyDeviceToHost));
     }
     else
     {
         h_rocblas_result = *d_rocblas_result;
     }
 
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(h_rocblas_result, 0);
     ASSERT_EQ(status, rocblas_status_success);
-    #else
-    if ( h_rocblas_result != 0 )
+#else
+    if(h_rocblas_result != 0)
     {
         std::cerr << "result should be 0, result =  " << h_rocblas_result << std::endl;
     }
-    #endif
+#endif
 }
 
-template<>
+template <>
 void asum_arg_check(rocblas_status status, float* d_rocblas_result)
 {
     float h_rocblas_result;
-    if( rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device )
+    if(rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device)
     {
-        PRINT_IF_HIP_ERROR(hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(float), hipMemcpyDeviceToHost));
+        PRINT_IF_HIP_ERROR(
+            hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(float), hipMemcpyDeviceToHost));
     }
     else
     {
         h_rocblas_result = *d_rocblas_result;
     }
 
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(h_rocblas_result, 0.0);
     ASSERT_EQ(status, rocblas_status_success);
-    #else
-    if ( h_rocblas_result != 0.0 )
+#else
+    if(h_rocblas_result != 0.0)
     {
         std::cerr << "result should be 0.0, result =  " << h_rocblas_result << std::endl;
     }
-    #endif
+#endif
 }
 
-template<>
+template <>
 void asum_arg_check(rocblas_status status, double* d_rocblas_result)
 {
     double h_rocblas_result;
-    if( rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device )
+    if(rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device)
     {
-        PRINT_IF_HIP_ERROR(hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(double), hipMemcpyDeviceToHost));
+        PRINT_IF_HIP_ERROR(
+            hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(double), hipMemcpyDeviceToHost));
     }
     else
     {
         h_rocblas_result = *d_rocblas_result;
     }
 
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(h_rocblas_result, 0.0);
-    #else
-    if ( h_rocblas_result != 0.0 )
+#else
+    if(h_rocblas_result != 0.0)
     {
         std::cerr << "result should be 0.0, result =  " << h_rocblas_result << std::endl;
     }
-    #endif
+#endif
 }
 
-template<>
+template <>
 void nrm2_dot_arg_check(rocblas_status status, double* d_rocblas_result)
 {
     double h_rocblas_result;
 
-    if( rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device )
+    if(rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device)
     {
-        PRINT_IF_HIP_ERROR(hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(double), hipMemcpyDeviceToHost));
+        PRINT_IF_HIP_ERROR(
+            hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(double), hipMemcpyDeviceToHost));
     }
     else
     {
         h_rocblas_result = *d_rocblas_result;
     }
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(h_rocblas_result, 0.0);
     ASSERT_EQ(status, rocblas_status_success);
-    #else
-    if ( h_rocblas_result != 0.0 )
+#else
+    if(h_rocblas_result != 0.0)
     {
         std::cerr << "result should be 0.0, result =  " << h_rocblas_result << std::endl;
     }
-    #endif
+#endif
 }
 
-template<>
+template <>
 void nrm2_dot_arg_check(rocblas_status status, float* d_rocblas_result)
 {
     float h_rocblas_result;
-    if( rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device )
+    if(rocblas_pointer_to_mode(d_rocblas_result) == rocblas_pointer_mode_device)
     {
-        PRINT_IF_HIP_ERROR(hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(float), hipMemcpyDeviceToHost));
+        PRINT_IF_HIP_ERROR(
+            hipMemcpy(&h_rocblas_result, d_rocblas_result, sizeof(float), hipMemcpyDeviceToHost));
     }
     else
     {
         h_rocblas_result = *d_rocblas_result;
     }
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(h_rocblas_result, 0.0);
-    #else
-    if ( h_rocblas_result != 0.0 )
+#else
+    if(h_rocblas_result != 0.0)
     {
         std::cerr << "result should be 0.0, result =  " << h_rocblas_result << std::endl;
     }
-    #endif
+#endif
 }
 
 void verify_rocblas_status_invalid_pointer(rocblas_status status, const char* message)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_pointer);
-    #else
-    if (status != rocblas_status_invalid_pointer)
+#else
+    if(status != rocblas_status_invalid_pointer)
     {
         std::cerr << message << std::endl;
     }
-    #endif
+#endif
 }
 
 void verify_rocblas_status_invalid_size(rocblas_status status, const char* message)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_size);
-    #else
-    if (status != rocblas_status_invalid_size)
+#else
+    if(status != rocblas_status_invalid_size)
     {
         std::cerr << "rocBLAS TEST ERROR: status != rocblas_status_invalid_size, ";
         std::cerr << message << std::endl;
     }
-    #endif
+#endif
 }
 
-//void handle_check(rocblas_status status)
+// void handle_check(rocblas_status status)
 void verify_rocblas_status_invalid_handle(rocblas_status status)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_invalid_handle);
-    #else
-    if (status != rocblas_status_invalid_handle)
+#else
+    if(status != rocblas_status_invalid_handle)
     {
         std::cerr << "rocBLAS TEST ERROR: handle is null pointer" << std::endl;
     }
-    #endif
+#endif
 }
 
 void verify_rocblas_status_success(rocblas_status status, const char* message)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(status, rocblas_status_success);
-    #else
+#else
     if(status != rocblas_status_success)
     {
         std::cerr << message << std::endl;
         std::cerr << "rocBLAS TEST ERROR: status should be rocblas_status_success" << std::endl;
         std::cerr << "rocBLAS TEST ERROR: status = " << status << std::endl;
     }
-    #endif
+#endif
 }
 
-template<>
+template <>
 void verify_not_nan(float arg)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(arg, arg);
-    #else
+#else
     if(arg != arg)
     {
         std::cerr << "rocBLAS TEST ERROR: argument is NaN" << std::endl;
     }
-    #endif
+#endif
 }
 
-template<>
+template <>
 void verify_not_nan(double arg)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(arg, arg);
-    #else
+#else
     if(arg != arg)
     {
         std::cerr << "rocBLAS TEST ERROR: argument is NaN" << std::endl;
     }
-    #endif
+#endif
 }
 
-template<>
+template <>
 void verify_equal(int arg1, int arg2, const char* message)
 {
-    #ifdef GOOGLE_TEST
+#ifdef GOOGLE_TEST
     ASSERT_EQ(arg1, arg2);
-    #else
+#else
     if(arg1 != arg2)
     {
         std::cerr << message << std::endl;
         std::cerr << "rocBLAS TEST ERROR: arguments not equal" << std::endl;
     }
-    #endif
+#endif
 }

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -3,7 +3,6 @@
  *
  * ************************************************************************/
 
-
 #include <typeinfo>
 #include <memory>
 #include "rocblas.h"
@@ -12,699 +11,953 @@
 #include "utility.h"
 
 /*!\file
- * \brief provide template functions interfaces to CBLAS C89 interfaces, it is only used for testing not part of the GPU library
+ * \brief provide template functions interfaces to CBLAS C89 interfaces, it is only used for testing
+ * not part of the GPU library
 */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-    void    strtri_(char* uplo, char* diag, int* n, float* A, int* lda, int *info);
-    void    dtrtri_(char* uplo, char* diag, int* n, double* A, int* lda, int *info);
-    void    ctrtri_(char* uplo, char* diag, int* n, rocblas_float_complex* A,  int* lda, int *info);
-    void    ztrtri_(char* uplo, char* diag, int* n, rocblas_double_complex* A, int* lda, int *info);
+void strtri_(char* uplo, char* diag, int* n, float* A, int* lda, int* info);
+void dtrtri_(char* uplo, char* diag, int* n, double* A, int* lda, int* info);
+void ctrtri_(char* uplo, char* diag, int* n, rocblas_float_complex* A, int* lda, int* info);
+void ztrtri_(char* uplo, char* diag, int* n, rocblas_double_complex* A, int* lda, int* info);
 
-    void    sgetrf_(int* m, int* n, float* A, int* lda, int* ipiv, int *info);
-    void    dgetrf_(int* m, int* n, double* A, int* lda, int* ipiv, int *info);
-    void    cgetrf_(int* m, int* n, rocblas_float_complex* A, int* lda, int* ipiv, int *info);
-    void    zgetrf_(int* m, int* n, rocblas_double_complex* A, int* lda, int* ipiv, int *info);
+void sgetrf_(int* m, int* n, float* A, int* lda, int* ipiv, int* info);
+void dgetrf_(int* m, int* n, double* A, int* lda, int* ipiv, int* info);
+void cgetrf_(int* m, int* n, rocblas_float_complex* A, int* lda, int* ipiv, int* info);
+void zgetrf_(int* m, int* n, rocblas_double_complex* A, int* lda, int* ipiv, int* info);
 
-    void    spotrf_(char* uplo, int* m, float* A, int* lda, int *info);
-    void    dpotrf_(char* uplo, int* m, double* A, int* lda, int *info);
-    void    cpotrf_(char* uplo, int* m, rocblas_float_complex* A, int* lda, int *info);
-    void    zpotrf_(char* uplo, int* m, rocblas_double_complex* A, int* lda, int *info);
+void spotrf_(char* uplo, int* m, float* A, int* lda, int* info);
+void dpotrf_(char* uplo, int* m, double* A, int* lda, int* info);
+void cpotrf_(char* uplo, int* m, rocblas_float_complex* A, int* lda, int* info);
+void zpotrf_(char* uplo, int* m, rocblas_double_complex* A, int* lda, int* info);
 
 #ifdef __cplusplus
 }
 #endif
 
-    /*
-     * ===========================================================================
-     *    level 1 BLAS
-     * ===========================================================================
-     */
-    //scal
-    template<>
-    void cblas_scal<float>( rocblas_int n,
-                            const float alpha,
-                            float *x, rocblas_int incx)
-    {
-        cblas_sscal(n, alpha, x, incx);
-    }
-
-    template<>
-    void cblas_scal<double>(rocblas_int n,
-                            const double alpha,
-                            double *x, rocblas_int incx)
-    {
-        cblas_dscal(n, alpha, x, incx);
-    }
-
-    template<>
-    void cblas_scal<rocblas_float_complex>( rocblas_int n,
-                            const rocblas_float_complex alpha,
-                            rocblas_float_complex *x, rocblas_int incx)
-    {
-        cblas_cscal(n, &alpha, x, incx);
-    }
-
-    template<>
-    void cblas_scal<rocblas_double_complex>( rocblas_int n,
-                            const rocblas_double_complex alpha,
-                            rocblas_double_complex *x, rocblas_int incx)
-    {
-        cblas_zscal(n, &alpha, x, incx);
-    }
-
-    //copy
-    template<>
-    void cblas_copy<float>( rocblas_int n,
-                            float *x, rocblas_int incx,
-                            float *y, rocblas_int incy)
-    {
-        cblas_scopy(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_copy<double>(rocblas_int n,
-                            double *x, rocblas_int incx,
-                            double *y, rocblas_int incy)
-    {
-        cblas_dcopy(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_copy<rocblas_float_complex>( rocblas_int n,
-                            rocblas_float_complex *x, rocblas_int incx,
-                            rocblas_float_complex *y, rocblas_int incy)
-    {
-        cblas_ccopy(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_copy<rocblas_double_complex>( rocblas_int n,
-                            rocblas_double_complex *x, rocblas_int incx,
-                            rocblas_double_complex *y, rocblas_int incy)
-    {
-        cblas_zcopy(n, x, incx, y, incy);
-    }
-
-    //axpy
-    template<>
-    void cblas_axpy<rocblas_half>( rocblas_int n,
-                            rocblas_half alpha,
-                            rocblas_half *x, rocblas_int incx,
-                            rocblas_half *y, rocblas_int incy)
-    {
-        rocblas_int abs_incx = incx >=0 ? incx : -incx;
-        rocblas_int abs_incy = incy >=0 ? incy : -incy;
-        float alpha_float = half_to_float( alpha );
-        std::unique_ptr<float []> x_float(new float[n*abs_incx]());
-        std::unique_ptr<float []> y_float(new float[n*abs_incy]());
-        for (int i = 0; i < n; i++)
-        {
-            x_float[i * abs_incx] = half_to_float(x[i * abs_incx]);
-            y_float[i * abs_incy] = half_to_float(y[i * abs_incy]);
-        }
-
-        cblas_saxpy(n, alpha_float, x_float.get(), incx, y_float.get(), incy);
-
-        for (int i = 0; i < n; i++)
-        {
-            x[i * abs_incx] = float_to_half(x_float[i * abs_incx]);
-            y[i * abs_incy] = float_to_half(y_float[i * abs_incy]);
-        }
-    }
-
-    template<>
-    void cblas_axpy<float>( rocblas_int n,
-                            float alpha,
-                            float *x, rocblas_int incx,
-                            float *y, rocblas_int incy)
-    {
-        cblas_saxpy(n, alpha, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_axpy<double>(rocblas_int n,
-                            double alpha,
-                            double *x, rocblas_int incx,
-                            double *y, rocblas_int incy)
-    {
-        cblas_daxpy(n, alpha, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_axpy<rocblas_float_complex>( rocblas_int n,
-                            rocblas_float_complex alpha,
-                            rocblas_float_complex *x, rocblas_int incx,
-                            rocblas_float_complex *y, rocblas_int incy)
-    {
-        cblas_caxpy(n, &alpha, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_axpy<rocblas_double_complex>( rocblas_int n,
-                            rocblas_double_complex alpha,
-                            rocblas_double_complex *x, rocblas_int incx,
-                            rocblas_double_complex *y, rocblas_int incy)
-    {
-        cblas_zaxpy(n, &alpha, x, incx, y, incy);
-    }
-
-    //swap
-    template<>
-    void cblas_swap<float>( rocblas_int n,
-                            float *x, rocblas_int incx,
-                            float *y, rocblas_int incy)
-    {
-        cblas_sswap(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_swap<double>(rocblas_int n,
-                            double *x, rocblas_int incx,
-                            double *y, rocblas_int incy)
-    {
-        cblas_dswap(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_swap<rocblas_float_complex>( rocblas_int n,
-                            rocblas_float_complex *x, rocblas_int incx,
-                            rocblas_float_complex *y, rocblas_int incy)
-    {
-        cblas_cswap(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_swap<rocblas_double_complex>( rocblas_int n,
-                            rocblas_double_complex *x, rocblas_int incx,
-                            rocblas_double_complex *y, rocblas_int incy)
-    {
-        cblas_zswap(n, x, incx, y, incy);
-    }
-
-    //dot
-    template<>
-    void cblas_dot<float>(  rocblas_int n,
-                            const float *x, rocblas_int incx,
-                            const float *y, rocblas_int incy,
-                            float *result)
-    {
-        *result = cblas_sdot(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_dot<double>( rocblas_int n,
-                            const double *x, rocblas_int incx,
-                            const double *y, rocblas_int incy,
-                            double *result)
-    {
-        *result = cblas_ddot(n, x, incx, y, incy);
-    }
-
-    template<>
-    void cblas_dot<rocblas_float_complex>( rocblas_int n,
-                            const rocblas_float_complex *x, rocblas_int incx,
-                            const rocblas_float_complex *y, rocblas_int incy,
-                            rocblas_float_complex *result)
-    {
-        cblas_cdotu_sub(n, x, incx, y, incy, result);
-    }
-
-    template<>
-    void cblas_dot<rocblas_double_complex>( rocblas_int n,
-                            const rocblas_double_complex *x, rocblas_int incx,
-                            const rocblas_double_complex *y, rocblas_int incy,
-                            rocblas_double_complex *result)
-    {
-        cblas_zdotu_sub(n, x, incx, y, incy, result);
-    }
-
-    //nrm2
-    template<>
-    void cblas_nrm2<float, float>( rocblas_int n,
-                            const float *x, rocblas_int incx,
-                            float *result)
-    {
-        *result = cblas_snrm2(n, x, incx);
-    }
-
-    template<>
-    void cblas_nrm2<double, double>( rocblas_int n,
-                             const double *x, rocblas_int incx,
-                             double *result)
-    {
-        *result = cblas_dnrm2(n, x, incx);
-    }
-
-    template<>
-    void cblas_nrm2<rocblas_float_complex, float>( rocblas_int n,
-                            const rocblas_float_complex *x, rocblas_int incx,
-                            float *result)
-    {
-        *result = cblas_scnrm2(n, x, incx);
-    }
-
-    template<>
-    void cblas_nrm2<rocblas_double_complex, double>( rocblas_int n,
-                            const rocblas_double_complex *x, rocblas_int incx,
-                            double *result)
-    {
-        *result = cblas_dznrm2(n, x, incx);
-    }
-
-
-    //asum
-    template<>
-    void cblas_asum<float, float>( rocblas_int n,
-                            const float *x, rocblas_int incx,
-                            float *result)
-    {
-        *result = cblas_sasum(n, x, incx);
-    }
-
-    template<>
-    void cblas_asum<double, double>( rocblas_int n,
-                             const double *x, rocblas_int incx,
-                             double *result)
-    {
-        *result = cblas_dasum(n, x, incx);
-    }
-
-    template<>
-    void cblas_asum<rocblas_float_complex, float>( rocblas_int n,
-                            const rocblas_float_complex *x, rocblas_int incx,
-                            float *result)
-    {
-        *result = cblas_scasum(n, x, incx);
-    }
-
-    template<>
-    void cblas_asum<rocblas_double_complex, double>( rocblas_int n,
-                            const rocblas_double_complex *x, rocblas_int incx,
-                            double *result)
-    {
-        *result = cblas_dzasum(n, x, incx);
-    }
-
-    //amax
-    template<>
-    void cblas_iamax<float>( rocblas_int n,
-                            const float *x, rocblas_int incx,
-                            rocblas_int *result)
-    {
-        *result = (rocblas_int)cblas_isamax(n, x, incx);
-    }
-
-    template<>
-    void cblas_iamax<double>( rocblas_int n,
-                            const double *x, rocblas_int incx,
-                            rocblas_int *result)
-    {
-        *result = (rocblas_int)cblas_idamax(n, x, incx);
-    }
-
-    template<>
-    void cblas_iamax<rocblas_float_complex>( rocblas_int n,
-                            const rocblas_float_complex *x, rocblas_int incx,
-                            rocblas_int *result)
-    {
-        *result = (rocblas_int)cblas_icamax(n, x, incx);
-    }
-
-    template<>
-    void cblas_iamax<rocblas_double_complex>( rocblas_int n,
-                            const rocblas_double_complex *x, rocblas_int incx,
-                            rocblas_int *result)
-    {
-        *result = (rocblas_int)cblas_izamax(n, x, incx);
-    }
-    /*
-     * ===========================================================================
-     *    level 2 BLAS
-     * ===========================================================================
-     */
-
-    template<>
-    void cblas_gemv<float>( rocblas_operation transA, rocblas_int m, rocblas_int n,
-                            float alpha,
-                            float *A, rocblas_int lda,
-                            float *x, rocblas_int incx,
-                            float beta, float *y, rocblas_int incy)
-    {
-        cblas_sgemv(CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
-    }
-
-    template<>
-    void cblas_gemv<double>(rocblas_operation transA, rocblas_int m, rocblas_int n,
-                            double alpha,
-                            double *A, rocblas_int lda,
-                            double *x, rocblas_int incx,
-                            double beta, double *y, rocblas_int incy)
-    {
-        cblas_dgemv(CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
-    }
-
-    template<>
-    void cblas_gemv<rocblas_float_complex>(rocblas_operation transA, rocblas_int m, rocblas_int n,
-                            rocblas_float_complex alpha,
-                            rocblas_float_complex *A, rocblas_int lda,
-                            rocblas_float_complex *x, rocblas_int incx,
-                            rocblas_float_complex beta, rocblas_float_complex *y, rocblas_int incy)
-    {
-        cblas_cgemv(CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x, incx, &beta, y, incy);
-    }
-
-    template<>
-    void cblas_gemv<rocblas_double_complex>(rocblas_operation transA, rocblas_int m, rocblas_int n,
-                            rocblas_double_complex alpha,
-                            rocblas_double_complex *A, rocblas_int lda,
-                            rocblas_double_complex *x, rocblas_int incx,
-                            rocblas_double_complex beta, rocblas_double_complex *y, rocblas_int incy)
-    {
-        cblas_zgemv(CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x, incx, &beta, y, incy);
-    }
-
-    template<>
-    void cblas_symv<float>( rocblas_fill uplo, rocblas_int n,
-                            float alpha,
-                            float *A, rocblas_int lda,
-                            float *x, rocblas_int incx,
-                            float beta, float *y, rocblas_int incy)
-    {
-        cblas_ssymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta, y, incy);
-    }
-
-    template<>
-    void cblas_symv<double>(rocblas_fill uplo, rocblas_int n,
-                            double alpha,
-                            double *A, rocblas_int lda,
-                            double *x, rocblas_int incx,
-                            double beta, double *y, rocblas_int incy)
-    {
-        cblas_dsymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta, y, incy);
-    }
-
-    template<>
-    void cblas_hemv<rocblas_float_complex>(rocblas_fill uplo, rocblas_int n,
-                            rocblas_float_complex alpha,
-                            rocblas_float_complex *A, rocblas_int lda,
-                            rocblas_float_complex *x, rocblas_int incx,
-                            rocblas_float_complex beta, rocblas_float_complex *y, rocblas_int incy)
-    {
-        cblas_chemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
-    }
-
-    template<>
-    void cblas_hemv<rocblas_double_complex>(rocblas_fill uplo, rocblas_int n,
-                            rocblas_double_complex alpha,
-                            rocblas_double_complex *A, rocblas_int lda,
-                            rocblas_double_complex *x, rocblas_int incx,
-                            rocblas_double_complex beta, rocblas_double_complex *y, rocblas_int incy)
-    {
-        cblas_zhemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
-    }
-
-    template<>
-    void cblas_ger<float>( rocblas_int m, rocblas_int n,
-                            float alpha,
-                            float *x, rocblas_int incx,
-                            float *y, rocblas_int incy,
-                            float *A, rocblas_int lda)
-    {
-        cblas_sger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
-    }
-
-    template<>
-    void cblas_ger<double>(rocblas_int m, rocblas_int n,
-                            double alpha,
-                            double *x, rocblas_int incx,
-                            double *y, rocblas_int incy,
-                            double *A, rocblas_int lda)
-    {
-        cblas_dger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
-    }
-
-    /*
-     * ===========================================================================
-     *    level 3 BLAS
-     * ===========================================================================
-     */
-
-    //gemm
-
-    template<>
-    void cblas_gemm<float>( rocblas_operation transA, rocblas_operation transB,
-                            rocblas_int m, rocblas_int n, rocblas_int k,
-                            float alpha, float *A, rocblas_int lda,
-                            float *B, rocblas_int ldb,
-                            float beta, float *C, rocblas_int ldc)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        //printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
-        cblas_sgemm(CblasColMajor, (CBLAS_TRANSPOSE)transA, (CBLAS_TRANSPOSE)transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
-    }
-
-    template<>
-    void cblas_gemm<double>(rocblas_operation transA, rocblas_operation transB,
-                            rocblas_int m, rocblas_int n, rocblas_int k,
-                            double alpha, double *A, rocblas_int lda,
-                            double *B, rocblas_int ldb,
-                            double beta, double *C, rocblas_int ldc)
-    {
-        cblas_dgemm(CblasColMajor, (CBLAS_TRANSPOSE)transA, (CBLAS_TRANSPOSE)transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
-    }
-
-    template<>
-    void cblas_gemm<rocblas_float_complex>(rocblas_operation transA, rocblas_operation transB,
-                            rocblas_int m, rocblas_int n, rocblas_int k,
-                            rocblas_float_complex alpha, rocblas_float_complex *A, rocblas_int lda,
-                            rocblas_float_complex *B, rocblas_int ldb,
-                            rocblas_float_complex beta, rocblas_float_complex *C, rocblas_int ldc)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_cgemm(CblasColMajor, (CBLAS_TRANSPOSE)transA, (CBLAS_TRANSPOSE)transB, m, n, k, &alpha, A, lda, B, ldb, &beta, C, ldc);
-    }
-
-    template<>
-    void cblas_gemm<rocblas_double_complex>(rocblas_operation transA, rocblas_operation transB,
-                            rocblas_int m, rocblas_int n, rocblas_int k,
-                            rocblas_double_complex alpha, rocblas_double_complex *A, rocblas_int lda,
-                            rocblas_double_complex *B, rocblas_int ldb,
-                            rocblas_double_complex beta, rocblas_double_complex *C, rocblas_int ldc)
-    {
-        cblas_zgemm(CblasColMajor, (CBLAS_TRANSPOSE)transA, (CBLAS_TRANSPOSE)transB, m, n, k, &alpha, A, lda, B, ldb, &beta, C, ldc);
-    }
-
-    //trsm
-    template<>
-    void cblas_trsm<float>( rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            float alpha,
-                            const float *A, rocblas_int lda,
-                            float *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_strsm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, alpha, A, lda, B, ldb);
-    }
-
-    template<>
-    void cblas_trsm<double>(rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            double alpha,
-                            const double *A, rocblas_int lda,
-                            double *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_dtrsm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, alpha, A, lda, B, ldb);
-    }
-
-    template<>
-    void cblas_trsm<rocblas_float_complex>( rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            rocblas_float_complex alpha,
-                            const rocblas_float_complex *A, rocblas_int lda,
-                            rocblas_float_complex *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_ctrsm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, &alpha, A, lda, B, ldb);
-    }
-
-    template<>
-    void cblas_trsm<rocblas_double_complex>( rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            rocblas_double_complex alpha,
-                            const rocblas_double_complex *A, rocblas_int lda,
-                            rocblas_double_complex *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_ztrsm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, &alpha, A, lda, B, ldb);
-    }
-
-    //trtri
-    template<>
-    rocblas_int cblas_trtri<float>(char uplo, char diag,
-                            rocblas_int n,
-                            float *A, rocblas_int lda)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        //printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
-        rocblas_int info;
-        strtri_(&uplo, &diag, &n, A, &lda, &info);
-        return info;
-    }
-
-    template<>
-    rocblas_int cblas_trtri<double>(char uplo, char diag,
-                            rocblas_int n,
-                            double *A, rocblas_int lda)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        //printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
-        rocblas_int info;
-        dtrtri_(&uplo, &diag, &n, A, &lda, &info);
-        return info;
-    }
-
-
-    //trmm
-    template<>
-    void cblas_trmm<float>( rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            float alpha,
-                            const float *A, rocblas_int lda,
-                            float *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_strmm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, alpha, A, lda, B, ldb);
-    }
-
-    template<>
-    void cblas_trmm<double>(rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            double alpha,
-                            const double *A, rocblas_int lda,
-                            double *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_dtrmm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, alpha, A, lda, B, ldb);
-    }
-
-    template<>
-    void cblas_trmm<rocblas_float_complex>( rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            rocblas_float_complex alpha,
-                            const rocblas_float_complex *A, rocblas_int lda,
-                            rocblas_float_complex *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_ctrmm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, &alpha, A, lda, B, ldb);
-    }
-
-    template<>
-    void cblas_trmm<rocblas_double_complex>( rocblas_side side, rocblas_fill uplo,
-                            rocblas_operation transA, rocblas_diagonal diag,
-                            rocblas_int m, rocblas_int n,
-                            rocblas_double_complex alpha,
-                            const rocblas_double_complex *A, rocblas_int lda,
-                            rocblas_double_complex *B, rocblas_int ldb)
-    {
-        //just directly cast, since transA, transB are integers in the enum
-        cblas_ztrmm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA, (CBLAS_DIAG)diag, m, n, &alpha, A, lda, B, ldb);
-    }
-
-    //getrf
-    template<>
-    rocblas_int cblas_getrf<float>(rocblas_int m,
-                            rocblas_int n,
-                            float *A, rocblas_int lda,
-                            rocblas_int *ipiv)
-    {
-        rocblas_int info;
-        sgetrf_(&m, &n, A, &lda, ipiv, &info);
-        return info;
-    }
-
-    template<>
-    rocblas_int cblas_getrf<double>(rocblas_int m,
-                            rocblas_int n,
-                            double *A, rocblas_int lda,
-                            rocblas_int *ipiv)
-    {
-        rocblas_int info;
-        dgetrf_(&m, &n, A, &lda, ipiv, &info);
-        return info;
-    }
-
-    template<>
-    rocblas_int cblas_getrf<rocblas_float_complex>(rocblas_int m,
-                            rocblas_int n,
-                            rocblas_float_complex *A, rocblas_int lda,
-                            rocblas_int *ipiv)
-    {
-        rocblas_int info;
-        cgetrf_(&m, &n, A, &lda, ipiv, &info);
-        return info;
-    }
-
-    template<>
-    rocblas_int cblas_getrf<rocblas_double_complex>(rocblas_int m,
-                            rocblas_int n,
-                            rocblas_double_complex *A, rocblas_int lda,
-                            rocblas_int *ipiv)
-    {
-        rocblas_int info;
-        zgetrf_(&m, &n, A, &lda, ipiv, &info);
-        return info;
-    }
-
-    //potrf
-    template<>
-    rocblas_int cblas_potrf<float>(char uplo,
-                            rocblas_int m,
-                            float *A, rocblas_int lda)
-    {
-        rocblas_int info;
-        spotrf_(&uplo, &m, A, &lda, &info);
-        return info;
-    }
-
-    template<>
-    rocblas_int cblas_potrf<double>(char uplo,
-                            rocblas_int m,
-                            double *A, rocblas_int lda)
-    {
-        rocblas_int info;
-        dpotrf_(&uplo, &m, A, &lda, &info);
-        return info;
-    }
-
-    template<>
-    rocblas_int cblas_potrf<rocblas_float_complex>(char uplo,
-                            rocblas_int m,
-                            rocblas_float_complex *A, rocblas_int lda)
-    {
-        rocblas_int info;
-        cpotrf_(&uplo, &m, A, &lda, &info);
-        return info;
-    }
-
-    template<>
-    rocblas_int cblas_potrf<rocblas_double_complex>(char uplo,
-                            rocblas_int m,
-                            rocblas_double_complex *A, rocblas_int lda)
-    {
-        rocblas_int info;
-        zpotrf_(&uplo, &m, A, &lda, &info);
-        return info;
-    }
-
+/*
+ * ===========================================================================
+ *    level 1 BLAS
+ * ===========================================================================
+ */
+// scal
+template <>
+void cblas_scal<float>(rocblas_int n, const float alpha, float* x, rocblas_int incx)
+{
+    cblas_sscal(n, alpha, x, incx);
+}
+
+template <>
+void cblas_scal<double>(rocblas_int n, const double alpha, double* x, rocblas_int incx)
+{
+    cblas_dscal(n, alpha, x, incx);
+}
+
+template <>
+void cblas_scal<rocblas_float_complex>(rocblas_int n,
+                                       const rocblas_float_complex alpha,
+                                       rocblas_float_complex* x,
+                                       rocblas_int incx)
+{
+    cblas_cscal(n, &alpha, x, incx);
+}
+
+template <>
+void cblas_scal<rocblas_double_complex>(rocblas_int n,
+                                        const rocblas_double_complex alpha,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx)
+{
+    cblas_zscal(n, &alpha, x, incx);
+}
+
+// copy
+template <>
+void cblas_copy<float>(rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy)
+{
+    cblas_scopy(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_copy<double>(rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy)
+{
+    cblas_dcopy(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_copy<rocblas_float_complex>(rocblas_int n,
+                                       rocblas_float_complex* x,
+                                       rocblas_int incx,
+                                       rocblas_float_complex* y,
+                                       rocblas_int incy)
+{
+    cblas_ccopy(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_copy<rocblas_double_complex>(rocblas_int n,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
+{
+    cblas_zcopy(n, x, incx, y, incy);
+}
+
+// axpy
+template <>
+void cblas_axpy<rocblas_half>(rocblas_int n,
+                              rocblas_half alpha,
+                              rocblas_half* x,
+                              rocblas_int incx,
+                              rocblas_half* y,
+                              rocblas_int incy)
+{
+    rocblas_int abs_incx = incx >= 0 ? incx : -incx;
+    rocblas_int abs_incy = incy >= 0 ? incy : -incy;
+    float alpha_float    = half_to_float(alpha);
+    std::unique_ptr<float[]> x_float(new float[n * abs_incx]());
+    std::unique_ptr<float[]> y_float(new float[n * abs_incy]());
+    for(int i = 0; i < n; i++)
+    {
+        x_float[i * abs_incx] = half_to_float(x[i * abs_incx]);
+        y_float[i * abs_incy] = half_to_float(y[i * abs_incy]);
+    }
+
+    cblas_saxpy(n, alpha_float, x_float.get(), incx, y_float.get(), incy);
+
+    for(int i = 0; i < n; i++)
+    {
+        x[i * abs_incx] = float_to_half(x_float[i * abs_incx]);
+        y[i * abs_incy] = float_to_half(y_float[i * abs_incy]);
+    }
+}
+
+template <>
+void cblas_axpy<float>(
+    rocblas_int n, float alpha, float* x, rocblas_int incx, float* y, rocblas_int incy)
+{
+    cblas_saxpy(n, alpha, x, incx, y, incy);
+}
+
+template <>
+void cblas_axpy<double>(
+    rocblas_int n, double alpha, double* x, rocblas_int incx, double* y, rocblas_int incy)
+{
+    cblas_daxpy(n, alpha, x, incx, y, incy);
+}
+
+template <>
+void cblas_axpy<rocblas_float_complex>(rocblas_int n,
+                                       rocblas_float_complex alpha,
+                                       rocblas_float_complex* x,
+                                       rocblas_int incx,
+                                       rocblas_float_complex* y,
+                                       rocblas_int incy)
+{
+    cblas_caxpy(n, &alpha, x, incx, y, incy);
+}
+
+template <>
+void cblas_axpy<rocblas_double_complex>(rocblas_int n,
+                                        rocblas_double_complex alpha,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
+{
+    cblas_zaxpy(n, &alpha, x, incx, y, incy);
+}
+
+// swap
+template <>
+void cblas_swap<float>(rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy)
+{
+    cblas_sswap(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_swap<double>(rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy)
+{
+    cblas_dswap(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_swap<rocblas_float_complex>(rocblas_int n,
+                                       rocblas_float_complex* x,
+                                       rocblas_int incx,
+                                       rocblas_float_complex* y,
+                                       rocblas_int incy)
+{
+    cblas_cswap(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_swap<rocblas_double_complex>(rocblas_int n,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
+{
+    cblas_zswap(n, x, incx, y, incy);
+}
+
+// dot
+template <>
+void cblas_dot<float>(rocblas_int n,
+                      const float* x,
+                      rocblas_int incx,
+                      const float* y,
+                      rocblas_int incy,
+                      float* result)
+{
+    *result = cblas_sdot(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_dot<double>(rocblas_int n,
+                       const double* x,
+                       rocblas_int incx,
+                       const double* y,
+                       rocblas_int incy,
+                       double* result)
+{
+    *result = cblas_ddot(n, x, incx, y, incy);
+}
+
+template <>
+void cblas_dot<rocblas_float_complex>(rocblas_int n,
+                                      const rocblas_float_complex* x,
+                                      rocblas_int incx,
+                                      const rocblas_float_complex* y,
+                                      rocblas_int incy,
+                                      rocblas_float_complex* result)
+{
+    cblas_cdotu_sub(n, x, incx, y, incy, result);
+}
+
+template <>
+void cblas_dot<rocblas_double_complex>(rocblas_int n,
+                                       const rocblas_double_complex* x,
+                                       rocblas_int incx,
+                                       const rocblas_double_complex* y,
+                                       rocblas_int incy,
+                                       rocblas_double_complex* result)
+{
+    cblas_zdotu_sub(n, x, incx, y, incy, result);
+}
+
+// nrm2
+template <>
+void cblas_nrm2<float, float>(rocblas_int n, const float* x, rocblas_int incx, float* result)
+{
+    *result = cblas_snrm2(n, x, incx);
+}
+
+template <>
+void cblas_nrm2<double, double>(rocblas_int n, const double* x, rocblas_int incx, double* result)
+{
+    *result = cblas_dnrm2(n, x, incx);
+}
+
+template <>
+void cblas_nrm2<rocblas_float_complex, float>(rocblas_int n,
+                                              const rocblas_float_complex* x,
+                                              rocblas_int incx,
+                                              float* result)
+{
+    *result = cblas_scnrm2(n, x, incx);
+}
+
+template <>
+void cblas_nrm2<rocblas_double_complex, double>(rocblas_int n,
+                                                const rocblas_double_complex* x,
+                                                rocblas_int incx,
+                                                double* result)
+{
+    *result = cblas_dznrm2(n, x, incx);
+}
+
+// asum
+template <>
+void cblas_asum<float, float>(rocblas_int n, const float* x, rocblas_int incx, float* result)
+{
+    *result = cblas_sasum(n, x, incx);
+}
+
+template <>
+void cblas_asum<double, double>(rocblas_int n, const double* x, rocblas_int incx, double* result)
+{
+    *result = cblas_dasum(n, x, incx);
+}
+
+template <>
+void cblas_asum<rocblas_float_complex, float>(rocblas_int n,
+                                              const rocblas_float_complex* x,
+                                              rocblas_int incx,
+                                              float* result)
+{
+    *result = cblas_scasum(n, x, incx);
+}
+
+template <>
+void cblas_asum<rocblas_double_complex, double>(rocblas_int n,
+                                                const rocblas_double_complex* x,
+                                                rocblas_int incx,
+                                                double* result)
+{
+    *result = cblas_dzasum(n, x, incx);
+}
+
+// amax
+template <>
+void cblas_iamax<float>(rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
+{
+    *result = (rocblas_int)cblas_isamax(n, x, incx);
+}
+
+template <>
+void cblas_iamax<double>(rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
+{
+    *result = (rocblas_int)cblas_idamax(n, x, incx);
+}
+
+template <>
+void cblas_iamax<rocblas_float_complex>(rocblas_int n,
+                                        const rocblas_float_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_int* result)
+{
+    *result = (rocblas_int)cblas_icamax(n, x, incx);
+}
+
+template <>
+void cblas_iamax<rocblas_double_complex>(rocblas_int n,
+                                         const rocblas_double_complex* x,
+                                         rocblas_int incx,
+                                         rocblas_int* result)
+{
+    *result = (rocblas_int)cblas_izamax(n, x, incx);
+}
+/*
+ * ===========================================================================
+ *    level 2 BLAS
+ * ===========================================================================
+ */
+
+template <>
+void cblas_gemv<float>(rocblas_operation transA,
+                       rocblas_int m,
+                       rocblas_int n,
+                       float alpha,
+                       float* A,
+                       rocblas_int lda,
+                       float* x,
+                       rocblas_int incx,
+                       float beta,
+                       float* y,
+                       rocblas_int incy)
+{
+    cblas_sgemv(
+        CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+template <>
+void cblas_gemv<double>(rocblas_operation transA,
+                        rocblas_int m,
+                        rocblas_int n,
+                        double alpha,
+                        double* A,
+                        rocblas_int lda,
+                        double* x,
+                        rocblas_int incx,
+                        double beta,
+                        double* y,
+                        rocblas_int incy)
+{
+    cblas_dgemv(
+        CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+template <>
+void cblas_gemv<rocblas_float_complex>(rocblas_operation transA,
+                                       rocblas_int m,
+                                       rocblas_int n,
+                                       rocblas_float_complex alpha,
+                                       rocblas_float_complex* A,
+                                       rocblas_int lda,
+                                       rocblas_float_complex* x,
+                                       rocblas_int incx,
+                                       rocblas_float_complex beta,
+                                       rocblas_float_complex* y,
+                                       rocblas_int incy)
+{
+    cblas_cgemv(
+        CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x, incx, &beta, y, incy);
+}
+
+template <>
+void cblas_gemv<rocblas_double_complex>(rocblas_operation transA,
+                                        rocblas_int m,
+                                        rocblas_int n,
+                                        rocblas_double_complex alpha,
+                                        rocblas_double_complex* A,
+                                        rocblas_int lda,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex beta,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
+{
+    cblas_zgemv(
+        CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x, incx, &beta, y, incy);
+}
+
+template <>
+void cblas_symv<float>(rocblas_fill uplo,
+                       rocblas_int n,
+                       float alpha,
+                       float* A,
+                       rocblas_int lda,
+                       float* x,
+                       rocblas_int incx,
+                       float beta,
+                       float* y,
+                       rocblas_int incy)
+{
+    cblas_ssymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+template <>
+void cblas_symv<double>(rocblas_fill uplo,
+                        rocblas_int n,
+                        double alpha,
+                        double* A,
+                        rocblas_int lda,
+                        double* x,
+                        rocblas_int incx,
+                        double beta,
+                        double* y,
+                        rocblas_int incy)
+{
+    cblas_dsymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+template <>
+void cblas_hemv<rocblas_float_complex>(rocblas_fill uplo,
+                                       rocblas_int n,
+                                       rocblas_float_complex alpha,
+                                       rocblas_float_complex* A,
+                                       rocblas_int lda,
+                                       rocblas_float_complex* x,
+                                       rocblas_int incx,
+                                       rocblas_float_complex beta,
+                                       rocblas_float_complex* y,
+                                       rocblas_int incy)
+{
+    cblas_chemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
+}
+
+template <>
+void cblas_hemv<rocblas_double_complex>(rocblas_fill uplo,
+                                        rocblas_int n,
+                                        rocblas_double_complex alpha,
+                                        rocblas_double_complex* A,
+                                        rocblas_int lda,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex beta,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
+{
+    cblas_zhemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
+}
+
+template <>
+void cblas_ger<float>(rocblas_int m,
+                      rocblas_int n,
+                      float alpha,
+                      float* x,
+                      rocblas_int incx,
+                      float* y,
+                      rocblas_int incy,
+                      float* A,
+                      rocblas_int lda)
+{
+    cblas_sger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
+}
+
+template <>
+void cblas_ger<double>(rocblas_int m,
+                       rocblas_int n,
+                       double alpha,
+                       double* x,
+                       rocblas_int incx,
+                       double* y,
+                       rocblas_int incy,
+                       double* A,
+                       rocblas_int lda)
+{
+    cblas_dger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
+}
+
+/*
+ * ===========================================================================
+ *    level 3 BLAS
+ * ===========================================================================
+ */
+
+// gemm
+
+template <>
+void cblas_gemm<float>(rocblas_operation transA,
+                       rocblas_operation transB,
+                       rocblas_int m,
+                       rocblas_int n,
+                       rocblas_int k,
+                       float alpha,
+                       float* A,
+                       rocblas_int lda,
+                       float* B,
+                       rocblas_int ldb,
+                       float beta,
+                       float* C,
+                       rocblas_int ldc)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
+    cblas_sgemm(CblasColMajor,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_TRANSPOSE)transB,
+                m,
+                n,
+                k,
+                alpha,
+                A,
+                lda,
+                B,
+                ldb,
+                beta,
+                C,
+                ldc);
+}
+
+template <>
+void cblas_gemm<double>(rocblas_operation transA,
+                        rocblas_operation transB,
+                        rocblas_int m,
+                        rocblas_int n,
+                        rocblas_int k,
+                        double alpha,
+                        double* A,
+                        rocblas_int lda,
+                        double* B,
+                        rocblas_int ldb,
+                        double beta,
+                        double* C,
+                        rocblas_int ldc)
+{
+    cblas_dgemm(CblasColMajor,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_TRANSPOSE)transB,
+                m,
+                n,
+                k,
+                alpha,
+                A,
+                lda,
+                B,
+                ldb,
+                beta,
+                C,
+                ldc);
+}
+
+template <>
+void cblas_gemm<rocblas_float_complex>(rocblas_operation transA,
+                                       rocblas_operation transB,
+                                       rocblas_int m,
+                                       rocblas_int n,
+                                       rocblas_int k,
+                                       rocblas_float_complex alpha,
+                                       rocblas_float_complex* A,
+                                       rocblas_int lda,
+                                       rocblas_float_complex* B,
+                                       rocblas_int ldb,
+                                       rocblas_float_complex beta,
+                                       rocblas_float_complex* C,
+                                       rocblas_int ldc)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_cgemm(CblasColMajor,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_TRANSPOSE)transB,
+                m,
+                n,
+                k,
+                &alpha,
+                A,
+                lda,
+                B,
+                ldb,
+                &beta,
+                C,
+                ldc);
+}
+
+template <>
+void cblas_gemm<rocblas_double_complex>(rocblas_operation transA,
+                                        rocblas_operation transB,
+                                        rocblas_int m,
+                                        rocblas_int n,
+                                        rocblas_int k,
+                                        rocblas_double_complex alpha,
+                                        rocblas_double_complex* A,
+                                        rocblas_int lda,
+                                        rocblas_double_complex* B,
+                                        rocblas_int ldb,
+                                        rocblas_double_complex beta,
+                                        rocblas_double_complex* C,
+                                        rocblas_int ldc)
+{
+    cblas_zgemm(CblasColMajor,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_TRANSPOSE)transB,
+                m,
+                n,
+                k,
+                &alpha,
+                A,
+                lda,
+                B,
+                ldb,
+                &beta,
+                C,
+                ldc);
+}
+
+// trsm
+template <>
+void cblas_trsm<float>(rocblas_side side,
+                       rocblas_fill uplo,
+                       rocblas_operation transA,
+                       rocblas_diagonal diag,
+                       rocblas_int m,
+                       rocblas_int n,
+                       float alpha,
+                       const float* A,
+                       rocblas_int lda,
+                       float* B,
+                       rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_strsm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+template <>
+void cblas_trsm<double>(rocblas_side side,
+                        rocblas_fill uplo,
+                        rocblas_operation transA,
+                        rocblas_diagonal diag,
+                        rocblas_int m,
+                        rocblas_int n,
+                        double alpha,
+                        const double* A,
+                        rocblas_int lda,
+                        double* B,
+                        rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_dtrsm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+template <>
+void cblas_trsm<rocblas_float_complex>(rocblas_side side,
+                                       rocblas_fill uplo,
+                                       rocblas_operation transA,
+                                       rocblas_diagonal diag,
+                                       rocblas_int m,
+                                       rocblas_int n,
+                                       rocblas_float_complex alpha,
+                                       const rocblas_float_complex* A,
+                                       rocblas_int lda,
+                                       rocblas_float_complex* B,
+                                       rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_ctrsm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                &alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+template <>
+void cblas_trsm<rocblas_double_complex>(rocblas_side side,
+                                        rocblas_fill uplo,
+                                        rocblas_operation transA,
+                                        rocblas_diagonal diag,
+                                        rocblas_int m,
+                                        rocblas_int n,
+                                        rocblas_double_complex alpha,
+                                        const rocblas_double_complex* A,
+                                        rocblas_int lda,
+                                        rocblas_double_complex* B,
+                                        rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_ztrsm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                &alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+// trtri
+template <>
+rocblas_int cblas_trtri<float>(char uplo, char diag, rocblas_int n, float* A, rocblas_int lda)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
+    rocblas_int info;
+    strtri_(&uplo, &diag, &n, A, &lda, &info);
+    return info;
+}
+
+template <>
+rocblas_int cblas_trtri<double>(char uplo, char diag, rocblas_int n, double* A, rocblas_int lda)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
+    rocblas_int info;
+    dtrtri_(&uplo, &diag, &n, A, &lda, &info);
+    return info;
+}
+
+// trmm
+template <>
+void cblas_trmm<float>(rocblas_side side,
+                       rocblas_fill uplo,
+                       rocblas_operation transA,
+                       rocblas_diagonal diag,
+                       rocblas_int m,
+                       rocblas_int n,
+                       float alpha,
+                       const float* A,
+                       rocblas_int lda,
+                       float* B,
+                       rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_strmm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+template <>
+void cblas_trmm<double>(rocblas_side side,
+                        rocblas_fill uplo,
+                        rocblas_operation transA,
+                        rocblas_diagonal diag,
+                        rocblas_int m,
+                        rocblas_int n,
+                        double alpha,
+                        const double* A,
+                        rocblas_int lda,
+                        double* B,
+                        rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_dtrmm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+template <>
+void cblas_trmm<rocblas_float_complex>(rocblas_side side,
+                                       rocblas_fill uplo,
+                                       rocblas_operation transA,
+                                       rocblas_diagonal diag,
+                                       rocblas_int m,
+                                       rocblas_int n,
+                                       rocblas_float_complex alpha,
+                                       const rocblas_float_complex* A,
+                                       rocblas_int lda,
+                                       rocblas_float_complex* B,
+                                       rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_ctrmm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                &alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+template <>
+void cblas_trmm<rocblas_double_complex>(rocblas_side side,
+                                        rocblas_fill uplo,
+                                        rocblas_operation transA,
+                                        rocblas_diagonal diag,
+                                        rocblas_int m,
+                                        rocblas_int n,
+                                        rocblas_double_complex alpha,
+                                        const rocblas_double_complex* A,
+                                        rocblas_int lda,
+                                        rocblas_double_complex* B,
+                                        rocblas_int ldb)
+{
+    // just directly cast, since transA, transB are integers in the enum
+    cblas_ztrmm(CblasColMajor,
+                (CBLAS_SIDE)side,
+                (CBLAS_UPLO)uplo,
+                (CBLAS_TRANSPOSE)transA,
+                (CBLAS_DIAG)diag,
+                m,
+                n,
+                &alpha,
+                A,
+                lda,
+                B,
+                ldb);
+}
+
+// getrf
+template <>
+rocblas_int
+cblas_getrf<float>(rocblas_int m, rocblas_int n, float* A, rocblas_int lda, rocblas_int* ipiv)
+{
+    rocblas_int info;
+    sgetrf_(&m, &n, A, &lda, ipiv, &info);
+    return info;
+}
+
+template <>
+rocblas_int
+cblas_getrf<double>(rocblas_int m, rocblas_int n, double* A, rocblas_int lda, rocblas_int* ipiv)
+{
+    rocblas_int info;
+    dgetrf_(&m, &n, A, &lda, ipiv, &info);
+    return info;
+}
+
+template <>
+rocblas_int cblas_getrf<rocblas_float_complex>(
+    rocblas_int m, rocblas_int n, rocblas_float_complex* A, rocblas_int lda, rocblas_int* ipiv)
+{
+    rocblas_int info;
+    cgetrf_(&m, &n, A, &lda, ipiv, &info);
+    return info;
+}
+
+template <>
+rocblas_int cblas_getrf<rocblas_double_complex>(
+    rocblas_int m, rocblas_int n, rocblas_double_complex* A, rocblas_int lda, rocblas_int* ipiv)
+{
+    rocblas_int info;
+    zgetrf_(&m, &n, A, &lda, ipiv, &info);
+    return info;
+}
+
+// potrf
+template <>
+rocblas_int cblas_potrf<float>(char uplo, rocblas_int m, float* A, rocblas_int lda)
+{
+    rocblas_int info;
+    spotrf_(&uplo, &m, A, &lda, &info);
+    return info;
+}
+
+template <>
+rocblas_int cblas_potrf<double>(char uplo, rocblas_int m, double* A, rocblas_int lda)
+{
+    rocblas_int info;
+    dpotrf_(&uplo, &m, A, &lda, &info);
+    return info;
+}
+
+template <>
+rocblas_int cblas_potrf<rocblas_float_complex>(char uplo,
+                                               rocblas_int m,
+                                               rocblas_float_complex* A,
+                                               rocblas_int lda)
+{
+    rocblas_int info;
+    cpotrf_(&uplo, &m, A, &lda, &info);
+    return info;
+}
+
+template <>
+rocblas_int cblas_potrf<rocblas_double_complex>(char uplo,
+                                                rocblas_int m,
+                                                rocblas_double_complex* A,
+                                                rocblas_int lda)
+{
+    rocblas_int info;
+    zpotrf_(&uplo, &m, A, &lda, &info);
+    return info;
+}

--- a/clients/common/flops.cpp
+++ b/clients/common/flops.cpp
@@ -3,72 +3,76 @@
  *
  * ************************************************************************/
 
-
-
 #include "rocblas.h"
 #include "flops.h"
 
 /*!\file
- * \brief provides Floating point counts of Basic Linear Algebra Subprograms (BLAS) of Level 2 and 3. No flops counts for Level 1 BLAS
+ * \brief provides Floating point counts of Basic Linear Algebra Subprograms (BLAS) of Level 2 and
+ * 3. No flops counts for Level 1 BLAS
 */
 
-    /*
-     * ===========================================================================
-     *    level 2 BLAS
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    level 2 BLAS
+ * ===========================================================================
+ */
 
-    /* \brief floating point counts of GEMV */
-    template<>
-    double  gemv_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n){
-        return (double)(8.0 * m * n)/1e9;
-    }
+/* \brief floating point counts of GEMV */
+template <>
+double gemv_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n)
+{
+    return (double)(8.0 * m * n) / 1e9;
+}
 
-    template<>
-    double  gemv_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n){
-        return (double)(8.0 * m * n)/1e9;
-    }
+template <>
+double gemv_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n)
+{
+    return (double)(8.0 * m * n) / 1e9;
+}
 
-    /* \brief floating point counts of SY(HE)MV */
+/* \brief floating point counts of SY(HE)MV */
 
+/*
+ * ===========================================================================
+ *    level 3 BLAS
+ * ===========================================================================
+ */
 
-    /*
-     * ===========================================================================
-     *    level 3 BLAS
-     * ===========================================================================
-     */
+/* \brief floating point counts of GEMM */
+template <>
+double gemm_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n, rocblas_int k)
+{
+    return (double)(8.0 * m * n * k) / 1e9;
+}
 
+template <>
+double gemm_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n, rocblas_int k)
+{
+    return (double)(8.0 * m * n * k) / 1e9;
+}
 
-    /* \brief floating point counts of GEMM */
-    template<>
-    double  gemm_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n, rocblas_int k){
-        return (double)(8.0 * m * n * k)/1e9;
-    }
+/* \brief floating point counts of TRMM */
+template <>
+double trsm_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n, rocblas_int k)
+{
+    return (double)(4.0 * m * n * (k + 1)) / 1e9;
+}
 
-    template<>
-    double  gemm_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n, rocblas_int k){
-        return (double)(8.0 * m * n * k)/1e9;
-    }
+template <>
+double trsm_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n, rocblas_int k)
+{
+    return (double)(4.0 * m * n * (k + 1)) / 1e9;
+}
 
-    /* \brief floating point counts of TRMM */
-    template<>
-    double  trsm_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n, rocblas_int k){
-        return (double)(4.0 * m * n * (k+1))/1e9;
-    }
+/* \brief floating point counts of TRTRI */
+template <>
+double trtri_gflop_count<rocblas_float_complex>(rocblas_int n)
+{
+    return (double)(8.0 * n * n * n) / 3.0 / 1e9;
+}
 
-    template<>
-    double  trsm_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n, rocblas_int k){
-        return (double)(4.0 * m * n * (k+1))/1e9;
-    }
-
-    /* \brief floating point counts of TRTRI */
-    template<>
-    double  trtri_gflop_count<rocblas_float_complex>(rocblas_int n){
-        return (double)(8.0 * n * n * n)/3.0/1e9;
-    }
-
-
-    template<>
-    double  trtri_gflop_count<rocblas_double_complex>(rocblas_int n){
-        return (double)(8.0 * n * n * n)/3.0/1e9;
-    }
+template <>
+double trtri_gflop_count<rocblas_double_complex>(rocblas_int n)
+{
+    return (double)(8.0 * n * n * n) / 3.0 / 1e9;
+}

--- a/clients/common/near.cpp
+++ b/clients/common/near.cpp
@@ -7,73 +7,102 @@
 #include "rocblas.h"
 #include "near.h"
 
-#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK) {\
-    hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != hipSuccess) { \
-        fprintf(stderr, "hip error code: %d at %s:%d\n",  TMP_STATUS_FOR_CHECK,__FILE__, __LINE__); \
-} }
-
-/* ========================================Gtest Near Check ==================================================== */
-
-
-    /*! \brief Template: gtest near compare two matrices float/double/complex */
-    //Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test case
-    // a wrapper will cause the loop keep going
-
-
-
-    template<>
-    void near_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, float *hCPU, float *hGPU, float abs_error){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
-#ifdef GOOGLE_TEST
-//              ASSERT_FLOAT_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);
-                ASSERT_NEAR(hCPU[i+j*lda], hGPU[i+j*lda], abs_error);
-#endif
-            }
-        }
+#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
+    {                                                             \
+        hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != hipSuccess)                    \
+        {                                                         \
+            fprintf(stderr,                                       \
+                    "hip error code: %d at %s:%d\n",              \
+                    TMP_STATUS_FOR_CHECK,                         \
+                    __FILE__,                                     \
+                    __LINE__);                                    \
+        }                                                         \
     }
 
-    template<>
-    void near_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, double *hCPU, double *hGPU, double abs_error){
-        #pragma unroll  
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
+/* ========================================Gtest Near Check
+ * ==================================================== */
+
+/*! \brief Template: gtest near compare two matrices float/double/complex */
+// Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test
+// case
+// a wrapper will cause the loop keep going
+
+template <>
+void near_check_general(
+    rocblas_int M, rocblas_int N, rocblas_int lda, float* hCPU, float* hGPU, float abs_error)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
 #ifdef GOOGLE_TEST
-                ASSERT_NEAR(hCPU[i+j*lda], hGPU[i+j*lda], abs_error);
+            //              ASSERT_FLOAT_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);
+            ASSERT_NEAR(hCPU[i + j * lda], hGPU[i + j * lda], abs_error);
 #endif
-            }
         }
     }
+}
 
-    template<>
-    void near_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_float_complex *hCPU, rocblas_float_complex *hGPU, float abs_error){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
+template <>
+void near_check_general(
+    rocblas_int M, rocblas_int N, rocblas_int lda, double* hCPU, double* hGPU, double abs_error)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
 #ifdef GOOGLE_TEST
-                ASSERT_NEAR(hCPU[i+j*lda].x, hGPU[i+j*lda].x, abs_error);
-                ASSERT_NEAR(hCPU[i+j*lda].y, hGPU[i+j*lda].y, abs_error);
+            ASSERT_NEAR(hCPU[i + j * lda], hGPU[i + j * lda], abs_error);
 #endif
-            }
         }
     }
+}
 
-    template<>
-    void near_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_double_complex *hCPU, rocblas_double_complex *hGPU, double abs_error){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
+template <>
+void near_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int lda,
+                        rocblas_float_complex* hCPU,
+                        rocblas_float_complex* hGPU,
+                        float abs_error)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
 #ifdef GOOGLE_TEST
-                ASSERT_NEAR(hCPU[i+j*lda].x, hGPU[i+j*lda].x, abs_error);
-                ASSERT_NEAR(hCPU[i+j*lda].y, hGPU[i+j*lda].y, abs_error);
+            ASSERT_NEAR(hCPU[i + j * lda].x, hGPU[i + j * lda].x, abs_error);
+            ASSERT_NEAR(hCPU[i + j * lda].y, hGPU[i + j * lda].y, abs_error);
 #endif
-            }
         }
     }
+}
 
+template <>
+void near_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int lda,
+                        rocblas_double_complex* hCPU,
+                        rocblas_double_complex* hGPU,
+                        double abs_error)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
+#ifdef GOOGLE_TEST
+            ASSERT_NEAR(hCPU[i + j * lda].x, hGPU[i + j * lda].x, abs_error);
+            ASSERT_NEAR(hCPU[i + j * lda].y, hGPU[i + j * lda].y, abs_error);
+#endif
+        }
+    }
+}

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -9,57 +9,69 @@
 #include "norm.h"
 #include "cblas.h"
 
-                    /* =====================================================================
-                         README: Norm check: norm(A-B)/norm(A), evaluate relative error
-                                 Numerically, it is recommended by lapack.
+/* =====================================================================
+     README: Norm check: norm(A-B)/norm(A), evaluate relative error
+             Numerically, it is recommended by lapack.
 
-                        Call lapack fortran routines that do not exsit in cblas library.
-                        No special header is required. But need to declare
-                        function prototype
+    Call lapack fortran routines that do not exsit in cblas library.
+    No special header is required. But need to declare
+    function prototype
 
-                        All the functions are fortran and should append underscore (_) while declaring prototype and calling.
-                        xlange and xaxpy prototype are like following
-                        =================================================================== */
+    All the functions are fortran and should append underscore (_) while declaring prototype and
+   calling.
+    xlange and xaxpy prototype are like following
+    =================================================================== */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-    float  slange_(char* norm_type, int* m, int* n, float* A, int* lda, float* work);
-    double dlange_(char* norm_type, int* m, int* n, double* A, int* lda, double* work);
-    float  clange_(char* norm_type, int* m, int* n, rocblas_float_complex* A, int* lda, float* work);
-    double zlange_(char* norm_type, int* m, int* n, rocblas_double_complex* A, int* lda, double* work);
+float slange_(char* norm_type, int* m, int* n, float* A, int* lda, float* work);
+double dlange_(char* norm_type, int* m, int* n, double* A, int* lda, double* work);
+float clange_(char* norm_type, int* m, int* n, rocblas_float_complex* A, int* lda, float* work);
+double zlange_(char* norm_type, int* m, int* n, rocblas_double_complex* A, int* lda, double* work);
 
-    float  slansy_(char* norm_type, char* uplo, int* n, float* A, int* lda, float* work);
-    double dlansy_(char* norm_type, char* uplo, int* n, double* A, int* lda, double* work);
-    float  clanhe_(char* norm_type, char* uplo, int* n, rocblas_float_complex* A, int* lda, float* work);
-    double zlanhe_(char* norm_type, char* uplo, int* n, rocblas_double_complex* A, int* lda, double* work);
+float slansy_(char* norm_type, char* uplo, int* n, float* A, int* lda, float* work);
+double dlansy_(char* norm_type, char* uplo, int* n, double* A, int* lda, double* work);
+float clanhe_(char* norm_type, char* uplo, int* n, rocblas_float_complex* A, int* lda, float* work);
+double
+zlanhe_(char* norm_type, char* uplo, int* n, rocblas_double_complex* A, int* lda, double* work);
 
-
-    void   saxpy_(int* n, float* alpha, float* x, int* incx, float* y, int* incy);
-    void   daxpy_(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
-    void   caxpy_(int* n, float* alpha, rocblas_float_complex* x, int* incx, rocblas_float_complex* y, int* incy);
-    void   zaxpy_(int* n, double* alpha, rocblas_double_complex* x, int* incx, rocblas_double_complex* y, int* incy);
-
+void saxpy_(int* n, float* alpha, float* x, int* incx, float* y, int* incy);
+void daxpy_(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
+void caxpy_(
+    int* n, float* alpha, rocblas_float_complex* x, int* incx, rocblas_float_complex* y, int* incy);
+void zaxpy_(int* n,
+            double* alpha,
+            rocblas_double_complex* x,
+            int* incx,
+            rocblas_double_complex* y,
+            int* incy);
 
 #ifdef __cplusplus
 }
 #endif
 
-/* ============================Norm Check for General Matrix: float/double/complex template speciliazation ======================================= */
+/* ============================Norm Check for General Matrix: float/double/complex template
+ * speciliazation ======================================= */
 
 /*! \brief compare the norm error of two matrices hCPU & hGPU */
-template<>
-double norm_check_general<rocblas_half>(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_half *hCPU, rocblas_half *hGPU)
+template <>
+double norm_check_general<rocblas_half>(char norm_type,
+                                        rocblas_int M,
+                                        rocblas_int N,
+                                        rocblas_int lda,
+                                        rocblas_half* hCPU,
+                                        rocblas_half* hGPU)
 {
-//norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
-//one norm is max column sum
-//infinity norm is max row sum
-//Frobenius is l2 norm of matrix entries
+    // norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
+    // one norm is max column sum
+    // infinity norm is max row sum
+    // Frobenius is l2 norm of matrix entries
 
-    std::unique_ptr<float []> hCPU_float(new float[N*lda]());
-    std::unique_ptr<float []> hGPU_float(new float[N*lda]());
-    for (int i = 0; i < N*lda; i++)
+    std::unique_ptr<float[]> hCPU_float(new float[N * lda]());
+    std::unique_ptr<float[]> hGPU_float(new float[N * lda]());
+    for(int i = 0; i < N * lda; i++)
     {
         hCPU_float[i] = static_cast<float>(hCPU[i]);
         hGPU_float[i] = static_cast<float>(hGPU[i]);
@@ -67,184 +79,198 @@ double norm_check_general<rocblas_half>(char norm_type, rocblas_int M, rocblas_i
 
     float work;
     rocblas_int incx = 1;
-    float alpha = -1.0f;
+    float alpha      = -1.0f;
     rocblas_int size = lda * N;
 
     float cpu_norm = slange_(&norm_type, &M, &N, hCPU_float.get(), &lda, &work);
     saxpy_(&size, &alpha, hCPU_float.get(), &incx, hGPU_float.get(), &incx);
 
-    float error = slange_(&norm_type, &M, &N, hGPU_float.get(), &lda, &work)/cpu_norm;
+    float error = slange_(&norm_type, &M, &N, hGPU_float.get(), &lda, &work) / cpu_norm;
 
     return static_cast<double>(error);
 }
 
-
-template<>
-double norm_check_general<float>(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, float *hCPU, float *hGPU)
+template <>
+double norm_check_general<float>(
+    char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, float* hCPU, float* hGPU)
 {
-//norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
-//one norm is max column sum
-//infinity norm is max row sum
-//Frobenius is l2 norm of matrix entries
+    // norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
+    // one norm is max column sum
+    // infinity norm is max row sum
+    // Frobenius is l2 norm of matrix entries
 
     float work;
     rocblas_int incx = 1;
-    float alpha = -1.0f;
+    float alpha      = -1.0f;
     rocblas_int size = lda * N;
 
     float cpu_norm = slange_(&norm_type, &M, &N, hCPU, &lda, &work);
     saxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-     float error = slange_(&norm_type, &M, &N, hGPU, &lda, &work)/cpu_norm;
+    float error = slange_(&norm_type, &M, &N, hGPU, &lda, &work) / cpu_norm;
 
     return (double)error;
 }
 
-
-template<>
-double norm_check_general<double>(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, double *hCPU, double *hGPU)
+template <>
+double norm_check_general<double>(
+    char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, double* hCPU, double* hGPU)
 {
-//norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
-//one norm is max column sum
-//infinity norm is max row sum
-//Frobenius is l2 norm of matrix entries
+    // norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
+    // one norm is max column sum
+    // infinity norm is max row sum
+    // Frobenius is l2 norm of matrix entries
 
     double work[1];
     rocblas_int incx = 1;
-    double alpha = -1.0;
+    double alpha     = -1.0;
     rocblas_int size = lda * N;
 
     double cpu_norm = dlange_(&norm_type, &M, &N, hCPU, &lda, work);
     daxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-    double error = dlange_(&norm_type, &M, &N, hGPU, &lda, work)/cpu_norm;
+    double error = dlange_(&norm_type, &M, &N, hGPU, &lda, work) / cpu_norm;
 
     return error;
 }
 
-
-template<>
-double norm_check_general<rocblas_float_complex>(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_float_complex *hCPU, rocblas_float_complex *hGPU)
+template <>
+double norm_check_general<rocblas_float_complex>(char norm_type,
+                                                 rocblas_int M,
+                                                 rocblas_int N,
+                                                 rocblas_int lda,
+                                                 rocblas_float_complex* hCPU,
+                                                 rocblas_float_complex* hGPU)
 {
-//norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
-//one norm is max column sum
-//infinity norm is max row sum
-//Frobenius is l2 norm of matrix entries
+    // norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
+    // one norm is max column sum
+    // infinity norm is max row sum
+    // Frobenius is l2 norm of matrix entries
 
     float work[1];
     rocblas_int incx = 1;
-    float alpha = -1.0f;
+    float alpha      = -1.0f;
     rocblas_int size = lda * N;
 
     float cpu_norm = clange_(&norm_type, &M, &N, hCPU, &lda, work);
     caxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-    float error = clange_(&norm_type, &M, &N, hGPU, &lda, work)/cpu_norm;
+    float error = clange_(&norm_type, &M, &N, hGPU, &lda, work) / cpu_norm;
 
     return (double)error;
 }
 
-
-template<>
-double norm_check_general<rocblas_double_complex>(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_double_complex *hCPU,
-rocblas_double_complex *hGPU)
+template <>
+double norm_check_general<rocblas_double_complex>(char norm_type,
+                                                  rocblas_int M,
+                                                  rocblas_int N,
+                                                  rocblas_int lda,
+                                                  rocblas_double_complex* hCPU,
+                                                  rocblas_double_complex* hGPU)
 {
-//norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
-//one norm is max column sum
-//infinity norm is max row sum
-//Frobenius is l2 norm of matrix entries
+    // norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
+    // one norm is max column sum
+    // infinity norm is max row sum
+    // Frobenius is l2 norm of matrix entries
 
     double work[1];
     rocblas_int incx = 1;
-    double alpha = -1.0;
+    double alpha     = -1.0;
     rocblas_int size = lda * N;
 
     double cpu_norm = zlange_(&norm_type, &M, &N, hCPU, &lda, work);
     zaxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-    double error = zlange_(&norm_type, &M, &N, hGPU, &lda, work)/cpu_norm;
+    double error = zlange_(&norm_type, &M, &N, hGPU, &lda, work) / cpu_norm;
 
     return error;
 }
 
-
-
-/* ============================Norm Check for Symmetric Matrix: float/double/complex template speciliazation ======================================= */
+/* ============================Norm Check for Symmetric Matrix: float/double/complex template
+ * speciliazation ======================================= */
 
 /*! \brief compare the norm error of two hermitian/symmetric matrices hCPU & hGPU */
 
-
-template<>
-double norm_check_symmetric<float>(char norm_type, char uplo, rocblas_int N, rocblas_int lda, float *hCPU, float *hGPU)
+template <>
+double norm_check_symmetric<float>(
+    char norm_type, char uplo, rocblas_int N, rocblas_int lda, float* hCPU, float* hGPU)
 {
-//norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
+    // norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
     float work[1];
     rocblas_int incx = 1;
-    float alpha = -1.0f;
+    float alpha      = -1.0f;
     rocblas_int size = lda * N;
 
     float cpu_norm = slansy_(&norm_type, &uplo, &N, hCPU, &lda, work);
     saxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-     float error = slansy_(&norm_type, &uplo, &N, hGPU, &lda, work)/cpu_norm;
+    float error = slansy_(&norm_type, &uplo, &N, hGPU, &lda, work) / cpu_norm;
 
     return (double)error;
-
 }
 
-
-template<>
-double norm_check_symmetric<double>(char norm_type, char uplo, rocblas_int N, rocblas_int lda, double *hCPU, double *hGPU)
+template <>
+double norm_check_symmetric<double>(
+    char norm_type, char uplo, rocblas_int N, rocblas_int lda, double* hCPU, double* hGPU)
 {
-//norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
+    // norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
     double work[1];
     rocblas_int incx = 1;
-    double alpha = -1.0;
+    double alpha     = -1.0;
     rocblas_int size = lda * N;
 
     double cpu_norm = dlansy_(&norm_type, &uplo, &N, hCPU, &lda, work);
     daxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-     double error = dlansy_(&norm_type, &uplo, &N, hGPU, &lda, work)/cpu_norm;
+    double error = dlansy_(&norm_type, &uplo, &N, hGPU, &lda, work) / cpu_norm;
 
     return error;
-
 }
 
-template<>
-double norm_check_symmetric<rocblas_float_complex>(char norm_type, char uplo, rocblas_int N, rocblas_int lda, rocblas_float_complex *hCPU, rocblas_float_complex *hGPU)
+template <>
+double norm_check_symmetric<rocblas_float_complex>(char norm_type,
+                                                   char uplo,
+                                                   rocblas_int N,
+                                                   rocblas_int lda,
+                                                   rocblas_float_complex* hCPU,
+                                                   rocblas_float_complex* hGPU)
 {
-//norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
+    // norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
     float work[1];
     rocblas_int incx = 1;
-    float alpha = -1.0f;
+    float alpha      = -1.0f;
     rocblas_int size = lda * N;
 
     float cpu_norm = clanhe_(&norm_type, &uplo, &N, hCPU, &lda, work);
     caxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-     float error = clanhe_(&norm_type, &uplo, &N, hGPU, &lda, work)/cpu_norm;
+    float error = clanhe_(&norm_type, &uplo, &N, hGPU, &lda, work) / cpu_norm;
 
     return (double)error;
 }
 
-template<>
-double norm_check_symmetric<rocblas_double_complex>(char norm_type, char uplo, rocblas_int N, rocblas_int lda, rocblas_double_complex *hCPU, rocblas_double_complex *hGPU)
+template <>
+double norm_check_symmetric<rocblas_double_complex>(char norm_type,
+                                                    char uplo,
+                                                    rocblas_int N,
+                                                    rocblas_int lda,
+                                                    rocblas_double_complex* hCPU,
+                                                    rocblas_double_complex* hGPU)
 {
-//norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
+    // norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
     double work[1];
     rocblas_int incx = 1;
-    double alpha = -1.0;
+    double alpha     = -1.0;
     rocblas_int size = lda * N;
 
     double cpu_norm = zlanhe_(&norm_type, &uplo, &N, hCPU, &lda, work);
     zaxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
 
-     double error = zlanhe_(&norm_type, &uplo, &N, hGPU, &lda, work)/cpu_norm;
+    double error = zlanhe_(&norm_type, &uplo, &N, hGPU, &lda, work) / cpu_norm;
 
     return error;
 }

--- a/clients/common/rocblas_template_specialization.cpp
+++ b/clients/common/rocblas_template_specialization.cpp
@@ -3,7 +3,6 @@
  *
  * ************************************************************************/
 
-
 #include <typeinfo>
 #include "rocblas.h"
 #include "rocblas.hpp"
@@ -12,33 +11,27 @@
  * \brief provide template functions interfaces to ROCBLAS C89 interfaces
 */
 
+/*
+ * ===========================================================================
+ *    level 1 BLAS
+ * ===========================================================================
+ */
+// scal
+template <>
+rocblas_status rocblas_scal<float>(
+    rocblas_handle handle, rocblas_int n, const float* alpha, float* x, rocblas_int incx)
+{
 
+    return rocblas_sscal(handle, n, alpha, x, incx);
+}
 
-    /*
-     * ===========================================================================
-     *    level 1 BLAS
-     * ===========================================================================
-     */
-    //scal
-    template<>
-    rocblas_status
-    rocblas_scal<float>(rocblas_handle handle,
-        rocblas_int n,
-        const float *alpha,
-        float *x, rocblas_int incx){
+template <>
+rocblas_status rocblas_scal<double>(
+    rocblas_handle handle, rocblas_int n, const double* alpha, double* x, rocblas_int incx)
+{
 
-        return rocblas_sscal(handle, n, alpha, x, incx);
-    }
-
-    template<>
-    rocblas_status
-    rocblas_scal<double>(rocblas_handle handle,
-        rocblas_int n,
-        const double *alpha,
-        double *x, rocblas_int incx){
-
-        return rocblas_dscal(handle, n, alpha, x, incx);
-    }
+    return rocblas_dscal(handle, n, alpha, x, incx);
+}
 
 /* not implemented
     template<>
@@ -62,37 +55,42 @@
     }
 */
 
-    //axpy
-    template<>
-    rocblas_status
-    rocblas_axpy<rocblas_half>(rocblas_handle handle, 
-                             rocblas_int n,
-                             const rocblas_half *alpha,
-                             const rocblas_half *x, rocblas_int incx,
-                                   rocblas_half *y, rocblas_int incy)
-    {
-        return rocblas_haxpy(handle, n, alpha, x, incx, y, incy);
-    }
+// axpy
+template <>
+rocblas_status rocblas_axpy<rocblas_half>(rocblas_handle handle,
+                                          rocblas_int n,
+                                          const rocblas_half* alpha,
+                                          const rocblas_half* x,
+                                          rocblas_int incx,
+                                          rocblas_half* y,
+                                          rocblas_int incy)
+{
+    return rocblas_haxpy(handle, n, alpha, x, incx, y, incy);
+}
 
-    template<>
-    rocblas_status
-    rocblas_axpy<float>(    rocblas_handle handle, rocblas_int n,
-                            const float *alpha,
-                            const float *x, rocblas_int incx,
-                                  float *y, rocblas_int incy)
-    {
-        return rocblas_saxpy(handle, n, alpha, x, incx, y, incy);
-    }
+template <>
+rocblas_status rocblas_axpy<float>(rocblas_handle handle,
+                                   rocblas_int n,
+                                   const float* alpha,
+                                   const float* x,
+                                   rocblas_int incx,
+                                   float* y,
+                                   rocblas_int incy)
+{
+    return rocblas_saxpy(handle, n, alpha, x, incx, y, incy);
+}
 
-    template<>
-    rocblas_status
-    rocblas_axpy<double>(   rocblas_handle handle, rocblas_int n,
-                            const double *alpha,
-                            const double *x, rocblas_int incx,
-                                  double *y, rocblas_int incy)
-    {
-        return rocblas_daxpy(handle, n, alpha, x, incx, y, incy);
-    }
+template <>
+rocblas_status rocblas_axpy<double>(rocblas_handle handle,
+                                    rocblas_int n,
+                                    const double* alpha,
+                                    const double* x,
+                                    rocblas_int incx,
+                                    double* y,
+                                    rocblas_int incy)
+{
+    return rocblas_daxpy(handle, n, alpha, x, incx, y, incy);
+}
 
 /* not implemented
     template<>
@@ -116,25 +114,20 @@
     }
 */
 
+// swap
+template <>
+rocblas_status rocblas_swap<float>(
+    rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy)
+{
+    return rocblas_sswap(handle, n, x, incx, y, incy);
+}
 
-    //swap
-    template<>
-    rocblas_status
-    rocblas_swap<float>(    rocblas_handle handle, rocblas_int n,
-                            float *x, rocblas_int incx,
-                            float *y, rocblas_int incy)
-    {
-        return rocblas_sswap(handle, n, x, incx, y, incy);
-    }
-
-    template<>
-    rocblas_status
-    rocblas_swap<double>(   rocblas_handle handle, rocblas_int n,
-                            double *x, rocblas_int incx,
-                            double *y, rocblas_int incy)
-    {
-        return rocblas_dswap(handle, n, x, incx, y, incy);
-    }
+template <>
+rocblas_status rocblas_swap<double>(
+    rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy)
+{
+    return rocblas_dswap(handle, n, x, incx, y, incy);
+}
 
 /* not implemented
     template<>
@@ -156,24 +149,28 @@
     }
 */
 
-    //copy
-    template<>
-    rocblas_status
-    rocblas_copy<float>(   rocblas_handle handle, rocblas_int n,
-                            const float *x, rocblas_int incx,
-                            float *y, rocblas_int incy)
-    {
-        return rocblas_scopy(handle, n, x, incx, y, incy);
-    }
+// copy
+template <>
+rocblas_status rocblas_copy<float>(rocblas_handle handle,
+                                   rocblas_int n,
+                                   const float* x,
+                                   rocblas_int incx,
+                                   float* y,
+                                   rocblas_int incy)
+{
+    return rocblas_scopy(handle, n, x, incx, y, incy);
+}
 
-    template<>
-    rocblas_status
-    rocblas_copy<double>(   rocblas_handle handle, rocblas_int n,
-                            const double *x, rocblas_int incx,
-                            double *y, rocblas_int incy)
-    {
-        return rocblas_dcopy(handle, n, x, incx, y, incy);
-    }
+template <>
+rocblas_status rocblas_copy<double>(rocblas_handle handle,
+                                    rocblas_int n,
+                                    const double* x,
+                                    rocblas_int incx,
+                                    double* y,
+                                    rocblas_int incy)
+{
+    return rocblas_dcopy(handle, n, x, incx, y, incy);
+}
 
 /* not implemented
     template<>
@@ -195,26 +192,30 @@
     }
 */
 
-    //dot
-    template<>
-    rocblas_status
-    rocblas_dot<float>(    rocblas_handle handle, rocblas_int n,
-                            const float *x, rocblas_int incx,
-                            const float *y, rocblas_int incy,
-                            float *result)
-    {
-        return rocblas_sdot(handle, n, x, incx, y, incy, result);
-    }
+// dot
+template <>
+rocblas_status rocblas_dot<float>(rocblas_handle handle,
+                                  rocblas_int n,
+                                  const float* x,
+                                  rocblas_int incx,
+                                  const float* y,
+                                  rocblas_int incy,
+                                  float* result)
+{
+    return rocblas_sdot(handle, n, x, incx, y, incy, result);
+}
 
-    template<>
-    rocblas_status
-    rocblas_dot<double>(    rocblas_handle handle, rocblas_int n,
-                            const double *x, rocblas_int incx,
-                            const double *y, rocblas_int incy,
-                            double *result)
-    {
-        return rocblas_ddot(handle, n, x, incx, y, incy, result);
-    }
+template <>
+rocblas_status rocblas_dot<double>(rocblas_handle handle,
+                                   rocblas_int n,
+                                   const double* x,
+                                   rocblas_int incx,
+                                   const double* y,
+                                   rocblas_int incy,
+                                   double* result)
+{
+    return rocblas_ddot(handle, n, x, incx, y, incy, result);
+}
 
 /* not implemented
     template<>
@@ -238,27 +239,22 @@
     }
 */
 
+// asum
+template <>
+rocblas_status rocblas_asum<float, float>(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result)
+{
 
-    //asum
-    template<>
-    rocblas_status
-    rocblas_asum<float, float>(rocblas_handle handle,
-        rocblas_int n,
-        const float *x, rocblas_int incx,
-        float *result){
+    return rocblas_sasum(handle, n, x, incx, result);
+}
 
-        return rocblas_sasum(handle, n, x, incx, result);
-    }
+template <>
+rocblas_status rocblas_asum<double, double>(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result)
+{
 
-    template<>
-    rocblas_status
-    rocblas_asum<double, double>(rocblas_handle handle,
-        rocblas_int n,
-        const double *x, rocblas_int incx,
-        double *result){
-
-        return rocblas_dasum(handle, n, x, incx, result);
-    }
+    return rocblas_dasum(handle, n, x, incx, result);
+}
 
 /* not implemented
     template<>
@@ -272,26 +268,22 @@
     }
 */
 
-    //nrm2
-    template<>
-    rocblas_status
-    rocblas_nrm2<float, float>(rocblas_handle handle,
-        rocblas_int n,
-        const float *x, rocblas_int incx,
-        float *result){
+// nrm2
+template <>
+rocblas_status rocblas_nrm2<float, float>(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result)
+{
 
-        return rocblas_snrm2(handle, n, x, incx, result);
-    }
+    return rocblas_snrm2(handle, n, x, incx, result);
+}
 
-    template<>
-    rocblas_status
-    rocblas_nrm2<double, double>(rocblas_handle handle,
-        rocblas_int n,
-        const double *x, rocblas_int incx,
-        double *result){
+template <>
+rocblas_status rocblas_nrm2<double, double>(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result)
+{
 
-        return rocblas_dnrm2(handle, n, x, incx, result);
-    }
+    return rocblas_dnrm2(handle, n, x, incx, result);
+}
 
 /* not implemented
     template<>
@@ -315,27 +307,22 @@
     }
 */
 
+// iamin
+template <>
+rocblas_status rocblas_iamin<float>(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
+{
 
-    //iamin
-    template<>
-    rocblas_status
-    rocblas_iamin<float>(rocblas_handle handle,
-        rocblas_int n,
-        const float *x, rocblas_int incx,
-        rocblas_int *result){
+    return rocblas_isamin(handle, n, x, incx, result);
+}
 
-        return rocblas_isamin(handle, n, x, incx, result);
-    }
+template <>
+rocblas_status rocblas_iamin<double>(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
+{
 
-    template<>
-    rocblas_status
-    rocblas_iamin<double>(rocblas_handle handle,
-        rocblas_int n,
-        const double *x, rocblas_int incx,
-        rocblas_int *result){
-
-        return rocblas_idamin(handle, n, x, incx, result);
-    }
+    return rocblas_idamin(handle, n, x, incx, result);
+}
 
 /* not implemented
     template<>
@@ -359,26 +346,22 @@
     }
 */
 
-    //iamax
-    template<>
-    rocblas_status
-    rocblas_iamax<float>(rocblas_handle handle,
-        rocblas_int n,
-        const float *x, rocblas_int incx,
-        rocblas_int *result){
+// iamax
+template <>
+rocblas_status rocblas_iamax<float>(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
+{
 
-        return rocblas_isamax(handle, n, x, incx, result);
-    }
+    return rocblas_isamax(handle, n, x, incx, result);
+}
 
-    template<>
-    rocblas_status
-    rocblas_iamax<double>(rocblas_handle handle,
-        rocblas_int n,
-        const double *x, rocblas_int incx,
-        rocblas_int *result){
+template <>
+rocblas_status rocblas_iamax<double>(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
+{
 
-        return rocblas_idamax(handle, n, x, incx, result);
-    }
+    return rocblas_idamax(handle, n, x, incx, result);
+}
 
 /* not implemented
     template<>
@@ -402,36 +385,45 @@
     }
 */
 
-    /*
-     * ===========================================================================
-     *    level 2 BLAS
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    level 2 BLAS
+ * ===========================================================================
+ */
 
-    template<>
-    rocblas_status
-    rocblas_gemv<float>(    rocblas_handle handle,
-                            rocblas_operation transA, rocblas_int m, rocblas_int n,
-                            const float *alpha,
-                            const float *A, rocblas_int lda,
-                            const float *x, rocblas_int incx,
-                            const float *beta, float *y, rocblas_int incy)
-    {
-        return rocblas_sgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
-    }
+template <>
+rocblas_status rocblas_gemv<float>(rocblas_handle handle,
+                                   rocblas_operation transA,
+                                   rocblas_int m,
+                                   rocblas_int n,
+                                   const float* alpha,
+                                   const float* A,
+                                   rocblas_int lda,
+                                   const float* x,
+                                   rocblas_int incx,
+                                   const float* beta,
+                                   float* y,
+                                   rocblas_int incy)
+{
+    return rocblas_sgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
 
-    template<>
-    rocblas_status
-    rocblas_gemv<double>(   rocblas_handle handle,
-                            rocblas_operation transA, rocblas_int m, rocblas_int n,
-                            const double *alpha,
-                            const double *A, rocblas_int lda,
-                            const double *x, rocblas_int incx,
-                            const double *beta, double *y, rocblas_int incy)
-    {
-        return rocblas_dgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
-    }
-
+template <>
+rocblas_status rocblas_gemv<double>(rocblas_handle handle,
+                                    rocblas_operation transA,
+                                    rocblas_int m,
+                                    rocblas_int n,
+                                    const double* alpha,
+                                    const double* A,
+                                    rocblas_int lda,
+                                    const double* x,
+                                    rocblas_int incx,
+                                    const double* beta,
+                                    double* y,
+                                    rocblas_int incy)
+{
+    return rocblas_dgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
 
 /* not implemented
     template<>
@@ -459,194 +451,298 @@
     }
 */
 
+template <>
+rocblas_status rocblas_ger<float>(rocblas_handle handle,
+                                  rocblas_int m,
+                                  rocblas_int n,
+                                  const float* alpha,
+                                  const float* x,
+                                  rocblas_int incx,
+                                  const float* y,
+                                  rocblas_int incy,
+                                  float* A,
+                                  rocblas_int lda)
+{
 
-    template<>
-    rocblas_status
-    rocblas_ger<float>(rocblas_handle handle,
-                 rocblas_int m, rocblas_int n,
-                 const float *alpha,
-                 const float *x, rocblas_int incx,
-                 const float *y, rocblas_int incy,
-                       float *A, rocblas_int lda){
+    return rocblas_sger(handle, m, n, alpha, x, incx, y, incy, A, lda);
+}
 
-        return rocblas_sger(handle, m, n, alpha, x, incx, y, incy, A, lda);
-    }
+template <>
+rocblas_status rocblas_ger<double>(rocblas_handle handle,
+                                   rocblas_int m,
+                                   rocblas_int n,
+                                   const double* alpha,
+                                   const double* x,
+                                   rocblas_int incx,
+                                   const double* y,
+                                   rocblas_int incy,
+                                   double* A,
+                                   rocblas_int lda)
+{
 
-    template<>
-    rocblas_status
-    rocblas_ger<double>(rocblas_handle handle,
-                 rocblas_int m, rocblas_int n,
-                 const double *alpha,
-                 const double *x, rocblas_int incx,
-                 const double *y, rocblas_int incy,
-                       double *A, rocblas_int lda){
+    return rocblas_dger(handle, m, n, alpha, x, incx, y, incy, A, lda);
+}
 
-        return rocblas_dger(handle, m, n, alpha, x, incx, y, incy, A, lda);
-    }
+/*
+ * ===========================================================================
+ *    level 3 BLAS
+ * ===========================================================================
+ */
 
-    /*
-     * ===========================================================================
-     *    level 3 BLAS
-     * ===========================================================================
-     */
+//
 
-    //
+template <>
+rocblas_status rocblas_trtri<float>(rocblas_handle handle,
+                                    rocblas_fill uplo,
+                                    rocblas_diagonal diag,
+                                    rocblas_int n,
+                                    float* A,
+                                    rocblas_int lda,
+                                    float* invA,
+                                    rocblas_int ldinvA)
+{
+    return rocblas_strtri(handle, uplo, diag, n, A, lda, invA, ldinvA);
+}
 
-    template<>
-    rocblas_status
-    rocblas_trtri<float>(rocblas_handle handle,
-        rocblas_fill uplo,
-        rocblas_diagonal diag,
-        rocblas_int n,
-        float *A, rocblas_int lda, 
-        float *invA, rocblas_int ldinvA){
-        return rocblas_strtri(handle, uplo, diag, n, A, lda, invA, ldinvA);
-    }
+template <>
+rocblas_status rocblas_trtri<double>(rocblas_handle handle,
+                                     rocblas_fill uplo,
+                                     rocblas_diagonal diag,
+                                     rocblas_int n,
+                                     double* A,
+                                     rocblas_int lda,
+                                     double* invA,
+                                     rocblas_int ldinvA)
+{
+    return rocblas_dtrtri(handle, uplo, diag, n, A, lda, invA, ldinvA);
+}
 
-    template<>
-    rocblas_status
-    rocblas_trtri<double>(rocblas_handle handle,
-        rocblas_fill uplo,
-        rocblas_diagonal diag,
-        rocblas_int n,
-        double *A, rocblas_int lda, 
-        double *invA, rocblas_int ldinvA){
-        return rocblas_dtrtri(handle, uplo, diag, n, A, lda, invA, ldinvA);
-    }
+template <>
+rocblas_status rocblas_trtri_batched<float>(rocblas_handle handle,
+                                            rocblas_fill uplo,
+                                            rocblas_diagonal diag,
+                                            rocblas_int n,
+                                            float* A,
+                                            rocblas_int lda,
+                                            rocblas_int bsa,
+                                            float* invA,
+                                            rocblas_int ldinvA,
+                                            rocblas_int bsinvA,
+                                            rocblas_int batch_count)
+{
+    return rocblas_strtri_batched(
+        handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
+}
 
-    template<>
-    rocblas_status
-    rocblas_trtri_batched<float>(rocblas_handle handle,
-        rocblas_fill uplo,
-        rocblas_diagonal diag,
-        rocblas_int n,
-        float *A, rocblas_int lda, rocblas_int bsa,
-        float *invA, rocblas_int ldinvA, rocblas_int bsinvA,
-        rocblas_int batch_count){
-        return rocblas_strtri_batched(handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
-    }
+template <>
+rocblas_status rocblas_trtri_batched<double>(rocblas_handle handle,
+                                             rocblas_fill uplo,
+                                             rocblas_diagonal diag,
+                                             rocblas_int n,
+                                             double* A,
+                                             rocblas_int lda,
+                                             rocblas_int bsa,
+                                             double* invA,
+                                             rocblas_int ldinvA,
+                                             rocblas_int bsinvA,
+                                             rocblas_int batch_count)
+{
+    return rocblas_dtrtri_batched(
+        handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
+}
 
-    template<>
-    rocblas_status
-    rocblas_trtri_batched<double>(rocblas_handle handle,
-        rocblas_fill uplo,
-        rocblas_diagonal diag,
-        rocblas_int n,
-        double *A, rocblas_int lda, rocblas_int bsa,
-        double *invA, rocblas_int ldinvA, rocblas_int bsinvA,
-        rocblas_int batch_count){
-        return rocblas_dtrtri_batched(handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
-    }
+template <>
+rocblas_status rocblas_geam<float>(rocblas_handle handle,
+                                   rocblas_operation transA,
+                                   rocblas_operation transB,
+                                   rocblas_int m,
+                                   rocblas_int n,
+                                   const float* alpha,
+                                   const float* A,
+                                   rocblas_int lda,
+                                   const float* beta,
+                                   const float* B,
+                                   rocblas_int ldb,
+                                   float* C,
+                                   rocblas_int ldc)
+{
+    return rocblas_sgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
+}
 
-    template<>
-    rocblas_status rocblas_geam<float>(rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n,
-        const float *alpha,
-        const float *A, rocblas_int lda,
-        const float *beta,
-        const float *B, rocblas_int ldb,
-        float *C, rocblas_int ldc){
-        return rocblas_sgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
-    }
-
-    template<>
-    rocblas_status rocblas_geam<double>(rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n,
-        const double *alpha,
-        const double *A, rocblas_int lda,
-        const double *beta,
-        const double *B, rocblas_int ldb,
-        double *C, rocblas_int ldc){
-        return rocblas_dgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
-    }
-
+template <>
+rocblas_status rocblas_geam<double>(rocblas_handle handle,
+                                    rocblas_operation transA,
+                                    rocblas_operation transB,
+                                    rocblas_int m,
+                                    rocblas_int n,
+                                    const double* alpha,
+                                    const double* A,
+                                    rocblas_int lda,
+                                    const double* beta,
+                                    const double* B,
+                                    rocblas_int ldb,
+                                    double* C,
+                                    rocblas_int ldc)
+{
+    return rocblas_dgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
+}
 
 #if BUILD_WITH_TENSILE
 
-    template<>
-    rocblas_status rocblas_gemm<float>(rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const float *alpha,
-        const float *A, rocblas_int lda,
-        const float *B, rocblas_int ldb,
-        const float *beta,
-        float *C, rocblas_int ldc){
-        return rocblas_sgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
-    }
+template <>
+rocblas_status rocblas_gemm<float>(rocblas_handle handle,
+                                   rocblas_operation transA,
+                                   rocblas_operation transB,
+                                   rocblas_int m,
+                                   rocblas_int n,
+                                   rocblas_int k,
+                                   const float* alpha,
+                                   const float* A,
+                                   rocblas_int lda,
+                                   const float* B,
+                                   rocblas_int ldb,
+                                   const float* beta,
+                                   float* C,
+                                   rocblas_int ldc)
+{
+    return rocblas_sgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+}
 
-    template<>
-    rocblas_status rocblas_gemm<double>(rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const double *alpha,
-        const double *A, rocblas_int lda,
-        const double *B, rocblas_int ldb,
-        const double *beta,
-        double *C, rocblas_int ldc){
-        return rocblas_dgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
-    }
+template <>
+rocblas_status rocblas_gemm<double>(rocblas_handle handle,
+                                    rocblas_operation transA,
+                                    rocblas_operation transB,
+                                    rocblas_int m,
+                                    rocblas_int n,
+                                    rocblas_int k,
+                                    const double* alpha,
+                                    const double* A,
+                                    rocblas_int lda,
+                                    const double* B,
+                                    rocblas_int ldb,
+                                    const double* beta,
+                                    double* C,
+                                    rocblas_int ldc)
+{
+    return rocblas_dgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+}
 
+template <>
+rocblas_status rocblas_gemm_strided_batched<float>(rocblas_handle handle,
+                                                   rocblas_operation transA,
+                                                   rocblas_operation transB,
+                                                   rocblas_int m,
+                                                   rocblas_int n,
+                                                   rocblas_int k,
+                                                   const float* alpha,
+                                                   const float* A,
+                                                   rocblas_int lda,
+                                                   rocblas_int bsa,
+                                                   const float* B,
+                                                   rocblas_int ldb,
+                                                   rocblas_int bsb,
+                                                   const float* beta,
+                                                   float* C,
+                                                   rocblas_int ldc,
+                                                   rocblas_int bsc,
+                                                   rocblas_int batch_count)
+{
 
-    template<>
-    rocblas_status rocblas_gemm_strided_batched<float>(
-        rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const float *alpha,
-        const float *A, rocblas_int lda, rocblas_int bsa,
-        const float *B, rocblas_int ldb, rocblas_int bsb,
-        const float *beta,
-        float *C, rocblas_int ldc, rocblas_int bsc,
-        rocblas_int batch_count){
+    return rocblas_sgemm_strided_batched(handle,
+                                         transA,
+                                         transB,
+                                         m,
+                                         n,
+                                         k,
+                                         alpha,
+                                         A,
+                                         lda,
+                                         bsa,
+                                         B,
+                                         ldb,
+                                         bsb,
+                                         beta,
+                                         C,
+                                         ldc,
+                                         bsc,
+                                         batch_count);
+}
 
-        return rocblas_sgemm_strided_batched(handle, transA, transB, m, n, k, alpha, A, lda, bsa, B, ldb, bsb, beta, C, ldc, bsc, batch_count);
-    }
+template <>
+rocblas_status rocblas_gemm_strided_batched<double>(rocblas_handle handle,
+                                                    rocblas_operation transA,
+                                                    rocblas_operation transB,
+                                                    rocblas_int m,
+                                                    rocblas_int n,
+                                                    rocblas_int k,
+                                                    const double* alpha,
+                                                    const double* A,
+                                                    rocblas_int lda,
+                                                    rocblas_int bsa,
+                                                    const double* B,
+                                                    rocblas_int ldb,
+                                                    rocblas_int bsb,
+                                                    const double* beta,
+                                                    double* C,
+                                                    rocblas_int ldc,
+                                                    rocblas_int bsc,
+                                                    rocblas_int batch_count)
+{
 
-    template<>
-    rocblas_status rocblas_gemm_strided_batched<double>(
-        rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const double *alpha,
-        const double *A, rocblas_int lda, rocblas_int bsa,
-        const double *B, rocblas_int ldb, rocblas_int bsb,
-        const double *beta,
-        double *C, rocblas_int ldc, rocblas_int bsc,
-        rocblas_int batch_count){
+    return rocblas_dgemm_strided_batched(handle,
+                                         transA,
+                                         transB,
+                                         m,
+                                         n,
+                                         k,
+                                         alpha,
+                                         A,
+                                         lda,
+                                         bsa,
+                                         B,
+                                         ldb,
+                                         bsb,
+                                         beta,
+                                         C,
+                                         ldc,
+                                         bsc,
+                                         batch_count);
+}
 
-        return rocblas_dgemm_strided_batched(handle, transA, transB, m, n, k, alpha, A, lda, bsa, B, ldb, bsb, beta, C, ldc, bsc, batch_count);
-    }
+template <>
+rocblas_status rocblas_trsm<float>(rocblas_handle handle,
+                                   rocblas_side side,
+                                   rocblas_fill uplo,
+                                   rocblas_operation transA,
+                                   rocblas_diagonal diag,
+                                   rocblas_int m,
+                                   rocblas_int n,
+                                   const float* alpha,
+                                   float* A,
+                                   rocblas_int lda,
+                                   float* B,
+                                   rocblas_int ldb)
+{
+    return rocblas_strsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
+}
 
+template <>
+rocblas_status rocblas_trsm<double>(rocblas_handle handle,
+                                    rocblas_side side,
+                                    rocblas_fill uplo,
+                                    rocblas_operation transA,
+                                    rocblas_diagonal diag,
+                                    rocblas_int m,
+                                    rocblas_int n,
+                                    const double* alpha,
+                                    double* A,
+                                    rocblas_int lda,
+                                    double* B,
+                                    rocblas_int ldb)
+{
+    return rocblas_dtrsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
+}
 
-    template<>
-    rocblas_status rocblas_trsm<float>(rocblas_handle handle,
-        rocblas_side side, rocblas_fill uplo,
-        rocblas_operation transA, rocblas_diagonal diag,
-        rocblas_int m, rocblas_int n,
-        const float* alpha,
-        float* A, rocblas_int lda,
-        float* B, rocblas_int ldb){
-        return rocblas_strsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
-    }
+#endif
 
-
-    template<>
-    rocblas_status rocblas_trsm<double>(rocblas_handle handle,
-        rocblas_side side, rocblas_fill uplo,
-        rocblas_operation transA, rocblas_diagonal diag,
-        rocblas_int m, rocblas_int n,
-        const double* alpha,
-        double* A, rocblas_int lda,
-        double* B, rocblas_int ldb){
-        return rocblas_dtrsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
-    }
-
-#endif 
-
-
-    //
-
-
+//

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -7,110 +7,146 @@
 #include "rocblas.h"
 #include "unit.h"
 
-#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK) {\
-    hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != hipSuccess) { \
-        fprintf(stderr, "hip error code: %d at %s:%d\n",  TMP_STATUS_FOR_CHECK,__FILE__, __LINE__); \
-} }
-
-/* ========================================Gtest Unit Check ==================================================== */
-
-
-    /*! \brief Template: gtest unit compare two matrices float/double/complex */
-    //Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test case
-    // a wrapper will cause the loop keep going
-
-
-    template<>
-    void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_half *hCPU, rocblas_half *hGPU){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
-#ifdef GOOGLE_TEST
-                float cpu_float = static_cast<float>(hCPU[i+j*lda]);
-                float gpu_float = static_cast<float>(hGPU[i+j*lda]);
-                ASSERT_FLOAT_EQ(cpu_float, gpu_float);
-#endif
-            }
-        }
+#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
+    {                                                             \
+        hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != hipSuccess)                    \
+        {                                                         \
+            fprintf(stderr,                                       \
+                    "hip error code: %d at %s:%d\n",              \
+                    TMP_STATUS_FOR_CHECK,                         \
+                    __FILE__,                                     \
+                    __LINE__);                                    \
+        }                                                         \
     }
 
-    template<>
-    void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, float *hCPU, float *hGPU){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
-#ifdef GOOGLE_TEST
-                ASSERT_FLOAT_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);
-#endif
-            }
-        }
-    }
-
-    template<>
-    void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, double *hCPU, double *hGPU){
-        #pragma unroll  
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
-#ifdef GOOGLE_TEST
-                ASSERT_DOUBLE_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);
-#endif
-            }
-        }
-    }
-
-    template<>
-    void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_float_complex *hCPU, rocblas_float_complex *hGPU){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
-#ifdef GOOGLE_TEST
-                ASSERT_FLOAT_EQ(hCPU[i+j*lda].x, hGPU[i+j*lda].x);
-                ASSERT_FLOAT_EQ(hCPU[i+j*lda].y, hGPU[i+j*lda].y);
-#endif
-            }
-        }
-    }
-
-    template<>
-    void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_double_complex *hCPU, rocblas_double_complex *hGPU){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
-#ifdef GOOGLE_TEST
-                ASSERT_DOUBLE_EQ(hCPU[i+j*lda].x, hGPU[i+j*lda].x);
-                ASSERT_DOUBLE_EQ(hCPU[i+j*lda].y, hGPU[i+j*lda].y);
-#endif
-            }
-        }
-    }
-
-    template<>
-    void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int *hCPU, rocblas_int *hGPU){
-        #pragma unroll
-        for(rocblas_int j=0; j<N; j++){
-            #pragma unroll
-            for(rocblas_int i=0;i<M;i++){
-#ifdef GOOGLE_TEST
-                ASSERT_EQ(hCPU[i+j*lda], hGPU[i+j*lda]);
-#endif
-            }
-        }
-    }
-
-/* ========================================Gtest Unit Check TRSM ==================================================== */
-
+/* ========================================Gtest Unit Check
+ * ==================================================== */
 
 /*! \brief Template: gtest unit compare two matrices float/double/complex */
-//Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test case
+// Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test
+// case
 // a wrapper will cause the loop keep going
 
-template<>
+template <>
+void unit_check_general(
+    rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_half* hCPU, rocblas_half* hGPU)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
+#ifdef GOOGLE_TEST
+            float cpu_float = static_cast<float>(hCPU[i + j * lda]);
+            float gpu_float = static_cast<float>(hGPU[i + j * lda]);
+            ASSERT_FLOAT_EQ(cpu_float, gpu_float);
+#endif
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, float* hCPU, float* hGPU)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
+#ifdef GOOGLE_TEST
+            ASSERT_FLOAT_EQ(hCPU[i + j * lda], hGPU[i + j * lda]);
+#endif
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, double* hCPU, double* hGPU)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
+#ifdef GOOGLE_TEST
+            ASSERT_DOUBLE_EQ(hCPU[i + j * lda], hGPU[i + j * lda]);
+#endif
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int lda,
+                        rocblas_float_complex* hCPU,
+                        rocblas_float_complex* hGPU)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
+#ifdef GOOGLE_TEST
+            ASSERT_FLOAT_EQ(hCPU[i + j * lda].x, hGPU[i + j * lda].x);
+            ASSERT_FLOAT_EQ(hCPU[i + j * lda].y, hGPU[i + j * lda].y);
+#endif
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int lda,
+                        rocblas_double_complex* hCPU,
+                        rocblas_double_complex* hGPU)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
+#ifdef GOOGLE_TEST
+            ASSERT_DOUBLE_EQ(hCPU[i + j * lda].x, hGPU[i + j * lda].x);
+            ASSERT_DOUBLE_EQ(hCPU[i + j * lda].y, hGPU[i + j * lda].y);
+#endif
+        }
+    }
+}
+
+template <>
+void unit_check_general(
+    rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int* hCPU, rocblas_int* hGPU)
+{
+#pragma unroll
+    for(rocblas_int j = 0; j < N; j++)
+    {
+#pragma unroll
+        for(rocblas_int i = 0; i < M; i++)
+        {
+#ifdef GOOGLE_TEST
+            ASSERT_EQ(hCPU[i + j * lda], hGPU[i + j * lda]);
+#endif
+        }
+    }
+}
+
+/* ========================================Gtest Unit Check TRSM
+ * ==================================================== */
+
+/*! \brief Template: gtest unit compare two matrices float/double/complex */
+// Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test
+// case
+// a wrapper will cause the loop keep going
+
+template <>
 void trsm_err_res_check(float max_error, rocblas_int M, float forward_tolerance, float eps)
 {
 #ifdef GOOGLE_TEST
@@ -118,7 +154,7 @@ void trsm_err_res_check(float max_error, rocblas_int M, float forward_tolerance,
 #endif
 }
 
-template<>
+template <>
 void trsm_err_res_check(double max_error, rocblas_int M, double forward_tolerance, double eps)
 {
 #ifdef GOOGLE_TEST

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -3,197 +3,216 @@
  *
  * ************************************************************************ */
 
-
 #include <sys/time.h>
 #include "rocblas.h"
 #include "utility.h"
 
-    template<>
-    char type2char<float>(){
-        return 's';
-    }
+template <>
+char type2char<float>()
+{
+    return 's';
+}
 
-    template<>
-    char type2char<double>(){
-        return 'd';
-    }
+template <>
+char type2char<double>()
+{
+    return 'd';
+}
 
-    template<>
-    char type2char<rocblas_float_complex>(){
-        return 'c';
-    }
+template <>
+char type2char<rocblas_float_complex>()
+{
+    return 'c';
+}
 
-    template<>
-    char type2char<rocblas_double_complex>(){
-        return 'z';
-    }
+template <>
+char type2char<rocblas_double_complex>()
+{
+    return 'z';
+}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/* ============================================================================================ */
+/*  timing:*/
 
-    /* ============================================================================================ */
-    /*  timing:*/
+/*! \brief  CPU Timer(in microsecond): synchronize with the default device and return wall time */
+double get_time_us(void)
+{
+    hipDeviceSynchronize();
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (tv.tv_sec * 1000 * 1000) + tv.tv_usec;
+};
 
-    /*! \brief  CPU Timer(in microsecond): synchronize with the default device and return wall time */
-    double get_time_us( void ){
-        hipDeviceSynchronize();
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
-        return (tv.tv_sec * 1000 * 1000) + tv.tv_usec ;
+/*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
+double get_time_us_sync(hipStream_t stream)
+{
+    hipStreamSynchronize(stream);
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (tv.tv_sec * 1000 * 1000) + tv.tv_usec;
+};
 
-    };
+/* ============================================================================================ */
+/*  device query and print out their ID and name; return number of compute-capable devices. */
+rocblas_int query_device_property()
+{
+    int device_count;
+    rocblas_status status = (rocblas_status)hipGetDeviceCount(&device_count);
+    if(status != rocblas_status_success)
+    {
+        printf("Query device error: cannot get device count \n");
+        return -1;
+    }
+    else
+    {
+        printf("Query device success: there are %d devices \n", device_count);
+    }
 
-
-    /*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
-    double get_time_us_sync( hipStream_t stream ){
-        hipStreamSynchronize (stream);
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
-        return (tv.tv_sec * 1000 * 1000) + tv.tv_usec ;
-    };
-
-    /* ============================================================================================ */
-    /*  device query and print out their ID and name; return number of compute-capable devices. */
-    rocblas_int query_device_property(){
-        int device_count;
-        rocblas_status status = (rocblas_status)hipGetDeviceCount(&device_count);
-        if(status != rocblas_status_success){
-               printf ("Query device error: cannot get device count \n");
-               return -1;
-        }
-        else{
-            printf("Query device success: there are %d devices \n", device_count);
-        }
-
-        for(rocblas_int i=0;i<device_count; i++)
+    for(rocblas_int i = 0; i < device_count; i++)
+    {
+        hipDeviceProp_t props;
+        rocblas_status status = (rocblas_status)hipGetDeviceProperties(&props, i);
+        if(status != rocblas_status_success)
         {
-            hipDeviceProp_t props;
-            rocblas_status status = (rocblas_status)hipGetDeviceProperties(&props, i);
-            if(status != rocblas_status_success){
-               printf ("Query device error: cannot get device ID %d's property\n", i);
-            }
-            else{
-                printf("Device ID %d : %s ------------------------------------------------------\n", i, props.name);
-                printf ("with %3.1f GB memory, clock rate %dMHz @ computing capability %d.%d \n",
-                         props.totalGlobalMem/1e9, (int)(props.clockRate/1000), props.major, props.minor);
-                printf ("maxGridDimX %d, sharedMemPerBlock %3.1f KB, maxThreadsPerBlock %d, warpSize %d\n",
-                         props.maxGridSize[0], props.sharedMemPerBlock/1e3, props.maxThreadsPerBlock, props.warpSize);
-
-                printf("-------------------------------------------------------------------------\n");
-            }
+            printf("Query device error: cannot get device ID %d's property\n", i);
         }
+        else
+        {
+            printf("Device ID %d : %s ------------------------------------------------------\n",
+                   i,
+                   props.name);
+            printf("with %3.1f GB memory, clock rate %dMHz @ computing capability %d.%d \n",
+                   props.totalGlobalMem / 1e9,
+                   (int)(props.clockRate / 1000),
+                   props.major,
+                   props.minor);
+            printf(
+                "maxGridDimX %d, sharedMemPerBlock %3.1f KB, maxThreadsPerBlock %d, warpSize %d\n",
+                props.maxGridSize[0],
+                props.sharedMemPerBlock / 1e3,
+                props.maxThreadsPerBlock,
+                props.warpSize);
 
-        return device_count;
-    }
-
-    /*  set current device to device_id */
-    void set_device(rocblas_int device_id){
-        rocblas_status status = (rocblas_status)hipSetDevice(device_id);
-        if(status != rocblas_status_success){
-               printf ("Set device error: cannot set device ID %d, there may not be such device ID\n", (int)device_id);
+            printf("-------------------------------------------------------------------------\n");
         }
     }
 
-    /* ============================================================================================ */
-    /*  Convert rocblas constants to lapack char. */
+    return device_count;
+}
 
-    char
-    rocblas2char_operation(rocblas_operation value)
+/*  set current device to device_id */
+void set_device(rocblas_int device_id)
+{
+    rocblas_status status = (rocblas_status)hipSetDevice(device_id);
+    if(status != rocblas_status_success)
     {
-        switch (value) {
-            case rocblas_operation_none:                   return 'N';
-            case rocblas_operation_transpose:              return 'T';
-            case rocblas_operation_conjugate_transpose:    return 'C';
-        }
-        return '\0';
+        printf("Set device error: cannot set device ID %d, there may not be such device ID\n",
+               (int)device_id);
     }
+}
 
-    char
-    rocblas2char_fill(rocblas_fill value)
+/* ============================================================================================ */
+/*  Convert rocblas constants to lapack char. */
+
+char rocblas2char_operation(rocblas_operation value)
+{
+    switch(value)
     {
-        switch (value) {
-            case rocblas_fill_upper:  return 'U';
-            case rocblas_fill_lower:  return 'L';
-            case rocblas_fill_full :  return 'F';
-        }
-        return '\0';
+    case rocblas_operation_none: return 'N';
+    case rocblas_operation_transpose: return 'T';
+    case rocblas_operation_conjugate_transpose: return 'C';
     }
+    return '\0';
+}
 
-    char
-    rocblas2char_diagonal(rocblas_diagonal value)
+char rocblas2char_fill(rocblas_fill value)
+{
+    switch(value)
     {
-        switch (value) {
-            case rocblas_diagonal_unit:        return 'U';
-            case rocblas_diagonal_non_unit:    return 'N';
-        }
-        return '\0';
+    case rocblas_fill_upper: return 'U';
+    case rocblas_fill_lower: return 'L';
+    case rocblas_fill_full: return 'F';
     }
+    return '\0';
+}
 
-    char
-    rocblas2char_side(rocblas_side value)
+char rocblas2char_diagonal(rocblas_diagonal value)
+{
+    switch(value)
     {
-        switch (value) {
-            case rocblas_side_left:   return 'L';
-            case rocblas_side_right:  return 'R';
-            case rocblas_side_both:   return 'B';
-        }
-        return '\0';
+    case rocblas_diagonal_unit: return 'U';
+    case rocblas_diagonal_non_unit: return 'N';
     }
+    return '\0';
+}
 
-    /* ============================================================================================ */
-    /*  Convert lapack char constants to rocblas type. */
-
-    rocblas_operation
-    char2rocblas_operation(char value)
+char rocblas2char_side(rocblas_side value)
+{
+    switch(value)
     {
-        switch (value) {
-            case 'N':    return               rocblas_operation_none;
-            case 'T':    return          rocblas_operation_transpose;
-            case 'C':    return rocblas_operation_conjugate_transpose;
-            case 'n':    return                rocblas_operation_none;
-            case 't':    return           rocblas_operation_transpose;
-            case 'c':    return rocblas_operation_conjugate_transpose;
-        }
-        return rocblas_operation_none;
+    case rocblas_side_left: return 'L';
+    case rocblas_side_right: return 'R';
+    case rocblas_side_both: return 'B';
     }
+    return '\0';
+}
 
-    rocblas_fill
-    char2rocblas_fill(char value)
-    {
-        switch (value) {
-            case 'U':  return rocblas_fill_upper;
-            case 'L':  return rocblas_fill_lower;
-            case 'u':  return rocblas_fill_upper;
-            case 'l':  return rocblas_fill_lower;
-        }
-        return rocblas_fill_lower;
-    }
+/* ============================================================================================ */
+/*  Convert lapack char constants to rocblas type. */
 
-    rocblas_diagonal
-    char2rocblas_diagonal(char value)
+rocblas_operation char2rocblas_operation(char value)
+{
+    switch(value)
     {
-        switch (value) {
-            case 'U':    return     rocblas_diagonal_unit;
-            case 'N':    return rocblas_diagonal_non_unit;
-            case 'u':    return     rocblas_diagonal_unit;
-            case 'n':    return rocblas_diagonal_non_unit;
-        }
-        return rocblas_diagonal_non_unit;
+    case 'N': return rocblas_operation_none;
+    case 'T': return rocblas_operation_transpose;
+    case 'C': return rocblas_operation_conjugate_transpose;
+    case 'n': return rocblas_operation_none;
+    case 't': return rocblas_operation_transpose;
+    case 'c': return rocblas_operation_conjugate_transpose;
     }
+    return rocblas_operation_none;
+}
 
-    rocblas_side
-    char2rocblas_side(char value)
+rocblas_fill char2rocblas_fill(char value)
+{
+    switch(value)
     {
-        switch (value) {
-            case 'L':   return rocblas_side_left;
-            case 'R':  return rocblas_side_right;
-            case 'l':   return rocblas_side_left;
-            case 'r':  return rocblas_side_right;
-        }
-        return rocblas_side_left;
+    case 'U': return rocblas_fill_upper;
+    case 'L': return rocblas_fill_lower;
+    case 'u': return rocblas_fill_upper;
+    case 'l': return rocblas_fill_lower;
     }
+    return rocblas_fill_lower;
+}
+
+rocblas_diagonal char2rocblas_diagonal(char value)
+{
+    switch(value)
+    {
+    case 'U': return rocblas_diagonal_unit;
+    case 'N': return rocblas_diagonal_non_unit;
+    case 'u': return rocblas_diagonal_unit;
+    case 'n': return rocblas_diagonal_non_unit;
+    }
+    return rocblas_diagonal_non_unit;
+}
+
+rocblas_side char2rocblas_side(char value)
+{
+    switch(value)
+    {
+    case 'L': return rocblas_side_left;
+    case 'R': return rocblas_side_right;
+    case 'l': return rocblas_side_left;
+    case 'r': return rocblas_side_right;
+    }
+    return rocblas_side_left;
+}
 
 #ifdef __cplusplus
 }

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -22,10 +22,8 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 typedef std::tuple<int, vector<double>, vector<int>> blas1_tuple;
-
 
 /* =====================================================================
 README: This file contains testers to verify the correctness of
@@ -43,10 +41,10 @@ from ‘testing::internal::CartesianProductHolder3<testing::internal::ParamGener
 testing::internal::ParamGenerator<std::vector<double> >,
 testing::internal::ParamGenerator<std::vector<int> > >’
 
-to ‘testing::internal::ParamGenerator<std::tuple<int, std::vector<double, std::allocator<double> >, std::vector<int, std::allocator<int> > > >’
+to ‘testing::internal::ParamGenerator<std::tuple<int, std::vector<double, std::allocator<double> >,
+std::vector<int, std::allocator<int> > > >’
 
 */
-
 
 /* =====================================================================
 Advance users only: BrainStorm the parameters
@@ -54,96 +52,67 @@ Advance users only: BrainStorm the parameters
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
-  int N_range[] = {
-                    -1,
-                    0,
-                    5,
-                    10,
-                    500,
-                    1000,
-                    7111,
-                    10000,
-                  };
+int N_range[] = {
+    -1, 0, 5, 10, 500, 1000, 7111, 10000,
+};
 
-//vector of vector, each pair is a {alpha, beta};
-//add/delete this list in pairs, like {2.0, 4.0}
-vector<vector<double>> alpha_beta_range = { 
-                                            {1.0, 0.0},
-                                            {2.0, -1.0}
-                                          };
+// vector of vector, each pair is a {alpha, beta};
+// add/delete this list in pairs, like {2.0, 4.0}
+vector<vector<double>> alpha_beta_range = {{1.0, 0.0}, {2.0, -1.0}};
 
-//vector of vector, each pair is a {incx, incy};
-//add/delete this list in pairs, like {1, 2}
-//incx , incy must > 0, otherwise there is no real computation taking place,
-//but throw a message, which will still be detected by gtest
+// vector of vector, each pair is a {incx, incy};
+// add/delete this list in pairs, like {1, 2}
+// incx , incy must > 0, otherwise there is no real computation taking place,
+// but throw a message, which will still be detected by gtest
 vector<vector<int>> incx_incy_range = {
-                                        {1, 1},
-                                        {1, 2},
-                                        {2, 1},
-                                        { 1, -1},
-                                        {-1,  1},
-                                        {-1, -1},
-                                       };
-
+    {1, 1}, {1, 2}, {2, 1}, {1, -1}, {-1, 1}, {-1, -1},
+};
 
 /* ===============Google Unit Test==================================================== */
 
-
 /* =====================================================================
-     BLAS-1:  iamax, asum, axpy, copy, dot, nrm2, scal, swap 
+     BLAS-1:  iamax, asum, axpy, copy, dot, nrm2, scal, swap
 =================================================================== */
 
-class parameterized: public :: TestWithParam <blas1_tuple>
+class parameterized : public ::TestWithParam<blas1_tuple>
 {
     protected:
-        parameterized(){}
-        virtual ~parameterized(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized() {}
+    virtual ~parameterized() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
-
 
 Arguments setup_blas1_arguments(blas1_tuple tup)
 {
-    int N = std::get<0>(tup);
+    int N                     = std::get<0>(tup);
     vector<double> alpha_beta = std::get<1>(tup);
-    vector<int> incx_incy = std::get<2>(tup);
+    vector<int> incx_incy     = std::get<2>(tup);
 
-    //the first element of alpha_beta_range is always alpha, and the second is always beta
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
     double alpha = alpha_beta[0];
-    double beta = alpha_beta[1];
+    double beta  = alpha_beta[1];
 
     int incx = incx_incy[0];
     int incy = incx_incy[1];
 
     Arguments arg;
-    arg.N = N;
+    arg.N     = N;
     arg.alpha = alpha;
-    arg.beta = beta;
-    arg.incx = incx;
-    arg.incy = incy;
+    arg.beta  = beta;
+    arg.incx  = incx;
+    arg.incy  = incy;
 
-    arg.timing = 0;//disable timing data print out. Not supposed to collect performance data in gtest
+    arg.timing =
+        0; // disable timing data print out. Not supposed to collect performance data in gtest
 
     return arg;
 }
 
-TEST(checkin_blas1_bad_arg, iamax_float)
-{
-    testing_iamax_bad_arg<float>();
-}
-TEST(checkin_blas1_bad_arg, asum_float)
-{
-    testing_asum_bad_arg<float, float>();
-}
-TEST(checkin_blas1_bad_arg, axpy_float)
-{
-    testing_axpy_bad_arg<float>();
-}
-TEST(checkin_blas1_bad_arg, copy_float)
-{
-    testing_copy_bad_arg<float>();
-}
+TEST(checkin_blas1_bad_arg, iamax_float) { testing_iamax_bad_arg<float>(); }
+TEST(checkin_blas1_bad_arg, asum_float) { testing_asum_bad_arg<float, float>(); }
+TEST(checkin_blas1_bad_arg, axpy_float) { testing_axpy_bad_arg<float>(); }
+TEST(checkin_blas1_bad_arg, copy_float) { testing_copy_bad_arg<float>(); }
 TEST(checkin_blas1_bad_arg, dot_float)
 {
     rocblas_status status = testing_dot_bad_arg<float>();
@@ -156,14 +125,8 @@ TEST(checkin_blas1_bad_arg, nrm2_float)
     EXPECT_EQ(rocblas_status_success, status);
 }
 
-TEST(checkin_blas1_bad_arg, scal_float)
-{
-    testing_scal_bad_arg<float>();
-}
-TEST(checkin_blas1_bad_arg, swap_float)
-{
-    testing_swap_bad_arg<float>();
-}
+TEST(checkin_blas1_bad_arg, scal_float) { testing_scal_bad_arg<float>(); }
+TEST(checkin_blas1_bad_arg, swap_float) { testing_swap_bad_arg<float>(); }
 
 TEST_P(parameterized, iamax_float)
 {
@@ -171,9 +134,9 @@ TEST_P(parameterized, iamax_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_iamax<float>( arg );
+    rocblas_status status = testing_iamax<float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -184,9 +147,9 @@ TEST_P(parameterized, iamax_double)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_iamax<double>( arg );
+    rocblas_status status = testing_iamax<double>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -197,9 +160,9 @@ TEST_P(parameterized, asum_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_asum<float, float>( arg );
+    rocblas_status status = testing_asum<float, float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -210,9 +173,9 @@ TEST_P(parameterized, axpy_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_axpy<float>( arg );
+    rocblas_status status = testing_axpy<float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -223,9 +186,9 @@ TEST_P(parameterized, axpy_double)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_axpy<double>( arg );
+    rocblas_status status = testing_axpy<double>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -236,9 +199,9 @@ TEST_P(parameterized, axpy_half)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_axpy<rocblas_half>( arg );
+    rocblas_status status = testing_axpy<rocblas_half>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -249,9 +212,9 @@ TEST_P(parameterized, copy_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_copy<float>( arg );
+    rocblas_status status = testing_copy<float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -262,9 +225,9 @@ TEST_P(parameterized, dot_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_dot<float>( arg );
+    rocblas_status status = testing_dot<float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -275,9 +238,9 @@ TEST_P(parameterized, dot_double)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_dot<double>( arg );
+    rocblas_status status = testing_dot<double>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -288,9 +251,9 @@ TEST_P(parameterized, nrm2_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_nrm2<float, float>( arg );
+    rocblas_status status = testing_nrm2<float, float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -301,9 +264,9 @@ TEST_P(parameterized, scal_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_scal<float>( arg );
+    rocblas_status status = testing_scal<float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
@@ -314,23 +277,20 @@ TEST_P(parameterized, swap_float)
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
-    Arguments arg = setup_blas1_arguments( GetParam() );
+    Arguments arg = setup_blas1_arguments(GetParam());
 
-    rocblas_status status = testing_swap<float>( arg );
+    rocblas_status status = testing_swap<float>(arg);
 
     EXPECT_EQ(rocblas_status_success, status);
 }
 
-//Values is for a single item; ValuesIn is for an array
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// Values is for a single item; ValuesIn is for an array
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { N, {alpha, beta}, {incx, incy} }
 INSTANTIATE_TEST_CASE_P(checkin_blas1,
                         parameterized,
-                        Combine(
-                                  ValuesIn(N_range), 
-                                  ValuesIn(alpha_beta_range), 
-                                  ValuesIn(incx_incy_range)
-                               )
-                        );
+                        Combine(ValuesIn(N_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(incx_incy_range)));

--- a/clients/gtest/geam_gtest.cpp
+++ b/clients/gtest/geam_gtest.cpp
@@ -23,70 +23,52 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<vector<int>, vector<double>, vector<char>> geam_tuple;
 
-//vector of vector, each vector is a {M, N, lda, ldb, ldc};
-//add/delete as a group
-const
-vector<vector<int>> small_matrix_size_range = {
-                                             {-1, -1, -1, 1, 1},
-                                             { 0,  0,  1, 1, 1},
-                                             { 3, 33,  35, 35, 35},
-                                             { 5,  5,  5, 5, 5},
-                                             {10, 11, 100, 12, 13},
-                                             {600,500, 601, 602, 603},
-                                       };
+// vector of vector, each vector is a {M, N, lda, ldb, ldc};
+// add/delete as a group
+const vector<vector<int>> small_matrix_size_range = {
+    {-1, -1, -1, 1, 1},
+    {0, 0, 1, 1, 1},
+    {3, 33, 35, 35, 35},
+    {5, 5, 5, 5, 5},
+    {10, 11, 100, 12, 13},
+    {600, 500, 601, 602, 603},
+};
 
-const
-vector<vector<int>> large_matrix_size_range = {
-                                             {192, 192, 192, 192, 192},
-                                             {192, 193, 194, 195, 196},
-                                             {640, 641, 960, 961, 962},
-                                             {1001, 1000, 1003, 1002, 1001},
-                                             };
-const
-vector<vector<int>> huge_matrix_size_range = {
-                                             {4011, 4012, 4012, 4013, 4014},
-                                             };
+const vector<vector<int>> large_matrix_size_range = {
+    {192, 192, 192, 192, 192},
+    {192, 193, 194, 195, 196},
+    {640, 641, 960, 961, 962},
+    {1001, 1000, 1003, 1002, 1001},
+};
+const vector<vector<int>> huge_matrix_size_range = {
+    {4011, 4012, 4012, 4013, 4014},
+};
 
-//vector of vector, each pair is a {alpha, beta};
-//add/delete this list in pairs, like {2.0, 4.0}
-const
-vector<vector<double>> small_alpha_beta_range = {
-                                                    { 1.0,  0.0},
-                                                    { 0.0,  1.0},
-                                                    { 3.0,  1.0},
-                                                    {-1.0, -1.0},
-                                                    {-1.0,  0.0},
-                                                    { 0.0, -1.0},
-                                               };
-const
-vector<vector<double>> large_alpha_beta_range = { 
-                                                    { 1.0, 0.0},
-                                                    { 1.0, 3.0},
-                                                    { 0.0, 1.0},
-                                                    { 0.0, 0.0},
-                                          };
-const
-vector<vector<double>> huge_alpha_beta_range = { 
-                                                    { 1.0, 3.0},
-                                          };
+// vector of vector, each pair is a {alpha, beta};
+// add/delete this list in pairs, like {2.0, 4.0}
+const vector<vector<double>> small_alpha_beta_range = {
+    {1.0, 0.0}, {0.0, 1.0}, {3.0, 1.0}, {-1.0, -1.0}, {-1.0, 0.0}, {0.0, -1.0},
+};
+const vector<vector<double>> large_alpha_beta_range = {
+    {1.0, 0.0}, {1.0, 3.0}, {0.0, 1.0}, {0.0, 0.0},
+};
+const vector<vector<double>> huge_alpha_beta_range = {
+    {1.0, 3.0},
+};
 
-
-//vector of vector, each pair is a {transA, transB};
-//add/delete this list in pairs, like {'N', 'T'}
-//for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in sgeam/dgeam,
-const
-vector<vector<char>> transA_transB_range = {
-                                                {'N', 'N'},
-                                                {'N', 'T'},
-                                                {'T', 'N'},
-                                                {'T', 'T'},
-                                         //     {'C', 'N'},
-                                         //     {'T', 'C'}
-                                           };
+// vector of vector, each pair is a {transA, transB};
+// add/delete this list in pairs, like {'N', 'T'}
+// for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
+// sgeam/dgeam,
+const vector<vector<char>> transA_transB_range = {
+    {'N', 'N'}, {'N', 'T'}, {'T', 'N'}, {'T', 'T'},
+    //     {'C', 'N'},
+    //     {'T', 'C'}
+};
 
 /* ===============Google Unit Test==================================================== */
 
@@ -95,31 +77,32 @@ vector<vector<char>> transA_transB_range = {
 =================================================================== */
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_geam_arguments(geam_tuple tup)
 {
-    vector<int> matrix_size = std::get<0>(tup);
-    vector<double> alpha_beta = std::get<1>(tup);
+    vector<int> matrix_size    = std::get<0>(tup);
+    vector<double> alpha_beta  = std::get<1>(tup);
     vector<char> transA_transB = std::get<2>(tup);
 
     Arguments arg;
 
     // see the comments about small_matrix_size_range above
-    arg.M = matrix_size[0];
-    arg.N = matrix_size[1];
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
     arg.ldb = matrix_size[3];
     arg.ldc = matrix_size[4];
 
-    //the first element of alpha_beta_range is always alpha, and the second is always beta
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
     arg.alpha = alpha_beta[0];
-    arg.beta = alpha_beta[1];
+    arg.beta  = alpha_beta[1];
 
     arg.transA_option = transA_transB[0];
     arg.transB_option = transA_transB[1];
@@ -129,13 +112,13 @@ Arguments setup_geam_arguments(geam_tuple tup)
     return arg;
 }
 
-class parameterized_geam: public :: TestWithParam <geam_tuple>
+class parameterized_geam : public ::TestWithParam<geam_tuple>
 {
     protected:
-        parameterized_geam(){}
-        virtual ~parameterized_geam(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized_geam() {}
+    virtual ~parameterized_geam() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(parameterized_geam, float)
@@ -145,15 +128,14 @@ TEST_P(parameterized_geam, float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_geam_arguments(GetParam());
 
-    Arguments arg = setup_geam_arguments( GetParam() );
-
-    rocblas_status status = testing_geam<float>( arg );
+    rocblas_status status = testing_geam<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 || arg.N < 0 )
+        if(arg.M < 0 || arg.N < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -183,14 +165,14 @@ TEST_P(parameterized_geam, double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_geam_arguments( GetParam() );
+    Arguments arg = setup_geam_arguments(GetParam());
 
-    rocblas_status status = testing_geam<double>( arg );
+    rocblas_status status = testing_geam<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 || arg.N < 0 )
+        if(arg.M < 0 || arg.N < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -213,36 +195,27 @@ TEST_P(parameterized_geam, double)
     }
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda, ldb, ldc}, {alpha, beta}, {transA, transB} }
 
-TEST(checkin_blas3_bad_arg, geam_float)
-{
-    testing_geam_bad_arg<float>();
-}
+TEST(checkin_blas3_bad_arg, geam_float) { testing_geam_bad_arg<float>(); }
 
-INSTANTIATE_TEST_CASE_P(checkin_blas3, parameterized_geam,
-                        Combine(
-                                  ValuesIn(small_matrix_size_range), 
-                                  ValuesIn(small_alpha_beta_range), 
-                                  ValuesIn(transA_transB_range)
-                               )
-                        );
+INSTANTIATE_TEST_CASE_P(checkin_blas3,
+                        parameterized_geam,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(small_alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_1, parameterized_geam,
-                        Combine(
-                                  ValuesIn(large_matrix_size_range), 
-                                  ValuesIn(large_alpha_beta_range), 
-                                  ValuesIn(transA_transB_range)
-                               )
-                        );
+INSTANTIATE_TEST_CASE_P(daily_blas3_1,
+                        parameterized_geam,
+                        Combine(ValuesIn(large_matrix_size_range),
+                                ValuesIn(large_alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_2, parameterized_geam,
-                        Combine(
-                                  ValuesIn(huge_matrix_size_range), 
-                                  ValuesIn(huge_alpha_beta_range), 
-                                  ValuesIn(transA_transB_range)
-                               )
-                        );
+INSTANTIATE_TEST_CASE_P(daily_blas3_2,
+                        parameterized_geam,
+                        Combine(ValuesIn(huge_matrix_size_range),
+                                ValuesIn(huge_alpha_beta_range),
+                                ValuesIn(transA_transB_range)));

--- a/clients/gtest/gemm_gtest.cpp
+++ b/clients/gtest/gemm_gtest.cpp
@@ -24,76 +24,55 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<vector<int>, vector<double>, vector<char>> gemm_tuple;
 
-//vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
-//add/delete as a group
-const
-vector<vector<int>> tiny_matrix_size_range = {
-                                             {1, 1,  1,  1,  1,  1},
-                                             {1, 2,  3,  4,  5,  6},
-                                             {7, 9, 15, 17, 18, 19},
-                                       };
+// vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
+// add/delete as a group
+const vector<vector<int>> tiny_matrix_size_range = {
+    {1, 1, 1, 1, 1, 1}, {1, 2, 3, 4, 5, 6}, {7, 9, 15, 17, 18, 19},
+};
 
-const
-vector<vector<int>> small_matrix_size_range = {
-                                             {  -1,   -1,   -1,   -1,    1,    1},
-                                             {   3,   33,    3,   33,   35,   35},
-                                             {   5,    6,    7,    9,   11,   13},
-                                             {  10,   10,   20,  100,   21,   22},
-                                             { 500,  501,  502,  503,  604,  505},
-                                             { 500,  501,  502,  203,  204,  205},
-                                       };
+const vector<vector<int>> small_matrix_size_range = {
+    {-1, -1, -1, -1, 1, 1},
+    {3, 33, 3, 33, 35, 35},
+    {5, 6, 7, 9, 11, 13},
+    {10, 10, 20, 100, 21, 22},
+    {500, 501, 502, 503, 604, 505},
+    {500, 501, 502, 203, 204, 205},
+};
 
-const
-vector<vector<int>> large_matrix_size_range = {
-                                             { 191,  193, 194,  195,  196,  197},
-                                             { 640,  640, 347,  960,  961,  962},
-                                             {1000, 1001, 101, 1002, 1003, 1004},
-                                             {1025, 1026, 1027, 1028, 1029, 1031},
-                                             {4011, 4012, 103, 4014, 4015, 4016},
-                                             };
+const vector<vector<int>> large_matrix_size_range = {
+    {191, 193, 194, 195, 196, 197},
+    {640, 640, 347, 960, 961, 962},
+    {1000, 1001, 101, 1002, 1003, 1004},
+    {1025, 1026, 1027, 1028, 1029, 1031},
+    {4011, 4012, 103, 4014, 4015, 4016},
+};
 
-const
-vector<vector<int>> NaN_matrix_size_range = {
-                                             {   5,    6,  7,     8,    9,   10},
-                                             {4011, 4012, 111, 4013, 4014, 4015},
-                                            };
+const vector<vector<int>> NaN_matrix_size_range = {
+    {5, 6, 7, 8, 9, 10}, {4011, 4012, 111, 4013, 4014, 4015},
+};
 
-//vector of vector, each pair is a {alpha, beta};
-//add/delete this list in pairs, like {2.0, 4.0}
-const
-vector<vector<double>> NaN_alpha_beta_range = { 
-                                            {1.0, 0.0},
-                                          };
+// vector of vector, each pair is a {alpha, beta};
+// add/delete this list in pairs, like {2.0, 4.0}
+const vector<vector<double>> NaN_alpha_beta_range = {
+    {1.0, 0.0},
+};
 
-const
-vector<vector<double>> alpha_beta_range = { 
-                                            {5.0, 0.0},
-                                            {0.0, 3.0},
-                                            {1.0, 3.0},
-                                          };
+const vector<vector<double>> alpha_beta_range = {
+    {5.0, 0.0}, {0.0, 3.0}, {1.0, 3.0},
+};
 
-const
-vector<vector<double>> full_alpha_beta_range = {
-                                                    { 1.0,  0.0},
-                                                    {-1.0, -1.0},
-                                                    { 2.0,  1.0},
-                                                    { 0.0,  1.0}
-                                               };
+const vector<vector<double>> full_alpha_beta_range = {
+    {1.0, 0.0}, {-1.0, -1.0}, {2.0, 1.0}, {0.0, 1.0}};
 
-//vector of vector, each pair is a {transA, transB};
-//add/delete this list in pairs, like {'N', 'T'}
-//for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in sgemm/dgemm,
-const
-vector<vector<char>> transA_transB_range = {
-                                                {'N', 'N'},
-                                                {'N', 'T'},
-                                                {'C', 'N'},
-                                                {'T', 'C'}
-                                           };
+// vector of vector, each pair is a {transA, transB};
+// add/delete this list in pairs, like {'N', 'T'}
+// for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
+// sgemm/dgemm,
+const vector<vector<char>> transA_transB_range = {{'N', 'N'}, {'N', 'T'}, {'C', 'N'}, {'T', 'C'}};
 
 /* ===============Google Unit Test==================================================== */
 
@@ -102,32 +81,33 @@ vector<vector<char>> transA_transB_range = {
 =================================================================== */
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_gemm_arguments(gemm_tuple tup)
 {
-    vector<int> matrix_size = std::get<0>(tup);
-    vector<double> alpha_beta = std::get<1>(tup);
+    vector<int> matrix_size    = std::get<0>(tup);
+    vector<double> alpha_beta  = std::get<1>(tup);
     vector<char> transA_transB = std::get<2>(tup);
 
     Arguments arg;
 
     // see the comments about matrix_size_range above
-    arg.M = matrix_size[0];
-    arg.N = matrix_size[1];
-    arg.K = matrix_size[2];
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
+    arg.K   = matrix_size[2];
     arg.lda = matrix_size[3];
     arg.ldb = matrix_size[4];
     arg.ldc = matrix_size[5];
 
-    //the first element of alpha_beta_range is always alpha, and the second is always beta
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
     arg.alpha = alpha_beta[0];
-    arg.beta = alpha_beta[1];
+    arg.beta  = alpha_beta[1];
 
     arg.transA_option = transA_transB[0];
     arg.transB_option = transA_transB[1];
@@ -137,36 +117,36 @@ Arguments setup_gemm_arguments(gemm_tuple tup)
     return arg;
 }
 
-class parameterized_gemm_NaN: public :: TestWithParam <gemm_tuple>
+class parameterized_gemm_NaN : public ::TestWithParam<gemm_tuple>
 {
     protected:
-        parameterized_gemm_NaN(){}
-        virtual ~parameterized_gemm_NaN(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized_gemm_NaN() {}
+    virtual ~parameterized_gemm_NaN() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(parameterized_gemm_NaN, float)
 {
-    Arguments arg = setup_gemm_arguments( GetParam() );
+    Arguments arg = setup_gemm_arguments(GetParam());
 
     testing_gemm_NaN<float>(arg);
 }
-  
+
 TEST_P(parameterized_gemm_NaN, double)
 {
-    Arguments arg = setup_gemm_arguments( GetParam() );
+    Arguments arg = setup_gemm_arguments(GetParam());
 
     testing_gemm_NaN<double>(arg);
 }
-  
-class parameterized_gemm: public :: TestWithParam <gemm_tuple>
+
+class parameterized_gemm : public ::TestWithParam<gemm_tuple>
 {
     protected:
-        parameterized_gemm(){}
-        virtual ~parameterized_gemm(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized_gemm() {}
+    virtual ~parameterized_gemm() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(parameterized_gemm, float)
@@ -176,15 +156,14 @@ TEST_P(parameterized_gemm, float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_gemm_arguments(GetParam());
 
-    Arguments arg = setup_gemm_arguments( GetParam() );
-
-    rocblas_status status = testing_gemm<float>( arg );
+    rocblas_status status = testing_gemm<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 || arg.N < 0 || arg.K < 0 )
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -210,14 +189,14 @@ TEST_P(parameterized_gemm, double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_gemm_arguments( GetParam() );
+    Arguments arg = setup_gemm_arguments(GetParam());
 
-    rocblas_status status = testing_gemm<double>( arg );
+    rocblas_status status = testing_gemm<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 || arg.N < 0 || arg.K < 0 )
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -236,53 +215,41 @@ TEST_P(parameterized_gemm, double)
     }
 }
 
-TEST(checkin_blas3_bad_arg, gemm_float)
-{
-    testing_gemm_bad_arg<float>();
-}
+TEST(checkin_blas3_bad_arg, gemm_float) { testing_gemm_bad_arg<float>(); }
 
-TEST(checkin_blas3_bad_arg, gemm_double)
-{
-    testing_gemm_bad_arg<double>();
-}
+TEST(checkin_blas3_bad_arg, gemm_double) { testing_gemm_bad_arg<double>(); }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB} }
 
 // INSTANTIATE_TEST_CASE_P(rocblas_gemm_beta_eq_0, parameterized_gemm_NaN,
-INSTANTIATE_TEST_CASE_P(checkin_blas3_NaN, parameterized_gemm_NaN,
-                        Combine(
-                                  ValuesIn(NaN_matrix_size_range), 
-                                  ValuesIn(NaN_alpha_beta_range), 
-                                  ValuesIn(transA_transB_range)
-                               )
-                        );
+INSTANTIATE_TEST_CASE_P(checkin_blas3_NaN,
+                        parameterized_gemm_NaN,
+                        Combine(ValuesIn(NaN_matrix_size_range),
+                                ValuesIn(NaN_alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
 
-//THis function mainly test the scope of matrix_size. the scope of alpha_beta, transA_transB is small
-INSTANTIATE_TEST_CASE_P(daily_blas3_large, parameterized_gemm,
-                        Combine(
-                                  ValuesIn(large_matrix_size_range), 
-                                  ValuesIn(alpha_beta_range), 
-                                  ValuesIn(transA_transB_range)
-                               )
-                        );
+// THis function mainly test the scope of matrix_size. the scope of alpha_beta, transA_transB is
+// small
+INSTANTIATE_TEST_CASE_P(daily_blas3_large,
+                        parameterized_gemm,
+                        Combine(ValuesIn(large_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
 
-//THis function mainly test the scope of alpha_beta, transA_transB,.the scope of matrix_size_range is small
-  
-INSTANTIATE_TEST_CASE_P(checkin_blas3_small, parameterized_gemm,
-                        Combine(
-                                  ValuesIn(small_matrix_size_range), 
-                                  ValuesIn(full_alpha_beta_range), 
-                                  ValuesIn(transA_transB_range)
-                               )
-                        );
+// THis function mainly test the scope of alpha_beta, transA_transB,.the scope of matrix_size_range
+// is small
 
-INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny, parameterized_gemm,
-                        Combine(
-                                  ValuesIn(tiny_matrix_size_range), 
-                                  ValuesIn(full_alpha_beta_range), 
-                                  ValuesIn(transA_transB_range)
-                               )
-                        );
+INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
+                        parameterized_gemm,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(full_alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
+                        parameterized_gemm,
+                        Combine(ValuesIn(tiny_matrix_size_range),
+                                ValuesIn(full_alpha_beta_range),
+                                ValuesIn(transA_transB_range)));

--- a/clients/gtest/gemm_strided_batched_gtest.cpp
+++ b/clients/gtest/gemm_strided_batched_gtest.cpp
@@ -25,56 +25,44 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
-like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers inside API of course.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
+// vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
+// add/delete as a group, in batched gemm, the matrix is much smaller than standard gemm
+const vector<vector<int>> matrix_size_range = {
+    {-1, -1, -1, -1, 1, 1},
+    {31, 33, 35, 101, 102, 103},
+    {59, 61, 63, 129, 131, 137},
+    {129, 130, 131, 132, 133, 134},
+    {501, 502, 103, 504, 605, 506},
+};
 
-//vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
-//add/delete as a group, in batched gemm, the matrix is much smaller than standard gemm
-const
-vector<vector<int>> matrix_size_range = {
-                                        { -1,  -1,  -1,  -1,   1,   1},
-                                        { 31,  33,  35, 101, 102, 103},
-                                        { 59,  61,  63, 129, 131, 137},
-                                        {129, 130, 131, 132, 133, 134},
-                                        {501, 502, 103, 504, 605, 506},
-                                       };
+// vector of vector, each pair is a {alpha, beta};
+// add/delete this list in pairs, like {2.0, 4.0}
+const vector<vector<double>> alpha_beta_range = {
+    {1.0, 0.0}, {-1.0, -1.0},
+};
 
-//vector of vector, each pair is a {alpha, beta};
-//add/delete this list in pairs, like {2.0, 4.0}
-const
-vector<vector<double>> alpha_beta_range = { { 1.0,  0.0},
-                                            {-1.0, -1.0},
-                                          };
+// vector of vector, each pair is a {transA, transB};
+// add/delete this list in pairs, like {'N', 'T'}
+// for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
+// sgemm_strided_batched/dgemm_strided_batched,
+const vector<vector<char>> transA_transB_range = {{'N', 'N'}, {'N', 'T'}, {'C', 'N'}, {'T', 'C'}};
 
-//vector of vector, each pair is a {transA, transB};
-//add/delete this list in pairs, like {'N', 'T'}
-//for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in sgemm_strided_batched/dgemm_strided_batched,
-const
-vector<vector<char>> transA_transB_range = {
-                                        {'N', 'N'},
-                                        {'N', 'T'},
-                                        {'C', 'N'},
-                                        {'T', 'C'}
-                                       };
-
-//number of gemms in batched gemm
-const
-vector<int> batch_count_range = {
-                                        -1,
-                                         0,
-                                         1,
-                                         3,
-                                       };
+// number of gemms in batched gemm
+const vector<int> batch_count_range = {
+    -1, 0, 1, 3,
+};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS-3 gemm_strided_batched:
@@ -82,54 +70,53 @@ vector<int> batch_count_range = {
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_gemm_strided_batched_arguments(gemm_strided_batched_tuple tup)
 {
 
-    vector<int> matrix_size = std::get<0>(tup);
-    vector<double> alpha_beta = std::get<1>(tup);
+    vector<int> matrix_size    = std::get<0>(tup);
+    vector<double> alpha_beta  = std::get<1>(tup);
     vector<char> transA_transB = std::get<2>(tup);
-    int batch_count = std::get<3>(tup);
+    int batch_count            = std::get<3>(tup);
 
     Arguments arg;
 
     // see the comments about matrix_size_range above
-    arg.M = matrix_size[0];
-    arg.N = matrix_size[1];
-    arg.K = matrix_size[2];
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
+    arg.K   = matrix_size[2];
     arg.lda = matrix_size[3];
     arg.ldb = matrix_size[4];
     arg.ldc = matrix_size[5];
 
-    //the first element of alpha_beta_range is always alpha, and the second is always beta
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
     arg.alpha = alpha_beta[0];
-    arg.beta = alpha_beta[1];
+    arg.beta  = alpha_beta[1];
 
     arg.transA_option = transA_transB[0];
     arg.transB_option = transA_transB[1];
 
     arg.batch_count = batch_count;
-    arg.timing = 0;
+    arg.timing      = 0;
 
     return arg;
 }
 
-
-class gemm_strided_batched: public :: TestWithParam <gemm_strided_batched_tuple>
+class gemm_strided_batched : public ::TestWithParam<gemm_strided_batched_tuple>
 {
     protected:
-        gemm_strided_batched(){}
-        virtual ~gemm_strided_batched(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    gemm_strided_batched() {}
+    virtual ~gemm_strided_batched() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
-
 
 TEST_P(gemm_strided_batched, float)
 {
@@ -138,15 +125,14 @@ TEST_P(gemm_strided_batched, float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_gemm_strided_batched_arguments(GetParam());
 
-    Arguments arg = setup_gemm_strided_batched_arguments( GetParam() );
-
-    rocblas_status status = testing_gemm_strided_batched<float>( arg );
+    rocblas_status status = testing_gemm_strided_batched<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 || arg.N < 0 || arg.K < 0 )
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -176,15 +162,14 @@ TEST_P(gemm_strided_batched, double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_gemm_strided_batched_arguments(GetParam());
 
-    Arguments arg = setup_gemm_strided_batched_arguments( GetParam() );
-
-    rocblas_status status = testing_gemm_strided_batched<double>( arg );
+    rocblas_status status = testing_gemm_strided_batched<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 || arg.N < 0 || arg.K < 0 )
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -204,24 +189,22 @@ TEST_P(gemm_strided_batched, double)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else 
+        else
         {
             EXPECT_EQ(rocblas_status_success, status);
         }
     }
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
-// The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB}, {batch_count} }
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
+// The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB}, {batch_count}
+// }
 
 INSTANTIATE_TEST_CASE_P(checkin_blas3,
                         gemm_strided_batched,
-                        Combine(
-                                  ValuesIn(matrix_size_range), 
-                                  ValuesIn(alpha_beta_range), 
-                                  ValuesIn(transA_transB_range), 
-                                  ValuesIn(batch_count_range)
-                               )
-                        );
+                        Combine(ValuesIn(matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(batch_count_range)));

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -15,7 +15,7 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<vector<int>, vector<int>, vector<double>, char> gemv_tuple;
 
@@ -27,88 +27,58 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
-like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers inside API of course.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
+// vector of vector, each vector is a {M, N, lda};
+// add/delete as a group
+const vector<vector<int>> small_matrix_size_range = {
+    {-1, 1, 1},
+    {1, -1, 1},
+    {1, 1, 0},
+    {10, 10, 9},
+    {0, 1, 1},
+    {1, 0, 1},
+    {-1, -1, -1},
+    {10, 10, 2},
+    {300, 400, 400},
+    {600, 500, 601},
+};
 
-//vector of vector, each vector is a {M, N, lda};
-//add/delete as a group
-const
-vector<vector<int>> small_matrix_size_range = {
-                                        {-1,  1,  1},
-                                        { 1, -1,  1},
-                                        { 1,  1,  0},
-                                        {10, 10,  9},
-                                        { 0,  1,  1},
-                                        { 1,  0,  1},
-                                        {-1, -1, -1},
-                                        {10, 10, 2},
-                                        {300,400, 400},
-                                        {600,500, 601},
-                                       };
+const vector<vector<int>> large_matrix_size_range = {
+    {1000, 1000, 1000}, {2000, 2000, 2000}, {4011, 4011, 4011}, {8000, 8000, 8000},
+};
 
-const
-vector<vector<int>> large_matrix_size_range = {
-                                        {1000, 1000, 1000},
-                                        {2000, 2000, 2000},
-                                        {4011, 4011, 4011},
-                                        {8000, 8000, 8000},
-                                       };
+// vector of vector, each pair is a {incx, incy};
+// add/delete this list in pairs, like {1, 1}
+const vector<vector<int>> small_incx_incy_range = {
+    {2, 1}, {-1, -2}, {1, 1}, {-1, 3}, {3, -1}, {0, 1}, {1, 0}, {0, -1}, {10, 100},
+};
 
-//vector of vector, each pair is a {incx, incy};
-//add/delete this list in pairs, like {1, 1}
-const
-vector<vector<int>> small_incx_incy_range = {
-                                            { 2,   1},
-                                            {-1,  -2},
-                                            { 1,   1},
-                                            {-1,   3},
-                                            { 3,  -1},
-                                            { 0,   1},
-                                            { 1,   0},
-                                            { 0,  -1},
-                                            {10, 100},
-                                          };
+const vector<vector<int>> large_incx_incy_range = {
+    {2, 1}, {-1, 3}, {3, -1}, {0, 1}, {1, 0},
+};
 
-const
-vector<vector<int>> large_incx_incy_range = {
-                                            { 2,   1},
-                                            {-1,   3},
-                                            { 3,  -1},
-                                            { 0,   1},
-                                            { 1,   0},
-                                          };
+// vector of vector, each pair is a {alpha, beta};
+// add/delete this list in pairs, like {2.0, 4.0}
+const vector<vector<double>> alpha_beta_range = {
+    {2.0, 0.0}, {-1.0, -1.0}, {2.0, 1.0}, {0.0, 1.0},
+};
 
-//vector of vector, each pair is a {alpha, beta};
-//add/delete this list in pairs, like {2.0, 4.0}
-const
-vector<vector<double>> alpha_beta_range = {
-                                            { 2.0,  0.0},
-                                            {-1.0, -1.0},
-                                            { 2.0,  1.0},
-                                            { 0.0,  1.0},
-                                          };
-
-
-//for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in sgemv/dgemv,
-const
-vector<char> transA_range = {
-                                        'N',
-                                        'T',
-                                        'C',
-                                       };
-
-
-
+// for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
+// sgemv/dgemv,
+const vector<char> transA_range = {
+    'N', 'T', 'C',
+};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS-3 gemv:
@@ -116,34 +86,35 @@ vector<char> transA_range = {
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_gemv_arguments(gemv_tuple tup)
 {
-    vector<int> matrix_size = std::get<0>(tup);
-    vector<int> incx_incy = std::get<1>(tup);
+    vector<int> matrix_size   = std::get<0>(tup);
+    vector<int> incx_incy     = std::get<1>(tup);
     vector<double> alpha_beta = std::get<2>(tup);
-    char transA = std::get<3>(tup);
+    char transA               = std::get<3>(tup);
 
     Arguments arg;
 
     // see the comments about matrix_size_range above
-    arg.M = matrix_size[0];
-    arg.N = matrix_size[1];
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
 
     // see the comments about matrix_size_range above
     arg.incx = incx_incy[0];
     arg.incy = incx_incy[1];
 
-    //the first element of alpha_beta_range is always alpha, and the second is always beta
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
     arg.alpha = alpha_beta[0];
-    arg.beta = alpha_beta[1];
+    arg.beta  = alpha_beta[1];
 
     arg.transA_option = transA;
 
@@ -152,14 +123,13 @@ Arguments setup_gemv_arguments(gemv_tuple tup)
     return arg;
 }
 
-
-class parameterized_gemv: public :: TestWithParam <gemv_tuple>
+class parameterized_gemv : public ::TestWithParam<gemv_tuple>
 {
     protected:
-        parameterized_gemv(){}
-        virtual ~parameterized_gemv(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized_gemv() {}
+    virtual ~parameterized_gemv() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(parameterized_gemv, float)
@@ -169,26 +139,26 @@ TEST_P(parameterized_gemv, float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_gemv_arguments( GetParam() );
+    Arguments arg = setup_gemv_arguments(GetParam());
 
-    rocblas_status status = testing_gemv<float>( arg );
+    rocblas_status status = testing_gemv<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if (status != rocblas_status_success)
+    if(status != rocblas_status_success)
     {
-        if (arg.M < 0 || arg.N < 0)
+        if(arg.M < 0 || arg.N < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.lda < arg.M || arg.lda < 1)
+        else if(arg.lda < arg.M || arg.lda < 1)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (0 == arg.incx)
+        else if(0 == arg.incx)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (0 == arg.incy)
+        else if(0 == arg.incy)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -202,59 +172,49 @@ TEST_P(parameterized_gemv, double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_gemv_arguments(GetParam());
 
-    Arguments arg = setup_gemv_arguments( GetParam() );
-
-    rocblas_status status = testing_gemv<double>( arg );
+    rocblas_status status = testing_gemv<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if (arg.M < 0 || arg.N < 0)
+        if(arg.M < 0 || arg.N < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.lda < arg.M || arg.lda < 1)
+        else if(arg.lda < arg.M || arg.lda < 1)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (0 == arg.incx)
+        else if(0 == arg.incx)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (0 == arg.incy)
+        else if(0 == arg.incy)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
     }
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda}, {incx,incy} {alpha, beta}, {transA} }
 
-TEST(checkin_blas2_bad_arg, gemv_bad_arg_float)
-{
-    testing_gemv_bad_arg<float>();
-}
+TEST(checkin_blas2_bad_arg, gemv_bad_arg_float) { testing_gemv_bad_arg<float>(); }
 
 INSTANTIATE_TEST_CASE_P(checkin_blas2,
                         parameterized_gemv,
-                        Combine(
-                                  ValuesIn(small_matrix_size_range), 
-                                  ValuesIn(small_incx_incy_range), 
-                                  ValuesIn(alpha_beta_range), 
-                                  ValuesIn(transA_range)
-                               )
-                        );
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(small_incx_incy_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_range)));
 
 INSTANTIATE_TEST_CASE_P(daily_blas2,
                         parameterized_gemv,
-                        Combine(
-                                  ValuesIn(large_matrix_size_range), 
-                                  ValuesIn(large_incx_incy_range), 
-                                  ValuesIn(alpha_beta_range), 
-                                  ValuesIn(transA_range)
-                               )
-                        );
+                        Combine(ValuesIn(large_matrix_size_range),
+                                ValuesIn(large_incx_incy_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_range)));

--- a/clients/gtest/ger_gtest.cpp
+++ b/clients/gtest/ger_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<vector<int>, vector<int>, double> ger_tuple;
 
@@ -28,82 +28,54 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
-like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers inside API of course.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
+// vector of vector, each vector is a {M, N, lda};
+// add/delete as a group
+const vector<vector<int>> small_matrix_size_range = {
+    {-1, 1, 1},
+    {1, -1, 1},
+    {1, 1, -1},
+    {10, 1, 9},
+    {0, 1, 1},
+    {1, 0, 1},
+    {1, 1, 0},
+    {11, 12, 13},
+    {16, 16, 16},
+    {33, 32, 33},
+    {65, 65, 66},
+    /*   {10, 10, 2},       */
+    /*   {600,500, 500},    */
+    {1000, 1000, 1000},
+};
 
-//vector of vector, each vector is a {M, N, lda};
-//add/delete as a group
-const
-vector<vector<int>> small_matrix_size_range = {
-                                        {-1,  1,  1},
-                                        { 1, -1,  1},
-                                        { 1,  1, -1},
-                                        {10,  1,  9},
-                                        { 0,  1,  1},
-                                        { 1,  0,  1},
-                                        { 1,  1,  0},
-                                        {11, 12, 13},
-                                        {16, 16, 16},
-                                        {33, 32, 33},
-                                        {65, 65, 66},
-                                   /*   {10, 10, 2},       */
-                                   /*   {600,500, 500},    */
-                                        {1000, 1000, 1000},
-                                       };
+const vector<vector<int>> large_matrix_size_range = {
+    {2000, 2000, 2000}, {4011, 4011, 4011}, {8000, 8000, 8000}};
 
-const
-vector<vector<int>> large_matrix_size_range = {
-                                        {2000, 2000, 2000},
-                                        {4011, 4011, 4011},
-                                        {8000, 8000, 8000}
-                                       };
+// vector of vector, each pair is a {incx, incy};
+// add/delete this list in pairs, like {1, 1}
+const vector<vector<int>> small_incx_incy_range = {
+    {1, 1}, {-1, 1}, {1, -1}, {-1, -1}, {0, -1}, {0, 1}, {1, 0}, {2, 1}, {10, 99}};
+const vector<vector<int>> large_incx_incy_range = {
+    {1, 1}, {-1, 1}, {1, 2},
+};
 
-//vector of vector, each pair is a {incx, incy};
-//add/delete this list in pairs, like {1, 1}
-const
-vector<vector<int>> small_incx_incy_range = {
-                                            { 1,   1},
-                                            {-1,   1},
-                                            { 1,  -1},
-                                            {-1,  -1},
-                                            { 0,  -1},
-                                            { 0,   1},
-                                            { 1,   0},
-                                            { 2,   1},
-                                            {10,  99}
-                                          };
-const
-vector<vector<int>> large_incx_incy_range = {
-                                            { 1,   1},
-                                            {-1,   1},
-                                            { 1,   2},
-                                          };
-
-//vector, each entry is  {alpha};
-//add/delete single values, like {2.0}
-const
-vector<double> small_alpha_range = {
-                                            -0.5,
-                                             2.0,
-                                             0.0
-                                          };
-const
-vector<double> large_alpha_range = {
-                                             0.6,
-                                          };
-
-
-
+// vector, each entry is  {alpha};
+// add/delete single values, like {2.0}
+const vector<double> small_alpha_range = {-0.5, 2.0, 0.0};
+const vector<double> large_alpha_range = {
+    0.6,
+};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS-2 ger:
@@ -111,25 +83,26 @@ vector<double> large_alpha_range = {
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_ger_arguments(ger_tuple tup)
 {
 
     vector<int> matrix_size = std::get<0>(tup);
-    vector<int> incx_incy = std::get<1>(tup);
-    double alpha = std::get<2>(tup);
+    vector<int> incx_incy   = std::get<1>(tup);
+    double alpha            = std::get<2>(tup);
 
     Arguments arg;
 
     // see the comments about small_matrix_size_range above
-    arg.M = matrix_size[0];
-    arg.N = matrix_size[1];
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
 
     // see the comments about small_matrix_size_range above
@@ -143,14 +116,13 @@ Arguments setup_ger_arguments(ger_tuple tup)
     return arg;
 }
 
-
-class parameterized_ger: public :: TestWithParam <ger_tuple>
+class parameterized_ger : public ::TestWithParam<ger_tuple>
 {
     protected:
-        parameterized_ger(){}
-        virtual ~parameterized_ger(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized_ger() {}
+    virtual ~parameterized_ger() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(parameterized_ger, parameterized_ger_double)
@@ -160,24 +132,28 @@ TEST_P(parameterized_ger, parameterized_ger_double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_ger_arguments(GetParam());
 
-    Arguments arg = setup_ger_arguments( GetParam() );
-
-    rocblas_status status = testing_ger<double>( arg );
+    rocblas_status status = testing_ger<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if(status != rocblas_status_success){
+    if(status != rocblas_status_success)
+    {
 
-        if( arg.M < 0 || arg.N < 0 ){
+        if(arg.M < 0 || arg.N < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.lda < arg.M){
+        else if(arg.lda < arg.M)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.incx <= 0){
+        else if(arg.incx <= 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.incy <= 0){
+        else if(arg.incy <= 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
     }
@@ -190,53 +166,48 @@ TEST_P(parameterized_ger, parameterized_ger_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_ger_arguments(GetParam());
 
-    Arguments arg = setup_ger_arguments( GetParam() );
-
-    rocblas_status status = testing_ger<float>( arg );
+    rocblas_status status = testing_ger<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if(status != rocblas_status_success){
+    if(status != rocblas_status_success)
+    {
 
-        if( arg.M < 0 || arg.N < 0 ){
+        if(arg.M < 0 || arg.N < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.lda < arg.M){
+        else if(arg.lda < arg.M)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.incx <= 0){
+        else if(arg.incx <= 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.incy <= 0){
+        else if(arg.incy <= 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
     }
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda}, {incx,incy} {alpha} }
 
-TEST(checkin_blas2_bad_arg, ger_float)
-{
-    testing_ger_bad_arg<float>();
-}
+TEST(checkin_blas2_bad_arg, ger_float) { testing_ger_bad_arg<float>(); }
 
 INSTANTIATE_TEST_CASE_P(checkin_blas2,
                         parameterized_ger,
-                        Combine(
-                                  ValuesIn(small_matrix_size_range), 
-                                  ValuesIn(small_incx_incy_range), 
-                                  ValuesIn(small_alpha_range)
-                               )
-                        );
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(small_incx_incy_range),
+                                ValuesIn(small_alpha_range)));
 
 INSTANTIATE_TEST_CASE_P(daily_rocblas_blas2,
                         parameterized_ger,
-                        Combine(
-                                  ValuesIn(large_matrix_size_range), 
-                                  ValuesIn(large_incx_incy_range), 
-                                  ValuesIn(large_alpha_range)
-                               )
-                        );
+                        Combine(ValuesIn(large_matrix_size_range),
+                                ValuesIn(large_incx_incy_range),
+                                ValuesIn(large_alpha_range)));

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -10,21 +10,22 @@
       Main function:
 =================================================================== */
 
-
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
 
-    //Device Query
+    // Device Query
 
     int device_id = 0;
 
     int device_count = query_device_property();
 
-    if(device_count <= device_id){
+    if(device_count <= device_id)
+    {
         printf("Error: invalid device ID. There may not be such device ID. Will exit \n");
         return -1;
     }
-    else{
+    else
+    {
         set_device(device_id);
     }
 

--- a/clients/gtest/set_get_matrix_gtest.cpp
+++ b/clients/gtest/set_get_matrix_gtest.cpp
@@ -18,7 +18,7 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<vector<int>, vector<int>> set_get_matrix_tuple;
 
@@ -30,9 +30,9 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
@@ -40,74 +40,61 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 
 // small sizes
 
-//vector of vector, each triple is a {rows, cols};
-//add/delete this list in pairs, like {3, 4}
+// vector of vector, each triple is a {rows, cols};
+// add/delete this list in pairs, like {3, 4}
 
-const
-vector<vector<int>> rows_cols_range = {
-                                            { 3,  3},
-                                            { 3, 30},
-                                            { 30, 3}
-                                      };
+const vector<vector<int>> rows_cols_range = {{3, 3}, {3, 30}, {30, 3}};
 
-//vector of vector, each triple is a {lda, ldb, ldc};
-//add/delete this list in pairs, like {3, 4, 3}
+// vector of vector, each triple is a {lda, ldb, ldc};
+// add/delete this list in pairs, like {3, 4, 3}
 
-const
-vector<vector<int>> lda_ldb_ldc_range = {
-      {3,3,3}, {3,3,4}, {3,3,5}, {3,4,3}, {3,4,4}, {3,4,5}, {3,5,3}, {3,5,4}, {3,5,5},
-      {5,3,3}, {5,3,4}, {5,3,5}, {5,4,3}, {5,4,4}, {5,4,5}, {5,5,3}, {5,5,4}, {5,5,5},
-      {30,30,30}, {31,32,33}
-                                        };
+const vector<vector<int>> lda_ldb_ldc_range = {
+    {3, 3, 3}, {3, 3, 4}, {3, 3, 5}, {3, 4, 3}, {3, 4, 4},    {3, 4, 5},   {3, 5, 3},
+    {3, 5, 4}, {3, 5, 5}, {5, 3, 3}, {5, 3, 4}, {5, 3, 5},    {5, 4, 3},   {5, 4, 4},
+    {5, 4, 5}, {5, 5, 3}, {5, 5, 4}, {5, 5, 5}, {30, 30, 30}, {31, 32, 33}};
 
 // large sizes   {{rows, cols},{lda,ldb,ldc}}
-set_get_matrix_tuple gemm_values1 {{300000, 21}, {300000,300001,300002}};
-set_get_matrix_tuple gemm_values2 {{300001, 22}, {300001,300001,300010}};
-set_get_matrix_tuple gemm_values3 {{300002, 23}, {300002,300020,300002}};
-set_get_matrix_tuple gemm_values4 {{300003, 24}, {300003,300021,300011}};
-set_get_matrix_tuple gemm_values5 {{300004, 25}, {300030,300004,300000}};
-set_get_matrix_tuple gemm_values6 {{300005, 26}, {300031,300005,300012}};
-set_get_matrix_tuple gemm_values7 {{300006, 27}, {300032,300022,300006}};
-set_get_matrix_tuple gemm_values8 {{300007, 28}, {300033,300023,300013}};
+set_get_matrix_tuple gemm_values1{{300000, 21}, {300000, 300001, 300002}};
+set_get_matrix_tuple gemm_values2{{300001, 22}, {300001, 300001, 300010}};
+set_get_matrix_tuple gemm_values3{{300002, 23}, {300002, 300020, 300002}};
+set_get_matrix_tuple gemm_values4{{300003, 24}, {300003, 300021, 300011}};
+set_get_matrix_tuple gemm_values5{{300004, 25}, {300030, 300004, 300000}};
+set_get_matrix_tuple gemm_values6{{300005, 26}, {300031, 300005, 300012}};
+set_get_matrix_tuple gemm_values7{{300006, 27}, {300032, 300022, 300006}};
+set_get_matrix_tuple gemm_values8{{300007, 28}, {300033, 300023, 300013}};
 
-set_get_matrix_tuple gemm_values11 {{20,300000},{ 20, 21, 22}};
-set_get_matrix_tuple gemm_values12 {{21,300001},{ 21, 21, 40}};
-set_get_matrix_tuple gemm_values13 {{22,300011},{ 22, 31, 22}};
-set_get_matrix_tuple gemm_values14 {{23,300111},{ 23, 32, 33}};
-set_get_matrix_tuple gemm_values15 {{24,301111},{ 34, 24, 24}};
-set_get_matrix_tuple gemm_values16 {{25,311111},{ 35, 25, 36}};
-set_get_matrix_tuple gemm_values17 {{26,300002},{ 37, 38, 36}};
-set_get_matrix_tuple gemm_values18 {{27,300022},{ 39, 40, 41}};
+set_get_matrix_tuple gemm_values11{{20, 300000}, {20, 21, 22}};
+set_get_matrix_tuple gemm_values12{{21, 300001}, {21, 21, 40}};
+set_get_matrix_tuple gemm_values13{{22, 300011}, {22, 31, 22}};
+set_get_matrix_tuple gemm_values14{{23, 300111}, {23, 32, 33}};
+set_get_matrix_tuple gemm_values15{{24, 301111}, {34, 24, 24}};
+set_get_matrix_tuple gemm_values16{{25, 311111}, {35, 25, 36}};
+set_get_matrix_tuple gemm_values17{{26, 300002}, {37, 38, 36}};
+set_get_matrix_tuple gemm_values18{{27, 300022}, {39, 40, 41}};
 
-set_get_matrix_tuple gemm_values21 {{3,3000222},{  4,  4,  4}};
+set_get_matrix_tuple gemm_values21{{3, 3000222}, {4, 4, 4}};
 
-const vector<set_get_matrix_tuple> small_gemm_values_vec = {
-                                        gemm_values1, 
-                                        gemm_values11 
-                                                           };
+const vector<set_get_matrix_tuple> small_gemm_values_vec = {gemm_values1, gemm_values11};
 
-const vector<set_get_matrix_tuple> large_gemm_values_vec = {
-                                        gemm_values1, 
-                                        gemm_values2,
-                                        gemm_values3,
-                                        gemm_values4,
-                                        gemm_values5,
-                                        gemm_values6,
-                                        gemm_values7,
-                                        gemm_values8,
-                                        gemm_values11, 
-                                        gemm_values12,
-                                        gemm_values13,
-                                        gemm_values14,
-                                        gemm_values15,
-                                        gemm_values16,
-                                        gemm_values17,
-                                        gemm_values18,
-                                        gemm_values21
-                                                           };
+const vector<set_get_matrix_tuple> large_gemm_values_vec = {gemm_values1,
+                                                            gemm_values2,
+                                                            gemm_values3,
+                                                            gemm_values4,
+                                                            gemm_values5,
+                                                            gemm_values6,
+                                                            gemm_values7,
+                                                            gemm_values8,
+                                                            gemm_values11,
+                                                            gemm_values12,
+                                                            gemm_values13,
+                                                            gemm_values14,
+                                                            gemm_values15,
+                                                            gemm_values16,
+                                                            gemm_values17,
+                                                            gemm_values18,
+                                                            gemm_values21};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS auxiliary:
@@ -115,17 +102,18 @@ const vector<set_get_matrix_tuple> large_gemm_values_vec = {
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_set_get_matrix_arguments(set_get_matrix_tuple tup)
 {
 
-    vector<int> rows_cols = std::get<0>(tup);
+    vector<int> rows_cols   = std::get<0>(tup);
     vector<int> lda_ldb_ldc = std::get<1>(tup);
 
     Arguments arg;
@@ -140,16 +128,14 @@ Arguments setup_set_get_matrix_arguments(set_get_matrix_tuple tup)
     return arg;
 }
 
-
-class parameterized_set_matrix_get_matrix: public :: TestWithParam <set_get_matrix_tuple>
+class parameterized_set_matrix_get_matrix : public ::TestWithParam<set_get_matrix_tuple>
 {
     protected:
-        parameterized_set_matrix_get_matrix(){}
-        virtual ~parameterized_set_matrix_get_matrix(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized_set_matrix_get_matrix() {}
+    virtual ~parameterized_set_matrix_get_matrix() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
-
 
 TEST_P(parameterized_set_matrix_get_matrix, float)
 {
@@ -158,42 +144,42 @@ TEST_P(parameterized_set_matrix_get_matrix, float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_set_get_matrix_arguments( GetParam() );
+    Arguments arg = setup_set_get_matrix_arguments(GetParam());
 
-    rocblas_status status = testing_set_get_matrix<float>( arg );
+    rocblas_status status = testing_set_get_matrix<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if (status != rocblas_status_success)
+    if(status != rocblas_status_success)
     {
-        if (arg.rows < 0)
+        if(arg.rows < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.cols <= 0)
+        else if(arg.cols <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.lda <= 0)
+        else if(arg.lda <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldb <= 0)
+        else if(arg.ldb <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldc <= 0)
+        else if(arg.ldc <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.lda < arg.rows)
+        else if(arg.lda < arg.rows)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldb < arg.rows)
+        else if(arg.ldb < arg.rows)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldc < arg.rows)
+        else if(arg.ldc < arg.rows)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -203,7 +189,6 @@ TEST_P(parameterized_set_matrix_get_matrix, float)
         }
     }
 }
-
 
 TEST_P(parameterized_set_matrix_get_matrix, double)
 {
@@ -212,42 +197,42 @@ TEST_P(parameterized_set_matrix_get_matrix, double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_set_get_matrix_arguments( GetParam() );
+    Arguments arg = setup_set_get_matrix_arguments(GetParam());
 
-    rocblas_status status = testing_set_get_matrix<double>( arg );
+    rocblas_status status = testing_set_get_matrix<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if (status != rocblas_status_success)
+    if(status != rocblas_status_success)
     {
-        if (arg.rows < 0)
+        if(arg.rows < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.cols <= 0)
+        else if(arg.cols <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.lda <= 0)
+        else if(arg.lda <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldb <= 0)
+        else if(arg.ldb <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldc <= 0)
+        else if(arg.ldc <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.lda < arg.rows)
+        else if(arg.lda < arg.rows)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldb < arg.rows)
+        else if(arg.ldb < arg.rows)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if (arg.ldc < arg.rows)
+        else if(arg.ldc < arg.rows)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -258,25 +243,19 @@ TEST_P(parameterized_set_matrix_get_matrix, double)
     }
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda}, {incx,incy} {alpha} }
 
 INSTANTIATE_TEST_CASE_P(checkin_auxilliary,
                         parameterized_set_matrix_get_matrix,
-                        Combine(
-                                  ValuesIn(rows_cols_range),
-                                  ValuesIn(lda_ldb_ldc_range)
-                               )
-                       );
+                        Combine(ValuesIn(rows_cols_range), ValuesIn(lda_ldb_ldc_range)));
 
 INSTANTIATE_TEST_CASE_P(checkin_auxilliary_2,
                         parameterized_set_matrix_get_matrix,
-                        ValuesIn(small_gemm_values_vec)
-                       );
+                        ValuesIn(small_gemm_values_vec));
 
 INSTANTIATE_TEST_CASE_P(daily_auxilliary,
                         parameterized_set_matrix_get_matrix,
-                        ValuesIn(large_gemm_values_vec)
-                       );
+                        ValuesIn(large_gemm_values_vec));

--- a/clients/gtest/set_get_pointer_mode_gtest.cpp
+++ b/clients/gtest/set_get_pointer_mode_gtest.cpp
@@ -30,18 +30,18 @@ TEST(checkin_auxilliary, set_pointer_mode_get_pointer_mode)
     rocblas_handle handle;
     rocblas_create_handle(&handle);
 
-    status = rocblas_set_pointer_mode( handle, rocblas_pointer_mode_device);
+    status = rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
     EXPECT_EQ(status, rocblas_status_success);
 
-    status = rocblas_get_pointer_mode( handle, &mode);
+    status = rocblas_get_pointer_mode(handle, &mode);
     EXPECT_EQ(status, rocblas_status_success);
 
     EXPECT_EQ(rocblas_pointer_mode_device, mode);
 
-    status = rocblas_set_pointer_mode( handle, rocblas_pointer_mode_host);
+    status = rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
     EXPECT_EQ(status, rocblas_status_success);
 
-    status = rocblas_get_pointer_mode( handle, &mode);
+    status = rocblas_get_pointer_mode(handle, &mode);
     EXPECT_EQ(status, rocblas_status_success);
 
     EXPECT_EQ(rocblas_pointer_mode_host, mode);

--- a/clients/gtest/set_get_vector_gtest.cpp
+++ b/clients/gtest/set_get_vector_gtest.cpp
@@ -3,7 +3,6 @@
  *
  * ************************************************************************ */
 
-
 #include <gtest/gtest.h>
 #include <math.h>
 #include <stdexcept>
@@ -17,7 +16,7 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<int, vector<int>> set_get_vector_tuple;
 
@@ -29,61 +28,45 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
+// vector of vector, each vector is a {M};
+// add/delete as a group
+const int small_M_range[] = {10, 600, 600000};
 
-//vector of vector, each vector is a {M};
-//add/delete as a group
-const
-int small_M_range[] = { 10, 600, 600000 };
+const int large_M_range[] = {1000000, 6000000};
 
-const
-int large_M_range[] = { 1000000, 6000000 };
+// vector of vector, each triple is a {incx, incy, incb};
+// add/delete this list in pairs, like {1, 1, 1}
+const vector<vector<int>> small_incx_incy_incb_range = {{1, 1, 1},
+                                                        {1, 1, 2},
+                                                        {1, 1, 3},
+                                                        {1, 2, 1},
+                                                        {1, 2, 2},
+                                                        {1, 2, 3},
+                                                        {1, 3, 1},
+                                                        {1, 3, 2},
+                                                        {1, 3, 3},
+                                                        {3, 1, 1},
+                                                        {3, 1, 2},
+                                                        {3, 1, 3},
+                                                        {3, 2, 1},
+                                                        {3, 2, 2},
+                                                        {3, 2, 3},
+                                                        {3, 3, 1},
+                                                        {3, 3, 2},
+                                                        {3, 3, 3}};
 
-//vector of vector, each triple is a {incx, incy, incb};
-//add/delete this list in pairs, like {1, 1, 1}
-const
-vector<vector<int>> small_incx_incy_incb_range = {
-                                            {1, 1, 1},
-                                            {1, 1, 2},
-                                            {1, 1, 3},
-                                            {1, 2, 1},
-                                            {1, 2, 2},
-                                            {1, 2, 3},
-                                            {1, 3, 1},
-                                            {1, 3, 2},
-                                            {1, 3, 3},
-                                            {3, 1, 1},
-                                            {3, 1, 2},
-                                            {3, 1, 3},
-                                            {3, 2, 1},
-                                            {3, 2, 2},
-                                            {3, 2, 3},
-                                            {3, 3, 1},
-                                            {3, 3, 2},
-                                            {3, 3, 3}
-                                          };
-
-const
-vector<vector<int>> large_incx_incy_incb_range = {
-                                            {1, 1, 1},
-                                            {1, 1, 3},
-                                            {1, 3, 1},
-                                            {1, 3, 3},
-                                            {3, 1, 1},
-                                            {3, 1, 3},
-                                            {3, 3, 1},
-                                            {3, 3, 3}
-                                          };
+const vector<vector<int>> large_incx_incy_incb_range = {
+    {1, 1, 1}, {1, 1, 3}, {1, 3, 1}, {1, 3, 3}, {3, 1, 1}, {3, 1, 3}, {3, 3, 1}, {3, 3, 3}};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS set_get_vector:
@@ -91,17 +74,18 @@ vector<vector<int>> large_incx_incy_incb_range = {
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_set_get_vector_arguments(set_get_vector_tuple tup)
 {
 
-    int M = std::get<0>(tup);
+    int M                      = std::get<0>(tup);
     vector<int> incx_incy_incb = std::get<1>(tup);
 
     Arguments arg;
@@ -117,18 +101,16 @@ Arguments setup_set_get_vector_arguments(set_get_vector_tuple tup)
     return arg;
 }
 
-
-class parameterized_set_vector_get_vector: public :: TestWithParam <set_get_vector_tuple>
+class parameterized_set_vector_get_vector : public ::TestWithParam<set_get_vector_tuple>
 {
     protected:
-        parameterized_set_vector_get_vector(){}
-        virtual ~parameterized_set_vector_get_vector(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    parameterized_set_vector_get_vector() {}
+    virtual ~parameterized_set_vector_get_vector() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
-
-//TEST_P(parameterized_set_vector_get_vector, set_get_vector_float)
+// TEST_P(parameterized_set_vector_get_vector, set_get_vector_float)
 TEST_P(parameterized_set_vector_get_vector, float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -136,14 +118,14 @@ TEST_P(parameterized_set_vector_get_vector, float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_set_get_vector_arguments( GetParam() );
+    Arguments arg = setup_set_get_vector_arguments(GetParam());
 
-    rocblas_status status = testing_set_get_vector<float>( arg );
+    rocblas_status status = testing_set_get_vector<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 )
+        if(arg.M < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -173,14 +155,14 @@ TEST_P(parameterized_set_vector_get_vector, double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_set_get_vector_arguments( GetParam() );
+    Arguments arg = setup_set_get_vector_arguments(GetParam());
 
-    rocblas_status status = testing_set_get_vector<double>( arg );
+    rocblas_status status = testing_set_get_vector<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if( arg.M < 0 )
+        if(arg.M < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -203,21 +185,15 @@ TEST_P(parameterized_set_vector_get_vector, double)
     }
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda}, {incx,incy} {alpha} }
 
 INSTANTIATE_TEST_CASE_P(checkin_auxiliary,
                         parameterized_set_vector_get_vector,
-                        Combine(
-                                  ValuesIn(small_M_range), ValuesIn(small_incx_incy_incb_range)
-                               )
-                        );
+                        Combine(ValuesIn(small_M_range), ValuesIn(small_incx_incy_incb_range)));
 
 INSTANTIATE_TEST_CASE_P(daily_auxiliary,
                         parameterized_set_vector_get_vector,
-                        Combine(
-                                  ValuesIn(large_M_range), ValuesIn(large_incx_incy_incb_range)
-                               )
-                        );
+                        Combine(ValuesIn(large_M_range), ValuesIn(large_incx_incy_incb_range)));

--- a/clients/gtest/symv_gtest.cpp
+++ b/clients/gtest/symv_gtest.cpp
@@ -3,7 +3,6 @@
  *
  * ************************************************************************ */
 
-
 #include <gtest/gtest.h>
 #include <math.h>
 #include <stdexcept>
@@ -17,7 +16,7 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<vector<int>, vector<int>, vector<double>, char> symv_tuple;
 
@@ -29,61 +28,45 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
-like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers inside API of course.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
+// vector of vector, each vector is a {N, lda};
+// add/delete as a group
+const vector<vector<int>> matrix_size_range = {
+    {-1, -1},
+    /*  {10, 2},       */
+    /*  {500, 500},    */
+    {1000, 1000},
+    {2000, 2000},
+    {4011, 4011},
+    {8000, 8000},
+};
 
-//vector of vector, each vector is a {N, lda};
-//add/delete as a group
-const
-vector<vector<int>> matrix_size_range = {
-                                        {-1, -1},
-                                    /*  {10, 2},       */
-                                    /*  {500, 500},    */
-                                        {1000, 1000},
-                                        {2000, 2000},
-                                        {4011, 4011},
-                                        {8000, 8000},
-                                       };
+// vector of vector, each pair is a {incx, incy};
+// add/delete this list in pairs, like {1, 1}
+const vector<vector<int>> incx_incy_range = {
+    {1, 1}, {0, -1}, {2, 1}, {10, 100},
+};
 
-//vector of vector, each pair is a {incx, incy};
-//add/delete this list in pairs, like {1, 1}
-const
-vector<vector<int>> incx_incy_range = {
-                                            {1, 1},
-                                            {0, -1},
-                                            {2, 1},
-                                            {10, 100},
-                                          };
+// vector of vector, each pair is a {alpha, beta};
+// add/delete this list in pairs, like {2.0, 4.0}
+const vector<vector<double>> alpha_beta_range = {
+    {1.0, 0.0}, {-1.0, -1.0}, {2.0, 1.0}, {0.0, 1.0},
+};
 
-//vector of vector, each pair is a {alpha, beta};
-//add/delete this list in pairs, like {2.0, 4.0}
-const
-vector<vector<double>> alpha_beta_range = {
-                                            {1.0, 0.0},
-                                            {-1.0, -1.0},
-                                            {2.0, 1.0},
-                                            {0.0, 1.0},
-                                          };
-
-
-const
-vector<char> uplo_range = {
-                                        'U',
-                                        'L',
-                                       };
-
-
-
+const vector<char> uplo_range = {
+    'U', 'L',
+};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS-3 symv:
@@ -91,34 +74,35 @@ vector<char> uplo_range = {
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 SYMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 SYMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_symv_arguments(symv_tuple tup)
 {
 
-    vector<int> matrix_size = std::get<0>(tup);
-    vector<int> incx_incy = std::get<1>(tup);
+    vector<int> matrix_size   = std::get<0>(tup);
+    vector<int> incx_incy     = std::get<1>(tup);
     vector<double> alpha_beta = std::get<2>(tup);
-    char uplo = std::get<3>(tup);
+    char uplo                 = std::get<3>(tup);
 
     Arguments arg;
 
     // see the comments about matrix_size_range above
-    arg.N = matrix_size[0];
+    arg.N   = matrix_size[0];
     arg.lda = matrix_size[1];
 
     // see the comments about matrix_size_range above
     arg.incx = incx_incy[0];
     arg.incy = incx_incy[1];
 
-    //the first element of alpha_beta_range is always alpha, and the second is always beta
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
     arg.alpha = alpha_beta[0];
-    arg.beta = alpha_beta[1];
+    arg.beta  = alpha_beta[1];
 
     arg.uplo_option = uplo;
 
@@ -127,16 +111,14 @@ Arguments setup_symv_arguments(symv_tuple tup)
     return arg;
 }
 
-
-class symv_gtest: public :: TestWithParam <symv_tuple>
+class symv_gtest : public ::TestWithParam<symv_tuple>
 {
     protected:
-        symv_gtest(){}
-        virtual ~symv_gtest(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    symv_gtest() {}
+    virtual ~symv_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
-
 
 TEST_P(symv_gtest, symv_gtest_float)
 {
@@ -145,38 +127,41 @@ TEST_P(symv_gtest, symv_gtest_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_symv_arguments(GetParam());
 
-    Arguments arg = setup_symv_arguments( GetParam() );
-
-    rocblas_status status = testing_symv<float>( arg );
+    rocblas_status status = testing_symv<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if(status != rocblas_status_success){
+    if(status != rocblas_status_success)
+    {
 
-        if( arg.N < 0 ){
+        if(arg.N < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.lda < arg.M){
+        else if(arg.lda < arg.M)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.incx <= 0){
+        else if(arg.incx <= 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.incy <= 0){
+        else if(arg.incy <= 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
     }
-
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda}, {incx,incy} {alpha, beta}, {uplo} }
 
 INSTANTIATE_TEST_CASE_P(rocblas_symv,
                         symv_gtest,
-                        Combine(
-                                  ValuesIn(matrix_size_range), ValuesIn(incx_incy_range), ValuesIn(alpha_beta_range), ValuesIn(uplo_range)
-                               )
-                        );
+                        Combine(ValuesIn(matrix_size_range),
+                                ValuesIn(incx_incy_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(uplo_range)));

--- a/clients/gtest/trsm_gtest.cpp
+++ b/clients/gtest/trsm_gtest.cpp
@@ -3,7 +3,6 @@
  *
  * ************************************************************************ */
 
-
 #include <gtest/gtest.h>
 #include <math.h>
 #include <stdexcept>
@@ -17,7 +16,7 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-//only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
 typedef std::tuple<vector<int>, double, vector<char>> trsm_tuple;
 
@@ -29,78 +28,68 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
-like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers inside API of course.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
+// vector of vector, each vector is a {M, N, lda, ldb};
+// add/delete as a group
+const vector<vector<int>> matrix_size_range = {
+    {-1, -1, 1, 1}, {10, 10, 20, 100}, {600, 500, 600, 600},
+};
 
-//vector of vector, each vector is a {M, N, lda, ldb};
-//add/delete as a group
-const
-vector<vector<int>> matrix_size_range = {
-                                        {  -1,   -1,    1,   1},
-                                        {  10,   10,   20,  100},
-                                        { 600,  500,  600,  600},
-                                       };
+const vector<vector<int>> large_matrix_size_range = {
+    {192, 192, 192, 192},
+    {640, 640, 960, 960},
+    {1000, 1000, 1000, 1000},
+    {1024, 1024, 1024, 1024},
+    {2000, 2000, 2000, 2000},
+};
 
-const
-vector<vector<int>> large_matrix_size_range = {
-                                        { 192,  192,  192,  192},
-                                        { 640,  640,  960,  960},
-                                        {1000, 1000, 1000, 1000},
-                                        {1024, 1024, 1024, 1024},
-                                        {2000, 2000, 2000, 2000},
-                                       };
+const vector<double> alpha_range = {1.0, -5.0};
 
-const
-vector<double> alpha_range = {1.0, -5.0};
-
-
-//vector of vector, each pair is a {side, uplo, transA, diag};
+// vector of vector, each pair is a {side, uplo, transA, diag};
 // side has two option "Lefe (L), Right (R)"
 // uplo has two "Lower (L), Upper (U)"
 // transA has three ("Nontranspose (N), conjTranspose(C), transpose (T)")
-// for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) automatically in strsm/dtrsm,
+// for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) automatically
+// in strsm/dtrsm,
 // so we use 'C'
 // Diag has two options ("Non-unit (N), Unit (U)")
 
-//Each letter is capitalizied, e.g. do not use 'l', but use 'L' instead.
+// Each letter is capitalizied, e.g. do not use 'l', but use 'L' instead.
 
-const
-vector<vector<char>> side_uplo_transA_diag_range = {
-                                        {'L', 'L', 'N', 'N'},
-                                        {'R', 'L', 'N', 'N'},
-                                        {'L', 'U', 'C', 'N'},
-                                       };
+const vector<vector<char>> side_uplo_transA_diag_range = {
+    {'L', 'L', 'N', 'N'}, {'R', 'L', 'N', 'N'}, {'L', 'U', 'C', 'N'},
+};
 
-//has all the 16 options
-const
-vector<vector<char>> full_side_uplo_transA_diag_range = {
-                                        {'L', 'L', 'N', 'N'},
-                                        {'R', 'L', 'N', 'N'},
-                                        {'L', 'U', 'N', 'N'},
-                                        {'R', 'U', 'N', 'N'},
-                                        {'L', 'L', 'C', 'N'},
-                                        {'R', 'L', 'C', 'N'},
-                                        {'L', 'U', 'C', 'N'},
-                                        {'R', 'U', 'C', 'N'},
-                                        {'L', 'L', 'N', 'U'},
-                                        {'R', 'L', 'N', 'U'},
-                                        {'L', 'U', 'N', 'U'},
-                                        {'R', 'U', 'N', 'U'},
-                                        {'L', 'L', 'C', 'U'},
-                                        {'R', 'L', 'C', 'U'},
-                                        {'L', 'U', 'C', 'U'},
-                                        {'R', 'U', 'C', 'U'},
-                                       };
+// has all the 16 options
+const vector<vector<char>> full_side_uplo_transA_diag_range = {
+    {'L', 'L', 'N', 'N'},
+    {'R', 'L', 'N', 'N'},
+    {'L', 'U', 'N', 'N'},
+    {'R', 'U', 'N', 'N'},
+    {'L', 'L', 'C', 'N'},
+    {'R', 'L', 'C', 'N'},
+    {'L', 'U', 'C', 'N'},
+    {'R', 'U', 'C', 'N'},
+    {'L', 'L', 'N', 'U'},
+    {'R', 'L', 'N', 'U'},
+    {'L', 'U', 'N', 'U'},
+    {'R', 'U', 'N', 'U'},
+    {'L', 'L', 'C', 'U'},
+    {'R', 'L', 'C', 'U'},
+    {'L', 'U', 'C', 'U'},
+    {'R', 'U', 'C', 'U'},
+};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS-3 trsm:
@@ -108,25 +97,26 @@ vector<vector<char>> full_side_uplo_transA_diag_range = {
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
 
 Arguments setup_trsm_arguments(trsm_tuple tup)
 {
 
-    vector<int> matrix_size = std::get<0>(tup);
-    double alpha = std::get<1>(tup);
+    vector<int> matrix_size            = std::get<0>(tup);
+    double alpha                       = std::get<1>(tup);
     vector<char> side_uplo_transA_diag = std::get<2>(tup);
 
     Arguments arg;
 
     // see the comments about matrix_size_range above
-    arg.M = matrix_size[0];
-    arg.N = matrix_size[1];
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
     arg.ldb = matrix_size[3];
 
@@ -142,16 +132,14 @@ Arguments setup_trsm_arguments(trsm_tuple tup)
     return arg;
 }
 
-
-class trsm_gtest: public :: TestWithParam <trsm_tuple>
+class trsm_gtest : public ::TestWithParam<trsm_tuple>
 {
     protected:
-        trsm_gtest(){}
-        virtual ~trsm_gtest(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    trsm_gtest() {}
+    virtual ~trsm_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
-
 
 TEST_P(trsm_gtest, trsm_gtest_float)
 {
@@ -160,25 +148,27 @@ TEST_P(trsm_gtest, trsm_gtest_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_trsm_arguments(GetParam());
 
-    Arguments arg = setup_trsm_arguments( GetParam() );
-
-    rocblas_status status = testing_trsm<float>( arg );
+    rocblas_status status = testing_trsm<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if(status != rocblas_status_success){
+    if(status != rocblas_status_success)
+    {
 
-        if( arg.M < 0 || arg.N < 0 ){
+        if(arg.M < 0 || arg.N < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.side_option == 'L' ? arg.lda < arg.M : arg.lda < arg.N){
+        else if(arg.side_option == 'L' ? arg.lda < arg.M : arg.lda < arg.N)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.ldb < arg.M){
+        else if(arg.ldb < arg.M)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
     }
-
 }
 
 TEST_P(trsm_gtest, trsm_gtest_double)
@@ -188,54 +178,50 @@ TEST_P(trsm_gtest, trsm_gtest_double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_trsm_arguments(GetParam());
 
-    Arguments arg = setup_trsm_arguments( GetParam() );
-
-    rocblas_status status = testing_trsm<double>( arg );
+    rocblas_status status = testing_trsm<double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if(status != rocblas_status_success){
+    if(status != rocblas_status_success)
+    {
 
-        if( arg.M < 0 || arg.N < 0 ){
+        if(arg.M < 0 || arg.N < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.side_option == 'L' ? arg.lda < arg.M : arg.lda < arg.N){
+        else if(arg.side_option == 'L' ? arg.lda < arg.M : arg.lda < arg.N)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.ldb < arg.M){
+        else if(arg.ldb < arg.M)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
     }
-
 }
 
-//notice we are using vector of vector
-//so each elment in xxx_range is a avector,
-//ValuesIn take each element (a vector) and combine them and feed them to test_p
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda, ldb}, alpha, {side, uplo, transA, diag} }
 
-//THis function mainly test the scope of matrix_size. the scope of side_uplo_transA_diag_range is small
-//Testing order: side_uplo_transA_xx first, alpha_range second, full_matrix_size last
-//i.e fix the matrix size and alpha, test all the side_uplo_transA_xx first.
-//INSTANTIATE_TEST_CASE_P(rocblas_trsm_matrix_size,
+// THis function mainly test the scope of matrix_size. the scope of side_uplo_transA_diag_range is
+// small
+// Testing order: side_uplo_transA_xx first, alpha_range second, full_matrix_size last
+// i.e fix the matrix size and alpha, test all the side_uplo_transA_xx first.
+// INSTANTIATE_TEST_CASE_P(rocblas_trsm_matrix_size,
 INSTANTIATE_TEST_CASE_P(daily_blas3,
                         trsm_gtest,
-                        Combine(
-                                  ValuesIn(large_matrix_size_range), 
-                                  ValuesIn(alpha_range), 
-                                  ValuesIn(side_uplo_transA_diag_range)
-                               )
-                        );
+                        Combine(ValuesIn(large_matrix_size_range),
+                                ValuesIn(alpha_range),
+                                ValuesIn(side_uplo_transA_diag_range)));
 
-
-//THis function mainly test the scope of  full_side_uplo_transA_diag_range,.the scope of matrix_size_range is small
+// THis function mainly test the scope of  full_side_uplo_transA_diag_range,.the scope of
+// matrix_size_range is small
 
 INSTANTIATE_TEST_CASE_P(checkin_blas3,
                         trsm_gtest,
-                        Combine(
-                                  ValuesIn(matrix_size_range), 
-                                  ValuesIn(alpha_range), 
-                                  ValuesIn(full_side_uplo_transA_diag_range)
-                               )
-                        );
-
+                        Combine(ValuesIn(matrix_size_range),
+                                ValuesIn(alpha_range),
+                                ValuesIn(full_side_uplo_transA_diag_range)));

--- a/clients/gtest/trtri_gtest.cpp
+++ b/clients/gtest/trtri_gtest.cpp
@@ -3,7 +3,6 @@
  *
  * ************************************************************************ */
 
-
 #include <gtest/gtest.h>
 #include <math.h>
 #include <stdexcept>
@@ -17,9 +16,7 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
-
 typedef std::tuple<vector<int>, char, char, int> trtri_tuple;
-
 
 /* =====================================================================
 README: This file contains testers to verify the correctness of
@@ -29,36 +26,28 @@ README: This file contains testers to verify the correctness of
         Normal users only need to get the library routines without testers
      =================================================================== */
 
-
 /* =====================================================================
-Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the matrix.
-like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers inside API of course.
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
 Yet, the goal of this file is to verify result correctness not argument-checkers.
 
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
-
-//vector of vector, each vector is a {N, lda}; N > 32 will return not implemented
-//add/delete as a group
-const
-vector<vector<int>> matrix_size_range = { {-1, -1},
-                                        {10, 10},
-                                        {20, 160},
-                                        {21, 14},
-                                        {32, 32},
-                                        {111, 122}
-                                       };
-
+// vector of vector, each vector is a {N, lda}; N > 32 will return not implemented
+// add/delete as a group
+const vector<vector<int>> matrix_size_range = {
+    {-1, -1}, {10, 10}, {20, 160}, {21, 14}, {32, 32}, {111, 122}};
 
 const vector<char> uplo_range = {'U', 'L'};
 const vector<char> diag_range = {'N', 'U'};
 
-//it applies on trtri_batched only
+// it applies on trtri_batched only
 const vector<int> batch_range = {-1, 1, 100, 1000};
 
 /* ===============Google Unit Test==================================================== */
-
 
 /* =====================================================================
      BLAS-3 TRTRI and TRTRI_Batched
@@ -66,24 +55,25 @@ const vector<int> batch_range = {-1, 1, 100, 1000};
 
 /* ============================Setup Arguments======================================= */
 
-//Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
-//Some routines may not touch/use certain "members" of objects "argus".
-//like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
-//That is fine. These testers & routines will leave untouched members alone.
-//Do not use std::tuple to directly pass parameters to testers
-//If soe, you unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// If soe, you unpack it with extreme care for each one by like "std::get<0>" which is not intuitive
+// and error-prone
 
 Arguments setup_trtri_arguments(trtri_tuple tup)
 {
 
     vector<int> matrix_size = std::get<0>(tup);
-    char uplo = std::get<1>(tup);
-    char diag = std::get<2>(tup);
-    int batch_count = std::get<2>(tup);
+    char uplo               = std::get<1>(tup);
+    char diag               = std::get<2>(tup);
+    int batch_count         = std::get<2>(tup);
 
     Arguments arg;
 
-    arg.N = matrix_size[1];
+    arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
 
     arg.uplo_option = uplo;
@@ -95,16 +85,14 @@ Arguments setup_trtri_arguments(trtri_tuple tup)
     return arg;
 }
 
-
-class trtri_gtest: public :: TestWithParam <trtri_tuple>
+class trtri_gtest : public ::TestWithParam<trtri_tuple>
 {
     protected:
-        trtri_gtest(){}
-        virtual ~trtri_gtest(){}
-        virtual void SetUp(){}
-        virtual void TearDown(){}
+    trtri_gtest() {}
+    virtual ~trtri_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
-
 
 TEST_P(trtri_gtest, trtri_float)
 {
@@ -113,27 +101,28 @@ TEST_P(trtri_gtest, trtri_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_trtri_arguments(GetParam());
 
-    Arguments arg = setup_trtri_arguments( GetParam() );
-
-    rocblas_status status = testing_trtri<float>( arg );
+    rocblas_status status = testing_trtri<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if(status != rocblas_status_success){
+    if(status != rocblas_status_success)
+    {
 
-        if(arg.N < 0){
+        if(arg.N < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.lda < arg.N){
+        else if(arg.lda < arg.N)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.N > 32){
+        else if(arg.N > 32)
+        {
             EXPECT_EQ(rocblas_status_not_implemented, status);
         }
     }
-
 }
-
 
 TEST_P(trtri_gtest, trtri_batched_float)
 {
@@ -142,39 +131,41 @@ TEST_P(trtri_gtest, trtri_batched_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
+    Arguments arg = setup_trtri_arguments(GetParam());
 
-    Arguments arg = setup_trtri_arguments( GetParam() );
-
-    rocblas_status status = testing_trtri_batched<float>( arg );
+    rocblas_status status = testing_trtri_batched<float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
-    if(status != rocblas_status_success){
+    if(status != rocblas_status_success)
+    {
 
-        if(arg.N < 0){
+        if(arg.N < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.lda < arg.N){
+        else if(arg.lda < arg.N)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.N > 32){
+        else if(arg.N > 32)
+        {
             EXPECT_EQ(rocblas_status_not_implemented, status);
         }
-        else if(arg.batch_count < 0){
+        else if(arg.batch_count < 0)
+        {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
     }
-
 }
 
-
-//notice we are using vector of vector for matrix size, and vector for uplo, diag
-//ValuesIn take each element (a vector or a char) and combine them and feed them to test_p
+// notice we are using vector of vector for matrix size, and vector for uplo, diag
+// ValuesIn take each element (a vector or a char) and combine them and feed them to test_p
 // The combinations are  { {N, lda}, uplo, diag }
 
-//THis function mainly test the scope of matrix_size.
+// THis function mainly test the scope of matrix_size.
 INSTANTIATE_TEST_CASE_P(rocblas_trtri,
                         trtri_gtest,
-                        Combine(
-                                  ValuesIn(matrix_size_range), ValuesIn(uplo_range), ValuesIn(diag_range), ValuesIn(batch_range)
-                               )
-                        );
+                        Combine(ValuesIn(matrix_size_range),
+                                ValuesIn(uplo_range),
+                                ValuesIn(diag_range),
+                                ValuesIn(batch_range)));

--- a/clients/include/arg_check.h
+++ b/clients/include/arg_check.h
@@ -13,64 +13,88 @@
 #include "gtest/gtest.h"
 #endif
 
-
-
-
-
-
 /* =====================================================================
 
     Google Unit check: ASSERT_EQ( elementof(A), elementof(B))
 
    =================================================================== */
 
-
 /*!\file
  * \brief compares two results (usually, CPU and GPU results); provides Google Unit check.
  */
 
+/* ========================================Gtest Arg Check
+ * ===================================================== */
 
-/* ========================================Gtest Arg Check ===================================================== */
+/*! \brief Template: tests arguments are valid */
 
+void set_get_matrix_arg_check(rocblas_status status,
+                              rocblas_int rows,
+                              rocblas_int cols,
+                              rocblas_int lda,
+                              rocblas_int ldb,
+                              rocblas_int ldc);
 
-    /*! \brief Template: tests arguments are valid */
+void set_get_vector_arg_check(
+    rocblas_status status, rocblas_int M, rocblas_int incx, rocblas_int incy, rocblas_int incd);
 
-    void set_get_matrix_arg_check(rocblas_status status, rocblas_int rows, rocblas_int cols, rocblas_int lda, rocblas_int ldb, rocblas_int ldc);
+void gemv_ger_arg_check(rocblas_status status,
+                        rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int lda,
+                        rocblas_int incx,
+                        rocblas_int incy);
 
-    void set_get_vector_arg_check(rocblas_status status, rocblas_int M, rocblas_int incx, rocblas_int incy, rocblas_int incd);
+void gemm_arg_check(rocblas_status status,
+                    rocblas_int M,
+                    rocblas_int N,
+                    rocblas_int K,
+                    rocblas_int lda,
+                    rocblas_int ldb,
+                    rocblas_int ldc);
 
-    void gemv_ger_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int incx, rocblas_int incy);
+void gemm_strided_batched_arg_check(rocblas_status status,
+                                    rocblas_int M,
+                                    rocblas_int N,
+                                    rocblas_int K,
+                                    rocblas_int lda,
+                                    rocblas_int ldb,
+                                    rocblas_int ldc,
+                                    rocblas_int batch_count);
 
-    void gemm_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int K, rocblas_int lda, rocblas_int ldb, rocblas_int ldc);
+void geam_arg_check(rocblas_status status,
+                    rocblas_int M,
+                    rocblas_int N,
+                    rocblas_int lda,
+                    rocblas_int ldb,
+                    rocblas_int ldc);
 
-    void gemm_strided_batched_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int K, rocblas_int lda, rocblas_int ldb, rocblas_int ldc, rocblas_int batch_count);
+void trsm_arg_check(
+    rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int ldb);
 
-    void geam_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int ldb, rocblas_int ldc);
+void symv_arg_check(
+    rocblas_status status, rocblas_int N, rocblas_int lda, rocblas_int incx, rocblas_int incy);
 
-    void trsm_arg_check(rocblas_status status, rocblas_int M, rocblas_int N, rocblas_int lda, rocblas_int ldb);
+void iamax_arg_check(rocblas_status status, rocblas_int* d_rocblas_result);
 
-    void symv_arg_check(rocblas_status status, rocblas_int N, rocblas_int lda, rocblas_int incx, rocblas_int incy);
+template <typename T2>
+void asum_arg_check(rocblas_status status, T2 d_rocblas_result);
 
-    void iamax_arg_check(rocblas_status status, rocblas_int* d_rocblas_result);
+template <typename T>
+void nrm2_dot_arg_check(rocblas_status status, T d_rocblas_result);
 
-    template<typename T2> 
-    void asum_arg_check(rocblas_status status, T2 d_rocblas_result);
+void verify_rocblas_status_invalid_pointer(rocblas_status status, const char* message);
 
-    template<typename T> 
-    void nrm2_dot_arg_check(rocblas_status status, T d_rocblas_result);
+void verify_rocblas_status_invalid_size(rocblas_status status, const char* message);
 
-    void verify_rocblas_status_invalid_pointer(rocblas_status status, const char* message);
+void verify_rocblas_status_invalid_handle(rocblas_status status);
 
-    void verify_rocblas_status_invalid_size(rocblas_status status, const char* message);
+void verify_rocblas_status_success(rocblas_status status, const char* message);
 
-    void verify_rocblas_status_invalid_handle(rocblas_status status);
+template <typename T>
+void verify_not_nan(T arg);
 
-    void verify_rocblas_status_success(rocblas_status status, const char* message);
-
-    template<typename T>
-    void verify_not_nan(T arg);
-
-    template<typename T> 
-    void verify_equal(T arg1, T arg2, const char* message);
+template <typename T>
+void verify_equal(T arg1, T arg2, const char* message);
 
 #endif

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -10,129 +10,140 @@
 #include "rocblas.h"
 
 /*!\file
- * \brief provide template functions interfaces to CBLAS C89 interfaces, it is only used for testing not part of the GPU library
+ * \brief provide template functions interfaces to CBLAS C89 interfaces, it is only used for testing
+ * not part of the GPU library
 */
 
+/*
+ * ===========================================================================
+ *    level 1 BLAS
+ * ===========================================================================
+ */
+template <typename T>
+void cblas_iamax(rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result);
 
-    /*
-     * ===========================================================================
-     *    level 1 BLAS
-     * ===========================================================================
-     */
-    template<typename T>
-    void cblas_iamax( rocblas_int n,
-                     const T *x, rocblas_int incx,
-                     rocblas_int *result);
+template <typename T>
+void cblas_iamin(rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result);
 
-    template<typename T>
-    void cblas_iamin( rocblas_int n,
-                     const T *x, rocblas_int incx,
-                     rocblas_int *result);
+template <typename T1, typename T2>
+void cblas_asum(rocblas_int n, const T1* x, rocblas_int incx, T2* result);
 
-    template<typename T1, typename T2>
-    void cblas_asum( rocblas_int n,
-                     const T1 *x, rocblas_int incx,
-                     T2 *result);
+template <typename T>
+void cblas_axpy(rocblas_int n, const T alpha, T* x, rocblas_int incx, T* y, rocblas_int incy);
 
-    template<typename T>
-    void cblas_axpy(rocblas_int n,
-                    const T alpha,
-                    T *x, rocblas_int incx,
-                    T *y, rocblas_int incy);
+template <typename T>
+void cblas_copy(rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy);
 
-    template<typename T>
-    void cblas_copy( rocblas_int n,
-                     T *x, rocblas_int incx,
-                     T *y, rocblas_int incy);
+template <typename T>
+void cblas_dot(
+    rocblas_int n, const T* x, rocblas_int incx, const T* y, rocblas_int incy, T* result);
 
-    template<typename T>
-    void cblas_dot( rocblas_int n,
-                    const T *x, rocblas_int incx,
-                    const T *y, rocblas_int incy,
-                    T *result);
+template <typename T1, typename T2>
+void cblas_nrm2(rocblas_int n, const T1* x, rocblas_int incx, T2* result);
 
-    template<typename T1, typename T2>
-    void cblas_nrm2( rocblas_int n,
-                     const T1 *x, rocblas_int incx,
-                     T2 *result);
+template <typename T>
+void cblas_scal(rocblas_int n, const T alpha, T* x, rocblas_int incx);
 
-    template<typename T>
-    void cblas_scal( rocblas_int n,
-                     const T alpha,
-                     T *x, rocblas_int incx);
+template <typename T>
+void cblas_swap(rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy);
 
-    template<typename T>
-    void cblas_swap( rocblas_int n,
-                     T *x, rocblas_int incx,
-                     T *y, rocblas_int incy);
+template <typename T>
+void cblas_gemv(rocblas_operation transA,
+                rocblas_int m,
+                rocblas_int n,
+                T alpha,
+                T* A,
+                rocblas_int lda,
+                T* x,
+                rocblas_int incx,
+                T beta,
+                T* y,
+                rocblas_int incy);
 
-    template<typename T>
-    void cblas_gemv( rocblas_operation transA, rocblas_int m, rocblas_int n,
-                     T alpha,
-                     T *A, rocblas_int lda,
-                     T *x, rocblas_int incx,
-                     T beta, T *y, rocblas_int incy);
+template <typename T>
+void cblas_symv(rocblas_fill uplo,
+                rocblas_int n,
+                T alpha,
+                T* A,
+                rocblas_int lda,
+                T* x,
+                rocblas_int incx,
+                T beta,
+                T* y,
+                rocblas_int incy);
 
-    template<typename T>
-    void cblas_symv( rocblas_fill uplo, rocblas_int n,
-                     T alpha,
-                     T *A, rocblas_int lda,
-                     T *x, rocblas_int incx,
-                     T beta, T *y, rocblas_int incy);
+template <typename T>
+void cblas_ger(rocblas_int m,
+               rocblas_int n,
+               T alpha,
+               T* x,
+               rocblas_int incx,
+               T* y,
+               rocblas_int incy,
+               T* A,
+               rocblas_int lda);
 
-    template<typename T>
-    void cblas_ger( rocblas_int m, rocblas_int n,
-                     T alpha,
-                     T *x, rocblas_int incx,
-                     T *y, rocblas_int incy,
-                     T *A, rocblas_int lda);
+template <typename T>
+void cblas_hemv(rocblas_fill uplo,
+                rocblas_int n,
+                T alpha,
+                T* A,
+                rocblas_int lda,
+                T* x,
+                rocblas_int incx,
+                T beta,
+                T* y,
+                rocblas_int incy);
 
-    template<typename T>
-    void cblas_hemv( rocblas_fill uplo, rocblas_int n,
-                     T alpha,
-                     T *A, rocblas_int lda,
-                     T *x, rocblas_int incx,
-                     T beta, T *y, rocblas_int incy);
+template <typename T>
+void cblas_gemm(rocblas_operation transA,
+                rocblas_operation transB,
+                rocblas_int m,
+                rocblas_int n,
+                rocblas_int k,
+                T alpha,
+                T* A,
+                rocblas_int lda,
+                T* B,
+                rocblas_int ldb,
+                T beta,
+                T* C,
+                rocblas_int ldc);
 
-    template<typename T>
-    void cblas_gemm( rocblas_operation transA, rocblas_operation transB,
-                     rocblas_int m, rocblas_int n, rocblas_int k,
-                     T alpha, T *A, rocblas_int lda,
-                     T *B, rocblas_int ldb,
-                     T beta, T *C, rocblas_int ldc);
+template <typename T>
+void cblas_trsm(rocblas_side side,
+                rocblas_fill uplo,
+                rocblas_operation transA,
+                rocblas_diagonal diag,
+                rocblas_int m,
+                rocblas_int n,
+                T alpha,
+                const T* A,
+                rocblas_int lda,
+                T* B,
+                rocblas_int ldb);
 
-    template<typename T>
-    void cblas_trsm( rocblas_side side, rocblas_fill uplo,
-                     rocblas_operation transA, rocblas_diagonal diag,
-                     rocblas_int m, rocblas_int n,
-                     T alpha,
-                     const T *A, rocblas_int lda,
-                     T *B, rocblas_int ldb);
+template <typename T>
+rocblas_int cblas_trtri(char uplo, char diag, rocblas_int n, T* A, rocblas_int lda);
 
-    template<typename T>
-    rocblas_int cblas_trtri(char uplo, char diag,
-                     rocblas_int n,
-                     T *A, rocblas_int lda);
+template <typename T>
+void cblas_trmm(rocblas_side side,
+                rocblas_fill uplo,
+                rocblas_operation transA,
+                rocblas_diagonal diag,
+                rocblas_int m,
+                rocblas_int n,
+                T alpha,
+                const T* A,
+                rocblas_int lda,
+                T* B,
+                rocblas_int ldb);
 
-    template<typename T>
-    void cblas_trmm( rocblas_side side, rocblas_fill uplo,
-                     rocblas_operation transA, rocblas_diagonal diag,
-                     rocblas_int m, rocblas_int n,
-                     T alpha,
-                     const T *A, rocblas_int lda,
-                     T *B, rocblas_int ldb);
+template <typename T>
+rocblas_int cblas_getrf(rocblas_int m, rocblas_int n, T* A, rocblas_int lda, rocblas_int* ipiv);
 
-    template<typename T>
-    rocblas_int cblas_getrf(rocblas_int m,
-                            rocblas_int n,
-                            T *A, rocblas_int lda, 
-                            rocblas_int *ipiv);
+template <typename T>
+rocblas_int cblas_potrf(char uplo, rocblas_int m, T* A, rocblas_int lda);
+/* ============================================================================================ */
 
-    template<typename T>
-    rocblas_int cblas_potrf(char uplo,
-                            rocblas_int m,
-                            T *A, rocblas_int lda);
-    /* ============================================================================================ */
-
-
-#endif  /* _CBLAS_INTERFACE_ */
+#endif /* _CBLAS_INTERFACE_ */

--- a/clients/include/flops.h
+++ b/clients/include/flops.h
@@ -11,81 +11,90 @@
 #include <typeinfo>
 
 /*!\file
- * \brief provides Floating point counts of Basic Linear Algebra Subprograms (BLAS) of Level 1, 2, 3.
+ * \brief provides Floating point counts of Basic Linear Algebra Subprograms (BLAS) of Level 1, 2,
+ * 3.
 */
 
-    /*
-     * ===========================================================================
-     *    level 1 BLAS
-     * ===========================================================================
-     */
-    template<typename T>
-    double  axpy_gflop_count(rocblas_int n){
-        return (2.0 * n)/1e9;
-    }
-    template<typename T>
-    double  dot_gflop_count(rocblas_int n){
-        return (2.0 * n)/1e9;
-    }
-    template<typename T>
-    double  scal_gflop_count(rocblas_int n){
-        return (1.0 * n)/1e9;
-    }
+/*
+ * ===========================================================================
+ *    level 1 BLAS
+ * ===========================================================================
+ */
+template <typename T>
+double axpy_gflop_count(rocblas_int n)
+{
+    return (2.0 * n) / 1e9;
+}
+template <typename T>
+double dot_gflop_count(rocblas_int n)
+{
+    return (2.0 * n) / 1e9;
+}
+template <typename T>
+double scal_gflop_count(rocblas_int n)
+{
+    return (1.0 * n) / 1e9;
+}
 
+/*
+ * ===========================================================================
+ *    level 2 BLAS
+ * ===========================================================================
+ */
 
-    /*
-     * ===========================================================================
-     *    level 2 BLAS
-     * ===========================================================================
-     */
+/* \brief floating point counts of GEMV */
+template <typename T>
+double gemv_gflop_count(rocblas_int m, rocblas_int n)
+{
+    return (2.0 * m * n) / 1e9;
+}
 
-    /* \brief floating point counts of GEMV */
-    template<typename T>
-    double  gemv_gflop_count(rocblas_int m, rocblas_int n){
-        return (2.0 * m * n)/1e9;
-    }
+/* \brief floating point counts of SY(HE)MV */
+template <typename T>
+double symv_gflop_count(rocblas_int n)
+{
+    return (2.0 * n * n) / 1e9;
+}
 
-    /* \brief floating point counts of SY(HE)MV */
-    template<typename T>
-    double  symv_gflop_count(rocblas_int n){
-        return (2.0 * n * n)/1e9;
-    }
+/* \brief floating point counts of GER */
+template <typename T>
+double ger_gflop_count(rocblas_int m, rocblas_int n)
+{
+    return (2.0 * m * n) / 1e9;
+}
 
-    /* \brief floating point counts of GER */
-    template<typename T>
-    double  ger_gflop_count(rocblas_int m, rocblas_int n){
-        return (2.0 * m * n)/1e9;
-    }
+/*
+ * ===========================================================================
+ *    level 3 BLAS
+ * ===========================================================================
+ */
 
-    /*
-     * ===========================================================================
-     *    level 3 BLAS
-     * ===========================================================================
-     */
+/* \brief floating point counts of GEMM */
+template <typename T>
+double gemm_gflop_count(rocblas_int m, rocblas_int n, rocblas_int k)
+{
+    return (2.0 * m * n * k) / 1e9;
+}
 
+/* \brief floating point counts of GEAM */
+template <typename T>
+double geam_gflop_count(rocblas_int m, rocblas_int n)
+{
+    return (3.0 * m * n) / 1e9;
+}
 
-    /* \brief floating point counts of GEMM */
-    template<typename T>
-    double  gemm_gflop_count(rocblas_int m, rocblas_int n, rocblas_int k){
-        return (2.0 * m * n * k)/1e9;
-    }
+/* \brief floating point counts of TRSM */
+template <typename T>
+double trsm_gflop_count(rocblas_int m, rocblas_int n, rocblas_int k)
+{
+    return (1.0 * m * n * (k + 1)) / 1e9;
+}
 
-    /* \brief floating point counts of GEAM */
-    template<typename T>
-    double  geam_gflop_count(rocblas_int m, rocblas_int n){
-        return (3.0 * m * n)/1e9;
-    }
+/* \brief floating point counts of TRTRI */
+template <typename T>
+double trtri_gflop_count(rocblas_int n)
+{
+    return (1.0 * n * n * n) / 3.0 / 1e9;
+}
 
-    /* \brief floating point counts of TRSM */
-    template<typename T>
-    double  trsm_gflop_count(rocblas_int m, rocblas_int n, rocblas_int k){
-        return (1.0 * m * n * (k+1))/1e9;
-    }
-
-    /* \brief floating point counts of TRTRI */
-    template<typename T>
-    double  trtri_gflop_count(rocblas_int n){
-        return (1.0 * n * n * n)/3.0/1e9;
-    }
-
-#endif  /* _ROCBLAS_FLOPS_H_ */
+#endif /* _ROCBLAS_FLOPS_H_ */

--- a/clients/include/near.h
+++ b/clients/include/near.h
@@ -19,19 +19,19 @@
 
    =================================================================== */
 
-
 /*!\file
  * \brief compares two results (usually, CPU and GPU results); provides Google Near check.
  */
 
+/* ========================================Gtest Near Check
+ * ==================================================== */
 
-/* ========================================Gtest Near Check ==================================================== */
-
-
-    /*! \brief Template: gtest near compare two matrices float/double/complex */
-    //Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test case
-    // a wrapper will cause the loop keep going
-    template<typename T1, typename T2>
-    void near_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, T1 *hCPU, T1 *hGPU, T2 abs_error);
+/*! \brief Template: gtest near compare two matrices float/double/complex */
+// Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test
+// case
+// a wrapper will cause the loop keep going
+template <typename T1, typename T2>
+void near_check_general(
+    rocblas_int M, rocblas_int N, rocblas_int lda, T1* hCPU, T1* hGPU, T2 abs_error);
 
 #endif

--- a/clients/include/norm.h
+++ b/clients/include/norm.h
@@ -13,25 +13,26 @@
         Norm check: norm(A-B)/norm(A), evaluate relative error
     =================================================================== */
 
-
 /*!\file
  * \brief compares two results (usually, CPU and GPU results); provides Norm check
  */
 
-/* ========================================Norm Check ==================================================== */
+/* ========================================Norm Check
+ * ==================================================== */
 
-    /*! \brief  Template: norm check for general Matrix: float/doubel/complex  */
+/*! \brief  Template: norm check for general Matrix: float/doubel/complex  */
 
-    // see check_norm.cpp for template speciliazation
-    // use auto as the return type is only allowed in c++14
-    // convert float/float to double
-    template<typename T>
-    double norm_check_general(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, T *hCPU, T *hGPU);
+// see check_norm.cpp for template speciliazation
+// use auto as the return type is only allowed in c++14
+// convert float/float to double
+template <typename T>
+double
+norm_check_general(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU);
 
-    /*! \brief  Template: norm check for hermitian/symmetric Matrix: float/double/complex */
+/*! \brief  Template: norm check for hermitian/symmetric Matrix: float/double/complex */
 
-    template<typename T>
-    double norm_check_symmetric(char norm_type, char uplo, rocblas_int N, rocblas_int lda, T *hCPU, T *hGPU);
-
+template <typename T>
+double
+norm_check_symmetric(char norm_type, char uplo, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU);
 
 #endif

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -10,187 +10,200 @@
 /* library headers */
 #include "rocblas.h"
 
-
 /*!\file
  * \brief rocblas_template_api.h provides Basic Linear Algebra Subprograms of Level 1, 2 and 3,
- *  using HIP optimized for AMD HCC-based GPU hardware. This library can also run on CUDA-based NVIDIA GPUs.
+ *  using HIP optimized for AMD HCC-based GPU hardware. This library can also run on CUDA-based
+ * NVIDIA GPUs.
  *  This file exposes C++ templated BLAS interface with only the precision templated.
 */
 
-    /*
-     * ===========================================================================
-     *   READEME: Please follow the naming convention
-     *   Big case for matrix, e.g. matrix A, B, C   GEMM (C = A*B)
-     *   Lower case for vector, e.g. vector x, y    GEMV (y = A*x)
-     * ===========================================================================
-     */
-     template<typename T>
-     rocblas_status
-     rocblas_scal(rocblas_handle handle,
-         rocblas_int n,
-         const T *alpha,
-         T *x, rocblas_int incx);
+/*
+ * ===========================================================================
+ *   READEME: Please follow the naming convention
+ *   Big case for matrix, e.g. matrix A, B, C   GEMM (C = A*B)
+ *   Lower case for vector, e.g. vector x, y    GEMV (y = A*x)
+ * ===========================================================================
+ */
+template <typename T>
+rocblas_status
+rocblas_scal(rocblas_handle handle, rocblas_int n, const T* alpha, T* x, rocblas_int incx);
 
-     template<typename T>
-     rocblas_status
-     rocblas_copy(rocblas_handle handle,
-         rocblas_int n,
-         const T *x, rocblas_int incx,
-         T *y, rocblas_int incy);
+template <typename T>
+rocblas_status rocblas_copy(
+    rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, T* y, rocblas_int incy);
 
-     template<typename T>
-     rocblas_status
-     rocblas_swap(rocblas_handle handle,
-         rocblas_int n,
-         T *x, rocblas_int incx,
-         T *y, rocblas_int incy);
+template <typename T>
+rocblas_status
+rocblas_swap(rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy);
 
-     template<typename T>
-     rocblas_status
-     rocblas_dot(rocblas_handle handle,
-         rocblas_int n,
-         const T *x, rocblas_int incx,
-         const T *y, rocblas_int incy,
-         T *result);
+template <typename T>
+rocblas_status rocblas_dot(rocblas_handle handle,
+                           rocblas_int n,
+                           const T* x,
+                           rocblas_int incx,
+                           const T* y,
+                           rocblas_int incy,
+                           T* result);
 
-     template<typename T1, typename T2>
-     rocblas_status
-     rocblas_asum(rocblas_handle handle,
-         rocblas_int n,
-         const T1 *x, rocblas_int incx,
-         T2 *result);
+template <typename T1, typename T2>
+rocblas_status
+rocblas_asum(rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, T2* result);
 
-     template<typename T1, typename T2>
-     rocblas_status
-     rocblas_nrm2(rocblas_handle handle,
-         rocblas_int n,
-         const T1 *x, rocblas_int incx,
-         T2 *result);
+template <typename T1, typename T2>
+rocblas_status
+rocblas_nrm2(rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, T2* result);
 
-     template<typename T>
-     rocblas_status
-     rocblas_iamax(rocblas_handle handle,
-         rocblas_int n,
-         const T *x, rocblas_int incx,
-         rocblas_int *result);
+template <typename T>
+rocblas_status rocblas_iamax(
+    rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result);
 
-     template<typename T>
-     rocblas_status
-     rocblas_iamin(rocblas_handle handle,
-         rocblas_int n,
-         const T *x, rocblas_int incx,
-         rocblas_int *result);
+template <typename T>
+rocblas_status rocblas_iamin(
+    rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result);
 
-     template<typename T>
-     rocblas_status
-     rocblas_axpy(rocblas_handle handle,
-         rocblas_int n,
-         const T *alpha,
-         const T *x, rocblas_int incx,
-         T *y, rocblas_int incy);
+template <typename T>
+rocblas_status rocblas_axpy(rocblas_handle handle,
+                            rocblas_int n,
+                            const T* alpha,
+                            const T* x,
+                            rocblas_int incx,
+                            T* y,
+                            rocblas_int incy);
 
-     template<typename T>
-     rocblas_status
-     rocblas_ger(rocblas_handle handle,
-              rocblas_int m, rocblas_int n,
-              const T *alpha,
-              const T *x, rocblas_int incx,
-              const T *y, rocblas_int incy,
-                    T *A, rocblas_int lda);
+template <typename T>
+rocblas_status rocblas_ger(rocblas_handle handle,
+                           rocblas_int m,
+                           rocblas_int n,
+                           const T* alpha,
+                           const T* x,
+                           rocblas_int incx,
+                           const T* y,
+                           rocblas_int incy,
+                           T* A,
+                           rocblas_int lda);
 
-    template<typename T>
-    rocblas_status
-    rocblas_gemv(rocblas_handle handle,
-             rocblas_operation transA,
-             rocblas_int m, rocblas_int n,
-             const T *alpha,
-             const T *A, rocblas_int lda,
-             const T *x, rocblas_int incx,
-             const T *beta,
-             T *y, rocblas_int incy);
+template <typename T>
+rocblas_status rocblas_gemv(rocblas_handle handle,
+                            rocblas_operation transA,
+                            rocblas_int m,
+                            rocblas_int n,
+                            const T* alpha,
+                            const T* A,
+                            rocblas_int lda,
+                            const T* x,
+                            rocblas_int incx,
+                            const T* beta,
+                            T* y,
+                            rocblas_int incy);
 
-    template<typename T>
-    rocblas_status
-    rocblas_symv(rocblas_handle handle,
-             rocblas_fill uplo,
-             rocblas_int n,
-             const T *alpha,
-             const T *A, rocblas_int lda,
-             const T *x, rocblas_int incx,
-             const T *beta,
-             T *y, rocblas_int incy);
+template <typename T>
+rocblas_status rocblas_symv(rocblas_handle handle,
+                            rocblas_fill uplo,
+                            rocblas_int n,
+                            const T* alpha,
+                            const T* A,
+                            rocblas_int lda,
+                            const T* x,
+                            rocblas_int incx,
+                            const T* beta,
+                            T* y,
+                            rocblas_int incy);
 
-    template<typename T>
-    rocblas_status rocblas_geam(rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n,
-        const T *alpha,
-        const T *A, rocblas_int lda,
-        const T *beta,
-        const T *B, rocblas_int ldb,
-        T *C, rocblas_int ldc);
+template <typename T>
+rocblas_status rocblas_geam(rocblas_handle handle,
+                            rocblas_operation transA,
+                            rocblas_operation transB,
+                            rocblas_int m,
+                            rocblas_int n,
+                            const T* alpha,
+                            const T* A,
+                            rocblas_int lda,
+                            const T* beta,
+                            const T* B,
+                            rocblas_int ldb,
+                            T* C,
+                            rocblas_int ldc);
 
-    template<typename T>
-    rocblas_status rocblas_gemm(rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const T *alpha,
-        const T *A, rocblas_int lda,
-        const T *B, rocblas_int ldb,
-        const T *beta,
-        T *C, rocblas_int ldc);
+template <typename T>
+rocblas_status rocblas_gemm(rocblas_handle handle,
+                            rocblas_operation transA,
+                            rocblas_operation transB,
+                            rocblas_int m,
+                            rocblas_int n,
+                            rocblas_int k,
+                            const T* alpha,
+                            const T* A,
+                            rocblas_int lda,
+                            const T* B,
+                            rocblas_int ldb,
+                            const T* beta,
+                            T* C,
+                            rocblas_int ldc);
 
-    template<typename T>
-    rocblas_status rocblas_gemm_strided_batched(
-        rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const T *alpha,
-        const T *A, rocblas_int lda, rocblas_int bsa,
-        const T *B, rocblas_int ldb, rocblas_int bsb,
-        const T *beta,
-        T *C, rocblas_int ldc, rocblas_int bsc,
-        rocblas_int batch_count);
+template <typename T>
+rocblas_status rocblas_gemm_strided_batched(rocblas_handle handle,
+                                            rocblas_operation transA,
+                                            rocblas_operation transB,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            rocblas_int k,
+                                            const T* alpha,
+                                            const T* A,
+                                            rocblas_int lda,
+                                            rocblas_int bsa,
+                                            const T* B,
+                                            rocblas_int ldb,
+                                            rocblas_int bsb,
+                                            const T* beta,
+                                            T* C,
+                                            rocblas_int ldc,
+                                            rocblas_int bsc,
+                                            rocblas_int batch_count);
 
+template <typename T>
+rocblas_status rocblas_trsm(rocblas_handle handle,
+                            rocblas_side side,
+                            rocblas_fill uplo,
+                            rocblas_operation transA,
+                            rocblas_diagonal diag,
+                            rocblas_int m,
+                            rocblas_int n,
+                            const T* alpha,
+                            T* A,
+                            rocblas_int lda,
+                            T* B,
+                            rocblas_int ldb);
 
-    template<typename T>
-    rocblas_status rocblas_trsm(rocblas_handle handle,
-        rocblas_side side, rocblas_fill uplo,
-        rocblas_operation transA, rocblas_diagonal diag,
-        rocblas_int m, rocblas_int n,
-        const T* alpha,
-        T* A, rocblas_int lda,
-        T* B, rocblas_int ldb);
+template <typename T>
+rocblas_status rocblas_trtri(rocblas_handle handle,
+                             rocblas_fill uplo,
+                             rocblas_diagonal diag,
+                             rocblas_int n,
+                             T* A,
+                             rocblas_int lda,
+                             T* invA,
+                             rocblas_int ldinvA);
 
+template <typename T>
+rocblas_status rocblas_trtri_batched(rocblas_handle handle,
+                                     rocblas_fill uplo,
+                                     rocblas_diagonal diag,
+                                     rocblas_int n,
+                                     T* A,
+                                     rocblas_int lda,
+                                     rocblas_int bsa,
+                                     T* invA,
+                                     rocblas_int ldinvA,
+                                     rocblas_int bsinvA,
+                                     rocblas_int batch_count);
 
+template <typename T, rocblas_int NB>
+rocblas_status rocblas_trtri_trsm(rocblas_handle handle,
+                                  rocblas_fill uplo,
+                                  rocblas_diagonal diag,
+                                  rocblas_int n,
+                                  T* A,
+                                  rocblas_int lda,
+                                  T* invA);
 
-    template<typename T>
-    rocblas_status
-    rocblas_trtri(rocblas_handle handle,
-        rocblas_fill uplo,
-        rocblas_diagonal diag,
-        rocblas_int n,
-        T *A, rocblas_int lda, 
-        T *invA, rocblas_int ldinvA);
-
-    template<typename T>
-    rocblas_status
-    rocblas_trtri_batched(rocblas_handle handle,
-        rocblas_fill uplo,
-        rocblas_diagonal diag,
-        rocblas_int n,
-        T *A, rocblas_int lda, rocblas_int bsa,
-        T *invA, rocblas_int ldinvA, rocblas_int bsinvA,
-        rocblas_int batch_count);
-
-    template<typename T, rocblas_int NB>
-    rocblas_status
-    rocblas_trtri_trsm(rocblas_handle handle,
-        rocblas_fill uplo, rocblas_diagonal diag,
-        rocblas_int n,
-        T *A, rocblas_int lda,
-        T *invA);
-
-
-
-#endif  // _ROCBLAS_HPP_
+#endif // _ROCBLAS_HPP_

--- a/clients/include/rocblas_test_unique_ptr.hpp
+++ b/clients/include/rocblas_test_unique_ptr.hpp
@@ -3,47 +3,50 @@
 
 #include <memory>
 
-#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK) {\
-    hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != hipSuccess) { \
-        fprintf(stderr, "hip error code: %d at %s:%d\n",  TMP_STATUS_FOR_CHECK,__FILE__, __LINE__); \
-} }
+#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
+    {                                                             \
+        hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != hipSuccess)                    \
+        {                                                         \
+            fprintf(stderr,                                       \
+                    "hip error code: %d at %s:%d\n",              \
+                    TMP_STATUS_FOR_CHECK,                         \
+                    __FILE__,                                     \
+                    __LINE__);                                    \
+        \
+}                                                      \
+    }
 
-namespace rocblas_test
+namespace rocblas_test {
+// device_malloc wraps hipMalloc and provides same API as malloc
+static void* device_malloc(size_t byte_size)
 {
-    // device_malloc wraps hipMalloc and provides same API as malloc
-    static void* device_malloc(size_t byte_size)
+    void* pointer;
+    PRINT_IF_HIP_ERROR(hipMalloc(&pointer, byte_size));
+    return pointer;
+}
+
+// device_free wraps hipFree and provides same API as free
+static void device_free(void* ptr) { PRINT_IF_HIP_ERROR(hipFree(ptr)); }
+
+struct handle_struct
+{
+    rocblas_handle handle;
+    handle_struct()
     {
-        void *pointer;
-        PRINT_IF_HIP_ERROR(hipMalloc(&pointer, byte_size));
-        return pointer;
+        rocblas_status status = rocblas_create_handle(&handle);
+        verify_rocblas_status_success(status, "ERROR: handle_struct constructor");
     }
 
-    // device_free wraps hipFree and provides same API as free
-    static void device_free(void *ptr)
-    {   
-        PRINT_IF_HIP_ERROR(hipFree(ptr));
-    }
-
-    struct handle_struct
+    ~handle_struct()
     {
-        rocblas_handle handle;
-        handle_struct()
-        {
-            rocblas_status status = rocblas_create_handle(&handle);
-            verify_rocblas_status_success(status,"ERROR: handle_struct constructor");
-        }
-
-        ~handle_struct()
-        {
-            rocblas_status status = rocblas_destroy_handle(handle);
-            verify_rocblas_status_success(status,"ERROR: handle_struct destructor");
-        }
-    };
-
+        rocblas_status status = rocblas_destroy_handle(handle);
+        verify_rocblas_status_success(status, "ERROR: handle_struct destructor");
+    }
+};
 
 } // namespace rocblas_test
 
-using rocblas_unique_ptr = std::unique_ptr<void, void(*)(void*)>;
+using rocblas_unique_ptr = std::unique_ptr<void, void (*)(void*)>;
 
 #endif

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -17,14 +17,14 @@
 
 using namespace std;
 
-template<typename T1, typename T2>
+template <typename T1, typename T2>
 void testing_asum_bad_arg()
 {
-    rocblas_int N = 100;
-    rocblas_int incx = 1;
+    rocblas_int N         = 100;
+    rocblas_int incx      = 1;
     rocblas_int safe_size = 100;
-    T2 rocblas_result = 10;
-    T2 *h_rocblas_result;
+    T2 rocblas_result     = 10;
+    T2* h_rocblas_result;
     h_rocblas_result = &rocblas_result;
 
     rocblas_status status;
@@ -32,9 +32,10 @@ void testing_asum_bad_arg()
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),rocblas_test::device_free};
-    T1* dx = (T1*) dx_managed.get();
-    if (!dx)
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),
+                                         rocblas_test::device_free};
+    T1* dx = (T1*)dx_managed.get();
+    if(!dx)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -42,19 +43,19 @@ void testing_asum_bad_arg()
 
     // testing for (nullptr == dx)
     {
-        T1 *dx_null = nullptr;
+        T1* dx_null = nullptr;
 
         status = rocblas_asum<T1, T2>(handle, N, dx_null, incx, h_rocblas_result);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: dx is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: dx is nullptr");
     }
     // testing for (nullptr == d_rocblas_result)
     {
-        T2 *h_rocblas_result_null = nullptr;
+        T2* h_rocblas_result_null = nullptr;
 
         status = rocblas_asum<T1, T2>(handle, N, dx, incx, h_rocblas_result_null);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: result is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: result is nullptr");
     }
     // testing for ( nullptr == handle )
     {
@@ -66,12 +67,12 @@ void testing_asum_bad_arg()
     }
 }
 
-template<typename T1, typename T2>
+template <typename T1, typename T2>
 rocblas_status testing_asum(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    rocblas_int safe_size = 100;   // arbitrarily set to 100
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    rocblas_int safe_size = 100; // arbitrarily set to 100
 
     T2 rocblas_result_1;
     T2 rocblas_result_2;
@@ -86,13 +87,15 @@ rocblas_status testing_asum(Arguments argus)
     rocblas_handle handle = unique_ptr_handle->handle;
 
     // check to prevent undefined memory allocation error
-    if( N <= 0 || incx <= 0 )
+    if(N <= 0 || incx <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),rocblas_test::device_free};
-        auto d_rocblas_result_managed_2 = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)),rocblas_test::device_free};
-        T1* dx = (T1*) dx_managed.get();
-        T2* d_rocblas_result_2 = (T2*) d_rocblas_result_managed_2.get();
-        if (!dx || !d_rocblas_result_2)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),
+                                             rocblas_test::device_free};
+        auto d_rocblas_result_managed_2 =
+            rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)), rocblas_test::device_free};
+        T1* dx                 = (T1*)dx_managed.get();
+        T2* d_rocblas_result_2 = (T2*)d_rocblas_result_managed_2.get();
+        if(!dx || !d_rocblas_result_2)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
@@ -109,11 +112,13 @@ rocblas_status testing_asum(Arguments argus)
     rocblas_int size_x = N * incx;
 
     // allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * size_x),rocblas_test::device_free};
-    auto d_rocblas_result_managed_2 = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)),rocblas_test::device_free};
-    T1* dx = (T1*) dx_managed.get();
-    T2* d_rocblas_result_2 = (T2*) d_rocblas_result_managed_2.get();
-    if (!dx || !d_rocblas_result_2)
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * size_x),
+                                         rocblas_test::device_free};
+    auto d_rocblas_result_managed_2 =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)), rocblas_test::device_free};
+    T1* dx                 = (T1*)dx_managed.get();
+    T2* d_rocblas_result_2 = (T2*)d_rocblas_result_managed_2.get();
+    if(!dx || !d_rocblas_result_2)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
@@ -122,12 +127,12 @@ rocblas_status testing_asum(Arguments argus)
     // Naming: dx is in GPU (device) memory. hx is in CPU (host) memory, plz follow this practice
     vector<T1> hx(size_x);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T1>(hx, 1, N, incx);
 
     // copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1)*size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1) * size_x, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
 
@@ -135,13 +140,14 @@ rocblas_status testing_asum(Arguments argus)
     {
         // GPU BLAS rocblas_pointer_mode_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR((rocblas_asum<T1,T2>(handle, N, dx, incx, &rocblas_result_1)));
+        CHECK_ROCBLAS_ERROR((rocblas_asum<T1, T2>(handle, N, dx, incx, &rocblas_result_1)));
 
         // GPU BLAS rocblas_pointer_mode_device
-        CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1)*size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1) * size_x, hipMemcpyHostToDevice));
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR((rocblas_asum<T1,T2>(handle, N, dx, incx, d_rocblas_result_2)));
-        CHECK_HIP_ERROR(hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T1), hipMemcpyDeviceToHost));
+        CHECK_ROCBLAS_ERROR((rocblas_asum<T1, T2>(handle, N, dx, incx, d_rocblas_result_2)));
+        CHECK_HIP_ERROR(
+            hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T1), hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -154,13 +160,17 @@ rocblas_status testing_asum(Arguments argus)
             unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2);
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
-            printf("cpu=%e, gpu_host_ptr,=%e, gup_dev_ptr=%e\n", cpu_result, rocblas_result_1, rocblas_result_2);
-            rocblas_error_1 = fabs((cpu_result - rocblas_result_1)/cpu_result);
-            rocblas_error_2 = fabs((cpu_result - rocblas_result_2)/cpu_result);
+            printf("cpu=%e, gpu_host_ptr,=%e, gup_dev_ptr=%e\n",
+                   cpu_result,
+                   rocblas_result_1,
+                   rocblas_result_2);
+            rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
+            rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);
         }
     }
 
@@ -169,23 +179,25 @@ rocblas_status testing_asum(Arguments argus)
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        gpu_time_used = get_time_us();  // in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
-            rocblas_asum<T1,T2>(handle, N, dx, incx, &rocblas_result_1);
+            rocblas_asum<T1, T2>(handle, N, dx, incx, &rocblas_result_1);
         }
 
         gpu_time_used = (get_time_us() - gpu_time_used) / number_timing_iterations;
 
         cout << "N,rocblas(us)";
 
-        if(argus.norm_check) cout << ",CPU(us),error_host_ptr,error_dev_ptr" ;
+        if(argus.norm_check)
+            cout << ",CPU(us),error_host_ptr,error_dev_ptr";
 
         cout << endl;
         cout << N << "," << gpu_time_used;
 
-        if(argus.norm_check) cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
+        if(argus.norm_check)
+            cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
 
         cout << endl;
     }

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -19,25 +19,27 @@
 using namespace std;
 
 /* ============================================================================================ */
-template<typename T>
+template <typename T>
 void testing_axpy_bad_arg()
 {
-    rocblas_int N = 100;
-    rocblas_int incx = 1;
-    rocblas_int incy = 1;
+    rocblas_int N         = 100;
+    rocblas_int incx      = 1;
+    rocblas_int incy      = 1;
     rocblas_int safe_size = 100;
-    T alpha = 0.6;
+    T alpha               = 0.6;
 
     rocblas_status status;
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dx || !dy)
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    T* dx = (T*)dx_managed.get();
+    T* dy = (T*)dy_managed.get();
+    if(!dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -45,27 +47,27 @@ void testing_axpy_bad_arg()
 
     // testing for (nullptr == dx)
     {
-        T *dx_null = nullptr;
+        T* dx_null = nullptr;
 
         status = rocblas_axpy<T>(handle, N, &alpha, dx_null, incx, dy, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x is nullptr");
     }
     // testing for (nullptr == dy)
     {
-        T *dy_null = nullptr;
+        T* dy_null = nullptr;
 
         status = rocblas_axpy<T>(handle, N, &alpha, dx, incx, dy_null, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: y is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: y is nullptr");
     }
     // testing for (nullptr == d_alpha)
     {
-        T *d_alpha_null = nullptr;
+        T* d_alpha_null = nullptr;
 
         status = rocblas_axpy<T>(handle, N, d_alpha_null, dx, incx, dy, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: y is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: y is nullptr");
     }
     // testing (nullptr == handle)
     {
@@ -78,31 +80,32 @@ void testing_axpy_bad_arg()
     return;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_axpy(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    rocblas_int incy = argus.incy;
-    rocblas_int safe_size = 100;   // arbitrarily set to 100
-    T h_alpha = 0;
-    if (typeid(T) == typeid(rocblas_half))
-        h_alpha = float_to_half( argus.alpha );
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    rocblas_int incy      = argus.incy;
+    rocblas_int safe_size = 100; // arbitrarily set to 100
+    T h_alpha             = 0;
+    if(typeid(T) == typeid(rocblas_half))
+        h_alpha = float_to_half(argus.alpha);
     else
         h_alpha = argus.alpha;
 
-    std::unique_ptr<rocblas_test::handle_struct>
-        test_handle(new rocblas_test::handle_struct);
+    std::unique_ptr<rocblas_test::handle_struct> test_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = test_handle->handle;
 
-    //argument sanity check before allocating invalid memory
-    if ( N <= 0 )
+    // argument sanity check before allocating invalid memory
+    if(N <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dx = (T*) dx_managed.get();
-        T* dy = (T*) dy_managed.get();
-        if (!dx || !dy)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dx = (T*)dx_managed.get();
+        T* dy = (T*)dy_managed.get();
+        if(!dx || !dy)
         {
             verify_rocblas_status_success(rocblas_status_memory_error, "!dx || !dy");
             return rocblas_status_memory_error;
@@ -116,51 +119,57 @@ rocblas_status testing_axpy(Arguments argus)
 
     rocblas_int abs_incx = incx > 0 ? incx : -incx;
     rocblas_int abs_incy = incy > 0 ? incy : -incy;
-    rocblas_int size_x = N * abs_incx;
-    rocblas_int size_y = N * abs_incy;
+    rocblas_int size_x   = N * abs_incx;
+    rocblas_int size_y   = N * abs_incy;
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hx(size_x);
     vector<T> hy_1(size_y);
     vector<T> hy_2(size_y);
     vector<T> hy_gold(size_y);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hx, 1, N, abs_incx);
     rocblas_init<T>(hy_1, 1, N, abs_incy);
 
-    //copy vector is easy in STL; hy_gold = hx: save a copy in hy_gold which will be output of CPU BLAS
-    hy_2 = hy_1;
+    // copy vector is easy in STL; hy_gold = hx: save a copy in hy_gold which will be output of CPU
+    // BLAS
+    hy_2    = hy_1;
     hy_gold = hy_1;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto dy_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    auto dy_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy_1 = (T*) dy_1_managed.get();
-    T* dy_2 = (T*) dy_2_managed.get();
-    T* d_alpha = (T*) d_alpha_managed.get();
-    if (!dx || !dy_1 || !dy_2 || !d_alpha)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                           rocblas_test::device_free};
+    auto dy_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                           rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dx      = (T*)dx_managed.get();
+    T* dy_1    = (T*)dy_1_managed.get();
+    T* dy_2    = (T*)dy_2_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    if(!dx || !dy_1 || !dy_2 || !d_alpha)
     {
-        verify_rocblas_status_success(rocblas_status_memory_error, "!dx || !dy_1 || !dy_2 || !d_alpha");
+        verify_rocblas_status_success(rocblas_status_memory_error,
+                                      "!dx || !dy_1 || !dy_2 || !d_alpha");
         return rocblas_status_memory_error;
     }
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy_1, hy_1.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy_1, hy_1.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
     double rocblas_error_1 = 0.0;
     double rocblas_error_2 = 0.0;
 
-    if (argus.unit_check || argus.norm_check)
+    if(argus.unit_check || argus.norm_check)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dy_2, hy_2.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy_2, hy_2.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
         // ROCBLAS pointer mode host
@@ -171,9 +180,9 @@ rocblas_status testing_axpy(Arguments argus)
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         CHECK_ROCBLAS_ERROR(rocblas_axpy<T>(handle, N, d_alpha, dx, incx, dy_2, incy));
 
-        //copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T)*size_y, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hy_2.data(), dy_2, sizeof(T)*size_y, hipMemcpyDeviceToHost));
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T) * size_y, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_2.data(), dy_2, sizeof(T) * size_y, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -181,50 +190,55 @@ rocblas_status testing_axpy(Arguments argus)
         cblas_axpy<T>(N, h_alpha, hx.data(), incx, hy_gold.data(), incy);
 
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = axpy_gflop_count<T> (N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = axpy_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if (argus.unit_check)
+        if(argus.unit_check)
         {
             unit_check_general<T>(1, N, abs_incy, hy_gold.data(), hy_1.data());
             unit_check_general<T>(1, N, abs_incy, hy_gold.data(), hy_2.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-        if (argus.norm_check)
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
+        if(argus.norm_check)
         {
-            rocblas_error_1 = norm_check_general<T>('F', 1, N, abs_incy, hy_gold.data(), hy_1.data());
-            rocblas_error_2 = norm_check_general<T>('F', 1, N, abs_incy, hy_gold.data(), hy_2.data());
+            rocblas_error_1 =
+                norm_check_general<T>('F', 1, N, abs_incy, hy_gold.data(), hy_1.data());
+            rocblas_error_2 =
+                norm_check_general<T>('F', 1, N, abs_incy, hy_gold.data(), hy_2.data());
         }
     }
 
-    if (argus.timing)
+    if(argus.timing)
     {
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             rocblas_axpy<T>(handle, N, &h_alpha, dx, incx, dy_1, incy);
         }
 
-        gpu_time_used = (get_time_us() - gpu_time_used) / number_timing_iterations;
-        rocblas_gflops = axpy_gflop_count<T> (N) / gpu_time_used * 1e6 * 1;
-        rocblas_bandwidth = (3.0 * N) * sizeof(T)/ gpu_time_used / 1e3;
+        gpu_time_used     = (get_time_us() - gpu_time_used) / number_timing_iterations;
+        rocblas_gflops    = axpy_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_bandwidth = (3.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         cout << "N,rocblas-Gflops,rocblas-GB/s,rocblas-us";
 
-        if (argus.norm_check) cout << "CPU-Gflops,norm_error_host_ptr,norm_error_dev_ptr" ;
+        if(argus.norm_check)
+            cout << "CPU-Gflops,norm_error_host_ptr,norm_error_dev_ptr";
 
         cout << endl;
 
         cout << N << "," << rocblas_gflops << "," << rocblas_bandwidth << "," << gpu_time_used;
 
-        if (argus.norm_check) cout << "," << cblas_gflops << ',' << rocblas_error_1 << ',' << rocblas_error_2;
+        if(argus.norm_check)
+            cout << "," << cblas_gflops << ',' << rocblas_error_1 << ',' << rocblas_error_2;
 
         cout << endl;
     }

--- a/clients/include/testing_bandwidth.hpp
+++ b/clients/include/testing_bandwidth.hpp
@@ -21,24 +21,25 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template<typename T>
+template <typename T>
 rocblas_status testing_bandwidth(Arguments argus)
 {
 
-    rocblas_int N = 25*1e7;
+    rocblas_int N = 25 * 1e7;
 
     rocblas_int incx = 1;
 
     rocblas_status status = rocblas_status_success;
 
     rocblas_int size_X = N * incx;
-    T alpha = 2.0;
+    T alpha            = 2.0;
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hx(size_X);
     vector<T> hz(size_X);
 
-    if( N > hx.max_size()){
+    if(N > hx.max_size())
+    {
         printf("max_size of a std::vector is %lu, please reduce the input size \n", hx.max_size());
         return status;
     }
@@ -48,29 +49,30 @@ rocblas_status testing_bandwidth(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_X),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_X),rocblas_test::device_free};
-    auto d_rocblas_result_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    T* d_rocblas_result = (T*) d_rocblas_result_managed.get();
-    if (!dx || !dy || !d_rocblas_result)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_X),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_X),
+                                         rocblas_test::device_free};
+    auto d_rocblas_result_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dx               = (T*)dx_managed.get();
+    T* dy               = (T*)dy_managed.get();
+    T* d_rocblas_result = (T*)d_rocblas_result_managed.get();
+    if(!dx || !dy || !d_rocblas_result)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
     }
 
-
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hx, 1, N, incx);
 
-    //hz = hx;
+    // hz = hx;
 
-
-    //copy data from CPU to device,
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*N*incx, hipMemcpyHostToDevice));
+    // copy data from CPU to device,
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
 
     printf("Bandwidth     MByte    GPU (GB/s)    Time (us) \n");
 
@@ -78,50 +80,54 @@ rocblas_status testing_bandwidth(Arguments argus)
          Bandwidth
     =================================================================== */
 
-    for(size_t size = 1e6; size <= N; size *= 2){
+    for(size_t size = 1e6; size <= N; size *= 2)
+    {
 
-        CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size*incx, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size * incx, hipMemcpyHostToDevice));
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        //scal dx
-        status = rocblas_scal<T>(handle,
-                        N, &alpha,
-                        dx, incx);
-        if (status != rocblas_status_success) 
+        // scal dx
+        status = rocblas_scal<T>(handle, N, &alpha, dx, incx);
+        if(status != rocblas_status_success)
         {
             break;
             return status;
         }
 
-//       hipMemcpy(dy, dx, sizeof(T)*size*incx, hipMemcpyDeviceToDevice);
+        //       hipMemcpy(dy, dx, sizeof(T)*size*incx, hipMemcpyDeviceToDevice);
 
-//       hipMemset(dx, 0, size*sizeof(T));
+        //       hipMemset(dx, 0, size*sizeof(T));
 
         gpu_time_used = get_time_us() - gpu_time_used;
 
-        gpu_bandwidth = 2 * size * sizeof(T) / 1e6 / (gpu_time_used); //in GB/s
+        gpu_bandwidth = 2 * size * sizeof(T) / 1e6 / (gpu_time_used); // in GB/s
 
-        //CPU result, before GPU result copy back to CPU
-        #pragma unroll
-        for(size_t i=0; i<size; i++){
+// CPU result, before GPU result copy back to CPU
+#pragma unroll
+        for(size_t i = 0; i < size; i++)
+        {
             hz[i] = alpha * hx[i];
         }
 
-        //copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T)*size*incx, hipMemcpyDeviceToHost));
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * size * incx, hipMemcpyDeviceToHost));
 
-        //check error with CPU result
-        for(size_t i=0; i<size; i++){
+        // check error with CPU result
+        for(size_t i = 0; i < size; i++)
+        {
             T error = fabs(hz[i] - hx[i]);
-            if(error > 0){
+            if(error > 0)
+            {
                 printf("error is %f, CPU=%f, GPU=%f, at elment %zu", error, hz[i], hx[i], i);
                 break;
             }
         }
 
-        printf("              %6.2f     %8.2f  %8.2f        \n", (int)size*sizeof(T)/1e6, gpu_bandwidth, gpu_time_used);
-
+        printf("              %6.2f     %8.2f  %8.2f        \n",
+               (int)size * sizeof(T) / 1e6,
+               gpu_bandwidth,
+               gpu_time_used);
     }
 
     return rocblas_status_success;

--- a/clients/include/testing_copy.hpp
+++ b/clients/include/testing_copy.hpp
@@ -16,24 +16,26 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 void testing_copy_bad_arg()
 {
-    rocblas_int N = 100;
-    rocblas_int incx = 1;
-    rocblas_int incy = 1;
-    rocblas_int safe_size = 100;  //  arbitrarily set to 100
+    rocblas_int N         = 100;
+    rocblas_int incx      = 1;
+    rocblas_int incy      = 1;
+    rocblas_int safe_size = 100; //  arbitrarily set to 100
 
     rocblas_status status;
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dx || !dy)
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    T* dx = (T*)dx_managed.get();
+    T* dy = (T*)dy_managed.get();
+    if(!dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -41,19 +43,19 @@ void testing_copy_bad_arg()
 
     // check if (nullptr == dx)
     {
-        T *dx_null = nullptr;
+        T* dx_null = nullptr;
 
         status = rocblas_copy<T>(handle, N, dx_null, incx, dy, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x, y, is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x, y, is nullptr");
     }
     // check if (nullptr == dy )
     {
-        T *dy_null = nullptr;
+        T* dy_null = nullptr;
 
         status = rocblas_copy<T>(handle, N, dx, incx, dy_null, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x, y, is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x, y, is nullptr");
     }
     // check if ( nullptr == handle )
     {
@@ -67,27 +69,29 @@ void testing_copy_bad_arg()
     return;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_copy(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    rocblas_int incy = argus.incy;
-    rocblas_int safe_size = 100;  //  arbitrarily set to 100
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    rocblas_int incy      = argus.incy;
+    rocblas_int safe_size = 100; //  arbitrarily set to 100
 
     rocblas_status status;
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //argument sanity check before allocating invalid memory
-    if ( N <= 0 )
+    // argument sanity check before allocating invalid memory
+    if(N <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dx = (T*) dx_managed.get();
-        T* dy = (T*) dy_managed.get();
-        if (!dx || !dy)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dx = (T*)dx_managed.get();
+        T* dy = (T*)dy_managed.get();
+        if(!dx || !dy)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
@@ -100,36 +104,39 @@ rocblas_status testing_copy(Arguments argus)
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    rocblas_int size_x = N * abs_incx;
-    rocblas_int size_y = N * abs_incy;
+    rocblas_int size_x   = N * abs_incx;
+    rocblas_int size_y   = N * abs_incy;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x ),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y ),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dx || !dy)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                         rocblas_test::device_free};
+    T* dx = (T*)dx_managed.get();
+    T* dy = (T*)dy_managed.get();
+    if(!dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hx(size_x);
     vector<T> hy(size_y);
     vector<T> hy_gold(size_y);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hx, 1, N, abs_incx);
     rocblas_init<T>(hy, 1, N, abs_incy);
 
-    //copy vector is easy in STL; hy_gold = hx: save a copy in hy_gold which will be output of CPU BLAS
+    // copy vector is easy in STL; hy_gold = hx: save a copy in hy_gold which will be output of CPU
+    // BLAS
     hy_gold = hy;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_error = 0.0;
@@ -138,23 +145,23 @@ rocblas_status testing_copy(Arguments argus)
     {
         // GPU BLAS
         CHECK_ROCBLAS_ERROR(rocblas_copy<T>(handle, N, dx, incx, dy, incy));
-        CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T)*size_y, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
-        cblas_copy<T>( N, hx.data(), incx, hy_gold.data(), incy);
+        cblas_copy<T>(N, hx.data(), incx, hy_gold.data(), incy);
         cpu_time_used = get_time_us() - cpu_time_used;
 
-
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
             unit_check_general<T>(1, N, abs_incy, hy_gold.data(), hy.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
             rocblas_error = norm_check_general<T>('F', 1, N, abs_incy, hy_gold.data(), hy.data());
@@ -165,9 +172,9 @@ rocblas_status testing_copy(Arguments argus)
     {
         int number_timing_iterations = 1;
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             status = rocblas_copy<T>(handle, N, dx, incx, dy, incy);
         }
@@ -176,13 +183,15 @@ rocblas_status testing_copy(Arguments argus)
 
         cout << "N,rocblas-us";
 
-        if (argus.norm_check) cout << ",CPU-us,error";
+        if(argus.norm_check)
+            cout << ",CPU-us,error";
 
         cout << endl;
 
         cout << N << "," << gpu_time_used;
 
-        if (argus.norm_check) cout << "," << cpu_time_used << "," << rocblas_error;
+        if(argus.norm_check)
+            cout << "," << cpu_time_used << "," << rocblas_error;
 
         cout << endl;
     }

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -17,26 +17,29 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 rocblas_status testing_dot_bad_arg()
 {
-    rocblas_int N = 100;
-    rocblas_int incx = 1;
-    rocblas_int incy = 1;
-    rocblas_int safe_size = 100;  //  arbitrarily set to 100
+    rocblas_int N         = 100;
+    rocblas_int incx      = 1;
+    rocblas_int incy      = 1;
+    rocblas_int safe_size = 100; //  arbitrarily set to 100
 
     rocblas_status status;
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    auto d_rocblas_result_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    T* d_rocblas_result = (T*) d_rocblas_result_managed.get();
-    if (!dx || !dy || !d_rocblas_result)
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    auto d_rocblas_result_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dx               = (T*)dx_managed.get();
+    T* dy               = (T*)dy_managed.get();
+    T* d_rocblas_result = (T*)d_rocblas_result_managed.get();
+    if(!dx || !dy || !d_rocblas_result)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
@@ -44,30 +47,30 @@ rocblas_status testing_dot_bad_arg()
 
     // test if (nullptr == dx)
     {
-        T *dx_null = nullptr;
+        T* dx_null = nullptr;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         status = rocblas_dot<T>(handle, N, dx_null, incx, dy, incy, d_rocblas_result);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x, y, or result is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x, y, or result is nullptr");
     }
     // test if (nullptr == dy)
     {
-        T *dy_null = nullptr;
+        T* dy_null = nullptr;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         status = rocblas_dot<T>(handle, N, dx, incx, dy_null, incy, d_rocblas_result);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x, y, or result is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x, y, or result is nullptr");
     }
     // test if (nullptr == d_rocblas_result)
     {
-        T *d_rocblas_result_null = nullptr;
+        T* d_rocblas_result_null = nullptr;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         status = rocblas_dot<T>(handle, N, dx, incx, dy, incy, d_rocblas_result_null);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x, y, or result is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x, y, or result is nullptr");
     }
     // test if ( nullptr == handle )
     {
@@ -81,13 +84,13 @@ rocblas_status testing_dot_bad_arg()
     return rocblas_status_success;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_dot(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    rocblas_int incy = argus.incy;
-    rocblas_int safe_size = 100;   // arbitrarily set to 100
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    rocblas_int incy      = argus.incy;
+    rocblas_int safe_size = 100; // arbitrarily set to 100
 
     T cpu_result;
     T rocblas_result_1;
@@ -102,15 +105,18 @@ rocblas_status testing_dot(Arguments argus)
     rocblas_handle handle = unique_ptr_handle->handle;
 
     // check to prevent undefined memmory allocation error
-    if ( N <= 0 )
+    if(N <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto d_rocblas_result_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-        T* dx = (T*) dx_managed.get();
-        T* dy = (T*) dy_managed.get();
-        T* d_rocblas_result = (T*) d_rocblas_result_managed.get();
-        if (!dx || !dy || !d_rocblas_result)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto d_rocblas_result_managed =
+            rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+        T* dx               = (T*)dx_managed.get();
+        T* dy               = (T*)dy_managed.get();
+        T* d_rocblas_result = (T*)d_rocblas_result_managed.get();
+        if(!dx || !dy || !d_rocblas_result)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
@@ -126,34 +132,37 @@ rocblas_status testing_dot(Arguments argus)
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    rocblas_int size_x = N * abs_incx;
-    rocblas_int size_y = N * abs_incy;
+    rocblas_int size_x   = N * abs_incx;
+    rocblas_int size_y   = N * abs_incy;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    auto d_rocblas_result_managed_2 = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    T* d_rocblas_result_2 = (T*) d_rocblas_result_managed_2.get();
-    if (!dx || !dy || !d_rocblas_result_2)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                         rocblas_test::device_free};
+    auto d_rocblas_result_managed_2 =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dx                 = (T*)dx_managed.get();
+    T* dy                 = (T*)dy_managed.get();
+    T* d_rocblas_result_2 = (T*)d_rocblas_result_managed_2.get();
+    if(!dx || !dy || !d_rocblas_result_2)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hx(size_x);
     vector<T> hy(size_y);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hx, 1, N, abs_incx);
     rocblas_init<T>(hy, 1, N, abs_incy);
 
-    //copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
@@ -167,13 +176,14 @@ rocblas_status testing_dot(Arguments argus)
         // GPU BLAS, rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         CHECK_ROCBLAS_ERROR(rocblas_dot<T>(handle, N, dx, incx, dy, incy, d_rocblas_result_2));
-        CHECK_HIP_ERROR(hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T), hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
         cblas_dot<T>(N, hx.data(), incx, hy.data(), incy, &cpu_result);
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = axpy_gflop_count<T> (N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = axpy_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
 
         if(argus.unit_check)
         {
@@ -181,13 +191,17 @@ rocblas_status testing_dot(Arguments argus)
             unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2);
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
-            printf("cpu=%f, gpu_host_ptr=%f, gpu_device_ptr=%f\n", cpu_result, rocblas_result_1, rocblas_result_2);
-            rocblas_error_1 = fabs((cpu_result - rocblas_result_1)/cpu_result);
-            rocblas_error_2 = fabs((cpu_result - rocblas_result_2)/cpu_result);
+            printf("cpu=%f, gpu_host_ptr=%f, gpu_device_ptr=%f\n",
+                   cpu_result,
+                   rocblas_result_1,
+                   rocblas_result_2);
+            rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
+            rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);
         }
     }
 
@@ -196,26 +210,28 @@ rocblas_status testing_dot(Arguments argus)
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
             rocblas_dot<T>(handle, N, dx, incx, dy, incy, &rocblas_result_1);
         }
 
-        gpu_time_used = (get_time_us() - gpu_time_used) / number_timing_iterations;
-        rocblas_gflops = dot_gflop_count<T> (N) / gpu_time_used * 1e6 * 1;
-        rocblas_bandwidth = (2.0 * N) * sizeof(T)/ gpu_time_used / 1e3;
+        gpu_time_used     = (get_time_us() - gpu_time_used) / number_timing_iterations;
+        rocblas_gflops    = dot_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_bandwidth = (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         cout << "N,rocblas-Gflops,rocblas-GB/s,rocblas-us";
 
-        if(argus.norm_check) cout << ",CPU-Gflops,norm_error_host_ptr,norm_error_dev_ptr" ;
+        if(argus.norm_check)
+            cout << ",CPU-Gflops,norm_error_host_ptr,norm_error_dev_ptr";
 
         cout << endl;
         cout << N << "," << rocblas_gflops << "," << rocblas_bandwidth << "," << gpu_time_used;
-       
-        if(argus.norm_check) cout << "," << cblas_gflops << "," << rocblas_error_1 << "," << rocblas_error_2;
+
+        if(argus.norm_check)
+            cout << "," << cblas_gflops << "," << rocblas_error_1 << "," << rocblas_error_2;
 
         cout << endl;
     }

--- a/clients/include/testing_geam.hpp
+++ b/clients/include/testing_geam.hpp
@@ -22,7 +22,7 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template<typename T>
+template <typename T>
 void testing_geam_bad_arg()
 {
     const rocblas_int M = 100;
@@ -33,7 +33,7 @@ void testing_geam_bad_arg()
     const rocblas_int ldc = 100;
 
     const T h_alpha = 1.0;
-    const T h_beta = 1.0;
+    const T h_beta  = 1.0;
 
     const rocblas_operation transA = rocblas_operation_none;
     const rocblas_operation transB = rocblas_operation_none;
@@ -56,70 +56,79 @@ void testing_geam_bad_arg()
     rocblas_init<T>(hB, M, N, ldb);
     rocblas_init<T>(hC, M, N, ldc);
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    if (!dA || !dB || !dC)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    T* dA = (T*)dA_managed.get();
+    T* dB = (T*)dB_managed.get();
+    T* dC = (T*)dC_managed.get();
+    if(!dA || !dB || !dC)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
     }
 
-    //copy data from CPU to device, does not work for lda != A_row
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T)*size_B, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*size_C, hipMemcpyHostToDevice));
+    // copy data from CPU to device, does not work for lda != A_row
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
 
     {
-        T *dA_null = nullptr;
+        T* dA_null = nullptr;
 
-        status = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA_null, lda, &h_beta, dB, ldb, dC, ldc);
+        status = rocblas_geam<T>(
+            handle, transA, transB, M, N, &h_alpha, dA_null, lda, &h_beta, dB, ldb, dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: A is nullptr");
     }
     {
-        T *dB_null = nullptr;
+        T* dB_null = nullptr;
 
-        status = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB_null, ldb, dC, ldc);
+        status = rocblas_geam<T>(
+            handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB_null, ldb, dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: B is nullptr");
     }
     {
-        T *dC_null = nullptr;
+        T* dC_null = nullptr;
 
-        status = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC_null, ldc);
+        status = rocblas_geam<T>(
+            handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC_null, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: C is nullptr");
     }
     {
-        T *h_alpha_null = nullptr;
+        T* h_alpha_null = nullptr;
 
-        status = rocblas_geam<T>(handle, transA, transB, M, N, h_alpha_null, dA, lda, &h_beta, dB, ldb, dC, ldc);
+        status = rocblas_geam<T>(
+            handle, transA, transB, M, N, h_alpha_null, dA, lda, &h_beta, dB, ldb, dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: h_alpha is nullptr");
     }
     {
-        T *h_beta_null= nullptr;
+        T* h_beta_null = nullptr;
 
-        status = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, h_beta_null, dB, ldb, dC, ldc);
+        status = rocblas_geam<T>(
+            handle, transA, transB, M, N, &h_alpha, dA, lda, h_beta_null, dB, ldb, dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: h_beta is nullptr");
     }
     {
         rocblas_handle handle_null = nullptr;
 
-        status = rocblas_geam<T>(handle_null, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
+        status = rocblas_geam<T>(
+            handle_null, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
 
         verify_rocblas_status_invalid_handle(status);
     }
     return;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_geam(Arguments argus)
 {
     rocblas_operation transA = char2rocblas_operation(argus.transA_option);
@@ -133,23 +142,23 @@ rocblas_status testing_geam(Arguments argus)
     rocblas_int ldc = argus.ldc;
 
     T h_alpha = argus.alpha;
-    T h_beta = argus.beta;
+    T h_beta  = argus.beta;
 
-    rocblas_int safe_size = 100;   // arbitararily set to 100
+    rocblas_int safe_size = 100; // arbitararily set to 100
 
-    T *dC_in_place;
+    T* dC_in_place;
 
-    rocblas_int  size_A, size_B, size_C, A_row, A_col, B_row, B_col;
-    rocblas_int  inc1_A, inc2_A, inc1_B, inc2_B;
+    rocblas_int size_A, size_B, size_C, A_row, A_col, B_row, B_col;
+    rocblas_int inc1_A, inc2_A, inc1_B, inc2_B;
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops;
 
     T rocblas_error_1 = std::numeric_limits<T>::max();
     T rocblas_error_2 = std::numeric_limits<T>::max();
-    T rocblas_error = std::numeric_limits<T>::max();
+    T rocblas_error   = std::numeric_limits<T>::max();
 
-    rocblas_status status = rocblas_status_success;
+    rocblas_status status   = rocblas_status_success;
     rocblas_status status_h = rocblas_status_success;
     rocblas_status status_d = rocblas_status_success;
 
@@ -158,58 +167,72 @@ rocblas_status testing_geam(Arguments argus)
 
     if(transA == rocblas_operation_none)
     {
-        A_row = M; A_col = N;
-        inc1_A = 1; inc2_A = lda;
+        A_row  = M;
+        A_col  = N;
+        inc1_A = 1;
+        inc2_A = lda;
     }
     else
     {
-        A_row = N; A_col = M;
-        inc1_A = lda; inc2_A = 1;
+        A_row  = N;
+        A_col  = M;
+        inc1_A = lda;
+        inc2_A = 1;
     }
     if(transB == rocblas_operation_none)
     {
-        B_row = M; B_col = N;
-        inc1_B = 1; inc2_B = ldb;
+        B_row  = M;
+        B_col  = N;
+        inc1_B = 1;
+        inc2_B = ldb;
     }
     else
     {
-        B_row = N; B_col = M;
-        inc1_B = ldb; inc2_B = 1;
+        B_row  = N;
+        B_col  = M;
+        inc1_B = ldb;
+        inc2_B = 1;
     }
 
-    size_A = lda * A_col; size_B = ldb * B_col; size_C = ldc * N;
+    size_A = lda * A_col;
+    size_B = ldb * B_col;
+    size_C = ldc * N;
 
-    //check here to prevent undefined memory allocation error
-    if( M <= 0 || N <= 0 || lda < A_row || ldb < B_row || ldc < M )
+    // check here to prevent undefined memory allocation error
+    if(M <= 0 || N <= 0 || lda < A_row || ldb < B_row || ldc < M)
     {
-        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dA = (T*) dA_managed.get();
-        T* dB = (T*) dB_managed.get();
-        T* dC = (T*) dC_managed.get();
-        if (!dA || !dB || !dC)
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dA = (T*)dA_managed.get();
+        T* dB = (T*)dB_managed.get();
+        T* dC = (T*)dC_managed.get();
+        if(!dA || !dB || !dC)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
         }
-    
+
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        status = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
+        status = rocblas_geam<T>(
+            handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
 
         geam_arg_check(status, M, N, lda, ldb, ldc);
 
         return status;
     }
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A), hA_copy(size_A);
     vector<T> hB(size_B), hB_copy(size_B);
     vector<T> hC_1(size_C);
     vector<T> hC_2(size_C);
     vector<T> hC_gold(size_C);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, A_row, A_col, lda);
     rocblas_init<T>(hB, B_row, B_col, ldb);
@@ -217,24 +240,29 @@ rocblas_status testing_geam(Arguments argus)
     hA_copy = hA;
     hB_copy = hB;
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
-    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    auto d_beta_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    T* d_alpha = (T*) d_alpha_managed.get();
-    T* d_beta = (T*) d_beta_managed.get();
-    if (!dA || !dB || !dC || !d_alpha || !d_beta)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    auto d_beta_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA      = (T*)dA_managed.get();
+    T* dB      = (T*)dB_managed.get();
+    T* dC      = (T*)dC_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    T* d_beta  = (T*)d_beta_managed.get();
+    if(!dA || !dB || !dC || !d_alpha || !d_beta)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //copy data from CPU to device
+    // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
@@ -244,31 +272,33 @@ rocblas_status testing_geam(Arguments argus)
     {
         // ROCBLAS
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc));
+        CHECK_ROCBLAS_ERROR(rocblas_geam<T>(
+            handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc));
 
         CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(rocblas_geam<T>(handle, transA, transB, M, N, d_alpha, dA, lda, d_beta, dB, ldb, dC, ldc));
+        CHECK_ROCBLAS_ERROR(rocblas_geam<T>(
+            handle, transA, transB, M, N, d_alpha, dA, lda, d_beta, dB, ldb, dC, ldc));
 
         CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
-         // reference calculation for golden result
+        // reference calculation for golden result
         cpu_time_used = get_time_us();
 
-        for (int i1 = 0; i1 < M; i1++)
+        for(int i1 = 0; i1 < M; i1++)
         {
-            for (int i2 = 0; i2 < N; i2++)
+            for(int i2 = 0; i2 < N; i2++)
             {
-                hC_gold[i1 + i2*ldc] = h_alpha * hA_copy[i1*inc1_A + i2*inc2_A] + h_beta * hB_copy[i1*inc1_B + i2*inc2_B];
+                hC_gold[i1 + i2 * ldc] = h_alpha * hA_copy[i1 * inc1_A + i2 * inc2_A] +
+                                         h_beta * hB_copy[i1 * inc1_B + i2 * inc2_B];
             }
         }
 
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = geam_gflop_count<T>(M, N) / cpu_time_used * 1e6;
+        cblas_gflops  = geam_gflop_count<T>(M, N) / cpu_time_used * 1e6;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
@@ -276,9 +306,9 @@ rocblas_status testing_geam(Arguments argus)
             unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_2.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched 
-        //in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched
+        // in compilation time
         if(argus.norm_check)
         {
             rocblas_error_1 = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
@@ -290,40 +320,56 @@ rocblas_status testing_geam(Arguments argus)
             dC_in_place = dA;
 
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-            status_h = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC_in_place, ldc);
+            status_h = rocblas_geam<T>(handle,
+                                       transA,
+                                       transB,
+                                       M,
+                                       N,
+                                       &h_alpha,
+                                       dA,
+                                       lda,
+                                       &h_beta,
+                                       dB,
+                                       ldb,
+                                       dC_in_place,
+                                       ldc);
 
-            if (lda != ldc || transA != rocblas_operation_none)
+            if(lda != ldc || transA != rocblas_operation_none)
             {
                 verify_rocblas_status_invalid_size(status_h, "rocblas_geam inplace C==A");
             }
             else
             {
-                CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC_in_place, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+                CHECK_HIP_ERROR(
+                    hipMemcpy(hC_1.data(), dC_in_place, sizeof(T) * size_C, hipMemcpyDeviceToHost));
                 // dA was clobbered by dC_in_place, so copy hA back to dA
-                CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+                CHECK_HIP_ERROR(
+                    hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
 
                 // reference calculation
-                for (int i1 = 0; i1 < M; i1++)
+                for(int i1 = 0; i1 < M; i1++)
                 {
-                    for (int i2 = 0; i2 < N; i2++)
+                    for(int i2 = 0; i2 < N; i2++)
                     {
-                        hC_gold[i1 + i2*ldc] = h_alpha * hA_copy[i1*inc1_A + i2*inc2_A] + h_beta * hB[i1*inc1_B + i2*inc2_B];
+                        hC_gold[i1 + i2 * ldc] = h_alpha * hA_copy[i1 * inc1_A + i2 * inc2_A] +
+                                                 h_beta * hB[i1 * inc1_B + i2 * inc2_B];
                     }
                 }
 
-                //enable unit check, notice unit check is not invasive, but norm check is,
+                // enable unit check, notice unit check is not invasive, but norm check is,
                 // unit check and norm check can not be interchanged their order
                 if(argus.unit_check)
                 {
                     unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_1.data());
                 }
 
-                //if enable norm check, norm check is invasive
-                //any typeinfo(T) will not work here, because template deduction is matched 
-                //in compilation time
+                // if enable norm check, norm check is invasive
+                // any typeinfo(T) will not work here, because template deduction is matched
+                // in compilation time
                 if(argus.norm_check)
                 {
-                    rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
+                    rocblas_error =
+                        norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
                 }
             }
         }
@@ -333,9 +379,21 @@ rocblas_status testing_geam(Arguments argus)
             dC_in_place = dB;
 
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-            status_h = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC_in_place, ldc);
+            status_h = rocblas_geam<T>(handle,
+                                       transA,
+                                       transB,
+                                       M,
+                                       N,
+                                       &h_alpha,
+                                       dA,
+                                       lda,
+                                       &h_beta,
+                                       dB,
+                                       ldb,
+                                       dC_in_place,
+                                       ldc);
 
-            if (ldb != ldc || transB != rocblas_operation_none)
+            if(ldb != ldc || transB != rocblas_operation_none)
             {
                 verify_rocblas_status_invalid_size(status_h, "rocblas_geam inplace C==A");
             }
@@ -343,65 +401,69 @@ rocblas_status testing_geam(Arguments argus)
             {
                 verify_rocblas_status_success(status_h, "status_h rocblas_geam inplace C==A");
 
-                CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC_in_place, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+                CHECK_HIP_ERROR(
+                    hipMemcpy(hC_1.data(), dC_in_place, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
                 // reference calculation
-                for (int i1 = 0; i1 < M; i1++)
+                for(int i1 = 0; i1 < M; i1++)
                 {
-                    for (int i2 = 0; i2 < N; i2++)
+                    for(int i2 = 0; i2 < N; i2++)
                     {
-                        hC_gold[i1 + i2*ldc] = h_alpha * hA_copy[i1*inc1_A + i2*inc2_A] + h_beta * hB_copy[i1*inc1_B + i2*inc2_B];
+                        hC_gold[i1 + i2 * ldc] = h_alpha * hA_copy[i1 * inc1_A + i2 * inc2_A] +
+                                                 h_beta * hB_copy[i1 * inc1_B + i2 * inc2_B];
                     }
                 }
 
-                //enable unit check, notice unit check is not invasive, but norm check is,
+                // enable unit check, notice unit check is not invasive, but norm check is,
                 // unit check and norm check can not be interchanged their order
                 if(argus.unit_check)
                 {
                     unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_1.data());
                 }
 
-                //if enable norm check, norm check is invasive
-                //any typeinfo(T) will not work here, because template deduction is matched 
-                //in compilation time
+                // if enable norm check, norm check is invasive
+                // any typeinfo(T) will not work here, because template deduction is matched
+                // in compilation time
                 if(argus.norm_check)
                 {
-                    rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
+                    rocblas_error =
+                        norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
                 }
             }
         }
-    }// end of if unit/norm check
+    } // end of if unit/norm check
 
     if(argus.timing)
     {
         int number_cold_calls = 2;
-        int number_hot_calls = 10;
+        int number_hot_calls  = 10;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        for (int i = 0; i < number_cold_calls; i++)
+        for(int i = 0; i < number_cold_calls; i++)
         {
-            status = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
+            status = rocblas_geam<T>(
+                handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
         }
 
-        gpu_time_used = get_time_us();   // in microseconds
-        for (int i = 0; i < number_hot_calls; i++)
+        gpu_time_used = get_time_us(); // in microseconds
+        for(int i = 0; i < number_hot_calls; i++)
         {
-            status = rocblas_geam<T>(handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
+            status = rocblas_geam<T>(
+                handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc);
         }
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = geam_gflop_count<T> (M, N) * number_hot_calls / gpu_time_used * 1e6;
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = geam_gflop_count<T>(M, N) * number_hot_calls / gpu_time_used * 1e6;
 
         cout << "Shape,M,N,lda,ldb,ldc,rocblas-Gflops,us,";
         if(argus.unit_check || argus.norm_check)
         {
-            cout << "CPU-Gflops,us,norm_error_ptr_host,norm_error_ptr_dev" ;
+            cout << "CPU-Gflops,us,norm_error_ptr_host,norm_error_ptr_dev";
         }
         cout << endl;
 
-        cout << argus.transA_option << argus.transB_option << ',' 
-            << M << ',' << N << ',' << lda << ',' << ldb << ',' << ldc <<',' 
-            << rocblas_gflops << "," << gpu_time_used << ",";
+        cout << argus.transA_option << argus.transB_option << ',' << M << ',' << N << ',' << lda
+             << ',' << ldb << ',' << ldc << ',' << rocblas_gflops << "," << gpu_time_used << ",";
 
         if(argus.unit_check || argus.norm_check)
         {

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -22,7 +22,7 @@
 using namespace std;
 
 /* ============================================================================================ */
-template<typename T>
+template <typename T>
 void testing_gemm_NaN(Arguments argus)
 {
     rocblas_int M = argus.M;
@@ -36,9 +36,9 @@ void testing_gemm_NaN(Arguments argus)
     rocblas_operation transA = char2rocblas_operation(argus.transA_option);
     rocblas_operation transB = char2rocblas_operation(argus.transB_option);
 
-    rocblas_int  size_A, size_B, size_C, A_row, A_col, B_row, B_col;
+    rocblas_int size_A, size_B, size_C, A_row, A_col, B_row, B_col;
     T alpha = argus.alpha;
-    T beta = argus.beta;
+    T beta  = argus.beta;
 
     rocblas_status status;
 
@@ -50,73 +50,83 @@ void testing_gemm_NaN(Arguments argus)
     B_row = transB == rocblas_operation_none ? K : N;
     B_col = transB == rocblas_operation_none ? N : K;
 
-    size_A = lda * A_col; size_B = ldb * B_col; size_C = ldc * N;
+    size_A = lda * A_col;
+    size_B = ldb * B_col;
+    size_C = ldc * N;
 
-    //check here to prevent undefined memory allocation error
-    if( M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M )
+    // check here to prevent undefined memory allocation error
+    if(M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M)
     {
         // bad arguments are tested in other tests
         return;
     }
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory.
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory.
     vector<T> hA(size_A);
     vector<T> hB(size_B);
     vector<T> hC(size_C);
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    if (!dA || !dB || !dC)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    T* dA = (T*)dA_managed.get();
+    T* dB = (T*)dB_managed.get();
+    T* dC = (T*)dC_managed.get();
+    if(!dA || !dB || !dC)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
     }
 
-    //Initial Data on CPU
-    for (int i = 0; i < size_A; i++) hA[i] = 1.0;
-    for (int i = 0; i < size_B; i++) hB[i] = 1.0;
-    for (int i = 0; i < size_C; i++) hC[i] = 1.0;
+    // Initial Data on CPU
+    for(int i = 0; i < size_A; i++)
+        hA[i] = 1.0;
+    for(int i = 0; i < size_B; i++)
+        hB[i] = 1.0;
+    for(int i = 0; i < size_C; i++)
+        hC[i] = 1.0;
 
-    for (int i = 0; i < N; i++) 
+    for(int i = 0; i < N; i++)
     {
-        for (int j = 0; j < M; j++)
+        for(int j = 0; j < M; j++)
         {
-            hC[j + i*ldc] = std::numeric_limits<T>::quiet_NaN();
+            hC[j + i * ldc] = std::numeric_limits<T>::quiet_NaN();
         }
     }
 
-    //copy data from CPU to device, does not work for lda != A_row
+    // copy data from CPU to device, does not work for lda != A_row
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
 
     // ROCBLAS
-    status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
+    status =
+        rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
 
     verify_rocblas_status_success(status, "rocblas_gemm return error in testing_gemm_NaN");
 
-    //copy output from device to CPU
+    // copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
-    for (int i = 0; i < N; i++) 
+    for(int i = 0; i < N; i++)
     {
-        for (int j = 0; j < M; j++)
+        for(int j = 0; j < M; j++)
         {
-            verify_not_nan(hC[j + i*ldc]);
-            if(hC[j + i*ldc] != hC[j + i*ldc]) goto finish_nested_loops;
+            verify_not_nan(hC[j + i * ldc]);
+            if(hC[j + i * ldc] != hC[j + i * ldc])
+                goto finish_nested_loops;
         }
     }
-    finish_nested_loops:
+finish_nested_loops:
 
     return;
 }
 
-template<typename T>
+template <typename T>
 void testing_gemm_bad_arg()
 {
     const rocblas_int M = 100;
@@ -128,7 +138,7 @@ void testing_gemm_bad_arg()
     const rocblas_int ldc = 100;
 
     const T alpha = 1.0;
-    const T beta = 1.0;
+    const T beta  = 1.0;
 
     const rocblas_int safe_size = 100;
 
@@ -140,58 +150,67 @@ void testing_gemm_bad_arg()
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    if (!dA || !dB || !dC)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    T* dA = (T*)dA_managed.get();
+    T* dB = (T*)dB_managed.get();
+    T* dC = (T*)dC_managed.get();
+    if(!dA || !dB || !dC)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
     }
 
     {
-        T *dA_null = nullptr;
+        T* dA_null = nullptr;
 
-        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA_null, lda, dB, ldb, &beta, dC, ldc);
+        status = rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &alpha, dA_null, lda, dB, ldb, &beta, dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: A is nullptr");
     }
     {
-        T *dB_null = nullptr;
+        T* dB_null = nullptr;
 
-        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB_null, ldb, &beta, dC, ldc);
+        status = rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &alpha, dA, lda, dB_null, ldb, &beta, dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: B is nullptr");
     }
     {
-        T *dC_null = nullptr;
+        T* dC_null = nullptr;
 
-        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC_null, ldc);
-
-        verify_rocblas_status_invalid_pointer(status, "ERROR: C is nullptr");
-    }
-    {
-        T *alpha_null = nullptr;
-
-        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, alpha_null, dA, lda, dB, ldb, &beta, dC, ldc);
+        status = rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC_null, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: C is nullptr");
     }
     {
-        T *beta_null= nullptr;
+        T* alpha_null = nullptr;
 
-        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, beta_null, dC, ldc);
+        status = rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, alpha_null, dA, lda, dB, ldb, &beta, dC, ldc);
+
+        verify_rocblas_status_invalid_pointer(status, "ERROR: C is nullptr");
+    }
+    {
+        T* beta_null = nullptr;
+
+        status = rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, beta_null, dC, ldc);
 
         verify_rocblas_status_invalid_pointer(status, "ERROR: C is nullptr");
     }
     {
         rocblas_handle handle_null = nullptr;
 
-        status = rocblas_gemm<T>(handle_null, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
+        status = rocblas_gemm<T>(
+            handle_null, transA, transB, M, N, K, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
 
         verify_rocblas_status_invalid_handle(status);
     }
@@ -199,7 +218,7 @@ void testing_gemm_bad_arg()
     return;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_gemm(Arguments argus)
 {
     rocblas_operation transA = char2rocblas_operation(argus.transA_option);
@@ -214,7 +233,7 @@ rocblas_status testing_gemm(Arguments argus)
     rocblas_int ldc = argus.ldc;
 
     T h_alpha = argus.alpha;
-    T h_beta = argus.beta;
+    T h_beta  = argus.beta;
 
     rocblas_int safe_size = 100;
 
@@ -233,22 +252,26 @@ rocblas_status testing_gemm(Arguments argus)
     rocblas_int B_row = transB == rocblas_operation_none ? K : N;
     rocblas_int B_col = transB == rocblas_operation_none ? N : K;
 
-    //check here to prevent undefined memory allocation error
-    if( M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M )
+    // check here to prevent undefined memory allocation error
+    if(M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M)
     {
-        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dA = (T*) dA_managed.get();
-        T* dB = (T*) dB_managed.get();
-        T* dC = (T*) dC_managed.get();
-        if (!dA || !dB || !dC)
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dA = (T*)dA_managed.get();
+        T* dB = (T*)dB_managed.get();
+        T* dC = (T*)dC_managed.get();
+        if(!dA || !dB || !dC)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
         }
 
-        status = rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
+        status = rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
 
         gemm_arg_check(status, M, N, K, lda, ldb, ldc);
 
@@ -259,40 +282,45 @@ rocblas_status testing_gemm(Arguments argus)
     rocblas_int size_B = ldb * B_col;
     rocblas_int size_C = ldc * N;
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
-    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    auto d_beta_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    T* d_alpha = (T*) d_alpha_managed.get();
-    T* d_beta  = (T*) d_beta_managed.get();
-    if (!dA || !dB || !dC || !d_alpha || !d_beta)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    auto d_beta_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA      = (T*)dA_managed.get();
+    T* dB      = (T*)dB_managed.get();
+    T* dC      = (T*)dC_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    T* d_beta  = (T*)d_beta_managed.get();
+    if(!dA || !dB || !dC || !d_alpha || !d_beta)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> hB(size_B);
     vector<T> hC_1(size_C);
     vector<T> hC_2(size_C);
     vector<T> hC_gold(size_C);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, A_row, A_col, lda);
     rocblas_init<T>(hB, B_row, B_col, ldb);
     rocblas_init<T>(hC_1, M, N, ldc);
 
-    hC_2 = hC_1;
+    hC_2    = hC_1;
     hC_gold = hC_1;
 
-    //copy data from CPU to device
+    // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
 
@@ -303,7 +331,8 @@ rocblas_status testing_gemm(Arguments argus)
 
         CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
 
-        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
 
         CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
@@ -316,23 +345,36 @@ rocblas_status testing_gemm(Arguments argus)
 
         CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
 
         CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
 
-        cblas_gemm<T>(transA, transB, M, N, K, h_alpha, hA.data(), lda, hB.data(), ldb, h_beta, hC_gold.data(), ldc);
+        cblas_gemm<T>(transA,
+                      transB,
+                      M,
+                      N,
+                      K,
+                      h_alpha,
+                      hA.data(),
+                      lda,
+                      hB.data(),
+                      ldb,
+                      h_beta,
+                      hC_gold.data(),
+                      ldc);
 
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = gemm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
+        cblas_gflops  = gemm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
 
-        #ifndef NDEBUG
-        print_matrix(hC_gold, hC, min(M,3), min(N,3), ldc);
-        #endif
+#ifndef NDEBUG
+        print_matrix(hC_gold, hC, min(M, 3), min(N, 3), ldc);
+#endif
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
@@ -340,9 +382,9 @@ rocblas_status testing_gemm(Arguments argus)
             unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_2.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched 
-        //in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched
+        // in compilation time
         if(argus.norm_check)
         {
             rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
@@ -353,32 +395,35 @@ rocblas_status testing_gemm(Arguments argus)
     if(argus.timing)
     {
         int number_cold_calls = 2;
-        int number_hot_calls = 10;
+        int number_hot_calls  = 10;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        for (int i = 0; i < number_cold_calls; i++)
+        for(int i = 0; i < number_cold_calls; i++)
         {
-            rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
+            rocblas_gemm<T>(
+                handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
         }
 
-        gpu_time_used = get_time_us();   // in microseconds
-        for (int i = 0; i < number_hot_calls; i++)
+        gpu_time_used = get_time_us(); // in microseconds
+        for(int i = 0; i < number_hot_calls; i++)
         {
-            rocblas_gemm<T>(handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
+            rocblas_gemm<T>(
+                handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
         }
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = gemm_gflop_count<T> (M, N, K) * number_hot_calls / gpu_time_used * 1e6;
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = gemm_gflop_count<T>(M, N, K) * number_hot_calls / gpu_time_used * 1e6;
 
         cout << "Shape,M,N,K,lda,ldb,ldc,rocblas-Gflops,us";
 
-        if(argus.unit_check || argus.norm_check) cout << ",CPU-Gflops(us),norm-error";
+        if(argus.unit_check || argus.norm_check)
+            cout << ",CPU-Gflops(us),norm-error";
 
         cout << endl;
 
-        cout << argus.transA_option << argus.transB_option << ',' 
-            << M << ',' << N << ',' << K << ',' << lda << ',' << ldb << ',' << ldc <<',' 
-            << rocblas_gflops << "," << gpu_time_used;
+        cout << argus.transA_option << argus.transB_option << ',' << M << ',' << N << ',' << K
+             << ',' << lda << ',' << ldb << ',' << ldc << ',' << rocblas_gflops << ","
+             << gpu_time_used;
 
         if(argus.unit_check || argus.norm_check)
         {
@@ -396,27 +441,28 @@ subsequent steps get a sub-matrix. The memory allocation/deallocation overhead i
 Intended for long time running
 */
 
-template<typename T>
+template <typename T>
 rocblas_status range_testing_gemm(Arguments argus)
 {
     rocblas_int start = argus.start;
-    rocblas_int step = argus.step;
-    rocblas_int end = argus.end;
+    rocblas_int step  = argus.step;
+    rocblas_int end   = argus.end;
 
     rocblas_operation transA = char2rocblas_operation(argus.transA_option);
     rocblas_operation transB = char2rocblas_operation(argus.transB_option);
 
-    rocblas_int  size_A, size_B, size_C;
+    rocblas_int size_A, size_B, size_C;
     T alpha = argus.alpha;
-    T beta = argus.beta;
+    T beta  = argus.beta;
 
     double rocblas_gflops, cblas_gflops;
     double gpu_time_used, cpu_time_used;
 
     T rocblas_error = 0.0;
 
-    //argument sanity check, quick return if input parameters are invalid before allocating invalid memory
-    if( start < 0 || end < 0 || step < 0 || end < start )
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(start < 0 || end < 0 || step < 0 || end < start)
     {
         cout << "Invalid matrix dimension input, will return" << endl;
         return rocblas_status_invalid_size;
@@ -424,7 +470,7 @@ rocblas_status range_testing_gemm(Arguments argus)
 
     size_A = size_B = size_C = end * end;
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hA(size_A);
     vector<T> hB(size_B);
     vector<T> hC(size_C);
@@ -435,129 +481,143 @@ rocblas_status range_testing_gemm(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    if (!dA || !dB || !dC)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    T* dA = (T*)dA_managed.get();
+    T* dB = (T*)dB_managed.get();
+    T* dC = (T*)dC_managed.get();
+    if(!dA || !dB || !dC)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, end, end, end);
     rocblas_init<T>(hB, end, end, end);
     rocblas_init<T>(hC, end, end, end);
 
-    //copy vector is easy in STL; hz = hx: save a copy in hC_gold which will be output of CPU BLAS
+    // copy vector is easy in STL; hz = hx: save a copy in hC_gold which will be output of CPU BLAS
     hC_gold = hC;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*end*end,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T)*end*end,  hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * end * end, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * end * end, hipMemcpyHostToDevice));
 
     char precision = type2char<T>(); // like turn float-> 's'
 
-    string filename = string("benchmark_")  + precision + string("gemm_") + argus.transA_option + argus.transB_option +
-            string("_") + to_string(start) + "to" + to_string(end) + "_step" + to_string(step) + ".csv";
+    string filename = string("benchmark_") + precision + string("gemm_") + argus.transA_option +
+                      argus.transB_option + string("_") + to_string(start) + "to" + to_string(end) +
+                      "_step" + to_string(step) + ".csv";
 
     ofstream myfile;
     myfile.open(filename);
-    if (myfile.is_open())
+    if(myfile.is_open())
     {
         myfile << "M, N, K, lda, ldb, ldc, rocblas-Gflops (us) ";
         if(argus.norm_check)
         {
-            myfile << "CPU-Gflops(us), norm-error" ;
+            myfile << "CPU-Gflops(us), norm-error";
         }
         myfile << endl;
     }
 
     for(rocblas_int size = start; size <= end; size += step)
     {
-        cout << "Benchmarking M:" << (int)size << ", N:"<< (int) size <<", K:" << (int)size << endl ;
+        cout << "Benchmarking M:" << (int)size << ", N:" << (int)size << ", K:" << (int)size
+             << endl;
 
-        //make sure CPU and GPU routines see the same input
+        // make sure CPU and GPU routines see the same input
         hC = hC_gold;
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T)*size*size,      hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * size * size, hipMemcpyHostToDevice));
 
         /* =====================================================================
              ROCBLAS
         =================================================================== */
 
-        gpu_time_used = get_time_us();// in microseconds
-        rocblas_gflops = gemm_gflop_count<T> (size, size, size) / gpu_time_used * 1e6 ;
+        gpu_time_used  = get_time_us(); // in microseconds
+        rocblas_gflops = gemm_gflop_count<T>(size, size, size) / gpu_time_used * 1e6;
 
-        //library interface
-        status = rocblas_gemm<T>(handle, transA, transB,
-                        size, size, size,
-                        &alpha, dA, size,
-                        dB, size,
-                        &beta, dC, size);
+        // library interface
+        status = rocblas_gemm<T>(
+            handle, transA, transB, size, size, size, &alpha, dA, size, dB, size, &beta, dC, size);
 
         gpu_time_used = get_time_us() - gpu_time_used;
 
-        //copy output from device to CPU
-        hipMemcpy(hC.data(), dC, sizeof(T)*size*size,      hipMemcpyDeviceToHost);
+        // copy output from device to CPU
+        hipMemcpy(hC.data(), dC, sizeof(T) * size * size, hipMemcpyDeviceToHost);
 
         if(argus.norm_check)
         {
-             /* =====================================================================
-                         CPU BLAS
-             =================================================================== */
+            /* =====================================================================
+                        CPU BLAS
+            =================================================================== */
 
             cpu_time_used = get_time_us();
 
-            cblas_gemm<T>(
-                         transA, transB, size, size, size,
-                         alpha, hA.data(), size,
-                         hB.data(), size,
-                         beta, hC_gold.data(), size);
-
+            cblas_gemm<T>(transA,
+                          transB,
+                          size,
+                          size,
+                          size,
+                          alpha,
+                          hA.data(),
+                          size,
+                          hB.data(),
+                          size,
+                          beta,
+                          hC_gold.data(),
+                          size);
 
             cpu_time_used = get_time_us() - cpu_time_used;
 
-            cblas_gflops = gemm_gflop_count<T> (size, size, size) / cpu_time_used * 1e6 ;
+            cblas_gflops = gemm_gflop_count<T>(size, size, size) / cpu_time_used * 1e6;
 
-            //if enable norm check, norm check is invasive
-            //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-            if(argus.norm_check) 
+            // if enable norm check, norm check is invasive
+            // any typeinfo(T) will not work here, because template deduction is matched in
+            // compilation time
+            if(argus.norm_check)
             {
-                rocblas_error = norm_check_general<T>('F', size, size, size, hC_gold.data(), hC.data());
+                rocblas_error =
+                    norm_check_general<T>('F', size, size, size, hC_gold.data(), hC.data());
             }
 
-        }// end of if unit/norm check
+        } // end of if unit/norm check
 
-        if (myfile.is_open())
+        if(myfile.is_open())
         {
-        //only norm_check return an norm error, unit check won't return anything, only return the real part, imag part does not make sense
-            myfile << size <<','<< size <<',' << size <<',' << size <<','<< size <<',' << size <<',' << rocblas_gflops << "(" << gpu_time_used << "),";
+            // only norm_check return an norm error, unit check won't return anything, only return
+            // the real part, imag part does not make sense
+            myfile << size << ',' << size << ',' << size << ',' << size << ',' << size << ','
+                   << size << ',' << rocblas_gflops << "(" << gpu_time_used << "),";
 
             if(argus.norm_check)
             {
                 myfile << cblas_gflops << "(" << cpu_time_used << "),";
-                //cout << rocblas_error;
+                // cout << rocblas_error;
             }
 
             myfile << endl;
         }
-    }// end of loop
+    } // end of loop
 
-    if (myfile.is_open()) myfile.close();
+    if(myfile.is_open())
+        myfile.close();
 
     return status;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status benchmark_gemm(Arguments argus)
 {
-    //if negative, fall back to specific matrix size testing
-    //otherwise, range testing. only norm check is enabled in range_test
+    // if negative, fall back to specific matrix size testing
+    // otherwise, range testing. only norm check is enabled in range_test
     if(argus.start < 0 || argus.end < 0 || argus.step < 0)
     {
         cout << "Specific matrix size testing: output will be displayed on terminal" << endl;
@@ -566,10 +626,12 @@ rocblas_status benchmark_gemm(Arguments argus)
     }
     else
     {
-        argus.timing = 1; //timing is enabled
-        cout << "Range matrix size testing: output will be benchmark_xgemm_(transpose)_(begin)to(end)_(step).csv ..." << endl;
+        argus.timing = 1; // timing is enabled
+        cout << "Range matrix size testing: output will be "
+                "benchmark_xgemm_(transpose)_(begin)to(end)_(step).csv ..."
+             << endl;
         cout << endl;
-        //cout << "==================================================================" << endl;
+        // cout << "==================================================================" << endl;
         return range_testing_gemm<T>(argus);
     }
 }

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 rocblas_status testing_gemm_strided_batched(Arguments argus)
 {
     rocblas_int M = argus.M;
@@ -28,16 +28,16 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     rocblas_int K = argus.K;
 
     T h_alpha = argus.alpha;
-    T h_beta = argus.beta;
+    T h_beta  = argus.beta;
 
-    rocblas_int lda = argus.lda;
-    rocblas_int ldb = argus.ldb;
-    rocblas_int ldc = argus.ldc;
-    rocblas_int batch_count = argus.batch_count;
+    rocblas_int lda          = argus.lda;
+    rocblas_int ldb          = argus.ldb;
+    rocblas_int ldc          = argus.ldc;
+    rocblas_int batch_count  = argus.batch_count;
     rocblas_operation transA = char2rocblas_operation(argus.transA_option);
     rocblas_operation transB = char2rocblas_operation(argus.transB_option);
 
-    rocblas_int safe_size = 100;  // arbitrarily set to 100
+    rocblas_int safe_size = 100; // arbitrarily set to 100
 
     rocblas_status status;
 
@@ -49,31 +49,47 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     rocblas_int B_row = transB == rocblas_operation_none ? K : N;
     rocblas_int B_col = transB == rocblas_operation_none ? N : K;
 
-//  make bsa, bsb, bsc two times minimum size so matrices are non-contiguous
-    rocblas_int bsa = lda * A_col * 2; 
-    rocblas_int bsb = ldb * B_col * 2; 
+    //  make bsa, bsb, bsc two times minimum size so matrices are non-contiguous
+    rocblas_int bsa = lda * A_col * 2;
+    rocblas_int bsb = ldb * B_col * 2;
     rocblas_int bsc = ldc * N * 2;
 
-    //check here to prevent undefined memory allocation error
-    if( M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 || batch_count < 0)
+    // check here to prevent undefined memory allocation error
+    if(M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 || batch_count < 0)
     {
-        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dA = (T*) dA_managed.get();
-        T* dB = (T*) dB_managed.get();
-        T* dC = (T*) dC_managed.get();
-        if (!dA || !dB || !dC)
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dA = (T*)dA_managed.get();
+        T* dB = (T*)dB_managed.get();
+        T* dC = (T*)dC_managed.get();
+        if(!dA || !dB || !dC)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
         }
 
-        status = rocblas_gemm_strided_batched<T>(handle, transA, transB,
-                    M, N, K,
-                    &h_alpha, dA, lda, bsa,
-                    dB, ldb, bsb,
-                    &h_beta, dC, ldc, bsc, batch_count);
+        status = rocblas_gemm_strided_batched<T>(handle,
+                                                 transA,
+                                                 transB,
+                                                 M,
+                                                 N,
+                                                 K,
+                                                 &h_alpha,
+                                                 dA,
+                                                 lda,
+                                                 bsa,
+                                                 dB,
+                                                 ldb,
+                                                 bsb,
+                                                 &h_beta,
+                                                 dC,
+                                                 ldc,
+                                                 bsc,
+                                                 batch_count);
 
         gemm_strided_batched_arg_check(status, M, N, K, lda, ldb, ldc, batch_count);
 
@@ -89,99 +105,142 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     rocblas_int size_B = bsb * batch_count;
     rocblas_int size_C = bsc * batch_count;
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),rocblas_test::device_free};
-    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    auto d_beta_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    T* d_alpha = (T*) d_alpha_managed.get();
-    T* d_beta  = (T*) d_beta_managed.get();
-    if ((!dA && (size_A != 0)) || (!dB && (size_B != 0)) || (!dC && (size_C != 0)) || !d_alpha || !d_beta)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    auto d_beta_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA      = (T*)dA_managed.get();
+    T* dB      = (T*)dB_managed.get();
+    T* dC      = (T*)dC_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    T* d_beta  = (T*)d_beta_managed.get();
+    if((!dA && (size_A != 0)) || (!dB && (size_B != 0)) || (!dC && (size_C != 0)) || !d_alpha ||
+       !d_beta)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
-    
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hA(size_A);
     vector<T> hB(size_B);
     vector<T> hC_1(size_C);
     vector<T> hC_2(size_C);
     vector<T> hC_gold(size_C);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, A_row, A_col * batch_count, lda);
     rocblas_init<T>(hB, B_row, B_col * batch_count, ldb);
     rocblas_init<T>(hC_1, M, N * batch_count, ldc);
-    hC_2 = hC_1;
+    hC_2    = hC_1;
     hC_gold = hC_1;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T)*size_B,  hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
     {
         // ROCBLAS rocblas_pointer_mode_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T)*size_C,  hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
 
-        CHECK_ROCBLAS_ERROR(rocblas_gemm_strided_batched<T>(handle, transA, transB,
-                    M, N, K,
-                    &h_alpha, dA, lda, bsa,
-                    dB, ldb, bsb,
-                    &h_beta, dC, ldc, bsc, batch_count));
+        CHECK_ROCBLAS_ERROR(rocblas_gemm_strided_batched<T>(handle,
+                                                            transA,
+                                                            transB,
+                                                            M,
+                                                            N,
+                                                            K,
+                                                            &h_alpha,
+                                                            dA,
+                                                            lda,
+                                                            bsa,
+                                                            dB,
+                                                            ldb,
+                                                            bsb,
+                                                            &h_beta,
+                                                            dC,
+                                                            ldc,
+                                                            bsc,
+                                                            batch_count));
 
-        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T)*size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
         // ROCBLAS rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC_2.data(), sizeof(T)*size_C,  hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_2.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-        CHECK_ROCBLAS_ERROR(rocblas_gemm_strided_batched<T>(handle, transA, transB,
-                    M, N, K,
-                    d_alpha, dA, lda, bsa,
-                    dB, ldb, bsb,
-                    d_beta, dC, ldc, bsc, batch_count));
+        CHECK_ROCBLAS_ERROR(rocblas_gemm_strided_batched<T>(handle,
+                                                            transA,
+                                                            transB,
+                                                            M,
+                                                            N,
+                                                            K,
+                                                            d_alpha,
+                                                            dA,
+                                                            lda,
+                                                            bsa,
+                                                            dB,
+                                                            ldb,
+                                                            bsb,
+                                                            d_beta,
+                                                            dC,
+                                                            ldc,
+                                                            bsc,
+                                                            batch_count));
 
-        CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T)*size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
-        for(rocblas_int i=0;i<batch_count; i++)
+        for(rocblas_int i = 0; i < batch_count; i++)
         {
-            cblas_gemm<T>(
-                     transA, transB, M, N, K,
-                     h_alpha, hA.data() + bsa * i, lda,
-                     hB.data() + bsb * i, ldb,
-                     h_beta, hC_gold.data() + bsc * i, ldc);
+            cblas_gemm<T>(transA,
+                          transB,
+                          M,
+                          N,
+                          K,
+                          h_alpha,
+                          hA.data() + bsa * i,
+                          lda,
+                          hB.data() + bsb * i,
+                          ldb,
+                          h_beta,
+                          hC_gold.data() + bsc * i,
+                          ldc);
         }
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = gemm_gflop_count<T>(M, N, K) * batch_count / cpu_time_used * 1e6;
+        cblas_gflops  = gemm_gflop_count<T>(M, N, K) * batch_count / cpu_time_used * 1e6;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N*batch_count, lda, hC_gold.data(), hC_1.data());
-            unit_check_general<T>(M, N*batch_count, lda, hC_gold.data(), hC_2.data());
+            unit_check_general<T>(M, N * batch_count, lda, hC_gold.data(), hC_1.data());
+            unit_check_general<T>(M, N * batch_count, lda, hC_gold.data(), hC_2.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
-            rocblas_error = norm_check_general<T>('F', M, N*batch_count, lda, hC_gold.data(), hC_1.data());
-            rocblas_error = norm_check_general<T>('F', M, N*batch_count, lda, hC_gold.data(), hC_2.data());
+            rocblas_error =
+                norm_check_general<T>('F', M, N * batch_count, lda, hC_gold.data(), hC_1.data());
+            rocblas_error =
+                norm_check_general<T>('F', M, N * batch_count, lda, hC_gold.data(), hC_2.data());
         }
     }
 
@@ -189,28 +248,43 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        gpu_time_used = get_time_us();  // in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        rocblas_gemm_strided_batched<T>(handle, transA, transB,
-                    M, N, K,
-                    &h_alpha, dA, lda, bsa,
-                    dB, ldb, bsb,
-                    &h_beta, dC, ldc, bsc, batch_count);
+        rocblas_gemm_strided_batched<T>(handle,
+                                        transA,
+                                        transB,
+                                        M,
+                                        N,
+                                        K,
+                                        &h_alpha,
+                                        dA,
+                                        lda,
+                                        bsa,
+                                        dB,
+                                        ldb,
+                                        bsb,
+                                        &h_beta,
+                                        dC,
+                                        ldc,
+                                        bsc,
+                                        batch_count);
 
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = gemm_gflop_count<T> (M, N, K) * batch_count / gpu_time_used * 1e6;
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = gemm_gflop_count<T>(M, N, K) * batch_count / gpu_time_used * 1e6;
 
         cout << "Shape,Batch_Count,M,N,K,lda,ldb,ldc,rocblas-Gflops,us";
 
-        if(argus.norm_check) cout << ",CPU-Gflops,us,norm-error" ;
+        if(argus.norm_check)
+            cout << ",CPU-Gflops,us,norm-error";
 
         cout << endl;
 
         cout << argus.transA_option << argus.transB_option << ',' << batch_count;
-        cout << ',' << M <<','<< N <<',' << K <<',' << lda <<','<< ldb <<',' << ldc;
+        cout << ',' << M << ',' << N << ',' << K << ',' << lda << ',' << ldb << ',' << ldc;
         cout << ',' << rocblas_gflops << "," << gpu_time_used;
 
-        if(argus.norm_check) cout << "," << cblas_gflops << "," << cpu_time_used << "," << rocblas_error;
+        if(argus.norm_check)
+            cout << "," << cblas_gflops << "," << cpu_time_used << "," << rocblas_error;
 
         cout << endl;
     }

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -19,16 +19,16 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 void testing_gemv_bad_arg()
 {
-    const rocblas_int M = 100;
-    const rocblas_int N = 100;
-    const rocblas_int lda = 100;
-    const rocblas_int incx = 1;
-    const rocblas_int incy = 1;
-    const T alpha = 1.0;
-    const T beta = 1.0;
+    const rocblas_int M            = 100;
+    const rocblas_int N            = 100;
+    const rocblas_int lda          = 100;
+    const rocblas_int incx         = 1;
+    const rocblas_int incy         = 1;
+    const T alpha                  = 1.0;
+    const T beta                   = 1.0;
     const rocblas_operation transA = rocblas_operation_none;
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
@@ -38,107 +38,120 @@ void testing_gemv_bad_arg()
 
     rocblas_int size_A = lda * N;
     rocblas_int size_x = N * incx;
-    rocblas_int size_y = M * incy;;
+    rocblas_int size_y = M * incy;
+    ;
 
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> hx(size_x);
     vector<T> hy(size_y);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, M, N, lda);
     rocblas_init<T>(hx, 1, N, incx);
     rocblas_init<T>(hy, 1, M, incy);
 
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dA || !dx || !dy)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                         rocblas_test::device_free};
+    T* dA = (T*)dA_managed.get();
+    T* dx = (T*)dx_managed.get();
+    T* dy = (T*)dy_managed.get();
+    if(!dA || !dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
     }
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T)*size_y * incy, hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * size_y * incy, hipMemcpyHostToDevice));
 
     {
-        T *dA_null = nullptr;
-        
-        status = rocblas_gemv<T>(handle, transA, M, N, (T*)&alpha, dA_null, lda, dx, incx, (T*)&beta, dy, incy);
+        T* dA_null = nullptr;
 
-        verify_rocblas_status_invalid_pointer(status,"rocBLAS TEST ERROR: A is null pointer");
+        status = rocblas_gemv<T>(
+            handle, transA, M, N, (T*)&alpha, dA_null, lda, dx, incx, (T*)&beta, dy, incy);
+
+        verify_rocblas_status_invalid_pointer(status, "rocBLAS TEST ERROR: A is null pointer");
     }
     {
-        T *dx_null = nullptr;
-        status = rocblas_gemv<T>(handle, transA, M, N, (T*)&alpha, dA, lda, dx_null, incx, (T*)&beta, dy, incy);
+        T* dx_null = nullptr;
+        status     = rocblas_gemv<T>(
+            handle, transA, M, N, (T*)&alpha, dA, lda, dx_null, incx, (T*)&beta, dy, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"rocBLAS TEST ERROR: x is null pointer");
+        verify_rocblas_status_invalid_pointer(status, "rocBLAS TEST ERROR: x is null pointer");
     }
     {
-        T *dy_null = nullptr;
-        status = rocblas_gemv<T>(handle, transA, M, N, (T*)&alpha, dA, lda, dx, incx, (T*)&beta, dy_null, incy);
+        T* dy_null = nullptr;
+        status     = rocblas_gemv<T>(
+            handle, transA, M, N, (T*)&alpha, dA, lda, dx, incx, (T*)&beta, dy_null, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"rocBLAS TEST ERROR: y is null pointer");
+        verify_rocblas_status_invalid_pointer(status, "rocBLAS TEST ERROR: y is null pointer");
     }
     {
-        T *beta_null = nullptr;
-        status = rocblas_gemv<T>(handle, transA, M, N, (T*)&alpha, dA, lda, dx, incx, beta_null, dy, incy);
+        T* beta_null = nullptr;
+        status       = rocblas_gemv<T>(
+            handle, transA, M, N, (T*)&alpha, dA, lda, dx, incx, beta_null, dy, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"rocBLAS TEST ERROR: beta is null pointer");
+        verify_rocblas_status_invalid_pointer(status, "rocBLAS TEST ERROR: beta is null pointer");
     }
     {
         rocblas_handle handle_null = nullptr;
 
-        status = rocblas_gemv<T>(handle_null, transA, M, N, (T*)&alpha, dA, lda, dx, incx, (T*)&beta, dy, incy);
+        status = rocblas_gemv<T>(
+            handle_null, transA, M, N, (T*)&alpha, dA, lda, dx, incx, (T*)&beta, dy, incy);
 
         verify_rocblas_status_invalid_handle(status);
     }
     return;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_gemv(Arguments argus)
 {
-    rocblas_int M = argus.M;
-    rocblas_int N = argus.N;
-    rocblas_int lda = argus.lda;
-    rocblas_int incx = argus.incx;
-    rocblas_int incy = argus.incy;
-    T h_alpha = (T)argus.alpha;
-    T h_beta = (T)argus.beta;
+    rocblas_int M            = argus.M;
+    rocblas_int N            = argus.N;
+    rocblas_int lda          = argus.lda;
+    rocblas_int incx         = argus.incx;
+    rocblas_int incy         = argus.incy;
+    T h_alpha                = (T)argus.alpha;
+    T h_beta                 = (T)argus.beta;
     rocblas_operation transA = char2rocblas_operation(argus.transA_option);
-    rocblas_int safe_size = 100;  // arbitrarily set to 100
+    rocblas_int safe_size    = 100; // arbitrarily set to 100
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
     rocblas_status status;
 
-    //argument sanity check before allocating invalid memory
-    if (M <= 0 || N <= 0 || lda < M || lda < 1 || 0 == incx || 0 == incy)
+    // argument sanity check before allocating invalid memory
+    if(M <= 0 || N <= 0 || lda < M || lda < 1 || 0 == incx || 0 == incy)
     {
-        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dy_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dA1 = (T*) dA_managed.get();
-        T* dx1 = (T*) dx_managed.get();
-        T* dy1 = (T*) dy_1_managed.get();
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dy_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                               rocblas_test::device_free};
+        T* dA1 = (T*)dA_managed.get();
+        T* dx1 = (T*)dx_managed.get();
+        T* dy1 = (T*)dy_1_managed.get();
 
-        if (!dA1 || !dx1 || !dy1)
+        if(!dA1 || !dx1 || !dy1)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
         }
 
-        status = rocblas_gemv<T>(handle, transA, M, N, (T*)&h_alpha, dA1, lda, dx1, incx, (T*)&h_beta, dy1, incy);
+        status = rocblas_gemv<T>(
+            handle, transA, M, N, (T*)&h_alpha, dA1, lda, dx1, incx, (T*)&h_beta, dy1, incy);
 
         gemv_ger_arg_check(status, M, N, lda, incx, incy);
 
@@ -151,13 +164,13 @@ rocblas_status testing_gemv(Arguments argus)
 
     if(transA == rocblas_operation_none)
     {
-        dim_x = N ;
-        dim_y = M ;
+        dim_x = N;
+        dim_y = M;
     }
     else
     {
-        dim_x = M ;
-        dim_y = N ;
+        dim_x = M;
+        dim_y = N;
     }
 
     abs_incx = incx >= 0 ? incx : -incx;
@@ -165,47 +178,55 @@ rocblas_status testing_gemv(Arguments argus)
 
     size_x = dim_x * abs_incx;
     size_y = dim_y * abs_incy;
-  
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> hx(size_x);
     vector<T> hy_1(size_y);
     vector<T> hy_2(size_y);
     vector<T> hy_gold(size_y);
 
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto dy_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    auto dy_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    auto d_beta_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dx = (T*) dx_managed.get();
-    T* dy_1 = (T*) dy_1_managed.get();
-    T* dy_2 = (T*) dy_2_managed.get();
-    T* d_alpha = (T*) d_alpha_managed.get();
-    T* d_beta= (T*) d_beta_managed.get();
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                           rocblas_test::device_free};
+    auto dy_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                           rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    auto d_beta_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA      = (T*)dA_managed.get();
+    T* dx      = (T*)dx_managed.get();
+    T* dy_1    = (T*)dy_1_managed.get();
+    T* dy_2    = (T*)dy_2_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    T* d_beta  = (T*)d_beta_managed.get();
 
-    if ((!dA && (size_A != 0)) || (!dx && (size_x != 0)) || ((!dy_1 || !dy_2) && (size_y != 0)) || !d_alpha || !d_beta)
+    if((!dA && (size_A != 0)) || (!dx && (size_x != 0)) || ((!dy_1 || !dy_2) && (size_y != 0)) ||
+       !d_alpha || !d_beta)
     {
-       PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
-       return rocblas_status_memory_error;
+        PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
+        return rocblas_status_memory_error;
     }
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hA, M, N, lda);
     rocblas_init<T>(hx, 1, dim_x, abs_incx);
     rocblas_init<T>(hy_1, 1, dim_y, abs_incy);
 
-    //copy vector is easy in STL; hy_gold = hy_1: save a copy in hy_gold which will be output of CPU BLAS
+    // copy vector is easy in STL; hy_gold = hy_1: save a copy in hy_gold which will be output of
+    // CPU BLAS
     hy_gold = hy_1;
-    hy_2 = hy_1;
+    hy_2    = hy_1;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy_1, hy_1.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy_1, hy_1.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
@@ -220,44 +241,48 @@ rocblas_status testing_gemv(Arguments argus)
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
-            rocblas_gemv<T>(handle, transA, M, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy_1, incy);
+            rocblas_gemv<T>(
+                handle, transA, M, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy_1, incy);
         }
 
-        gpu_time_used = (get_time_us() - gpu_time_used) / number_timing_iterations;
-        rocblas_gflops = gemv_gflop_count<T> (M, N) / gpu_time_used * 1e6 * 1;
-        rocblas_bandwidth = (1.0 * M * N) * sizeof(T)/ gpu_time_used / 1e3;
+        gpu_time_used     = (get_time_us() - gpu_time_used) / number_timing_iterations;
+        rocblas_gflops    = gemv_gflop_count<T>(M, N) / gpu_time_used * 1e6 * 1;
+        rocblas_bandwidth = (1.0 * M * N) * sizeof(T) / gpu_time_used / 1e3;
     }
 
     if(argus.unit_check || argus.norm_check)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dy_1, hy_1.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dy_2, hy_2.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy_1, hy_1.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy_2, hy_2.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice))
         CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice))
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_gemv<T>(handle, transA, M, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy_1, incy));
+        CHECK_ROCBLAS_ERROR(rocblas_gemv<T>(
+            handle, transA, M, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy_1, incy));
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(rocblas_gemv<T>(handle, transA, M, N, d_alpha, dA, lda, dx, incx, d_beta, dy_2, incy));
+        CHECK_ROCBLAS_ERROR(
+            rocblas_gemv<T>(handle, transA, M, N, d_alpha, dA, lda, dx, incx, d_beta, dy_2, incy));
 
-        //copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T)*size_y, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hy_2.data(), dy_2, sizeof(T)*size_y, hipMemcpyDeviceToHost));
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T) * size_y, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_2.data(), dy_2, sizeof(T) * size_y, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
 
-        cblas_gemv<T>(transA, M, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_gold.data(), incy);
+        cblas_gemv<T>(
+            transA, M, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_gold.data(), incy);
 
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = gemv_gflop_count<T>(M, N) / cpu_time_used * 1e6;
+        cblas_gflops  = gemv_gflop_count<T>(M, N) / cpu_time_used * 1e6;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
@@ -265,26 +290,30 @@ rocblas_status testing_gemv(Arguments argus)
             unit_check_general<T>(1, dim_y, abs_incy, hy_gold.data(), hy_2.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
-            rocblas_error_1 = norm_check_general<T>('F', 1, dim_y, abs_incy, hy_gold.data(), hy_1.data());
-            rocblas_error_2 = norm_check_general<T>('F', 1, dim_y, abs_incy, hy_gold.data(), hy_2.data());
+            rocblas_error_1 =
+                norm_check_general<T>('F', 1, dim_y, abs_incy, hy_gold.data(), hy_1.data());
+            rocblas_error_2 =
+                norm_check_general<T>('F', 1, dim_y, abs_incy, hy_gold.data(), hy_2.data());
         }
     }
 
     if(argus.timing)
     {
-        //only norm_check return an norm error, unit check won't return anything
+        // only norm_check return an norm error, unit check won't return anything
         cout << "M,N,lda,rocblas-Gflops,rocblas-GB/s,";
         if(argus.norm_check)
         {
-            cout << "CPU-Gflops,norm_error_host_ptr,norm_error_device_ptr" ;
+            cout << "CPU-Gflops,norm_error_host_ptr,norm_error_device_ptr";
         }
         cout << endl;
 
-        cout << "GGG,"<< M << ',' << N <<',' << lda <<','<< rocblas_gflops << ',' << rocblas_bandwidth << ','  ;
+        cout << "GGG," << M << ',' << N << ',' << lda << ',' << rocblas_gflops << ','
+             << rocblas_bandwidth << ',';
 
         if(argus.norm_check)
         {

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -18,15 +18,15 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 void testing_ger_bad_arg()
 {
-    rocblas_int M = 100;
-    rocblas_int N = 100;
+    rocblas_int M    = 100;
+    rocblas_int N    = 100;
     rocblas_int incx = 1;
     rocblas_int incy = 1;
-    rocblas_int lda = 100;
-    T alpha = 0.6;
+    rocblas_int lda  = 100;
+    T alpha          = 0.6;
 
     rocblas_status status;
 
@@ -35,18 +35,21 @@ void testing_ger_bad_arg()
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    rocblas_int size_A = lda * N;
-    rocblas_int size_x = M * abs_incx;
-    rocblas_int size_y = N * abs_incy;
+    rocblas_int size_A   = lda * N;
+    rocblas_int size_x   = M * abs_incx;
+    rocblas_int size_y   = N * abs_incy;
 
-    //allocate memory on device
-    auto dA_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    T* dA_1 = (T*) dA_1_managed.get();
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dA_1 || !dx || !dy)
+    // allocate memory on device
+    auto dA_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                           rocblas_test::device_free};
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                         rocblas_test::device_free};
+    T* dA_1 = (T*)dA_1_managed.get();
+    T* dx   = (T*)dx_managed.get();
+    T* dy   = (T*)dy_managed.get();
+    if(!dA_1 || !dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -54,24 +57,24 @@ void testing_ger_bad_arg()
 
     // test if (nullptr == dx)
     {
-        T *dx_null = nullptr;
-        status = rocblas_ger<T>(handle, M, N, (T*)&alpha, dx_null, incx, dy, incy, dA_1, lda);
+        T* dx_null = nullptr;
+        status     = rocblas_ger<T>(handle, M, N, (T*)&alpha, dx_null, incx, dy, incy, dA_1, lda);
 
-        verify_rocblas_status_invalid_pointer(status,"ERROR: A or x or y is null pointer");
+        verify_rocblas_status_invalid_pointer(status, "ERROR: A or x or y is null pointer");
     }
     // test if (nullptr == dy)
     {
-        T *dy_null = nullptr;
-        status = rocblas_ger<T>(handle, M, N, (T*)&alpha, dx, incx, dy_null, incy, dA_1, lda);
+        T* dy_null = nullptr;
+        status     = rocblas_ger<T>(handle, M, N, (T*)&alpha, dx, incx, dy_null, incy, dA_1, lda);
 
-        verify_rocblas_status_invalid_pointer(status,"ERROR: A or x or y is null pointer");
+        verify_rocblas_status_invalid_pointer(status, "ERROR: A or x or y is null pointer");
     }
     // test if (nullptr == dA_1)
     {
-        T *dA_1_null = nullptr;
-        status = rocblas_ger<T>(handle, M, N, (T*)&alpha, dx, incx, dy, incy, dA_1_null, lda);
+        T* dA_1_null = nullptr;
+        status       = rocblas_ger<T>(handle, M, N, (T*)&alpha, dx, incx, dy, incy, dA_1_null, lda);
 
-        verify_rocblas_status_invalid_pointer(status,"ERROR: A or x or y is null pointer");
+        verify_rocblas_status_invalid_pointer(status, "ERROR: A or x or y is null pointer");
     }
     // test if (handle == nullptr)
     {
@@ -83,33 +86,36 @@ void testing_ger_bad_arg()
     return;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_ger(Arguments argus)
 {
-    rocblas_int M = argus.M;
-    rocblas_int N = argus.N;
+    rocblas_int M    = argus.M;
+    rocblas_int N    = argus.N;
     rocblas_int incx = argus.incx;
     rocblas_int incy = argus.incy;
-    rocblas_int lda = argus.lda;
-    T h_alpha = (T)argus.alpha;
+    rocblas_int lda  = argus.lda;
+    T h_alpha        = (T)argus.alpha;
 
-    rocblas_int safe_size = 100;    // arbitrarily set to 100
+    rocblas_int safe_size = 100; // arbitrarily set to 100
 
     rocblas_status status;
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //argument check before allocating invalid memory
-    if ( M <= 0 || N <= 0 || lda < M || lda < 1 || 0 == incx || 0 == incy )
+    // argument check before allocating invalid memory
+    if(M <= 0 || N <= 0 || lda < M || lda < 1 || 0 == incx || 0 == incy)
     {
-        auto dA_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dA_1 = (T*) dA_1_managed.get();
-        T* dx = (T*) dx_managed.get();
-        T* dy = (T*) dy_managed.get();
-        if (!dA_1 || !dx || !dy)
+        auto dA_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                               rocblas_test::device_free};
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dA_1 = (T*)dA_1_managed.get();
+        T* dx   = (T*)dx_managed.get();
+        T* dy   = (T*)dy_managed.get();
+        if(!dA_1 || !dx || !dy)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
@@ -124,29 +130,34 @@ rocblas_status testing_ger(Arguments argus)
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    rocblas_int size_A = lda * N;
-    rocblas_int size_x = M * abs_incx;
-    rocblas_int size_y = N * abs_incy;
+    rocblas_int size_A   = lda * N;
+    rocblas_int size_x   = M * abs_incx;
+    rocblas_int size_y   = N * abs_incy;
 
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA_1(size_A);
     vector<T> hA_2(size_A);
     vector<T> hA_gold(size_A);
     vector<T> hx(M * abs_incx);
     vector<T> hy(N * abs_incy);
 
-    //allocate memory on device
-    auto dA_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dA_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),rocblas_test::device_free};
-    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dA_1 = (T*) dA_1_managed.get();
-    T* dA_2 = (T*) dA_2_managed.get();
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    T* d_alpha = (T*) d_alpha_managed.get();
-    if (!dA_1 || !dA_2 || !dx || !dy || !d_alpha)
+    // allocate memory on device
+    auto dA_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                           rocblas_test::device_free};
+    auto dA_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                           rocblas_test::device_free};
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                         rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA_1    = (T*)dA_1_managed.get();
+    T* dA_2    = (T*)dA_2_managed.get();
+    T* dx      = (T*)dx_managed.get();
+    T* dy      = (T*)dy_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    if(!dA_1 || !dA_2 || !dx || !dy || !d_alpha)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
@@ -157,39 +168,41 @@ rocblas_status testing_ger(Arguments argus)
     double rocblas_error_1;
     double rocblas_error_2;
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
-    if( lda >= M ) 
+    if(lda >= M)
     {
         rocblas_init<T>(hA_1, M, N, lda);
     }
     rocblas_init<T>(hx, 1, M, abs_incx);
     rocblas_init<T>(hy, 1, N, abs_incy);
 
-    //copy matrix is easy in STL; hA_gold = hA_1: save a copy in hA_gold which will be output of CPU BLAS
+    // copy matrix is easy in STL; hA_gold = hA_1: save a copy in hA_gold which will be output of
+    // CPU BLAS
     hA_gold = hA_1;
-    hA_2 = hA_1;
+    hA_2    = hA_1;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA_1, hA_1.data(), sizeof(T)*lda*N,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*M * abs_incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T)*N * abs_incy, hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA_1, hA_1.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * abs_incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * abs_incy, hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
     {
-        //copy data from CPU to device
-        CHECK_HIP_ERROR(hipMemcpy(dA_2, hA_2.data(), sizeof(T)*lda*N,  hipMemcpyHostToDevice));
+        // copy data from CPU to device
+        CHECK_HIP_ERROR(hipMemcpy(dA_2, hA_2.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_ger<T>(handle, M, N, (T*)&h_alpha, dx, incx, dy, incy, dA_1, lda));
+        CHECK_ROCBLAS_ERROR(
+            rocblas_ger<T>(handle, M, N, (T*)&h_alpha, dx, incx, dy, incy, dA_1, lda));
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         CHECK_ROCBLAS_ERROR(rocblas_ger<T>(handle, M, N, d_alpha, dx, incx, dy, incy, dA_2, lda));
 
-        //copy output from device to CPU
-        hipMemcpy(hA_1.data(), dA_1, sizeof(T)*N*lda, hipMemcpyDeviceToHost);
-        hipMemcpy(hA_2.data(), dA_2, sizeof(T)*N*lda, hipMemcpyDeviceToHost);
+        // copy output from device to CPU
+        hipMemcpy(hA_1.data(), dA_1, sizeof(T) * N * lda, hipMemcpyDeviceToHost);
+        hipMemcpy(hA_2.data(), dA_2, sizeof(T) * N * lda, hipMemcpyDeviceToHost);
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -197,9 +210,9 @@ rocblas_status testing_ger(Arguments argus)
         cblas_ger<T>(M, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_gold.data(), lda);
 
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = ger_gflop_count<T>(M, N) / cpu_time_used * 1e6;
+        cblas_gflops  = ger_gflop_count<T>(M, N) / cpu_time_used * 1e6;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
@@ -207,8 +220,9 @@ rocblas_status testing_ger(Arguments argus)
             unit_check_general<T>(M, N, lda, hA_gold.data(), hA_2.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
             rocblas_error_1 = norm_check_general<T>('F', M, N, lda, hA_gold.data(), hA_1.data());
@@ -221,27 +235,29 @@ rocblas_status testing_ger(Arguments argus)
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             rocblas_ger<T>(handle, M, N, (T*)&h_alpha, dx, incx, dy, incy, dA_1, lda);
         }
 
-        gpu_time_used = (get_time_us() - gpu_time_used) / number_timing_iterations;
-        rocblas_gflops = ger_gflop_count<T> (M, N) / gpu_time_used * 1e6 * 1;
-        rocblas_bandwidth = (2.0 * M * N) * sizeof(T)/ gpu_time_used / 1e3;
+        gpu_time_used     = (get_time_us() - gpu_time_used) / number_timing_iterations;
+        rocblas_gflops    = ger_gflop_count<T>(M, N) / gpu_time_used * 1e6 * 1;
+        rocblas_bandwidth = (2.0 * M * N) * sizeof(T) / gpu_time_used / 1e3;
 
-        //only norm_check return an norm error, unit check won't return anything
+        // only norm_check return an norm error, unit check won't return anything
         cout << "M,N,lda,rocblas-Gflops,rocblas-GB/s";
 
-        if(argus.norm_check) cout << ",CPU-Gflops,norm_error_host_ptr,norm_error_dev_ptr" ;
+        if(argus.norm_check)
+            cout << ",CPU-Gflops,norm_error_host_ptr,norm_error_dev_ptr";
 
         cout << endl;
 
         cout << M << "," << N << "," << lda << "," << rocblas_gflops << "," << rocblas_bandwidth;
 
-        if(argus.norm_check) cout << "," << cblas_gflops << "," << rocblas_error_1 << "," << rocblas_error_2;
+        if(argus.norm_check)
+            cout << "," << cblas_gflops << "," << rocblas_error_1 << "," << rocblas_error_2;
 
         cout << endl;
     }

--- a/clients/include/testing_iamax.hpp
+++ b/clients/include/testing_iamax.hpp
@@ -17,11 +17,11 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 void testing_iamax_bad_arg()
 {
-    rocblas_int N = 100;
-    rocblas_int incx = 1;
+    rocblas_int N         = 100;
+    rocblas_int incx      = 1;
     rocblas_int safe_size = 100;
 
     rocblas_status status;
@@ -29,9 +29,10 @@ void testing_iamax_bad_arg()
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    if (!dx)
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    T* dx = (T*)dx_managed.get();
+    if(!dx)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -41,19 +42,19 @@ void testing_iamax_bad_arg()
 
     // testing for (nullptr == dx)
     {
-        T *dx_null = nullptr;
+        T* dx_null = nullptr;
 
         status = rocblas_iamax<T>(handle, N, dx_null, incx, &h_rocblas_result);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x is nullptr");
     }
     // testing for (nullptr == h_rocblas_result)
     {
-        rocblas_int *h_rocblas_result_null = nullptr;
+        rocblas_int* h_rocblas_result_null = nullptr;
 
         status = rocblas_iamax<T>(handle, N, dx, incx, h_rocblas_result_null);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: result is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: result is nullptr");
     }
     // testing for (nullptr == handle)
     {
@@ -65,12 +66,12 @@ void testing_iamax_bad_arg()
     }
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_iamax(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    rocblas_int safe_size = 100;   // arbritrarily set to 100
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    rocblas_int safe_size = 100; // arbritrarily set to 100
 
     rocblas_int h_rocblas_result_1;
     rocblas_int h_rocblas_result_2;
@@ -84,14 +85,16 @@ rocblas_status testing_iamax(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //check to prevent undefined memory allocation error
-    if( N <= 0 || incx <= 0 )
+    // check to prevent undefined memory allocation error
+    if(N <= 0 || incx <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto d_rocblas_result_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(rocblas_int)),rocblas_test::device_free};
-        T* dx = (T*) dx_managed.get();
-        rocblas_int* d_rocblas_result = (rocblas_int*) d_rocblas_result_managed.get();
-        if (!dx || !d_rocblas_result)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto d_rocblas_result_managed = rocblas_unique_ptr{
+            rocblas_test::device_malloc(sizeof(rocblas_int)), rocblas_test::device_free};
+        T* dx                         = (T*)dx_managed.get();
+        rocblas_int* d_rocblas_result = (rocblas_int*)d_rocblas_result_managed.get();
+        if(!dx || !d_rocblas_result)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
@@ -106,26 +109,28 @@ rocblas_status testing_iamax(Arguments argus)
 
     rocblas_int size_x = N * incx;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto d_rocblas_result_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(rocblas_int)),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    rocblas_int* d_rocblas_result = (rocblas_int*) d_rocblas_result_managed.get();
-    if (!dx || !d_rocblas_result)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto d_rocblas_result_managed = rocblas_unique_ptr{
+        rocblas_test::device_malloc(sizeof(rocblas_int)), rocblas_test::device_free};
+    T* dx                         = (T*)dx_managed.get();
+    rocblas_int* d_rocblas_result = (rocblas_int*)d_rocblas_result_managed.get();
+    if(!dx || !d_rocblas_result)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Naming: dx is in GPU (device) memory. hx is in CPU (host) memory, plz follow this practice
+    // Naming: dx is in GPU (device) memory. hx is in CPU (host) memory, plz follow this practice
     vector<T> hx(size_x);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hx, 1, N, incx);
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
 
@@ -138,13 +143,14 @@ rocblas_status testing_iamax(Arguments argus)
         // GPU BLAS, rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         CHECK_ROCBLAS_ERROR(rocblas_iamax<T>(handle, N, dx, incx, d_rocblas_result));
-        CHECK_HIP_ERROR(hipMemcpy(&h_rocblas_result_2, d_rocblas_result, sizeof(rocblas_int), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(
+            &h_rocblas_result_2, d_rocblas_result, sizeof(rocblas_int), hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
         cblas_iamax<T>(N, hx.data(), incx, &cpu_result);
         cpu_time_used = get_time_us() - cpu_time_used;
-        cpu_result += 1;   // make index 1 based as in Fortran BLAS, not 0 based as in CBLAS
+        cpu_result += 1; // make index 1 based as in Fortran BLAS, not 0 based as in CBLAS
 
         if(argus.unit_check)
         {
@@ -152,8 +158,9 @@ rocblas_status testing_iamax(Arguments argus)
             unit_check_general<rocblas_int>(1, 1, 1, &cpu_result, &h_rocblas_result_2);
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
             rocblas_error_1 = h_rocblas_result_1 - cpu_result;
@@ -167,10 +174,10 @@ rocblas_status testing_iamax(Arguments argus)
     {
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        
-        gpu_time_used = get_time_us();// in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        gpu_time_used = get_time_us(); // in microseconds
+
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             rocblas_iamax<T>(handle, N, dx, incx, d_rocblas_result);
         }
@@ -179,13 +186,15 @@ rocblas_status testing_iamax(Arguments argus)
 
         cout << "N,rocblas-us";
 
-        if(argus.norm_check) cout << ",cpu_time_used,rocblas_error_host_ptr,rocblas_error_dev_ptr";
+        if(argus.norm_check)
+            cout << ",cpu_time_used,rocblas_error_host_ptr,rocblas_error_dev_ptr";
 
         cout << endl;
 
         cout << (int)N << "," << gpu_time_used;
 
-        if(argus.norm_check) cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
+        if(argus.norm_check)
+            cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
 
         cout << endl;
     }

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -19,11 +19,11 @@
 
 using namespace std;
 
-template<typename T1, typename T2>
+template <typename T1, typename T2>
 rocblas_status testing_nrm2_bad_arg()
 {
-    rocblas_int N = 100;
-    rocblas_int incx = 1;
+    rocblas_int N         = 100;
+    rocblas_int incx      = 1;
     rocblas_int safe_size = 100;
 
     rocblas_status status;
@@ -31,11 +31,13 @@ rocblas_status testing_nrm2_bad_arg()
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),rocblas_test::device_free};
-    auto d_rocblas_result_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)),rocblas_test::device_free};
-    T1* dx = (T1*) dx_managed.get();
-    T2* d_rocblas_result = (T2*) d_rocblas_result_managed.get();
-    if (!dx || !d_rocblas_result)
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),
+                                         rocblas_test::device_free};
+    auto d_rocblas_result_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)), rocblas_test::device_free};
+    T1* dx               = (T1*)dx_managed.get();
+    T2* d_rocblas_result = (T2*)d_rocblas_result_managed.get();
+    if(!dx || !d_rocblas_result)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
@@ -43,21 +45,21 @@ rocblas_status testing_nrm2_bad_arg()
 
     // test if (nullptr == dx)
     {
-        T1 *dx_null = nullptr;
+        T1* dx_null = nullptr;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         status = rocblas_nrm2<T1, T2>(handle, N, dx_null, incx, d_rocblas_result);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x or result is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x or result is nullptr");
     }
     // test if (nullptr == d_rocblas_result)
     {
-        T2 *d_rocblas_result_null = nullptr;
+        T2* d_rocblas_result_null = nullptr;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         status = rocblas_nrm2<T1, T2>(handle, N, dx, incx, d_rocblas_result_null);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x or result is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x or result is nullptr");
     }
     // test if (nullptr == handle)
     {
@@ -71,12 +73,12 @@ rocblas_status testing_nrm2_bad_arg()
     return rocblas_status_success;
 }
 
-template<typename T1, typename T2>
+template <typename T1, typename T2>
 rocblas_status testing_nrm2(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    rocblas_int safe_size = 100;   //  arbitrarily set to zero
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    rocblas_int safe_size = 100; //  arbitrarily set to zero
 
     T2 rocblas_result_1;
     T2 rocblas_result_2;
@@ -90,14 +92,16 @@ rocblas_status testing_nrm2(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //check to prevent undefined memory allocation error
-    if( N <= 0 || incx <= 0 )
+    // check to prevent undefined memory allocation error
+    if(N <= 0 || incx <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),rocblas_test::device_free};
-        auto d_rocblas_result_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)),rocblas_test::device_free};
-        T1* dx = (T1*) dx_managed.get();
-        T2* d_rocblas_result = (T2*) d_rocblas_result_managed.get();
-        if (!dx || !d_rocblas_result)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * safe_size),
+                                             rocblas_test::device_free};
+        auto d_rocblas_result_managed =
+            rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)), rocblas_test::device_free};
+        T1* dx               = (T1*)dx_managed.get();
+        T2* d_rocblas_result = (T2*)d_rocblas_result_managed.get();
+        if(!dx || !d_rocblas_result)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
@@ -113,26 +117,28 @@ rocblas_status testing_nrm2(Arguments argus)
 
     rocblas_int size_x = N * incx;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * size_x),rocblas_test::device_free};
-    auto d_rocblas_result_managed_2 = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)),rocblas_test::device_free};
-    T1* dx = (T1*) dx_managed.get();
-    T2* d_rocblas_result_2 = (T2*) d_rocblas_result_managed_2.get();
-    if (!dx || !d_rocblas_result_2)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T1) * size_x),
+                                         rocblas_test::device_free};
+    auto d_rocblas_result_managed_2 =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T2)), rocblas_test::device_free};
+    T1* dx                 = (T1*)dx_managed.get();
+    T2* d_rocblas_result_2 = (T2*)d_rocblas_result_managed_2.get();
+    if(!dx || !d_rocblas_result_2)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Naming: dx is in GPU (device) memory. hx is in CPU (host) memory, plz follow this practice
+    // Naming: dx is in GPU (device) memory. hx is in CPU (host) memory, plz follow this practice
     vector<T1> hx(size_x);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T1>(hx, 1, N, incx);
 
-    //copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1)*N*incx, hipMemcpyHostToDevice));
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1) * N * incx, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
 
@@ -145,33 +151,38 @@ rocblas_status testing_nrm2(Arguments argus)
         // GPU BLAS, rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         CHECK_ROCBLAS_ERROR((rocblas_nrm2<T1, T2>(handle, N, dx, incx, d_rocblas_result_2)));
-        CHECK_HIP_ERROR(hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T2), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T2), hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
         cblas_nrm2<T1, T2>(N, hx.data(), incx, &cpu_result);
         cpu_time_used = get_time_us() - cpu_time_used;
 
-//      allowable error is sqrt of precision. This is based on nrm2 calculating the 
-//      square root of a sum. It is assumed that the sum will have accuracy =approx=
-//      precision, so nrm2 will have accuracy =approx= sqrt(precision) 
-        T2 abs_error = pow(10.0, -(std::numeric_limits<T2>::digits10/2.0)) * cpu_result;
-        T2 tolerance = 2.0;  //  accounts for rounding in reduction sum. depends on n. 
-                             //  If test fails, try decreasing n or increasing tolerance.
+        //      allowable error is sqrt of precision. This is based on nrm2 calculating the
+        //      square root of a sum. It is assumed that the sum will have accuracy =approx=
+        //      precision, so nrm2 will have accuracy =approx= sqrt(precision)
+        T2 abs_error = pow(10.0, -(std::numeric_limits<T2>::digits10 / 2.0)) * cpu_result;
+        T2 tolerance = 2.0; //  accounts for rounding in reduction sum. depends on n.
+                            //  If test fails, try decreasing n or increasing tolerance.
         abs_error = abs_error * tolerance;
         if(argus.unit_check)
         {
-            near_check_general<T1,T2>(1, 1, 1, &cpu_result, &rocblas_result_1, abs_error);
-            near_check_general<T1,T2>(1, 1, 1, &cpu_result, &rocblas_result_2, abs_error);
+            near_check_general<T1, T2>(1, 1, 1, &cpu_result, &rocblas_result_1, abs_error);
+            near_check_general<T1, T2>(1, 1, 1, &cpu_result, &rocblas_result_2, abs_error);
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
-            printf("cpu=%e, gpu_host_ptr=%e, gpu_dev_ptr=%e\n", cpu_result, rocblas_result_1, rocblas_result_2);
-            rocblas_error_1 = fabs((cpu_result - rocblas_result_1)/cpu_result);
-            rocblas_error_2 = fabs((cpu_result - rocblas_result_2)/cpu_result);
+            printf("cpu=%e, gpu_host_ptr=%e, gpu_dev_ptr=%e\n",
+                   cpu_result,
+                   rocblas_result_1,
+                   rocblas_result_2);
+            rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
+            rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);
         }
     }
 
@@ -180,10 +191,10 @@ rocblas_status testing_nrm2(Arguments argus)
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             rocblas_nrm2<T1, T2>(handle, N, dx, incx, &rocblas_result_2);
         }
@@ -192,12 +203,14 @@ rocblas_status testing_nrm2(Arguments argus)
 
         cout << "N,rocblas(us)";
 
-        if(argus.norm_check) cout << ",CPU(us),error_host_ptr,error_dev_ptr";
+        if(argus.norm_check)
+            cout << ",CPU(us),error_host_ptr,error_dev_ptr";
 
         cout << endl;
         cout << N << "," << gpu_time_used;
 
-        if(argus.norm_check) cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
+        if(argus.norm_check)
+            cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
 
         cout << endl;
     }

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -16,12 +16,12 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 void testing_scal_bad_arg()
 {
-    rocblas_int N = 100;
+    rocblas_int N    = 100;
     rocblas_int incx = 1;
-    T alpha = 0.6;
+    T alpha          = 0.6;
 
     rocblas_status status;
 
@@ -30,10 +30,11 @@ void testing_scal_bad_arg()
 
     rocblas_int size_x = N * incx;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    if (!dx)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    T* dx = (T*)dx_managed.get();
+    if(!dx)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -41,19 +42,19 @@ void testing_scal_bad_arg()
 
     // test if (nullptr == dx)
     {
-        T *dx_null = nullptr;
+        T* dx_null = nullptr;
 
         status = rocblas_scal<T>(handle, N, &alpha, dx_null, incx);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x is nullptr");
     }
     // test if (nullptr == d_alpha)
     {
-        T *d_alpha_null = nullptr;
+        T* d_alpha_null = nullptr;
 
         status = rocblas_scal<T>(handle, N, d_alpha_null, dx, incx);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: alpha is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: alpha is nullptr");
     }
     // test if (nullptr == handle)
     {
@@ -66,25 +67,26 @@ void testing_scal_bad_arg()
     return;
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_scal(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    T h_alpha = argus.alpha;
-    rocblas_int safe_size = 100;  // arbitrarily set to 100
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    T h_alpha             = argus.alpha;
+    rocblas_int safe_size = 100; // arbitrarily set to 100
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
     rocblas_status status;
 
-    //argument sanity check before allocating invalid memory
-    if (N <= 0 || incx <= 0)
+    // argument sanity check before allocating invalid memory
+    if(N <= 0 || incx <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dx = (T*) dx_managed.get();
-        if (!dx)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dx = (T*)dx_managed.get();
+        if(!dx)
         {
             verify_rocblas_status_success(rocblas_status_memory_error, "!dx");
             return rocblas_status_memory_error;
@@ -98,45 +100,49 @@ rocblas_status testing_scal(Arguments argus)
 
     rocblas_int size_x = N * incx;
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hx_1(size_x);
     vector<T> hx_2(size_x);
     vector<T> hy_gold(size_x);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hx_1, 1, N, incx);
 
-    //copy vector is easy in STL; hy_gold = hx: save a copy in hy_gold which will be output of CPU BLAS
-    hx_2 = hx_1;
+    // copy vector is easy in STL; hy_gold = hx: save a copy in hy_gold which will be output of CPU
+    // BLAS
+    hx_2    = hx_1;
     hy_gold = hx_1;
 
-    //allocate memory on device
-    auto dx_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto dx_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),rocblas_test::device_free};
-    auto d_alpha_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dx_1 = (T*) dx_1_managed.get();
-    T* dx_2 = (T*) dx_2_managed.get();
-    T* d_alpha = (T*) d_alpha_managed.get();
-    if (!dx_1 || !dx_2 || !d_alpha)
+    // allocate memory on device
+    auto dx_1_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                           rocblas_test::device_free};
+    auto dx_2_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                           rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dx_1    = (T*)dx_1_managed.get();
+    T* dx_2    = (T*)dx_2_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    if(!dx_1 || !dx_2 || !d_alpha)
     {
         verify_rocblas_status_success(rocblas_status_memory_error, "!dx || !d_alpha");
         return rocblas_status_memory_error;
     }
 
-    //copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
     double rocblas_error_1 = 0.0;
     double rocblas_error_2 = 0.0;
 
-    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dx_2, hx_2.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dx_2, hx_2.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
         // GPU BLAS, rocblas_pointer_mode_host
@@ -147,17 +153,17 @@ rocblas_status testing_scal(Arguments argus)
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device))
         CHECK_ROCBLAS_ERROR(rocblas_scal<T>(handle, N, d_alpha, dx_2, incx));
 
-        //copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hx_1.data(), dx_1, sizeof(T)*N*incx, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hx_2.data(), dx_2, sizeof(T)*N*incx, hipMemcpyDeviceToHost));
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx_1.data(), dx_1, sizeof(T) * N * incx, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hx_2.data(), dx_2, sizeof(T) * N * incx, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
         cblas_scal<T>(N, h_alpha, hy_gold.data(), incx);
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = axpy_gflop_count<T> (N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = axpy_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
@@ -165,41 +171,44 @@ rocblas_status testing_scal(Arguments argus)
             unit_check_general<T>(1, N, incx, hy_gold.data(), hx_2.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
         if(argus.norm_check)
         {
             rocblas_error_1 = norm_check_general<T>('F', 1, N, incx, hy_gold.data(), hx_1.data());
             rocblas_error_2 = norm_check_general<T>('F', 1, N, incx, hy_gold.data(), hx_2.data());
         }
 
-    }// end of if unit/norm check
+    } // end of if unit/norm check
 
     if(argus.timing)
     {
         int number_timing_iterations = 1;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host))
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for(int iter=0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             rocblas_scal<T>(handle, N, &h_alpha, dx_1, incx);
         }
 
-        gpu_time_used = (get_time_us() - gpu_time_used) / number_timing_iterations;
-        rocblas_gflops = axpy_gflop_count<T> (N) / gpu_time_used * 1e6 * 1;
-        rocblas_bandwidth = (2.0 * N) * sizeof(T)/ gpu_time_used / 1e3;
+        gpu_time_used     = (get_time_us() - gpu_time_used) / number_timing_iterations;
+        rocblas_gflops    = axpy_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_bandwidth = (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         cout << "N,rocblas-Gflops,rocblas-GB/s,rocblas-us";
 
-        if(argus.norm_check) cout << ",CPU-Gflops,norm_error_host_ptr,norm_error_device_ptr" ;
+        if(argus.norm_check)
+            cout << ",CPU-Gflops,norm_error_host_ptr,norm_error_device_ptr";
 
         cout << endl;
 
         cout << N << "," << rocblas_gflops << "," << rocblas_bandwidth << "," << gpu_time_used;
 
-        if(argus.norm_check) cout << cblas_gflops << ',' << rocblas_error_1 << ',' << rocblas_error_2;
+        if(argus.norm_check)
+            cout << cblas_gflops << ',' << rocblas_error_1 << ',' << rocblas_error_2;
 
         cout << endl;
     }

--- a/clients/include/testing_set_get_matrix.hpp
+++ b/clients/include/testing_set_get_matrix.hpp
@@ -18,15 +18,15 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 rocblas_status testing_set_get_matrix(Arguments argus)
 {
-    rocblas_int rows = argus.rows;
-    rocblas_int cols = argus.cols;
-    rocblas_int lda = argus.lda;
-    rocblas_int ldb = argus.ldb;
-    rocblas_int ldc = argus.ldc;
-    rocblas_int safe_size = 100;  // arbritrarily set to 100
+    rocblas_int rows      = argus.rows;
+    rocblas_int cols      = argus.cols;
+    rocblas_int lda       = argus.lda;
+    rocblas_int ldb       = argus.ldb;
+    rocblas_int ldc       = argus.ldc;
+    rocblas_int safe_size = 100; // arbritrarily set to 100
 
     rocblas_status status_set = rocblas_status_success;
     rocblas_status status_get = rocblas_status_success;
@@ -34,27 +34,30 @@ rocblas_status testing_set_get_matrix(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //argument sanity check, quick return if input parameters are invalid before allocating invalid memory
-    if (rows < 0 || lda <= 0 || lda < rows || 
-        cols < 0 || ldb <= 0 || ldb < rows || 
-                    ldc <= 0 || ldc < rows || nullptr == handle)
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(rows < 0 || lda <= 0 || lda < rows || cols < 0 || ldb <= 0 || ldb < rows || ldc <= 0 ||
+       ldc < rows || nullptr == handle)
     {
         vector<T> ha(safe_size);
         vector<T> hb(safe_size);
         vector<T> hc(safe_size);
 
-        auto dc_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dc = (T*) dc_managed.get();
-        if (!dc)
+        auto dc_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dc = (T*)dc_managed.get();
+        if(!dc)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
         }
 
-        status_set = rocblas_set_matrix(rows, cols, sizeof(T), (void *) ha.data(), lda, (void *) dc, ldc);
-        status_get = rocblas_get_matrix(rows, cols, sizeof(T), (void *) dc, ldc, (void *) hb.data(), ldb);
+        status_set =
+            rocblas_set_matrix(rows, cols, sizeof(T), (void*)ha.data(), lda, (void*)dc, ldc);
+        status_get =
+            rocblas_get_matrix(rows, cols, sizeof(T), (void*)dc, ldc, (void*)hb.data(), ldb);
 
-        if ( nullptr == handle )
+        if(nullptr == handle)
         {
             verify_rocblas_status_invalid_handle(status_set);
             verify_rocblas_status_invalid_handle(status_get);
@@ -65,21 +68,21 @@ rocblas_status testing_set_get_matrix(Arguments argus)
             set_get_matrix_arg_check(status_get, rows, cols, lda, ldb, ldc);
         }
 
-        if (status_set != rocblas_status_success) 
+        if(status_set != rocblas_status_success)
         {
             return status_set;
         }
-        else if (status_get != rocblas_status_success) 
+        else if(status_get != rocblas_status_success)
         {
             return status_get;
         }
-        else 
+        else
         {
             return rocblas_status_success;
         }
     }
 
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> ha(cols * lda);
     vector<T> hb(cols * ldb);
     vector<T> hc(cols * ldc);
@@ -89,81 +92,88 @@ rocblas_status testing_set_get_matrix(Arguments argus)
     double rocblas_bandwidth, cpu_bandwidth;
     double rocblas_error = 0.0;
 
-    //allocate memory on device
-    auto dc_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * cols * ldc),rocblas_test::device_free};
-    T* dc = (T*) dc_managed.get();
-    if (!dc)
+    // allocate memory on device
+    auto dc_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * cols * ldc),
+                                         rocblas_test::device_free};
+    T* dc = (T*)dc_managed.get();
+    if(!dc)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(ha, rows, cols, lda);
     rocblas_init<T>(hb, rows, cols, ldb);
     rocblas_init<T>(hc, rows, cols, ldc);
     hb_gold = hb;
 
-    if (argus.unit_check || argus.norm_check) 
+    if(argus.unit_check || argus.norm_check)
     {
         // ROCBLAS
         rocblas_init<T>(hb, rows, cols, ldb);
         rocblas_init<T>(hc, rows, cols, ldc);
         CHECK_HIP_ERROR(hipMemcpy(dc, hc.data(), sizeof(T) * ldc * cols, hipMemcpyHostToDevice));
-        CHECK_ROCBLAS_ERROR(rocblas_set_matrix(rows, cols, sizeof(T), (void *) ha.data(), lda, (void *) dc, ldc));
-        CHECK_ROCBLAS_ERROR(rocblas_get_matrix(rows, cols, sizeof(T), (void *) dc, ldc, (void *) hb.data(), ldb));
+        CHECK_ROCBLAS_ERROR(
+            rocblas_set_matrix(rows, cols, sizeof(T), (void*)ha.data(), lda, (void*)dc, ldc));
+        CHECK_ROCBLAS_ERROR(
+            rocblas_get_matrix(rows, cols, sizeof(T), (void*)dc, ldc, (void*)hb.data(), ldb));
 
         // reference calculation
         cpu_time_used = get_time_us();
-        for (int i1 = 0; i1 < rows; i1++) 
+        for(int i1 = 0; i1 < rows; i1++)
         {
-            for (int i2 = 0; i2 < cols; i2++) 
+            for(int i2 = 0; i2 < cols; i2++)
             {
-                hb_gold[i1 + i2 * ldb ] = ha[i1 + i2 * lda];
+                hb_gold[i1 + i2 * ldb] = ha[i1 + i2 * lda];
             }
         }
         cpu_time_used = get_time_us() - cpu_time_used;
-        cpu_bandwidth = (rows * cols * sizeof(T))/ cpu_time_used / 1e3;
+        cpu_bandwidth = (rows * cols * sizeof(T)) / cpu_time_used / 1e3;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if (argus.unit_check)
+        if(argus.unit_check)
         {
             unit_check_general<T>(rows, cols, ldb, hb.data(), hb_gold.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-        if (argus.norm_check)
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
+        if(argus.norm_check)
         {
             rocblas_error = norm_check_general<T>('F', rows, cols, ldb, hb.data(), hb_gold.data());
         }
     }
 
-    if(argus.timing) 
+    if(argus.timing)
     {
         int number_timing_iterations = 1;
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used                = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
-            rocblas_set_matrix(rows, cols, sizeof(T), (void *) ha.data(), lda, (void *) dc, ldc);
-            rocblas_get_matrix(rows, cols, sizeof(T), (void *) dc, ldc, (void *) hb.data(), ldb);
+            rocblas_set_matrix(rows, cols, sizeof(T), (void*)ha.data(), lda, (void*)dc, ldc);
+            rocblas_get_matrix(rows, cols, sizeof(T), (void*)dc, ldc, (void*)hb.data(), ldb);
         }
 
         gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_bandwidth = (rows*cols * sizeof(T)) / gpu_time_used / 1e3 / number_timing_iterations;
+        rocblas_bandwidth =
+            (rows * cols * sizeof(T)) / gpu_time_used / 1e3 / number_timing_iterations;
 
         cout << "rows,cols,lda,ldb,rocblas-GB/s";
 
-        if(argus.norm_check) cout << ",CPU-GB/s" ;
+        if(argus.norm_check)
+            cout << ",CPU-GB/s";
 
         cout << endl;
 
-        cout << rows << "," << cols << "," << lda << ","<< ldb << "," << rocblas_bandwidth;
+        cout << rows << "," << cols << "," << lda << "," << ldb << "," << rocblas_bandwidth;
 
-        if(argus.norm_check) cout << "," << cpu_bandwidth ;
+        if(argus.norm_check)
+            cout << "," << cpu_bandwidth;
 
         cout << endl;
     }

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -17,25 +17,27 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 void testing_swap_bad_arg()
 {
-    rocblas_int N = 100;
-    rocblas_int incx = 1;
-    rocblas_int incy = 1;
-    rocblas_int safe_size = 100;  //  arbitrarily set to 100
+    rocblas_int N         = 100;
+    rocblas_int incx      = 1;
+    rocblas_int incy      = 1;
+    rocblas_int safe_size = 100; //  arbitrarily set to 100
 
     rocblas_status status;
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dx || !dy)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                         rocblas_test::device_free};
+    T* dx = (T*)dx_managed.get();
+    T* dy = (T*)dy_managed.get();
+    if(!dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -43,19 +45,19 @@ void testing_swap_bad_arg()
 
     // test if (nullptr == dx)
     {
-        T *dx_null = nullptr;
+        T* dx_null = nullptr;
 
         status = rocblas_swap<T>(handle, N, dx_null, incx, dy, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x, y, is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x, y, is nullptr");
     }
     // test if (nullptr == dy)
     {
-        T *dy_null = nullptr;
+        T* dy_null = nullptr;
 
         status = rocblas_swap<T>(handle, N, dx, incx, dy_null, incy);
 
-        verify_rocblas_status_invalid_pointer(status,"Error: x, y, is nullptr");
+        verify_rocblas_status_invalid_pointer(status, "Error: x, y, is nullptr");
     }
     // test if (nullptr == handle)
     {
@@ -67,13 +69,13 @@ void testing_swap_bad_arg()
     }
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_swap(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int incx = argus.incx;
-    rocblas_int incy = argus.incy;
-    rocblas_int safe_size = 100;  //  arbitrarily set to 100
+    rocblas_int N         = argus.N;
+    rocblas_int incx      = argus.incx;
+    rocblas_int incy      = argus.incy;
+    rocblas_int safe_size = 100; //  arbitrarily set to 100
 
     rocblas_status status;
 
@@ -82,14 +84,16 @@ rocblas_status testing_swap(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //argument sanity check before allocating invalid memory
-    if ( N <= 0 )
+    // argument sanity check before allocating invalid memory
+    if(N <= 0)
     {
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dx = (T*) dx_managed.get();
-        T* dy = (T*) dy_managed.get();
-        if (!dx || !dy)
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dx = (T*)dx_managed.get();
+        T* dy = (T*)dy_managed.get();
+        if(!dx || !dy)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
@@ -102,39 +106,45 @@ rocblas_status testing_swap(Arguments argus)
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    rocblas_int size_x = N * abs_incx;
-    rocblas_int size_y = N * abs_incy;
+    rocblas_int size_x   = N * abs_incx;
+    rocblas_int size_y   = N * abs_incy;
 
-    //allocate memory on device
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x ),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y ),rocblas_test::device_free};
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dx || !dy)
+    // allocate memory on device
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_y),
+                                         rocblas_test::device_free};
+    T* dx = (T*)dx_managed.get();
+    T* dy = (T*)dy_managed.get();
+    if(!dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hx(size_x);
     vector<T> hy(size_y);
     vector<T> hx_gold(size_x);
     vector<T> hy_gold(size_y);
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<T>(hx, 1, N, abs_incx);
     // make hy different to hx
-    for (int i = 0; i < N; i++){ hy[i * abs_incy] = hx[i * abs_incx] + 1.0; };
+    for(int i = 0; i < N; i++)
+    {
+        hy[i * abs_incy] = hx[i * abs_incx] + 1.0;
+    };
 
-    //swap vector is easy in STL; hy_gold = hx: save a swap in hy_gold which will be output of CPU BLAS
+    // swap vector is easy in STL; hy_gold = hx: save a swap in hy_gold which will be output of CPU
+    // BLAS
     hx_gold = hx;
     hy_gold = hy;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
 
@@ -142,9 +152,9 @@ rocblas_status testing_swap(Arguments argus)
     {
         int number_timing_iterations = 1;
 
-        gpu_time_used = get_time_us();// in microseconds
+        gpu_time_used = get_time_us(); // in microseconds
 
-        for (int iter = 0; iter < number_timing_iterations; iter++)
+        for(int iter = 0; iter < number_timing_iterations; iter++)
         {
             rocblas_swap<T>(handle, N, dx, incx, dy, incy);
         }
@@ -155,31 +165,33 @@ rocblas_status testing_swap(Arguments argus)
     if(argus.unit_check || argus.norm_check)
     {
         // GPU BLAS
-        CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T)*size_x, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T)*size_y, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * size_y, hipMemcpyHostToDevice));
         CHECK_ROCBLAS_ERROR(rocblas_swap<T>(handle, N, dx, incx, dy, incy));
-        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T)*size_x, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T)*size_y, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * size_x, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
-        cblas_swap<T>( N, hx_gold.data(), incx, hy_gold.data(), incy);
+        cblas_swap<T>(N, hx_gold.data(), incx, hy_gold.data(), incy);
         cpu_time_used = get_time_us() - cpu_time_used;
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if(argus.unit_check){
+        if(argus.unit_check)
+        {
             unit_check_general<T>(1, N, abs_incx, hx_gold.data(), hx.data());
             unit_check_general<T>(1, N, abs_incy, hy_gold.data(), hy.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-        if(argus.norm_check){
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
+        if(argus.norm_check)
+        {
             rocblas_error = norm_check_general<T>('F', 1, N, abs_incx, hx_gold.data(), hx.data());
             rocblas_error = norm_check_general<T>('F', 1, N, abs_incy, hy_gold.data(), hy.data());
         }
-
     }
 
     BLAS_1_RESULT_PRINT

--- a/clients/include/testing_symv.hpp
+++ b/clients/include/testing_symv.hpp
@@ -18,16 +18,16 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 rocblas_status testing_symv(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int lda = argus.lda;
+    rocblas_int N    = argus.N;
+    rocblas_int lda  = argus.lda;
     rocblas_int incx = argus.incx;
     rocblas_int incy = argus.incy;
 
     T alpha = (T)argus.alpha;
-    T beta = (T)argus.beta;
+    T beta  = (T)argus.beta;
 
     rocblas_int safe_size = 100;
 
@@ -44,49 +44,49 @@ rocblas_status testing_symv(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //argument sanity check before allocating invalid memory
-    if( N < 0 || lda < 0 || incx < 0 || incy < 0)
+    // argument sanity check before allocating invalid memory
+    if(N < 0 || lda < 0 || incx < 0 || incy < 0)
     {
-        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dA = (T*) dA_managed.get();
-        T* dx = (T*) dx_managed.get();
-        T* dy = (T*) dy_managed.get();
-        if (!dA || !dx || !dy)
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dA = (T*)dA_managed.get();
+        T* dx = (T*)dx_managed.get();
+        T* dy = (T*)dy_managed.get();
+        if(!dA || !dx || !dy)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return;
         }
 
-        status = rocblas_symv<T>(handle,
-                     uplo, N,
-                     (T*)&alpha,
-                     dA, lda,
-                     dx, incx,
-                     (T*)&beta,
-                     dy, incy);
+        status =
+            rocblas_symv<T>(handle, uplo, N, (T*)&alpha, dA, lda, dx, incx, (T*)&beta, dy, incy);
 
         symv_arg_check(status, N, lda, incx, incy);
 
         return status;
     }
 
-    if ( N < 0 ){
+    if(N < 0)
+    {
         status = rocblas_status_invalid_size;
         return status;
     }
-    else if ( lda < 0 ){
+    else if(lda < 0)
+    {
         status = rocblas_status_invalid_size;
         return status;
     }
-    else if ( incx < 0 ){
+    else if(incx < 0)
+    {
         status = rocblas_status_invalid_size;
         return status;
     }
 
-
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> hx(size_X);
     vector<T> hy(size_Y);
@@ -98,111 +98,118 @@ rocblas_status testing_symv(Arguments argus)
 
     char char_fill = argus.uplo_option;
 
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_X),rocblas_test::device_free};
-    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_Y),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dx = (T*) dx_managed.get();
-    T* dy = (T*) dy_managed.get();
-    if (!dA || !dx || !dy)
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_X),
+                                         rocblas_test::device_free};
+    auto dy_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_Y),
+                                         rocblas_test::device_free};
+    T* dA = (T*)dA_managed.get();
+    T* dx = (T*)dx_managed.get();
+    T* dy = (T*)dy_managed.get();
+    if(!dA || !dx || !dy)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
     }
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init_symmetric<T>(hA, N, lda);
     rocblas_init<T>(hx, 1, N, incx);
     rocblas_init<T>(hy, 1, N, incy);
 
-    //copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
+    // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
     hz = hy;
 
-    //copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T)*lda*N,  hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T)*N*incx, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T)*N*incy, hipMemcpyHostToDevice);
+    // copy data from CPU to device
+    hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice);
+    hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice);
+    hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice);
 
     /* =====================================================================
            ROCBLAS
     =================================================================== */
-    if(argus.timing){
-        gpu_time_used = get_time_us();// in microseconds
+    if(argus.timing)
+    {
+        gpu_time_used = get_time_us(); // in microseconds
     }
 
-    for(int iter=0;iter<1;iter++){
+    for(int iter = 0; iter < 1; iter++)
+    {
 
-        status = rocblas_symv<T>(handle,
-                     uplo, N,
-                     (T*)&alpha,
-                     dA, lda,
-                     dx, incx,
-                     (T*)&beta,
-                     dy, incy);
+        status =
+            rocblas_symv<T>(handle, uplo, N, (T*)&alpha, dA, lda, dx, incx, (T*)&beta, dy, incy);
 
-        if (status != rocblas_status_success) return status;
+        if(status != rocblas_status_success)
+            return status;
     }
-    if(argus.timing){
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = symv_gflop_count<T> (N) / gpu_time_used * 1e6 * 1;
+    if(argus.timing)
+    {
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = symv_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
     }
 
-    //copy output from device to CPU
-    hipMemcpy(hy.data(), dy, sizeof(T)*N*incy, hipMemcpyDeviceToHost);
+    // copy output from device to CPU
+    hipMemcpy(hy.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost);
 
-    if(argus.unit_check || argus.norm_check){
+    if(argus.unit_check || argus.norm_check)
+    {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us();
         }
 
-        cblas_symv<T>(uplo, N,
-               alpha,
-               hA.data(),lda,
-               hx.data(), incx,
-               beta,
-               hz.data(), incy);
+        cblas_symv<T>(uplo, N, alpha, hA.data(), lda, hx.data(), incx, beta, hz.data(), incy);
 
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us() - cpu_time_used;
-            cblas_gflops = symv_gflop_count<T>(N) / cpu_time_used * 1e6;
+            cblas_gflops  = symv_gflop_count<T>(N) / cpu_time_used * 1e6;
         }
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if(argus.unit_check){
+        if(argus.unit_check)
+        {
             unit_check_general<T>(1, N, incy, hz.data(), hy.data());
         }
 
-    for(int i=0; i<32; i++){
-        printf("CPU[%d]=%f, GPU[%d]=%f\n", i, hz[i], i, hy[i]);
-    }
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-        if(argus.norm_check){
+        for(int i = 0; i < 32; i++)
+        {
+            printf("CPU[%d]=%f, GPU[%d]=%f\n", i, hz[i], i, hy[i]);
+        }
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
+        if(argus.norm_check)
+        {
             rocblas_error = norm_check_general<T>('F', 1, N, incy, hz.data(), hy.data());
         }
     }
 
-    if(argus.timing){
-        //only norm_check return an norm error, unit check won't return anything
-            cout << "N, lda, rocblas-Gflops (us) ";
-            if(argus.norm_check){
-                cout << "CPU-Gflops(us), norm-error" ;
-            }
-            cout << endl;
+    if(argus.timing)
+    {
+        // only norm_check return an norm error, unit check won't return anything
+        cout << "N, lda, rocblas-Gflops (us) ";
+        if(argus.norm_check)
+        {
+            cout << "CPU-Gflops(us), norm-error";
+        }
+        cout << endl;
 
-            cout << N <<',' << lda <<','<< rocblas_gflops << "(" << gpu_time_used << "),";
+        cout << N << ',' << lda << ',' << rocblas_gflops << "(" << gpu_time_used << "),";
 
-            if(argus.norm_check){
-                cout << cblas_gflops << "(" << cpu_time_used << "),";
-                cout << rocblas_error;
-            }
+        if(argus.norm_check)
+        {
+            cout << cblas_gflops << "(" << cpu_time_used << "),";
+            cout << rocblas_error;
+        }
 
-            cout << endl;
+        cout << endl;
     }
 
     return rocblas_status_success;

--- a/clients/include/testing_trmm.hpp
+++ b/clients/include/testing_trmm.hpp
@@ -18,36 +18,37 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 rocblas_status testing_trmm(Arguments argus)
 {
-    rocblas_int M = argus.M;
-    rocblas_int N = argus.N;
+    rocblas_int M   = argus.M;
+    rocblas_int N   = argus.N;
     rocblas_int lda = argus.lda;
     rocblas_int ldb = argus.ldb;
 
-    char char_side = argus.side_option;
-    char char_uplo = argus.uplo_option;
+    char char_side   = argus.side_option;
+    char char_uplo   = argus.uplo_option;
     char char_transA = argus.transA_option;
-    char char_diag = argus.diag_option;
-    T alpha = argus.alpha;
+    char char_diag   = argus.diag_option;
+    T alpha          = argus.alpha;
 
-    rocblas_side side = char2rocblas_side(char_side);
-    rocblas_fill uplo = char2rocblas_fill(char_uplo);
+    rocblas_side side        = char2rocblas_side(char_side);
+    rocblas_fill uplo        = char2rocblas_fill(char_uplo);
     rocblas_operation transA = char2rocblas_operation(char_transA);
-    rocblas_diagonal diag = char2rocblas_diagonal(char_diag);
+    rocblas_diagonal diag    = char2rocblas_diagonal(char_diag);
 
-    rocblas_int K = (side == rocblas_side_left ? M : N);
+    rocblas_int K      = (side == rocblas_side_left ? M : N);
     rocblas_int size_A = lda * K;
     rocblas_int size_B = ldb * N;
 
     rocblas_status status = rocblas_status_success;
 
-    //check here to prevent undefined memory allocation error
-    if( M < 0 || N < 0 || lda < 0 || ldb < 0){
+    // check here to prevent undefined memory allocation error
+    if(M < 0 || N < 0 || lda < 0 || ldb < 0)
+    {
         return rocblas_status_invalid_size;
     }
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> hB(size_B);
     vector<T> hC(size_B);
@@ -62,107 +63,118 @@ rocblas_status testing_trmm(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //allocate memory on device
-    //dB and dC are exact the same size
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dB = (T*) dB_managed.get();
-    T* dC = (T*) dC_managed.get();
-    if (!dA || !dB || !dC)
+    // allocate memory on device
+    // dB and dC are exact the same size
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    T* dA = (T*)dA_managed.get();
+    T* dB = (T*)dB_managed.get();
+    T* dC = (T*)dC_managed.get();
+    if(!dA || !dB || !dC)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init_symmetric<T>(hA, K, lda);
     rocblas_init<T>(hB, M, N, ldb);
     hB_copy = hB;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T)*size_B,  hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
 
     /* =====================================================================
            ROCBLAS
     =================================================================== */
-    if(argus.timing){
-        gpu_time_used = get_time_us();// in microseconds
+    if(argus.timing)
+    {
+        gpu_time_used = get_time_us(); // in microseconds
     }
 
-/*
-    status = rocblas_trmm<T>(handle,
-            side, uplo,
-            transA, diag,
-            M, N,
-            &alpha,
-            dA,lda,
-            dB,ldb,
-            dC,ldc);
-*/
+    /*
+        status = rocblas_trmm<T>(handle,
+                side, uplo,
+                transA, diag,
+                M, N,
+                &alpha,
+                dA,lda,
+                dB,ldb,
+                dC,ldc);
+    */
 
-    if (status != rocblas_status_success) return status;
+    if(status != rocblas_status_success)
+        return status;
 
-    if(argus.timing){
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = trmm_gflop_count<T> (M, N, K) / gpu_time_used * 1e6 ;
+    if(argus.timing)
+    {
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = trmm_gflop_count<T>(M, N, K) / gpu_time_used * 1e6;
     }
 
-    //copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T)*size_B, hipMemcpyDeviceToHost));
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T) * size_B, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check || argus.norm_check){
+    if(argus.unit_check || argus.norm_check)
+    {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us();
         }
 
-        cblas_trmm<T>(
-                side, uplo,
-                transA, diag,
-                M, N, alpha,
-                hA.data(), lda,
-                hB_copy.data(), ldb);
+        cblas_trmm<T>(side, uplo, transA, diag, M, N, alpha, hA.data(), lda, hB_copy.data(), ldb);
 
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us() - cpu_time_used;
-            cblas_gflops = trmm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
+            cblas_gflops  = trmm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
         }
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if(argus.unit_check){
+        if(argus.unit_check)
+        {
             unit_check_general<T>(M, N, ldb, hB_copy.data(), hC.data());
         }
 
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-        if(argus.norm_check){
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
+        if(argus.norm_check)
+        {
             rocblas_error = norm_check_general<T>('F', M, N, ldb, hB_copy.data(), hC.data());
         }
     }
 
-    if(argus.timing){
-        //only norm_check return an norm error, unit check won't return anything
-            cout << "M, N, lda, rocblas-Gflops (us) ";
-            if(argus.norm_check){
-                cout << "CPU-Gflops(us), norm-error" ;
-            }
-            cout << endl;
+    if(argus.timing)
+    {
+        // only norm_check return an norm error, unit check won't return anything
+        cout << "M, N, lda, rocblas-Gflops (us) ";
+        if(argus.norm_check)
+        {
+            cout << "CPU-Gflops(us), norm-error";
+        }
+        cout << endl;
 
-            cout << M <<','<< N <<',' << lda <<','<< rocblas_gflops << "(" << gpu_time_used  << "),";
+        cout << M << ',' << N << ',' << lda << ',' << rocblas_gflops << "(" << gpu_time_used
+             << "),";
 
-            if(argus.norm_check){
-                cout << cblas_gflops << "(" << cpu_time_used << "),";
-                cout << rocblas_error;
-            }
+        if(argus.norm_check)
+        {
+            cout << cblas_gflops << "(" << cpu_time_used << "),";
+            cout << rocblas_error;
+        }
 
-            cout << endl;
+        cout << endl;
     }
 
     return rocblas_status_success;

--- a/clients/include/testing_trsm.hpp
+++ b/clients/include/testing_trsm.hpp
@@ -6,8 +6,8 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <limits>    // std::numeric_limits<T>::epsilon();
-#include <cmath>     // std::abs
+#include <limits> // std::numeric_limits<T>::epsilon();
+#include <cmath>  // std::abs
 
 #include "rocblas.hpp"
 #include "arg_check.h"
@@ -24,38 +24,41 @@
 using namespace std;
 
 template <typename T>
-void printMatrix(const char* name, T* A, rocblas_int m, rocblas_int n, rocblas_int lda) {
+void printMatrix(const char* name, T* A, rocblas_int m, rocblas_int n, rocblas_int lda)
+{
     printf("---------- %s ----------\n", name);
-    for( int i = 0; i < m; i++) {
-        for( int j = 0; j < n; j++) {
-            printf("%f ",A[i + j * lda]);
+    for(int i = 0; i < m; i++)
+    {
+        for(int j = 0; j < n; j++)
+        {
+            printf("%f ", A[i + j * lda]);
         }
         printf("\n");
     }
 }
 
-template<typename T>
+template <typename T>
 rocblas_status testing_trsm(Arguments argus)
 {
-    rocblas_int M = argus.M;
-    rocblas_int N = argus.N;
+    rocblas_int M   = argus.M;
+    rocblas_int N   = argus.N;
     rocblas_int lda = argus.lda;
     rocblas_int ldb = argus.ldb;
 
-    char char_side = argus.side_option;
-    char char_uplo = argus.uplo_option;
+    char char_side   = argus.side_option;
+    char char_uplo   = argus.uplo_option;
     char char_transA = argus.transA_option;
-    char char_diag = argus.diag_option;
-    T alpha_h = argus.alpha;
+    char char_diag   = argus.diag_option;
+    T alpha_h        = argus.alpha;
 
-    rocblas_int safe_size = 100;  // arbitrarily set to 100
+    rocblas_int safe_size = 100; // arbitrarily set to 100
 
-    rocblas_side side = char2rocblas_side(char_side);
-    rocblas_fill uplo = char2rocblas_fill(char_uplo);
+    rocblas_side side        = char2rocblas_side(char_side);
+    rocblas_fill uplo        = char2rocblas_fill(char_uplo);
     rocblas_operation transA = char2rocblas_operation(char_transA);
-    rocblas_diagonal diag = char2rocblas_diagonal(char_diag);
+    rocblas_diagonal diag    = char2rocblas_diagonal(char_diag);
 
-    rocblas_int K = side == rocblas_side_left ? M : N;
+    rocblas_int K      = side == rocblas_side_left ? M : N;
     rocblas_int size_A = lda * K;
     rocblas_int size_B = ldb * N;
 
@@ -64,28 +67,31 @@ rocblas_status testing_trsm(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    //check here to prevent undefined memory allocation error
-    if( M < 0 || N < 0 || lda < K || ldb < M)
+    // check here to prevent undefined memory allocation error
+    if(M < 0 || N < 0 || lda < K || ldb < M)
     {
-        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        auto dXorB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),rocblas_test::device_free};
-        T* dA = (T*) dA_managed.get();
-        T* dXorB = (T*) dXorB_managed.get();
-        if (!dA || !dXorB)
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dXorB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                                rocblas_test::device_free};
+        T* dA    = (T*)dA_managed.get();
+        T* dXorB = (T*)dXorB_managed.get();
+        if(!dA || !dXorB)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
             return rocblas_status_memory_error;
         }
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        status = rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, &alpha_h, dA,lda, dXorB,ldb);
+        status =
+            rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, &alpha_h, dA, lda, dXorB, ldb);
 
         trsm_arg_check(status, M, N, lda, ldb);
 
         return status;
     }
 
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> AAT(size_A);
     vector<T> hB(size_B);
@@ -93,58 +99,71 @@ rocblas_status testing_trsm(Arguments argus)
     vector<T> hXorB_1(size_B);
     vector<T> hXorB_2(size_B);
     vector<T> cpuXorB(size_B);
-    
+
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops;
     double rocblas_error;
-    T error_eps_multiplier =  ERROR_EPS_MULTIPLIER;
-    T residual_eps_multiplier =  RESIDUAL_EPS_MULTIPLIER;
-    T eps = std::numeric_limits<T>::epsilon();
+    T error_eps_multiplier    = ERROR_EPS_MULTIPLIER;
+    T residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
+    T eps                     = std::numeric_limits<T>::epsilon();
 
-
-    //allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dXorB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),rocblas_test::device_free};
-    auto alpha_d_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dXorB = (T*) dXorB_managed.get();
-    T* alpha_d = (T*) alpha_d_managed.get();
-    if (!dA || !dXorB || !alpha_d)
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dXorB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                            rocblas_test::device_free};
+    auto alpha_d_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA      = (T*)dA_managed.get();
+    T* dXorB   = (T*)dXorB_managed.get();
+    T* alpha_d = (T*)alpha_d_managed.get();
+    if(!dA || !dXorB || !alpha_d)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-//  Random lower triangular matrices have condition number
-//  that grows exponentially with matrix size. Random full
-//  matrices have condition that grows linearly with 
-//  matrix size. 
-//
-//  We want a triangular matrix with condition number that grows 
-//  lineary with matrix size. We start with full random matrix A. 
-//  Calculate symmetric AAT <- A A^T. Make AAT strictly diagonal 
-//  dominant. A strictly diagonal dominant matrix is SPD so we 
-//  can use Cholesky to calculate L L^T = AAT. These L factors 
-//  should have condition number approximately equal to
-//  the condition number of the original matrix A.
+    //  Random lower triangular matrices have condition number
+    //  that grows exponentially with matrix size. Random full
+    //  matrices have condition that grows linearly with
+    //  matrix size.
+    //
+    //  We want a triangular matrix with condition number that grows
+    //  lineary with matrix size. We start with full random matrix A.
+    //  Calculate symmetric AAT <- A A^T. Make AAT strictly diagonal
+    //  dominant. A strictly diagonal dominant matrix is SPD so we
+    //  can use Cholesky to calculate L L^T = AAT. These L factors
+    //  should have condition number approximately equal to
+    //  the condition number of the original matrix A.
 
-//  initialize full random matrix hA with all entries in [1, 10]
+    //  initialize full random matrix hA with all entries in [1, 10]
     rocblas_init<T>(hA, K, K, lda);
 
-//  pad untouched area into zero
+    //  pad untouched area into zero
     for(int i = K; i < lda; i++)
     {
         for(int j = 0; j < K; j++)
         {
-            hA[i+j*lda] = 0.0;
+            hA[i + j * lda] = 0.0;
         }
     }
 
-//  calculate AAT = hA * hA ^ T
-    cblas_gemm(rocblas_operation_none, rocblas_operation_transpose, 
-        K, K, K, (T)1.0, hA.data(), lda, hA.data(), lda, (T)0.0, AAT.data(), lda);
+    //  calculate AAT = hA * hA ^ T
+    cblas_gemm(rocblas_operation_none,
+               rocblas_operation_transpose,
+               K,
+               K,
+               K,
+               (T)1.0,
+               hA.data(),
+               lda,
+               hA.data(),
+               lda,
+               (T)0.0,
+               AAT.data(),
+               lda);
 
-//  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
+    //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
     for(int i = 0; i < K; i++)
     {
         T t = 0.0;
@@ -153,13 +172,13 @@ rocblas_status testing_trsm(Arguments argus)
             hA[i + j * lda] = AAT[i + j * lda];
             t += AAT[i + j * lda] > 0 ? AAT[i + j * lda] : -AAT[i + j * lda];
         }
-        hA[i+i*lda] = t;
+        hA[i + i * lda] = t;
     }
 
-//  calculate Cholesky factorization of SPD matrix hA
+    //  calculate Cholesky factorization of SPD matrix hA
     cblas_potrf(char_uplo, K, hA.data(), lda);
 
-//  make hA unit diagonal if diag == rocblas_diagonal_unit
+    //  make hA unit diagonal if diag == rocblas_diagonal_unit
     if(char_diag == 'U' || char_diag == 'u')
     {
         if('L' == char_uplo || 'l' == char_uplo)
@@ -169,7 +188,7 @@ rocblas_status testing_trsm(Arguments argus)
                 T diag = hA[i + i * lda];
                 for(int j = 0; j <= i; j++)
                 {
-                    hA[i+j*lda] = hA[i+j*lda] / diag;
+                    hA[i + j * lda] = hA[i + j * lda] / diag;
                 }
             }
         }
@@ -180,34 +199,35 @@ rocblas_status testing_trsm(Arguments argus)
                 T diag = hA[j + j * lda];
                 for(int i = 0; i <= j; i++)
                 {
-                    hA[i+j*lda] = hA[i+j*lda] / diag;
+                    hA[i + j * lda] = hA[i + j * lda] / diag;
                 }
             }
         }
     }
 
-    //Initial hX
+    // Initial hX
     rocblas_init<T>(hX, M, N, ldb);
-    //pad untouched area into zero
-    for(int i=M;i<ldb;i++)
+    // pad untouched area into zero
+    for(int i = M; i < ldb; i++)
     {
-        for(int j=0;j<N;j++)
+        for(int j = 0; j < N; j++)
         {
-            hX[i+j*ldb] = 0.0;
+            hX[i + j * ldb] = 0.0;
         }
-    }    
+    }
     hB = hX;
 
     // Calculate hB = hA*hX;
-    cblas_trmm<T>( side, uplo, transA, diag, M, N, 1.0/alpha_h, (const T*)hA.data(), lda, hB.data(), ldb);
-    
-    hXorB_1 = hB;        // hXorB <- B
-    hXorB_2 = hB;        // hXorB <- B
-    cpuXorB = hB;        // cpuXorB <- B
+    cblas_trmm<T>(
+        side, uplo, transA, diag, M, N, 1.0 / alpha_h, (const T*)hA.data(), lda, hB.data(), ldb);
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dXorB, hXorB_1.data(), sizeof(T)*size_B,  hipMemcpyHostToDevice));
+    hXorB_1 = hB; // hXorB <- B
+    hXorB_2 = hB; // hXorB <- B
+    cpuXorB = hB; // cpuXorB <- B
+
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dXorB, hXorB_1.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
 
     T max_err_1 = 0.0;
     T max_err_2 = 0.0;
@@ -217,41 +237,47 @@ rocblas_status testing_trsm(Arguments argus)
     {
         // calculate dXorB <- A^(-1) B   rocblas_device_pointer_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_HIP_ERROR(hipMemcpy(dXorB, hXorB_1.data(), sizeof(T)*size_B,  hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(dXorB, hXorB_1.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
 
-        CHECK_ROCBLAS_ERROR(rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, &alpha_h, dA,lda, dXorB, ldb));
+        CHECK_ROCBLAS_ERROR(
+            rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, &alpha_h, dA, lda, dXorB, ldb));
 
-        CHECK_HIP_ERROR(hipMemcpy(hXorB_1.data(), dXorB, sizeof(T)*size_B, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hXorB_1.data(), dXorB, sizeof(T) * size_B, hipMemcpyDeviceToHost));
 
         // calculate dXorB <- A^(-1) B   rocblas_device_pointer_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_HIP_ERROR(hipMemcpy(dXorB, hXorB_2.data(), sizeof(T)*size_B,  hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(dXorB, hXorB_2.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(alpha_d, &alpha_h, sizeof(T), hipMemcpyHostToDevice));
 
-        CHECK_ROCBLAS_ERROR(rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, alpha_d, dA,lda, dXorB, ldb));
+        CHECK_ROCBLAS_ERROR(
+            rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, alpha_d, dA, lda, dXorB, ldb));
 
-        CHECK_HIP_ERROR(hipMemcpy(hXorB_2.data(), dXorB, sizeof(T)*size_B, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hXorB_2.data(), dXorB, sizeof(T) * size_B, hipMemcpyDeviceToHost));
 
         // Error Check
-        // hXorB contains calculated X, so error is hX - hXorB 
+        // hXorB contains calculated X, so error is hX - hXorB
 
         // err is the one norm of the scaled error for a single column
         // max_err is the maximum of err for all columns
-        for (int i = 0; i < N; i++)
+        for(int i = 0; i < N; i++)
         {
             T err_1 = 0.0;
             T err_2 = 0.0;
-            for (int j = 0; j < M; j++)
+            for(int j = 0; j < M; j++)
             {
-                if(hX[j + i*ldb] != 0)
+                if(hX[j + i * ldb] != 0)
                 {
-                    err_1 += std::abs((hX[j + i*ldb] - hXorB_1[j + i*ldb]) / hX[j + i*ldb]); 
-                    err_2 += std::abs((hX[j + i*ldb] - hXorB_2[j + i*ldb]) / hX[j + i*ldb]); 
+                    err_1 += std::abs((hX[j + i * ldb] - hXorB_1[j + i * ldb]) / hX[j + i * ldb]);
+                    err_2 += std::abs((hX[j + i * ldb] - hXorB_2[j + i * ldb]) / hX[j + i * ldb]);
                 }
                 else
                 {
-                    err_1 += std::abs(hXorB_1[j + i*ldb]);
-                    err_2 += std::abs(hXorB_2[j + i*ldb]);
+                    err_1 += std::abs(hXorB_1[j + i * ldb]);
+                    err_2 += std::abs(hXorB_2[j + i * ldb]);
                 }
             }
             max_err_1 = max_err_1 > err_1 ? max_err_1 : err_1;
@@ -262,27 +288,47 @@ rocblas_status testing_trsm(Arguments argus)
 
         // Residual Check
         // hXorB <- hA * (A^(-1) B) ;
-        cblas_trmm<T>( side, uplo, transA, diag, M, N, 1.0/alpha_h, (const T*)hA.data(), lda, hXorB_1.data(), ldb);
-        cblas_trmm<T>( side, uplo, transA, diag, M, N, 1.0/alpha_h, (const T*)hA.data(), lda, hXorB_2.data(), ldb);
+        cblas_trmm<T>(side,
+                      uplo,
+                      transA,
+                      diag,
+                      M,
+                      N,
+                      1.0 / alpha_h,
+                      (const T*)hA.data(),
+                      lda,
+                      hXorB_1.data(),
+                      ldb);
+        cblas_trmm<T>(side,
+                      uplo,
+                      transA,
+                      diag,
+                      M,
+                      N,
+                      1.0 / alpha_h,
+                      (const T*)hA.data(),
+                      lda,
+                      hXorB_2.data(),
+                      ldb);
 
         // hXorB contains A * (calculated X), so residual = A * (calculated X) - B
-        //                                                = hXorB - hB 
+        //                                                = hXorB - hB
         // res is the one norm of the scaled residual for each column
-        for (int i = 0; i < N; i++)
+        for(int i = 0; i < N; i++)
         {
             T res_1 = 0.0;
             T res_2 = 0.0;
-            for (int j = 0; j < M; j++)
+            for(int j = 0; j < M; j++)
             {
-                if(hB[j + i*ldb] != 0)
+                if(hB[j + i * ldb] != 0)
                 {
-                    res_1 += std::abs((hXorB_1[j + i*ldb] - hB[j + i*ldb]) / hB[j + i*ldb]); 
-                    res_2 += std::abs((hXorB_2[j + i*ldb] - hB[j + i*ldb]) / hB[j + i*ldb]); 
+                    res_1 += std::abs((hXorB_1[j + i * ldb] - hB[j + i * ldb]) / hB[j + i * ldb]);
+                    res_2 += std::abs((hXorB_2[j + i * ldb] - hB[j + i * ldb]) / hB[j + i * ldb]);
                 }
                 else
                 {
-                    res_1 += std::abs(hXorB_1[j + i*ldb]);
-                    res_2 += std::abs(hXorB_2[j + i*ldb]);
+                    res_1 += std::abs(hXorB_1[j + i * ldb]);
+                    res_2 += std::abs(hXorB_2[j + i * ldb]);
                 }
             }
             max_res_1 = max_res_1 > res_1 ? max_res_1 : res_1;
@@ -295,35 +341,41 @@ rocblas_status testing_trsm(Arguments argus)
     if(argus.timing)
     {
         // GPU rocBLAS
-        CHECK_HIP_ERROR(hipMemcpy(dXorB, hXorB_1.data(), sizeof(T)*size_B,  hipMemcpyHostToDevice));
-        gpu_time_used = get_time_us();// in microseconds
+        CHECK_HIP_ERROR(
+            hipMemcpy(dXorB, hXorB_1.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
+        gpu_time_used = get_time_us(); // in microseconds
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, &alpha_h, dA,lda, dXorB,ldb));
+        CHECK_ROCBLAS_ERROR(
+            rocblas_trsm<T>(handle, side, uplo, transA, diag, M, N, &alpha_h, dA, lda, dXorB, ldb));
 
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = trsm_gflop_count<T> (M, N, K) / gpu_time_used * 1e6 ;
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = trsm_gflop_count<T>(M, N, K) / gpu_time_used * 1e6;
 
         // CPU cblas
         cpu_time_used = get_time_us();
 
-        cblas_trsm<T>(side, uplo, transA, diag, M, N, alpha_h, (const T*)hA.data(), lda, cpuXorB.data(), ldb);
+        cblas_trsm<T>(
+            side, uplo, transA, diag, M, N, alpha_h, (const T*)hA.data(), lda, cpuXorB.data(), ldb);
 
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops = trsm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
+        cblas_gflops  = trsm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
 
-        //only norm_check return an norm error, unit check won't return anything
+        // only norm_check return an norm error, unit check won't return anything
         cout << "M,N,lda,ldb,side,uplo,transA,diag,rocblas-Gflops,us";
 
-        if(argus.norm_check) cout << ",CPU-Gflops,us,norm_error_host_ptr,norm_error_dev_ptr" ;
+        if(argus.norm_check)
+            cout << ",CPU-Gflops,us,norm_error_host_ptr,norm_error_dev_ptr";
 
         cout << endl;
 
-        cout << M << ',' << N <<',' << lda <<','<< ldb <<',' << char_side << ',' << char_uplo << ',' 
-             << char_transA << ','  << char_diag << ',' <<
-             rocblas_gflops << "," << gpu_time_used;
+        cout << M << ',' << N << ',' << lda << ',' << ldb << ',' << char_side << ',' << char_uplo
+             << ',' << char_transA << ',' << char_diag << ',' << rocblas_gflops << ","
+             << gpu_time_used;
 
-        if(argus.norm_check) cout << "," << cblas_gflops << "," << cpu_time_used << "," << max_err_1 << "," << max_err_2;
+        if(argus.norm_check)
+            cout << "," << cblas_gflops << "," << cpu_time_used << "," << max_err_1 << ","
+                 << max_err_2;
 
         cout << endl;
     }

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 rocblas_status testing_trtri(Arguments argus)
 {
     rocblas_int N = argus.N;
@@ -28,11 +28,12 @@ rocblas_status testing_trtri(Arguments argus)
 
     rocblas_int size_A = lda * N;
 
-    //check here to prevent undefined memory allocation error
-    if( N < 0 || lda < 0 ){
+    // check here to prevent undefined memory allocation error
+    if(N < 0 || lda < 0)
+    {
         return rocblas_status_invalid_size;
     }
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hA(size_A);
     vector<T> hB(size_A);
 
@@ -43,8 +44,7 @@ rocblas_status testing_trtri(Arguments argus)
     char char_uplo = argus.uplo_option;
     char char_diag = argus.diag_option;
 
-
-    rocblas_fill uplo = char2rocblas_fill(char_uplo);
+    rocblas_fill uplo     = char2rocblas_fill(char_uplo);
     rocblas_diagonal diag = char2rocblas_diagonal(char_diag);
 
     rocblas_status status;
@@ -52,115 +52,125 @@ rocblas_status testing_trtri(Arguments argus)
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dinvA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dinvA = (T*) dinvA_managed.get();
-    if (!dA || !dinvA)
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dinvA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                            rocblas_test::device_free};
+    T* dA    = (T*)dA_managed.get();
+    T* dinvA = (T*)dinvA_managed.get();
+    if(!dA || !dinvA)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init_symmetric<T>(hA, N, lda);
 
-    //proprocess the matrix to avoid ill-conditioned matrix 
-    for(int i=0;i<N;i++){
-        for(int j=0;j<N;j++){
-            hA[i+j*lda] *= 0.01;
+    // proprocess the matrix to avoid ill-conditioned matrix
+    for(int i = 0; i < N; i++)
+    {
+        for(int j = 0; j < N; j++)
+        {
+            hA[i + j * lda] *= 0.01;
 
-            if(j % 2)  hA[i+j*lda] *= -1;
-            if(i == j) { 
-                if (diag == rocblas_diagonal_unit) hA[i+j*lda] = 1.0;
-                else  hA[i+j*lda] *= 100.0;
-            } 
+            if(j % 2)
+                hA[i + j * lda] *= -1;
+            if(i == j)
+            {
+                if(diag == rocblas_diagonal_unit)
+                    hA[i + j * lda] = 1.0;
+                else
+                    hA[i + j * lda] *= 100.0;
+            }
         }
     }
     hB = hA;
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
 
     /* =====================================================================
            ROCBLAS
     =================================================================== */
-    if(argus.timing){
-        gpu_time_used = get_time_us();// in microseconds
+    if(argus.timing)
+    {
+        gpu_time_used = get_time_us(); // in microseconds
     }
 
+    status = rocblas_trtri<T>(handle, uplo, diag, N, dA, lda, dinvA, ldinvA);
 
-    status = rocblas_trtri<T>(handle,
-            uplo, diag,
-            N,
-            dA,lda,
-            dinvA,ldinvA);
-
-    if(argus.timing){
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = trtri_gflop_count<T> (N) / gpu_time_used * 1e6 ;
+    if(argus.timing)
+    {
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = trtri_gflop_count<T>(N) / gpu_time_used * 1e6;
     }
 
-    //copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA.data(), dinvA, sizeof(T)*size_A, hipMemcpyDeviceToHost));
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hA.data(), dinvA, sizeof(T) * size_A, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check || argus.norm_check){
+    if(argus.unit_check || argus.norm_check)
+    {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us();
         }
 
-        rocblas_int info = cblas_trtri<T>(
-                char_uplo, char_diag,
-                N,
-                hB.data(),lda);
+        rocblas_int info = cblas_trtri<T>(char_uplo, char_diag, N, hB.data(), lda);
 
-        if(info != 0) printf("error in cblas_trtri\n");
+        if(info != 0)
+            printf("error in cblas_trtri\n");
 
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us() - cpu_time_used;
-            cblas_gflops = trtri_gflop_count<T>(N) / cpu_time_used * 1e6;
+            cblas_gflops  = trtri_gflop_count<T>(N) / cpu_time_used * 1e6;
         }
 
-        #ifndef NDEBUG
-        print_matrix(hB, hA,  N, N, lda);
-        #endif
+#ifndef NDEBUG
+        print_matrix(hB, hA, N, N, lda);
+#endif
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if(argus.unit_check){
+        if(argus.unit_check)
+        {
             unit_check_general<T>(N, N, lda, hB.data(), hA.data());
         }
 
-
-        //if enable norm check, norm check is invasive
-        //any typeinfo(T) will not work here, because template deduction is matched in compilation time
-        if(argus.norm_check){
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched in compilation
+        // time
+        if(argus.norm_check)
+        {
             rocblas_error = norm_check_symmetric<T>('F', char_uplo, N, lda, hB.data(), hA.data());
         }
     }
 
-    if(argus.timing){
-        //only norm_check return an norm error, unit check won't return anything
-            cout << "N, lda, uplo, diag, rocblas-Gflops (us) ";
-            if(argus.norm_check){
-                cout << "CPU-Gflops(us), norm-error" ;
-            }
-            cout << endl;
+    if(argus.timing)
+    {
+        // only norm_check return an norm error, unit check won't return anything
+        cout << "N, lda, uplo, diag, rocblas-Gflops (us) ";
+        if(argus.norm_check)
+        {
+            cout << "CPU-Gflops(us), norm-error";
+        }
+        cout << endl;
 
-            cout << N <<',' << lda <<','<< char_uplo << ',' << char_diag << ',' << 
-                 rocblas_gflops << "(" << gpu_time_used  << "),";
+        cout << N << ',' << lda << ',' << char_uplo << ',' << char_diag << ',' << rocblas_gflops
+             << "(" << gpu_time_used << "),";
 
-            if(argus.norm_check){
-                cout << cblas_gflops << "(" << cpu_time_used << "),";
-                cout << rocblas_error;
-            }
+        if(argus.norm_check)
+        {
+            cout << cblas_gflops << "(" << cpu_time_used << "),";
+            cout << rocblas_error;
+        }
 
-            cout << endl;
+        cout << endl;
     }
 
     return rocblas_status_success;

--- a/clients/include/testing_trtri_batched.hpp
+++ b/clients/include/testing_trtri_batched.hpp
@@ -18,42 +18,48 @@
 
 using namespace std;
 
-template<typename T>
+template <typename T>
 rocblas_status testing_trtri_batched(Arguments argus)
 {
-    rocblas_int N = argus.N;
-    rocblas_int lda = argus.lda;
+    rocblas_int N           = argus.N;
+    rocblas_int lda         = argus.lda;
     rocblas_int batch_count = argus.batch_count;
 
     rocblas_int size_A = lda * N * batch_count;
-    rocblas_int bsa = lda * N;
+    rocblas_int bsa    = lda * N;
 
     rocblas_status status = rocblas_status_success;
 
-    //argument sanity check, quick return if input parameters are invalid before allocating invalid memory
-    if ( N < 0 ){
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0)
+    {
         status = rocblas_status_invalid_size;
         return status;
     }
-    else if ( lda < 0 ){
+    else if(lda < 0)
+    {
         status = rocblas_status_invalid_size;
         return status;
     }
-    else if ( batch_count < 0 ){
+    else if(batch_count < 0)
+    {
         status = rocblas_status_invalid_size;
         return status;
     }
 
-    //Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     vector<T> hB(size_A);
     vector<T> hA;
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     vector<T> hA_sub(bsa);
-    for(size_t i=0;i<batch_count;i++){
+    for(size_t i = 0; i < batch_count; i++)
+    {
         rocblas_init_symmetric<T>(hA_sub, N, lda);
-        for(int j=0;j<bsa;j++){
+        for(int j = 0; j < bsa; j++)
+        {
             hA.push_back(hA_sub[j]);
         }
     }
@@ -66,108 +72,120 @@ rocblas_status testing_trtri_batched(Arguments argus)
     char char_uplo = argus.uplo_option;
     char char_diag = argus.diag_option;
 
-    //char_uplo = 'U';
-    rocblas_fill uplo = char2rocblas_fill(char_uplo);
+    // char_uplo = 'U';
+    rocblas_fill uplo     = char2rocblas_fill(char_uplo);
     rocblas_diagonal diag = char2rocblas_diagonal(char_diag);
 
     std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
     rocblas_handle handle = unique_ptr_handle->handle;
 
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    auto dinvA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),rocblas_test::device_free};
-    T* dA = (T*) dA_managed.get();
-    T* dinvA = (T*) dinvA_managed.get();
-    if (!dA || !dinvA)
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dinvA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                            rocblas_test::device_free};
+    T* dA    = (T*)dA_managed.get();
+    T* dinvA = (T*)dinvA_managed.get();
+    if(!dA || !dinvA)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
     }
 
-    //copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dinvA, hA.data(), sizeof(T)*size_A,  hipMemcpyHostToDevice));
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dinvA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
 
     /* =====================================================================
            ROCBLAS
     =================================================================== */
-    if(argus.timing){
-        gpu_time_used = get_time_us();// in microseconds
+    if(argus.timing)
+    {
+        gpu_time_used = get_time_us(); // in microseconds
     }
 
+    status =
+        rocblas_trtri_batched<T>(handle, uplo, diag, N, dA, lda, bsa, dinvA, lda, bsa, batch_count);
 
-    status = rocblas_trtri_batched<T>(handle,
-            uplo, diag,
-            N,
-            dA, lda, bsa,
-            dinvA, lda, bsa,
-            batch_count);
+    if(status != rocblas_status_success)
+        return status;
 
-    if (status != rocblas_status_success) return status;
-
-    if(argus.timing){
-        gpu_time_used = get_time_us() - gpu_time_used;
-        rocblas_gflops = trtri_gflop_count<T> (N) / gpu_time_used * 1e6 ;
+    if(argus.timing)
+    {
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = trtri_gflop_count<T>(N) / gpu_time_used * 1e6;
     }
 
-    //copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA.data(), dinvA, sizeof(T)*size_A, hipMemcpyDeviceToHost));
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hA.data(), dinvA, sizeof(T) * size_A, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check || argus.norm_check){
+    if(argus.unit_check || argus.norm_check)
+    {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us();
         }
 
-        for(size_t i=0;i<batch_count;i++){
-            rocblas_int info = cblas_trtri<T>(
-                    char_uplo, char_diag,
-                    N,
-                    hB.data() + i * bsa, lda);
-            if(info != 0) printf("error in cblas_trtri\n");
+        for(size_t i = 0; i < batch_count; i++)
+        {
+            rocblas_int info = cblas_trtri<T>(char_uplo, char_diag, N, hB.data() + i * bsa, lda);
+            if(info != 0)
+                printf("error in cblas_trtri\n");
         }
-        if(argus.timing){
+        if(argus.timing)
+        {
             cpu_time_used = get_time_us() - cpu_time_used;
-            cblas_gflops = trtri_gflop_count<T>(N) / cpu_time_used * 1e6;
+            cblas_gflops  = trtri_gflop_count<T>(N) / cpu_time_used * 1e6;
         }
 
-        //enable unit check, notice unit check is not invasive, but norm check is,
+        // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
-        if(argus.unit_check){
-            unit_check_general<T>(N, N*batch_count, lda, hB.data(), hA.data());
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(N, N * batch_count, lda, hB.data(), hA.data());
         }
 
-        for(int i=0; i<32; i++){
+        for(int i = 0; i < 32; i++)
+        {
             printf("CPU[%d]=%f, GPU[%d]=%f\n", i, hB[i], i, hA[i]);
         }
-        //if enable norm check, norm check is invasive
+        // if enable norm check, norm check is invasive
 
-        if(argus.norm_check){
-            for(size_t i=0;i<batch_count;i++){
-                rocblas_error = fmax(rocblas_error,
-                                     norm_check_symmetric<T>('F', char_uplo, N, lda, hB.data()+i*bsa, hA.data()+i*bsa));
-                //printf("error=%f, %lu\n", rocblas_error, i);
+        if(argus.norm_check)
+        {
+            for(size_t i = 0; i < batch_count; i++)
+            {
+                rocblas_error =
+                    fmax(rocblas_error,
+                         norm_check_symmetric<T>(
+                             'F', char_uplo, N, lda, hB.data() + i * bsa, hA.data() + i * bsa));
+                // printf("error=%f, %lu\n", rocblas_error, i);
             }
         }
     } // end of norm_check
 
-    if(argus.timing){
-        //only norm_check return an norm error, unit check won't return anything
-            cout << "batch, N, lda, rocblas-Gflops (us) ";
-            if(argus.norm_check){
-                cout << "CPU-Gflops(us), norm-error" ;
-            }
-            cout << endl;
+    if(argus.timing)
+    {
+        // only norm_check return an norm error, unit check won't return anything
+        cout << "batch, N, lda, rocblas-Gflops (us) ";
+        if(argus.norm_check)
+        {
+            cout << "CPU-Gflops(us), norm-error";
+        }
+        cout << endl;
 
-            cout << batch_count << ',' << N <<',' << lda <<','<< rocblas_gflops << "(" << gpu_time_used  << "),";
+        cout << batch_count << ',' << N << ',' << lda << ',' << rocblas_gflops << "("
+             << gpu_time_used << "),";
 
-            if(argus.norm_check){
-                cout << cblas_gflops << "(" << cpu_time_used << "),";
-                cout << rocblas_error;
-            }
+        if(argus.norm_check)
+        {
+            cout << cblas_gflops << "(" << cpu_time_used << "),";
+            cout << rocblas_error;
+        }
 
-            cout << endl;
+        cout << endl;
     }
 
     return rocblas_status_success;

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -19,22 +19,21 @@
 
    =================================================================== */
 
-
 /*!\file
  * \brief compares two results (usually, CPU and GPU results); provides Google Unit check.
  */
 
+/* ========================================Gtest Unit Check
+ * ==================================================== */
 
-/* ========================================Gtest Unit Check ==================================================== */
+/*! \brief Template: gtest unit compare two matrices float/double/complex */
+// Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test
+// case
+// a wrapper will cause the loop keep going
+template <typename T>
+void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU);
 
-
-    /*! \brief Template: gtest unit compare two matrices float/double/complex */
-    //Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test case
-    // a wrapper will cause the loop keep going
-    template<typename T>
-    void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, T *hCPU, T *hGPU);
-
-    template<typename T>
-    void trsm_err_res_check(T max_error, rocblas_int M, T forward_tolerance, T eps);
+template <typename T>
+void trsm_err_res_check(T max_error, rocblas_int M, T forward_tolerance, T eps);
 
 #endif

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -21,238 +21,278 @@ using namespace std;
  * \brief provide data initialization, timing, rocblas type <-> lapack char conversion utilities.
  */
 
-#define CHECK_HIP_ERROR(error) \
-    if (error != hipSuccess) { \
-      fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error,__FILE__, __LINE__); \
-      exit(EXIT_FAILURE);\
+#define CHECK_HIP_ERROR(error)                \
+    if(error != hipSuccess)                   \
+    {                                         \
+        fprintf(stderr,                       \
+                "error: '%s'(%d) at %s:%d\n", \
+                hipGetErrorString(error),     \
+                error,                        \
+                __FILE__,                     \
+                __LINE__);                    \
+        exit(EXIT_FAILURE);                   \
     }
 
-#define CHECK_ROCBLAS_ERROR(error) \
-    if (error != rocblas_status_success) { \
-            fprintf(stderr, "rocBLAS error: "); \
-            if(error == rocblas_status_invalid_handle){fprintf(stderr, "rocblas_status_invalid_handle");} \
-            else if(error == rocblas_status_not_implemented ){fprintf(stderr, " rocblas_status_not_implemented");} \
-            else if(error == rocblas_status_invalid_pointer){fprintf(stderr, "rocblas_status_invalid_pointer");} \
-            else if(error == rocblas_status_invalid_size){fprintf(stderr, "rocblas_status_invalid_size");} \
-            else if(error == rocblas_status_memory_error){fprintf(stderr, "rocblas_status_memory_error");} \
-            else if(error == rocblas_status_internal_error){fprintf(stderr, "rocblas_status_internal_error");} \
-            else {fprintf(stderr, "rocblas_status error");} \
-            fprintf(stderr, "\n"); \
-            return error; \
+#define CHECK_ROCBLAS_ERROR(error)                              \
+    if(error != rocblas_status_success)                         \
+    {                                                           \
+        fprintf(stderr, "rocBLAS error: ");                     \
+        if(error == rocblas_status_invalid_handle)              \
+        {                                                       \
+            fprintf(stderr, "rocblas_status_invalid_handle");   \
+        }                                                       \
+        else if(error == rocblas_status_not_implemented)        \
+        {                                                       \
+            fprintf(stderr, " rocblas_status_not_implemented"); \
+        }                                                       \
+        else if(error == rocblas_status_invalid_pointer)        \
+        {                                                       \
+            fprintf(stderr, "rocblas_status_invalid_pointer");  \
+        }                                                       \
+        else if(error == rocblas_status_invalid_size)           \
+        {                                                       \
+            fprintf(stderr, "rocblas_status_invalid_size");     \
+        }                                                       \
+        else if(error == rocblas_status_memory_error)           \
+        {                                                       \
+            fprintf(stderr, "rocblas_status_memory_error");     \
+        }                                                       \
+        else if(error == rocblas_status_internal_error)         \
+        {                                                       \
+            fprintf(stderr, "rocblas_status_internal_error");   \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            fprintf(stderr, "rocblas_status error");            \
+        }                                                       \
+        fprintf(stderr, "\n");                                  \
+        return error;                                           \
     }
 
-#define BLAS_1_RESULT_PRINT                                                      \
-    if(argus.timing){                                                            \
-        cout << "N, rocblas (us), ";                                             \
-        if(argus.norm_check){                                                    \
-            cout << "CPU (us), error" ;                                          \
-        }                                                                        \
-        cout << endl;                                                            \
-        cout << N <<',' << gpu_time_used << ',';                                 \
-        if(argus.norm_check){                                                    \
-            cout << cpu_time_used <<',';                                         \
-            cout << rocblas_error;                                               \
-        }                                                                        \
-        cout << endl;                                                            \
+#define BLAS_1_RESULT_PRINT                       \
+    if(argus.timing)                              \
+    {                                             \
+        cout << "N, rocblas (us), ";              \
+        if(argus.norm_check)                      \
+        {                                         \
+            cout << "CPU (us), error";            \
+        }                                         \
+        cout << endl;                             \
+        cout << N << ',' << gpu_time_used << ','; \
+        if(argus.norm_check)                      \
+        {                                         \
+            cout << cpu_time_used << ',';         \
+            cout << rocblas_error;                \
+        }                                         \
+        cout << endl;                             \
     }
 
-    // Helper routine to convert floats into their half equivalent; uses F16C instructions
-    inline rocblas_half float_to_half( float val )
+// Helper routine to convert floats into their half equivalent; uses F16C instructions
+inline rocblas_half float_to_half(float val)
+{
+    // return static_cast<rocblas_half>( _mm_cvtsi128_si32( _mm_cvtps_ph( _mm_set_ss( val ), 0 ) )
+    // );
+    return _cvtss_sh(val, 0);
+}
+
+// Helper routine to convert halfs into their floats equivalent; uses F16C instructions
+inline float half_to_float(rocblas_half val)
+{
+    // return static_cast<rocblas_half>(_mm_cvtss_f32(_mm_cvtph_ps(_mm_cvtsi32_si128(val), 0)));
+    return _cvtsh_ss(val);
+}
+
+/* ============================================================================================ */
+/* generate random number :*/
+
+/*! \brief  generate a random number between [0, 0.999...] . */
+template <typename T>
+T random_generator()
+{
+    // return rand()/( (T)RAND_MAX + 1);
+    return (T)(rand() % 10 + 1); // generate a integer number between [1, 10]
+};
+
+/* ============================================================================================ */
+/*! \brief  matrix/vector initialization: */
+// for vector x (M=1, N=lengthX, lda=incx);
+// for complex number, the real/imag part would be initialized with the same value
+template <typename T>
+void rocblas_init(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
+{
+    for(rocblas_int i = 0; i < M; ++i)
     {
-        //return static_cast<rocblas_half>( _mm_cvtsi128_si32( _mm_cvtps_ph( _mm_set_ss( val ), 0 ) ) );
-        return _cvtss_sh( val, 0 );
-    }
-
-    // Helper routine to convert halfs into their floats equivalent; uses F16C instructions
-    inline float half_to_float( rocblas_half val )
-    {
-        //return static_cast<rocblas_half>(_mm_cvtss_f32(_mm_cvtph_ps(_mm_cvtsi32_si128(val), 0)));
-        return _cvtsh_ss( val );
-    }
-
-    /* ============================================================================================ */
-    /* generate random number :*/
-
-    /*! \brief  generate a random number between [0, 0.999...] . */
-    template<typename T>
-    T random_generator(){
-        //return rand()/( (T)RAND_MAX + 1);
-        return (T)(rand() % 10 + 1); //generate a integer number between [1, 10]
-    };
-
-
-    /* ============================================================================================ */
-    /*! \brief  matrix/vector initialization: */
-    // for vector x (M=1, N=lengthX, lda=incx);
-    // for complex number, the real/imag part would be initialized with the same value
-    template<typename T>
-    void rocblas_init(vector<T> &A, rocblas_int M, rocblas_int N, rocblas_int lda){
-        for (rocblas_int i = 0; i < M; ++i){
-            for (rocblas_int j = 0; j < N; ++j){
-                A[i+j*lda] = random_generator<T>();
-            }
-        }
-    };
-
-    /*! \brief  matrix/vector initialization: */
-    // for vector x (M=1, N=lengthX, lda=incx);
-    // initializing vector with a constant value passed as a parameter
-    template <typename T>
-    void rocblas_init(vector<T> &A, rocblas_int M, rocblas_int N, rocblas_int lda, double value)
-    {
-        for (rocblas_int i = 0; i < M; ++i)
+        for(rocblas_int j = 0; j < N; ++j)
         {
-            for (rocblas_int j = 0; j < N; ++j)
-            {
-                A[i + j * lda] = value;
-            }
+            A[i + j * lda] = random_generator<T>();
         }
-    };
-
-    template<>
-    inline void rocblas_init(vector<rocblas_half> &A, rocblas_int M, rocblas_int N, rocblas_int lda, double value)
-    {
-        for (rocblas_int i = 0; i < M; ++i)
-        {
-            for (rocblas_int j = 0; j < N; ++j)
-            {
-                A[i + j * lda] = float_to_half( value );
-            }
-        }
-    };
-
-    /*! \brief  symmetric matrix initialization: */
-    // for real matrix only
-    template<typename T>
-    void rocblas_init_symmetric(vector<T> &A, rocblas_int N, rocblas_int lda){
-        for (rocblas_int i = 0; i < N; ++i){
-            for (rocblas_int j = 0; j <= i; ++j){
-                A[j+i*lda] = A[i+j*lda] = random_generator<T>();
-            }
-        }
-    };
-
-    /*! \brief  hermitian matrix initialization: */
-    // for complex matrix only, the real/imag part would be initialized with the same value
-    // except the diagonal elment must be real
-    template<typename T>
-    void rocblas_init_hermitian(vector<T> &A, rocblas_int N, rocblas_int lda){
-        for (rocblas_int i = 0; i < N; ++i){
-            for (rocblas_int j = 0; j <= i; ++j){
-                A[j+i*lda] = A[i+j*lda] = random_generator<T>();
-                if(i==j) A[j+i*lda].y = 0.0;
-            }
-        }
-    };
-
-    /*! \brief  matrix/vector initialization: */
-    // for vector x (M=1, N=lengthX, lda=incx);
-    // initializing vector with a constant value passed as a parameter
-    template <typename T>
-    void rocblas_print_vector(vector<T> &A, rocblas_int M, rocblas_int N, rocblas_int lda)
-    {
-        if (typeid(T) == typeid(float))
-            std::cout << "vec[float]: ";
-        else if (typeid(T) == typeid(double))
-            std::cout << "vec[double]: ";
-        else if (typeid(T) == typeid(rocblas_half))
-            std::cout << "vec[rocblas_half]: ";
-
-        for (rocblas_int i = 0; i < M; ++i)
-        {
-            for (rocblas_int j = 0; j < N; ++j)
-            {
-                if (typeid(T) == typeid(rocblas_half))
-                    printf("%04x,", A[i + j * lda] );
-                else
-                    std::cout << A[i + j * lda] << ", ";
-            }
-        }
-        std::cout << std::endl;
-    };
-
-    /* ============================================================================================ */
-    /*! \brief  turn float -> 's', double -> 'd', rocblas_float_complex -> 'c', rocblas_double_complex -> 'z' */
-    template<typename T>
-    char type2char();
-
-    /* ============================================================================================ */
-    /*! \brief  Debugging purpose, print out CPU and GPU result matrix, not valid in complex number  */
-    template<typename T>
-    void print_matrix(vector<T> CPU_result, vector<T> GPU_result, rocblas_int m, rocblas_int n, rocblas_int lda){
-        for(int i=0;i<m;i++)
-            for(int j=0;j<n;j++)
-            {
-                printf("matrix  col %d, row %d, CPU result=%f, GPU result=%f\n", i, j, CPU_result[j+i*lda], GPU_result[j+i*lda]);
-            }
     }
+};
+
+/*! \brief  matrix/vector initialization: */
+// for vector x (M=1, N=lengthX, lda=incx);
+// initializing vector with a constant value passed as a parameter
+template <typename T>
+void rocblas_init(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda, double value)
+{
+    for(rocblas_int i = 0; i < M; ++i)
+    {
+        for(rocblas_int j = 0; j < N; ++j)
+        {
+            A[i + j * lda] = value;
+        }
+    }
+};
+
+template <>
+inline void
+rocblas_init(vector<rocblas_half>& A, rocblas_int M, rocblas_int N, rocblas_int lda, double value)
+{
+    for(rocblas_int i = 0; i < M; ++i)
+    {
+        for(rocblas_int j = 0; j < N; ++j)
+        {
+            A[i + j * lda] = float_to_half(value);
+        }
+    }
+};
+
+/*! \brief  symmetric matrix initialization: */
+// for real matrix only
+template <typename T>
+void rocblas_init_symmetric(vector<T>& A, rocblas_int N, rocblas_int lda)
+{
+    for(rocblas_int i = 0; i < N; ++i)
+    {
+        for(rocblas_int j = 0; j <= i; ++j)
+        {
+            A[j + i * lda] = A[i + j * lda] = random_generator<T>();
+        }
+    }
+};
+
+/*! \brief  hermitian matrix initialization: */
+// for complex matrix only, the real/imag part would be initialized with the same value
+// except the diagonal elment must be real
+template <typename T>
+void rocblas_init_hermitian(vector<T>& A, rocblas_int N, rocblas_int lda)
+{
+    for(rocblas_int i = 0; i < N; ++i)
+    {
+        for(rocblas_int j = 0; j <= i; ++j)
+        {
+            A[j + i * lda] = A[i + j * lda] = random_generator<T>();
+            if(i == j)
+                A[j + i * lda].y = 0.0;
+        }
+    }
+};
+
+/*! \brief  matrix/vector initialization: */
+// for vector x (M=1, N=lengthX, lda=incx);
+// initializing vector with a constant value passed as a parameter
+template <typename T>
+void rocblas_print_vector(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
+{
+    if(typeid(T) == typeid(float))
+        std::cout << "vec[float]: ";
+    else if(typeid(T) == typeid(double))
+        std::cout << "vec[double]: ";
+    else if(typeid(T) == typeid(rocblas_half))
+        std::cout << "vec[rocblas_half]: ";
+
+    for(rocblas_int i = 0; i < M; ++i)
+    {
+        for(rocblas_int j = 0; j < N; ++j)
+        {
+            if(typeid(T) == typeid(rocblas_half))
+                printf("%04x,", A[i + j * lda]);
+            else
+                std::cout << A[i + j * lda] << ", ";
+        }
+    }
+    std::cout << std::endl;
+};
+
+/* ============================================================================================ */
+/*! \brief  turn float -> 's', double -> 'd', rocblas_float_complex -> 'c', rocblas_double_complex
+ * -> 'z' */
+template <typename T>
+char type2char();
+
+/* ============================================================================================ */
+/*! \brief  Debugging purpose, print out CPU and GPU result matrix, not valid in complex number  */
+template <typename T>
+void print_matrix(
+    vector<T> CPU_result, vector<T> GPU_result, rocblas_int m, rocblas_int n, rocblas_int lda)
+{
+    for(int i = 0; i < m; i++)
+        for(int j = 0; j < n; j++)
+        {
+            printf("matrix  col %d, row %d, CPU result=%f, GPU result=%f\n",
+                   i,
+                   j,
+                   CPU_result[j + i * lda],
+                   GPU_result[j + i * lda]);
+        }
+}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-    /* ============================================================================================ */
-    /*  device query and print out their ID and name */
-    rocblas_int query_device_property();
+/* ============================================================================================ */
+/*  device query and print out their ID and name */
+rocblas_int query_device_property();
 
-    /*  set current device to device_id */
-    void set_device(rocblas_int device_id);
+/*  set current device to device_id */
+void set_device(rocblas_int device_id);
 
-    /* ============================================================================================ */
-    /*  timing: HIP only provides very limited timers function clock() and not general;
-                rocblas sync CPU and device and use more accurate CPU timer*/
+/* ============================================================================================ */
+/*  timing: HIP only provides very limited timers function clock() and not general;
+            rocblas sync CPU and device and use more accurate CPU timer*/
 
-    /*! \brief  CPU Timer(in microsecond): synchronize with the default device and return wall time */
-    double get_time_us( void );
+/*! \brief  CPU Timer(in microsecond): synchronize with the default device and return wall time */
+double get_time_us(void);
 
+/*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
+double get_time_us_sync(hipStream_t stream);
 
-    /*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
-    double get_time_us_sync( hipStream_t stream );
+/* ============================================================================================ */
+/*  Convert rocblas constants to lapack char. */
 
-    /* ============================================================================================ */
-    /*  Convert rocblas constants to lapack char. */
+char rocblas2char_operation(rocblas_operation value);
 
-    char
-    rocblas2char_operation(rocblas_operation value);
+char rocblas2char_fill(rocblas_fill value);
 
-    char
-    rocblas2char_fill(rocblas_fill value);
+char rocblas2char_diagonal(rocblas_diagonal value);
 
-    char
-    rocblas2char_diagonal(rocblas_diagonal value);
+char rocblas2char_side(rocblas_side value);
 
-    char
-    rocblas2char_side(rocblas_side value);
+/* ============================================================================================ */
+/*  Convert lapack char constants to rocblas type. */
 
-    /* ============================================================================================ */
-    /*  Convert lapack char constants to rocblas type. */
+rocblas_operation char2rocblas_operation(char value);
 
-    rocblas_operation
-    char2rocblas_operation(char value);
+rocblas_fill char2rocblas_fill(char value);
 
-    rocblas_fill
-    char2rocblas_fill(char value);
+rocblas_diagonal char2rocblas_diagonal(char value);
 
-    rocblas_diagonal
-    char2rocblas_diagonal(char value);
-
-    rocblas_side
-    char2rocblas_side(char value);
+rocblas_side char2rocblas_side(char value);
 
 #ifdef __cplusplus
 }
 #endif
 
-
 /* ============================================================================================ */
-
 
 /*! \brief Class used to parse command arguments in both client & gtest   */
 
 // has to compile with option "-std=c++11", and this rocblas library uses c++11 everywhere
 // c++11 allows intilization of member of a struct
 
-class Arguments {
+class Arguments
+{
     public:
     rocblas_int M = 128;
     rocblas_int N = 128;
@@ -265,10 +305,10 @@ class Arguments {
     rocblas_int ldb = 128;
     rocblas_int ldc = 128;
 
-    rocblas_int incx = 1 ;
-    rocblas_int incy = 1 ;
-    rocblas_int incd = 1 ;
-    rocblas_int incb = 1 ;
+    rocblas_int incx = 1;
+    rocblas_int incy = 1;
+    rocblas_int incd = 1;
+    rocblas_int incb = 1;
 
     rocblas_int start = 1024;
     rocblas_int end   = 10240;
@@ -279,18 +319,18 @@ class Arguments {
 
     char transA_option = 'N';
     char transB_option = 'N';
-    char side_option = 'L';
-    char uplo_option = 'L';
-    char diag_option = 'N';
+    char side_option   = 'L';
+    char uplo_option   = 'L';
+    char diag_option   = 'N';
 
     rocblas_int apiCallCount = 1;
-    rocblas_int batch_count = 10;
+    rocblas_int batch_count  = 10;
 
     rocblas_int norm_check = 0;
     rocblas_int unit_check = 1;
-    rocblas_int timing = 0;
+    rocblas_int timing     = 0;
 
-    Arguments & operator=(const Arguments &rhs)
+    Arguments& operator=(const Arguments& rhs)
     {
         M = rhs.M;
         N = rhs.N;
@@ -306,24 +346,24 @@ class Arguments {
         incb = rhs.incb;
 
         start = rhs.start;
-        end = rhs.end;
-        step = rhs.step;
+        end   = rhs.end;
+        step  = rhs.step;
 
         alpha = rhs.alpha;
-        beta = rhs.beta;
+        beta  = rhs.beta;
 
         transA_option = rhs.transA_option;
         transB_option = rhs.transB_option;
-        side_option = rhs.side_option;
-        uplo_option = rhs.uplo_option;
-        diag_option = rhs.diag_option;
+        side_option   = rhs.side_option;
+        uplo_option   = rhs.uplo_option;
+        diag_option   = rhs.diag_option;
 
         apiCallCount = rhs.apiCallCount;
-        batch_count = rhs.batch_count;
+        batch_count  = rhs.batch_count;
 
         norm_check = rhs.norm_check;
         unit_check = rhs.unit_check;
-        timing = rhs.timing;
+        timing     = rhs.timing;
 
         return *this;
     }

--- a/clients/samples/example_openmp.cpp
+++ b/clients/samples/example_openmp.cpp
@@ -3,14 +3,15 @@
  *
  * ************************************************************************ */
 
-
 /*
   README:  Test multiple OpenMP threads
            The main thread creates NUM_THREADS handles/streams
            Each OpenMP thread calls a rocblas routine asscociated with one handle, one stream
            The main thread finally destroy all handles/streams
-           An alternate valid way is each thread creates its own handle/stream and destroy it locally.
-           But in the second way, the handles/streams can not persist across multiple parallel regions.
+           An alternate valid way is each thread creates its own handle/stream and destroy it
+  locally.
+           But in the second way, the handles/streams can not persist across multiple parallel
+  regions.
            In this example, we have two parallel regions
 
            It is NOT recommended that multiple thread share the same rocblas handle.
@@ -37,13 +38,13 @@ int main()
 {
 
     rocblas_int N = 102400;
-    float alpha = 10.0;
+    float alpha   = 10.0;
 
     omp_set_num_threads(NUM_THREADS);
     int thread_id;
     printf("%d OpenMP threads performing rocblas_scal \n", NUM_THREADS);
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<float> hx(N * NUM_THREADS);
     vector<float> hz(N * NUM_THREADS);
     float *dx, *dy;
@@ -53,77 +54,70 @@ int main()
     rocblas_handle handles[NUM_THREADS];
     hipStream_t streams[NUM_THREADS];
 
-    //Create handle/stream have overhead
-    for(rocblas_int i=0;i<NUM_THREADS;i++){
+    // Create handle/stream have overhead
+    for(rocblas_int i = 0; i < NUM_THREADS; i++)
+    {
         rocblas_create_handle(&handles[i]);
         hipStreamCreate(&streams[i]);
     }
 
-    //allocate memory on device
+    // allocate memory on device
     hipMalloc(&dx, N * NUM_THREADS * sizeof(float));
     hipMalloc(&dy, N * NUM_THREADS * sizeof(float));
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<float>(hx, 1, N * NUM_THREADS, 1);
 
-    //copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
+    // copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
     hz = hx;
 
-    hipMemcpy(dx, hx.data(), sizeof(float)*N * NUM_THREADS, hipMemcpyHostToDevice);
+    hipMemcpy(dx, hx.data(), sizeof(float) * N * NUM_THREADS, hipMemcpyHostToDevice);
 
     printf("N        rocblas(us)     \n");
 
-    gpu_time_used = get_time_us();// in microseconds
+    gpu_time_used = get_time_us(); // in microseconds
 
-    //1st parallel rocblas routine call : scal x
-    //spawn openmp threads
-    #pragma omp parallel private(thread_id)
+// 1st parallel rocblas routine call : scal x
+// spawn openmp threads
+#pragma omp parallel private(thread_id)
     {
 
         int thread_id = omp_get_thread_num(); // thread_id from 0,...,NUM_THREADS-1
-        //associate each handle with a stream
+        // associate each handle with a stream
         rocblas_set_stream(handles[thread_id], streams[thread_id]);
 
         /* =====================================================================
              ROCBLAS  template interface
         =================================================================== */
-        rocblas_scal<float>(handles[thread_id],
-                        N,
-                        &alpha,
-                        dx + thread_id*N, 1);
+        rocblas_scal<float>(handles[thread_id], N, &alpha, dx + thread_id * N, 1);
 
-
-        //Blocks until all stream has completed all operations.
+        // Blocks until all stream has completed all operations.
         hipStreamSynchronize(streams[thread_id]);
     }
 
-    //2nd parallel rocblas routine call : copy x to y
-    //spawn openmp threads
-    #pragma omp parallel private(thread_id)
+// 2nd parallel rocblas routine call : copy x to y
+// spawn openmp threads
+#pragma omp parallel private(thread_id)
     {
 
         int thread_id = omp_get_thread_num(); // thread_id from 0,...,NUM_THREADS-1
-        //associate each handle with a stream
+        // associate each handle with a stream
         rocblas_set_stream(handles[thread_id], streams[thread_id]);
 
         /* =====================================================================
              ROCBLAS  template interface
         =================================================================== */
-        rocblas_copy<float>(handles[thread_id],
-                        N,
-                        dx + thread_id*N, 1,
-                        dy + thread_id*N, 1);
+        rocblas_copy<float>(handles[thread_id], N, dx + thread_id * N, 1, dy + thread_id * N, 1);
 
-
-        //Blocks until all stream has completed all operations.
+        // Blocks until all stream has completed all operations.
         hipStreamSynchronize(streams[thread_id]);
     }
 
     gpu_time_used = get_time_us() - gpu_time_used;
 
-    //copy output from device to CPU
-    hipMemcpy(hx.data(), dy, sizeof(float)*N * NUM_THREADS, hipMemcpyDeviceToHost);
+    // copy output from device to CPU
+    hipMemcpy(hx.data(), dy, sizeof(float) * N * NUM_THREADS, hipMemcpyDeviceToHost);
 
 #if 0
     //verify rocblas_scal result
@@ -141,8 +135,9 @@ int main()
     hipFree(dx);
     hipFree(dy);
 
-    //Destroy handle/streams
-    for(rocblas_int i=0;i<NUM_THREADS;i++){
+    // Destroy handle/streams
+    for(rocblas_int i = 0; i < NUM_THREADS; i++)
+    {
         rocblas_destroy_handle(handles[i]);
         hipStreamDestroy(streams[i]);
     }

--- a/clients/samples/example_scal_template.cpp
+++ b/clients/samples/example_scal_template.cpp
@@ -17,65 +17,62 @@ using namespace std;
 int main()
 {
 
-    rocblas_int N = 10240;
+    rocblas_int N         = 10240;
     rocblas_status status = rocblas_status_success;
-    float alpha = 10.0;
+    float alpha           = 10.0;
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<float> hx(N);
     vector<float> hz(N);
-    float *dx;
+    float* dx;
 
     double gpu_time_used;
 
     rocblas_handle handle;
     rocblas_create_handle(&handle);
 
-    //allocate memory on device
+    // allocate memory on device
     hipMalloc(&dx, N * sizeof(float));
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<float>(hx, 1, N, 1);
 
-    //copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
+    // copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
     hz = hx;
 
-    hipMemcpy(dx, hx.data(), sizeof(float)*N, hipMemcpyHostToDevice);
+    hipMemcpy(dx, hx.data(), sizeof(float) * N, hipMemcpyHostToDevice);
 
     printf("N        rocblas(us)     \n");
 
-    gpu_time_used = get_time_us();// in microseconds
-
+    gpu_time_used = get_time_us(); // in microseconds
 
     /* =====================================================================
          ROCBLAS  C++ template interface
     =================================================================== */
 
-    status = rocblas_scal<float>(handle,
-                    N,
-                    &alpha,
-                    dx, 1);
-    if (status != rocblas_status_success) {
+    status = rocblas_scal<float>(handle, N, &alpha, dx, 1);
+    if(status != rocblas_status_success)
+    {
         return status;
     }
 
-
     gpu_time_used = get_time_us() - gpu_time_used;
 
-    //copy output from device to CPU
-    hipMemcpy(hx.data(), dx, sizeof(float)*N, hipMemcpyDeviceToHost);
+    // copy output from device to CPU
+    hipMemcpy(hx.data(), dx, sizeof(float) * N, hipMemcpyDeviceToHost);
 
-    //verify rocblas_scal result
-    for(rocblas_int i=0;i<N;i++){
-        if(hz[i] * alpha != hx[i]){
-            printf("error in element %d: CPU=%f, GPU=%f ", i, hz[i]*alpha, hx[i]);
+    // verify rocblas_scal result
+    for(rocblas_int i = 0; i < N; i++)
+    {
+        if(hz[i] * alpha != hx[i])
+        {
+            printf("error in element %d: CPU=%f, GPU=%f ", i, hz[i] * alpha, hx[i]);
             break;
         }
     }
 
     printf("%d    %8.2f        \n", (int)N, gpu_time_used);
-
 
     hipFree(dx);
     rocblas_destroy_handle(handle);

--- a/clients/samples/example_sgemm.cpp
+++ b/clients/samples/example_sgemm.cpp
@@ -11,26 +11,39 @@
 using namespace std;
 
 #ifndef CHECK_HIP_ERROR
-#define CHECK_HIP_ERROR(error) \
-if (error != hipSuccess) { \
-    fprintf(stderr, "Hip error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error,__FILE__, __LINE__); \
-    exit(EXIT_FAILURE);\
-}
+#define CHECK_HIP_ERROR(error)                    \
+    if(error != hipSuccess)                       \
+    {                                             \
+        fprintf(stderr,                           \
+                "Hip error: '%s'(%d) at %s:%d\n", \
+                hipGetErrorString(error),         \
+                error,                            \
+                __FILE__,                         \
+                __LINE__);                        \
+        exit(EXIT_FAILURE);                       \
+    }
 #endif
 
 #ifndef CHECK_ROCBLAS_ERROR
-#define CHECK_ROCBLAS_ERROR(error) \
-if (error != rocblas_status_success) { \
-    fprintf(stderr, "rocBLAS error: "); \
-    if(error == rocblas_status_invalid_handle)fprintf(stderr, "rocblas_status_invalid_handle"); \
-    if(error == rocblas_status_not_implemented )fprintf(stderr, " rocblas_status_not_implemented"); \
-    if(error == rocblas_status_invalid_pointer)fprintf(stderr, "rocblas_status_invalid_pointer"); \
-    if(error == rocblas_status_invalid_size)fprintf(stderr, "rocblas_status_invalid_size"); \
-    if(error == rocblas_status_memory_error)fprintf(stderr, "rocblas_status_memory_error"); \
-    if(error == rocblas_status_internal_error)fprintf(stderr, "rocblas_status_internal_error"); \
-    fprintf(stderr, "\n"); \
-    exit(EXIT_FAILURE); \
-}
+#define CHECK_ROCBLAS_ERROR(error)                              \
+    if(error != rocblas_status_success)                         \
+    {                                                           \
+        fprintf(stderr, "rocBLAS error: ");                     \
+        if(error == rocblas_status_invalid_handle)              \
+            fprintf(stderr, "rocblas_status_invalid_handle");   \
+        if(error == rocblas_status_not_implemented)             \
+            fprintf(stderr, " rocblas_status_not_implemented"); \
+        if(error == rocblas_status_invalid_pointer)             \
+            fprintf(stderr, "rocblas_status_invalid_pointer");  \
+        if(error == rocblas_status_invalid_size)                \
+            fprintf(stderr, "rocblas_status_invalid_size");     \
+        if(error == rocblas_status_memory_error)                \
+            fprintf(stderr, "rocblas_status_memory_error");     \
+        if(error == rocblas_status_internal_error)              \
+            fprintf(stderr, "rocblas_status_internal_error");   \
+        fprintf(stderr, "\n");                                  \
+        exit(EXIT_FAILURE);                                     \
+    }
 #endif
 
 #define DIM1 1023
@@ -38,19 +51,31 @@ if (error != rocblas_status_success) { \
 #define DIM3 1025
 
 template <typename T>
-void mat_mat_mult(T alpha, T beta, int M, int N, int K, T* A, int As1, int As2,
-                           T* B, int Bs1, int Bs2, T* C, int Cs1, int Cs2) 
+void mat_mat_mult(T alpha,
+                  T beta,
+                  int M,
+                  int N,
+                  int K,
+                  T* A,
+                  int As1,
+                  int As2,
+                  T* B,
+                  int Bs1,
+                  int Bs2,
+                  T* C,
+                  int Cs1,
+                  int Cs2)
 {
-    for(int i1=0; i1<M; i1++) 
+    for(int i1 = 0; i1 < M; i1++)
     {
-        for(int i2=0; i2<N; i2++) 
+        for(int i2 = 0; i2 < N; i2++)
         {
             T t = 0.0;
-            for(int i3=0; i3<K; i3++)
+            for(int i3 = 0; i3 < K; i3++)
             {
-                t +=  A[i1 * As1 + i3 * As2] * B[i3 * Bs1 + i2 * Bs2];
+                t += A[i1 * As1 + i3 * As2] * B[i3 * Bs1 + i2 * Bs2];
             }
-            C[i1*Cs1 +i2*Cs2] = beta * C[i1*Cs1+i2*Cs2] + alpha * t ;
+            C[i1 * Cs1 + i2 * Cs2] = beta * C[i1 * Cs1 + i2 * Cs2] + alpha * t;
         }
     }
 }
@@ -64,51 +89,64 @@ int main()
     rocblas_int lda, ldb, ldc, size_a, size_b, size_c;
     int a_stride_1, a_stride_2, b_stride_1, b_stride_2;
     cout << "sgemm example" << endl;
-    if (transa == rocblas_operation_none)
+    if(transa == rocblas_operation_none)
     {
-        lda = m;
-        size_a = k * lda;
-        a_stride_1 = 1; a_stride_2 = lda;
+        lda        = m;
+        size_a     = k * lda;
+        a_stride_1 = 1;
+        a_stride_2 = lda;
         cout << "N";
     }
     else
     {
-        lda = k;
-        size_a = m * lda;
-        a_stride_1 = lda; a_stride_2 = 1;
+        lda        = k;
+        size_a     = m * lda;
+        a_stride_1 = lda;
+        a_stride_2 = 1;
         cout << "T";
     }
-    if (transb == rocblas_operation_none)
+    if(transb == rocblas_operation_none)
     {
-        ldb = k;
-        size_b = n * ldb;
-        b_stride_1 = 1; b_stride_2 = ldb;
+        ldb        = k;
+        size_b     = n * ldb;
+        b_stride_1 = 1;
+        b_stride_2 = ldb;
         cout << "N: ";
     }
     else
     {
-        ldb = n;
-        size_b = k * ldb;
-        b_stride_1 = ldb; b_stride_2 = 1;
+        ldb        = n;
+        size_b     = k * ldb;
+        b_stride_1 = ldb;
+        b_stride_2 = 1;
         cout << "T: ";
     }
-    ldc = m;
+    ldc    = m;
     size_c = n * ldc;
 
-    //Naming: da is in GPU (device) memory. ha is in CPU (host) memory
+    // Naming: da is in GPU (device) memory. ha is in CPU (host) memory
     vector<float> ha(size_a);
     vector<float> hb(size_b);
     vector<float> hc(size_c);
     vector<float> hc_gold(size_c);
 
-    //initial data on host
+    // initial data on host
     srand(1);
-    for( int i = 0; i < size_a; ++i ) { ha[i] = rand() % 17; }
-    for( int i = 0; i < size_b; ++i ) { hb[i] = rand() % 17; }
-    for( int i = 0; i < size_c; ++i ) { hc[i] = rand() % 17; }
+    for(int i = 0; i < size_a; ++i)
+    {
+        ha[i] = rand() % 17;
+    }
+    for(int i = 0; i < size_b; ++i)
+    {
+        hb[i] = rand() % 17;
+    }
+    for(int i = 0; i < size_c; ++i)
+    {
+        hc[i] = rand() % 17;
+    }
     hc_gold = hc;
 
-    //allocate memory on device
+    // allocate memory on device
     float *da, *db, *dc;
     CHECK_HIP_ERROR(hipMalloc(&da, size_a * sizeof(float)));
     CHECK_HIP_ERROR(hipMalloc(&db, size_b * sizeof(float)));
@@ -121,34 +159,44 @@ int main()
 
     rocblas_handle handle;
     CHECK_ROCBLAS_ERROR(rocblas_create_handle(&handle));
-    
-    CHECK_ROCBLAS_ERROR(rocblas_sgemm(handle, transa, transb, m, n, k, &alpha, 
-                da, lda,
-                db, ldb, &beta, 
-                dc, ldc));
+
+    CHECK_ROCBLAS_ERROR(
+        rocblas_sgemm(handle, transa, transb, m, n, k, &alpha, da, lda, db, ldb, &beta, dc, ldc));
 
     // copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hc.data(), dc, sizeof(float) * size_c, hipMemcpyDeviceToHost));
 
-    cout << "m, n, k, lda, ldb, ldc = " << m << ", " << n << ", " << k << ", " << lda << ", " << ldb <<  ", " << ldc << endl;
+    cout << "m, n, k, lda, ldb, ldc = " << m << ", " << n << ", " << k << ", " << lda << ", " << ldb
+         << ", " << ldc << endl;
 
     float max_relative_error = numeric_limits<float>::min();
 
     // calculate golden or correct result
-    mat_mat_mult<float>(alpha, beta, m, n, k, 
-            ha.data(), a_stride_1, a_stride_2, 
-            hb.data(), b_stride_1, b_stride_2, 
-            hc_gold.data(), 1, ldc);
+    mat_mat_mult<float>(alpha,
+                        beta,
+                        m,
+                        n,
+                        k,
+                        ha.data(),
+                        a_stride_1,
+                        a_stride_2,
+                        hb.data(),
+                        b_stride_1,
+                        b_stride_2,
+                        hc_gold.data(),
+                        1,
+                        ldc);
 
-    for (int i = 0; i < size_c; i++)
+    for(int i = 0; i < size_c; i++)
     {
         float relative_error = (hc_gold[i] - hc[i]) / hc_gold[i];
-        relative_error = relative_error > 0 ? relative_error : -relative_error;
-        max_relative_error = relative_error < max_relative_error ? max_relative_error : relative_error;
+        relative_error       = relative_error > 0 ? relative_error : -relative_error;
+        max_relative_error =
+            relative_error < max_relative_error ? max_relative_error : relative_error;
     }
-    float eps = numeric_limits<float>::epsilon();
+    float eps       = numeric_limits<float>::epsilon();
     float tolerance = 10;
-    if (max_relative_error != max_relative_error || max_relative_error > eps * tolerance)
+    if(max_relative_error != max_relative_error || max_relative_error > eps * tolerance)
     {
         cout << "FAIL: max_relative_error = " << max_relative_error << endl;
     }

--- a/clients/samples/example_sgemm_strided_batched.cpp
+++ b/clients/samples/example_sgemm_strided_batched.cpp
@@ -11,26 +11,39 @@
 using namespace std;
 
 #ifndef CHECK_HIP_ERROR
-#define CHECK_HIP_ERROR(error) \
-if (error != hipSuccess) { \
-    fprintf(stderr, "Hip error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error,__FILE__, __LINE__); \
-    exit(EXIT_FAILURE);\
-}
+#define CHECK_HIP_ERROR(error)                    \
+    if(error != hipSuccess)                       \
+    {                                             \
+        fprintf(stderr,                           \
+                "Hip error: '%s'(%d) at %s:%d\n", \
+                hipGetErrorString(error),         \
+                error,                            \
+                __FILE__,                         \
+                __LINE__);                        \
+        exit(EXIT_FAILURE);                       \
+    }
 #endif
 
 #ifndef CHECK_ROCBLAS_ERROR
-#define CHECK_ROCBLAS_ERROR(error) \
-if (error != rocblas_status_success) { \
-    fprintf(stderr, "rocBLAS error: "); \
-    if(error == rocblas_status_invalid_handle)fprintf(stderr, "rocblas_status_invalid_handle"); \
-    if(error == rocblas_status_not_implemented )fprintf(stderr, " rocblas_status_not_implemented"); \
-    if(error == rocblas_status_invalid_pointer)fprintf(stderr, "rocblas_status_invalid_pointer"); \
-    if(error == rocblas_status_invalid_size)fprintf(stderr, "rocblas_status_invalid_size"); \
-    if(error == rocblas_status_memory_error)fprintf(stderr, "rocblas_status_memory_error"); \
-    if(error == rocblas_status_internal_error)fprintf(stderr, "rocblas_status_internal_error"); \
-    fprintf(stderr, "\n"); \
-    exit(EXIT_FAILURE); \
-}
+#define CHECK_ROCBLAS_ERROR(error)                              \
+    if(error != rocblas_status_success)                         \
+    {                                                           \
+        fprintf(stderr, "rocBLAS error: ");                     \
+        if(error == rocblas_status_invalid_handle)              \
+            fprintf(stderr, "rocblas_status_invalid_handle");   \
+        if(error == rocblas_status_not_implemented)             \
+            fprintf(stderr, " rocblas_status_not_implemented"); \
+        if(error == rocblas_status_invalid_pointer)             \
+            fprintf(stderr, "rocblas_status_invalid_pointer");  \
+        if(error == rocblas_status_invalid_size)                \
+            fprintf(stderr, "rocblas_status_invalid_size");     \
+        if(error == rocblas_status_memory_error)                \
+            fprintf(stderr, "rocblas_status_memory_error");     \
+        if(error == rocblas_status_internal_error)              \
+            fprintf(stderr, "rocblas_status_internal_error");   \
+        fprintf(stderr, "\n");                                  \
+        exit(EXIT_FAILURE);                                     \
+    }
 #endif
 
 #define DIM1 127
@@ -39,19 +52,31 @@ if (error != rocblas_status_success) { \
 #define BATCH_COUNT 10
 
 template <typename T>
-void mat_mat_mult(T alpha, T beta, int M, int N, int K, T* A, int As1, int As2,
-                           T* B, int Bs1, int Bs2, T* C, int Cs1, int Cs2) 
+void mat_mat_mult(T alpha,
+                  T beta,
+                  int M,
+                  int N,
+                  int K,
+                  T* A,
+                  int As1,
+                  int As2,
+                  T* B,
+                  int Bs1,
+                  int Bs2,
+                  T* C,
+                  int Cs1,
+                  int Cs2)
 {
-    for(int i1=0; i1<M; i1++) 
+    for(int i1 = 0; i1 < M; i1++)
     {
-        for(int i2=0; i2<N; i2++) 
+        for(int i2 = 0; i2 < N; i2++)
         {
             T t = 0.0;
-            for(int i3=0; i3<K; i3++)
+            for(int i3 = 0; i3 < K; i3++)
             {
-                t +=  A[i1 * As1 + i3 * As2] * B[i3 * Bs1 + i2 * Bs2];
+                t += A[i1 * As1 + i3 * As2] * B[i3 * Bs1 + i2 * Bs2];
             }
-            C[i1*Cs1 +i2*Cs2] = beta * C[i1*Cs1+i2*Cs2] + alpha * t ;
+            C[i1 * Cs1 + i2 * Cs2] = beta * C[i1 * Cs1 + i2 * Cs2] + alpha * t;
         }
     }
 }
@@ -65,57 +90,71 @@ int main()
     rocblas_int lda, ldb, ldc, bsa, bsb, bsc;
     int a_stride_1, a_stride_2, b_stride_1, b_stride_2;
     cout << "sgemm_strided_batched example" << endl;
-    if (transa == rocblas_operation_none)
+    if(transa == rocblas_operation_none)
     {
-        lda = m;
-        bsa = k * lda;
-        a_stride_1 = 1; a_stride_2 = lda;
+        lda        = m;
+        bsa        = k * lda;
+        a_stride_1 = 1;
+        a_stride_2 = lda;
         cout << "N";
     }
     else
     {
-        lda = k;
-        bsa = m * lda;
-        a_stride_1 = lda; a_stride_2 = 1;
+        lda        = k;
+        bsa        = m * lda;
+        a_stride_1 = lda;
+        a_stride_2 = 1;
         cout << "T";
     }
-    if (transb == rocblas_operation_none)
+    if(transb == rocblas_operation_none)
     {
-        ldb = k;
-        bsb = n * ldb;
-        b_stride_1 = 1; b_stride_2 = ldb;
+        ldb        = k;
+        bsb        = n * ldb;
+        b_stride_1 = 1;
+        b_stride_2 = ldb;
         cout << "N: ";
     }
     else
     {
-        ldb = n;
-        bsb = k * ldb;
-        b_stride_1 = ldb; b_stride_2 = 1;
+        ldb        = n;
+        bsb        = k * ldb;
+        b_stride_1 = ldb;
+        b_stride_2 = 1;
         cout << "T: ";
     }
     ldc = m;
     bsc = n * ldc;
 
-    cout << "M, N, K, lda, bsa, ldb, bsb, ldc, bsc = " << m << ", " << n << ", " << k << ", " << lda << ", " << bsa << ", " << ldb << ", " << bsb << ", " << ldc << ", " << bsc << endl;
+    cout << "M, N, K, lda, bsa, ldb, bsb, ldc, bsc = " << m << ", " << n << ", " << k << ", " << lda
+         << ", " << bsa << ", " << ldb << ", " << bsb << ", " << ldc << ", " << bsc << endl;
 
     int size_a = bsa * batch_count;
     int size_b = bsb * batch_count;
     int size_c = bsc * batch_count;
 
-    //Naming: da is in GPU (device) memory. ha is in CPU (host) memory
+    // Naming: da is in GPU (device) memory. ha is in CPU (host) memory
     vector<float> ha(size_a);
     vector<float> hb(size_b);
     vector<float> hc(size_c);
     vector<float> hc_gold(size_c);
 
-    //initial data on host
+    // initial data on host
     srand(1);
-    for( int i = 0; i < size_a; ++i ) { ha[i] = rand() % 17; }
-    for( int i = 0; i < size_b; ++i ) { hb[i] = rand() % 17; }
-    for( int i = 0; i < size_c; ++i ) { hc[i] = rand() % 17; }
+    for(int i = 0; i < size_a; ++i)
+    {
+        ha[i] = rand() % 17;
+    }
+    for(int i = 0; i < size_b; ++i)
+    {
+        hb[i] = rand() % 17;
+    }
+    for(int i = 0; i < size_c; ++i)
+    {
+        hc[i] = rand() % 17;
+    }
     hc_gold = hc;
 
-    //allocate memory on device
+    // allocate memory on device
     float *da, *db, *dc;
     CHECK_HIP_ERROR(hipMalloc(&da, size_a * sizeof(float)));
     CHECK_HIP_ERROR(hipMalloc(&db, size_b * sizeof(float)));
@@ -128,37 +167,62 @@ int main()
 
     rocblas_handle handle;
     CHECK_ROCBLAS_ERROR(rocblas_create_handle(&handle));
-    
-    CHECK_ROCBLAS_ERROR(rocblas_sgemm_strided_batched(handle, transa, transb, m, n, k, &alpha, 
-                da, lda, bsa, 
-                db, ldb, bsb, &beta, 
-                dc, ldc, bsc, batch_count));
+
+    CHECK_ROCBLAS_ERROR(rocblas_sgemm_strided_batched(handle,
+                                                      transa,
+                                                      transb,
+                                                      m,
+                                                      n,
+                                                      k,
+                                                      &alpha,
+                                                      da,
+                                                      lda,
+                                                      bsa,
+                                                      db,
+                                                      ldb,
+                                                      bsb,
+                                                      &beta,
+                                                      dc,
+                                                      ldc,
+                                                      bsc,
+                                                      batch_count));
 
     // copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hc.data(), dc, sizeof(float) * size_c, hipMemcpyDeviceToHost));
 
     // calculate golden or correct result
-    for (int i = 0; i < batch_count; i++)
+    for(int i = 0; i < batch_count; i++)
     {
-        float *a_ptr = &ha[i * bsa];
-        float *b_ptr = &hb[i * bsb];
-        float *c_ptr = &hc_gold[i * bsc];
-        mat_mat_mult<float>(alpha, beta, m, n, k, 
-                a_ptr, a_stride_1, a_stride_2, 
-                b_ptr, b_stride_1, b_stride_2, 
-                c_ptr, 1, ldc);
+        float* a_ptr = &ha[i * bsa];
+        float* b_ptr = &hb[i * bsb];
+        float* c_ptr = &hc_gold[i * bsc];
+        mat_mat_mult<float>(alpha,
+                            beta,
+                            m,
+                            n,
+                            k,
+                            a_ptr,
+                            a_stride_1,
+                            a_stride_2,
+                            b_ptr,
+                            b_stride_1,
+                            b_stride_2,
+                            c_ptr,
+                            1,
+                            ldc);
     }
 
     float max_relative_error = numeric_limits<float>::min();
-    for (int i = 0; i < size_c; i++)
+    for(int i = 0; i < size_c; i++)
     {
         float relative_error = (hc_gold[i] - hc[i]) / hc_gold[i];
-        relative_error = relative_error > 0 ? relative_error : -relative_error;
-        max_relative_error = relative_error < max_relative_error ? max_relative_error : relative_error;
+        relative_error       = relative_error > 0 ? relative_error : -relative_error;
+        max_relative_error =
+            relative_error < max_relative_error ? max_relative_error : relative_error;
     }
-    float eps = numeric_limits<float>::epsilon();
+    float eps       = numeric_limits<float>::epsilon();
     float tolerance = 10;
-    if (max_relative_error != max_relative_error || max_relative_error > eps * tolerance)
+    if(max_relative_error != max_relative_error || max_relative_error > eps * tolerance)
     {
         cout << "FAIL: max_relative_error = " << max_relative_error << endl;
     }

--- a/clients/samples/example_sscal.cpp
+++ b/clients/samples/example_sscal.cpp
@@ -17,60 +17,58 @@ using namespace std;
 int main()
 {
 
-    rocblas_int N = 10240;
+    rocblas_int N         = 10240;
     rocblas_status status = rocblas_status_success;
-    float alpha = 10.0;
+    float alpha           = 10.0;
 
-    //Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<float> hx(N);
     vector<float> hz(N);
-    float *dx;
+    float* dx;
 
     double gpu_time_used;
 
     rocblas_handle handle;
     rocblas_create_handle(&handle);
 
-    //allocate memory on device
+    // allocate memory on device
     hipMalloc(&dx, N * sizeof(float));
 
-    //Initial Data on CPU
+    // Initial Data on CPU
     srand(1);
     rocblas_init<float>(hx, 1, N, 1);
 
-    //copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
+    // copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
     hz = hx;
 
-    hipMemcpy(dx, hx.data(), sizeof(float)*N, hipMemcpyHostToDevice);
+    hipMemcpy(dx, hx.data(), sizeof(float) * N, hipMemcpyHostToDevice);
 
     printf("N        rocblas(us)     \n");
 
-    gpu_time_used = get_time_us();// in microseconds
-
+    gpu_time_used = get_time_us(); // in microseconds
 
     /* =====================================================================
          ROCBLAS  C interface
     =================================================================== */
 
-    status = rocblas_sscal(handle,
-                    N,
-                    &alpha,
-                    dx, 1);
-    if (status != rocblas_status_success) {
+    status = rocblas_sscal(handle, N, &alpha, dx, 1);
+    if(status != rocblas_status_success)
+    {
         return status;
     }
 
-
     gpu_time_used = get_time_us() - gpu_time_used;
 
-    //copy output from device to CPU
-    hipMemcpy(hx.data(), dx, sizeof(float)*N, hipMemcpyDeviceToHost);
+    // copy output from device to CPU
+    hipMemcpy(hx.data(), dx, sizeof(float) * N, hipMemcpyDeviceToHost);
 
-    //verify rocblas_scal result
+    // verify rocblas_scal result
     bool error_in_element = false;
-    for(rocblas_int i=0;i<N;i++){
-        if(hz[i] * alpha != hx[i]){
-            printf("error in element %d: CPU=%f, GPU=%f ", i, hz[i]*alpha, hx[i]);
+    for(rocblas_int i = 0; i < N; i++)
+    {
+        if(hz[i] * alpha != hx[i])
+        {
+            printf("error in element %d: CPU=%f, GPU=%f ", i, hz[i] * alpha, hx[i]);
             error_in_element = true;
             break;
         }
@@ -78,7 +76,7 @@ int main()
 
     printf("%d    %8.2f        \n", (int)N, gpu_time_used);
 
-    if (error_in_element)
+    if(error_in_element)
     {
         printf("SSCAL TEST FAILS\n");
     }
@@ -86,7 +84,6 @@ int main()
     {
         printf("SSCAL TEST PASSES\n");
     }
-
 
     hipFree(dx);
     rocblas_destroy_handle(handle);

--- a/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
+++ b/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
@@ -18,6 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     sudo \
     build-essential \
     cmake \
+    clang-format-3.8 \
     ca-certificates \
     git \
     pkg-config \

--- a/docker/dockerfile-build-nvidia-cuda-8
+++ b/docker/dockerfile-build-nvidia-cuda-8
@@ -21,6 +21,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sudo \
     cmake \
+    clang-format-3.8 \
     ca-certificates \
     git \
     pkg-config \

--- a/docker/dockerfile-build-rocm-terminal
+++ b/docker/dockerfile-build-rocm-terminal
@@ -19,6 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     cmake \
     ca-certificates \
     git \
+    clang-format-3.8 \
     pkg-config \
     python2.7 \
     python-yaml \

--- a/library/include/rocblas-auxiliary.h
+++ b/library/include/rocblas-auxiliary.h
@@ -14,14 +14,11 @@
  * \brief rocblas-auxiliary.h provides auxilary functions in rocblas
 */
 
-
-
 /* ============================================================================================ */
-/*! \brief  indicates whether the pointer is on the host or device. currently HIP API can only recoginize the input ptr on deive or not
+/*! \brief  indicates whether the pointer is on the host or device. currently HIP API can only
+recoginize the input ptr on deive or not
 can not recoginize it is on host or not */
-ROCBLAS_EXPORT rocblas_pointer_mode
-rocblas_pointer_to_mode(void *ptr);
-
+ROCBLAS_EXPORT rocblas_pointer_mode rocblas_pointer_to_mode(void* ptr);
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,92 +31,84 @@ extern "C" {
  * to all subsequent library function calls.
  * It should be destroyed at the end using rocblas_destroy_handle().
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_create_handle( rocblas_handle *handle);
-
+ROCBLAS_EXPORT rocblas_status rocblas_create_handle(rocblas_handle* handle);
 
 /********************************************************************************
  * \brief destroy handle
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_destroy_handle( rocblas_handle handle);
-
+ROCBLAS_EXPORT rocblas_status rocblas_destroy_handle(rocblas_handle handle);
 
 /********************************************************************************
  * \brief add stream to handle
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_add_stream( rocblas_handle handle, hipStream_t stream );
-
+ROCBLAS_EXPORT rocblas_status rocblas_add_stream(rocblas_handle handle, hipStream_t stream);
 
 /********************************************************************************
  * \brief remove any streams from handle, and add one
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_set_stream( rocblas_handle handle, hipStream_t stream );
-
+ROCBLAS_EXPORT rocblas_status rocblas_set_stream(rocblas_handle handle, hipStream_t stream);
 
 /********************************************************************************
  * \brief get stream [0] from handle
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_get_stream( rocblas_handle handle, hipStream_t *stream );
-
+ROCBLAS_EXPORT rocblas_status rocblas_get_stream(rocblas_handle handle, hipStream_t* stream);
 
 /********************************************************************************
  * \brief set rocblas_pointer_mode
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_set_pointer_mode( rocblas_handle handle, rocblas_pointer_mode pointer_mode);
-
+ROCBLAS_EXPORT rocblas_status rocblas_set_pointer_mode(rocblas_handle handle,
+                                                       rocblas_pointer_mode pointer_mode);
 
 /********************************************************************************
  * \brief get rocblas_pointer_mode
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_get_pointer_mode( rocblas_handle handle, rocblas_pointer_mode *pointer_mode);
-
+ROCBLAS_EXPORT rocblas_status rocblas_get_pointer_mode(rocblas_handle handle,
+                                                       rocblas_pointer_mode* pointer_mode);
 
 /********************************************************************************
  * \brief copy vector from host to device
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_set_vector(rocblas_int n, rocblas_int elem_size,
-    const void *x, rocblas_int incx,
-    void *y, rocblas_int incy);
-
+ROCBLAS_EXPORT rocblas_status rocblas_set_vector(rocblas_int n,
+                                                 rocblas_int elem_size,
+                                                 const void* x,
+                                                 rocblas_int incx,
+                                                 void* y,
+                                                 rocblas_int incy);
 
 /********************************************************************************
  * \brief copy vector from device to host
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_get_vector(rocblas_int n, rocblas_int elem_size,
-    const void *x, rocblas_int incx,
-    void *y, rocblas_int incy);
-
+ROCBLAS_EXPORT rocblas_status rocblas_get_vector(rocblas_int n,
+                                                 rocblas_int elem_size,
+                                                 const void* x,
+                                                 rocblas_int incx,
+                                                 void* y,
+                                                 rocblas_int incy);
 
 /********************************************************************************
  * \brief copy matrix from host to device
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_set_matrix(rocblas_int rows, rocblas_int cols,
-    rocblas_int elem_size,
-    const void *a, rocblas_int lda,
-    void *b, rocblas_int ldb);
-
+ROCBLAS_EXPORT rocblas_status rocblas_set_matrix(rocblas_int rows,
+                                                 rocblas_int cols,
+                                                 rocblas_int elem_size,
+                                                 const void* a,
+                                                 rocblas_int lda,
+                                                 void* b,
+                                                 rocblas_int ldb);
 
 /********************************************************************************
  * \brief copy matrix from device to host
  *******************************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_get_matrix(rocblas_int rows, rocblas_int cols,
-    rocblas_int elem_size,
-    const void *a, rocblas_int lda,
-    void *b, rocblas_int ldb);
-
+ROCBLAS_EXPORT rocblas_status rocblas_get_matrix(rocblas_int rows,
+                                                 rocblas_int cols,
+                                                 rocblas_int elem_size,
+                                                 const void* a,
+                                                 rocblas_int lda,
+                                                 void* b,
+                                                 rocblas_int ldb);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* _ROCBLAS_AUXILIARY_H_ */
+#endif /* _ROCBLAS_AUXILIARY_H_ */

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -9,10 +9,10 @@
 
 #include "rocblas-types.h"
 
-
 /*!\file
  * \brief rocblas_netlib.h provides Basic Linear Algebra Subprograms of Level 1, 2 and 3,
- *  using HIP optimized for AMD HCC-based GPU hardware. This library can also run on CUDA-based NVIDIA GPUs.
+ *  using HIP optimized for AMD HCC-based GPU hardware. This library can also run on CUDA-based
+ * NVIDIA GPUs.
  *  This file exposes C89 BLAS interface
 */
 
@@ -24,11 +24,9 @@
  * ===========================================================================
  */
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 /*
  * ===========================================================================
@@ -59,16 +57,10 @@ extern "C" {
     ********************************************************************/
 
 ROCBLAS_EXPORT rocblas_status
-rocblas_sscal(rocblas_handle handle,
-    rocblas_int n,
-    const float *alpha,
-    float *x, rocblas_int incx);
+rocblas_sscal(rocblas_handle handle, rocblas_int n, const float* alpha, float* x, rocblas_int incx);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dscal(rocblas_handle handle,
-    rocblas_int n,
-    const double *alpha,
-    double *x, rocblas_int incx);
+ROCBLAS_EXPORT rocblas_status rocblas_dscal(
+    rocblas_handle handle, rocblas_int n, const double* alpha, double* x, rocblas_int incx);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -83,7 +75,6 @@ rocblas_zscal(rocblas_handle handle,
     const rocblas_double_complex *alpha,
     rocblas_double_complex *x, rocblas_int incx);
 */
-
 
 /*! \brief BLAS Level 1 API
 
@@ -109,17 +100,19 @@ rocblas_zscal(rocblas_handle handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_scopy(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    float* y,       rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_scopy(rocblas_handle handle,
+                                            rocblas_int n,
+                                            const float* x,
+                                            rocblas_int incx,
+                                            float* y,
+                                            rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dcopy(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    double* y,       rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_dcopy(rocblas_handle handle,
+                                            rocblas_int n,
+                                            const double* x,
+                                            rocblas_int incx,
+                                            double* y,
+                                            rocblas_int incy);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -163,19 +156,21 @@ rocblas_zcopy(rocblas_handle handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_sdot(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    const float *y, rocblas_int incy,
-    float *result);
+ROCBLAS_EXPORT rocblas_status rocblas_sdot(rocblas_handle handle,
+                                           rocblas_int n,
+                                           const float* x,
+                                           rocblas_int incx,
+                                           const float* y,
+                                           rocblas_int incy,
+                                           float* result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_ddot(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    const double *y, rocblas_int incy,
-    double *result);
+ROCBLAS_EXPORT rocblas_status rocblas_ddot(rocblas_handle handle,
+                                           rocblas_int n,
+                                           const double* x,
+                                           rocblas_int incx,
+                                           const double* y,
+                                           rocblas_int incy,
+                                           double* result);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -192,7 +187,6 @@ rocblas_zdotu(rocblas_handle handle,
     const rocblas_double_complex *y, rocblas_int incy,
     rocblas_double_complex *result);
 */
-
 
 /*! \brief BLAS Level 1 API
 
@@ -218,17 +212,11 @@ rocblas_zdotu(rocblas_handle handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_sswap(rocblas_handle handle,
-    rocblas_int n,
-    float *x, rocblas_int incx,
-    float* y, rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_sswap(
+    rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dswap(rocblas_handle handle,
-    rocblas_int n,
-    double *x, rocblas_int incx,
-    double* y, rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_dswap(
+    rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -269,26 +257,29 @@ rocblas_zswap(rocblas_handle handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_haxpy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_half *alpha,
-    const rocblas_half *x, rocblas_int incx,
-    rocblas_half *y,  rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_haxpy(rocblas_handle handle,
+                                            rocblas_int n,
+                                            const rocblas_half* alpha,
+                                            const rocblas_half* x,
+                                            rocblas_int incx,
+                                            rocblas_half* y,
+                                            rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_saxpy(rocblas_handle handle,
-    rocblas_int n,
-    const float *alpha,
-    const float *x, rocblas_int incx,
-    float *y,  rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_saxpy(rocblas_handle handle,
+                                            rocblas_int n,
+                                            const float* alpha,
+                                            const float* x,
+                                            rocblas_int incx,
+                                            float* y,
+                                            rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_daxpy(rocblas_handle handle,
-    rocblas_int n,
-    const double *alpha,
-    const double *x, rocblas_int incx,
-    double *y,  rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_daxpy(rocblas_handle handle,
+                                            rocblas_int n,
+                                            const double* alpha,
+                                            const double* x,
+                                            rocblas_int incx,
+                                            double* y,
+                                            rocblas_int incy);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -310,7 +301,8 @@ rocblas_zaxpy(rocblas_handle handle,
 
     \details
     asum computes the sum of the magnitudes of elements of a real vector x,
-         or the sum of magnitudes of the real and imaginary parts of elements if x is a complex vector
+         or the sum of magnitudes of the real and imaginary parts of elements if x is a complex
+   vector
 
     @param[in]
     handle    rocblas_handle.
@@ -329,17 +321,11 @@ rocblas_zaxpy(rocblas_handle handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_sasum(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    float *result);
+ROCBLAS_EXPORT rocblas_status rocblas_sasum(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dasum(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    double *result);
+ROCBLAS_EXPORT rocblas_status rocblas_dasum(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -354,7 +340,6 @@ rocblas_dzasum(rocblas_handle handle,
     const rocblas_double_complex *x, rocblas_int incx,
     double *result);
 */
-
 
 /*! \brief BLAS Level 1 API
 
@@ -379,17 +364,11 @@ rocblas_dzasum(rocblas_handle handle,
               return is 0.0 if n, incx<=0.
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_snrm2(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    float *result);
+ROCBLAS_EXPORT rocblas_status rocblas_snrm2(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dnrm2(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    double *result);
+ROCBLAS_EXPORT rocblas_status rocblas_dnrm2(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -409,7 +388,8 @@ rocblas_dznrm2(rocblas_handle handle,
 
     \details
     amax finds the first index of the element of maximum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex vector
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+   vector
 
     @param[in]
     handle    rocblas_handle.
@@ -427,17 +407,11 @@ rocblas_dznrm2(rocblas_handle handle,
               return is 0.0 if n, incx<=0.
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_isamax(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    rocblas_int *result);
+ROCBLAS_EXPORT rocblas_status rocblas_isamax(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_idamax(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    rocblas_int *result);
+ROCBLAS_EXPORT rocblas_status rocblas_idamax(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -457,7 +431,8 @@ rocblas_idzamax(rocblas_handle handle,
 
     \details
     amin finds the first index of the element of minimum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex vector
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+   vector
 
     @param[in]
     handle    rocblas_handle.
@@ -475,17 +450,11 @@ rocblas_idzamax(rocblas_handle handle,
               return is 0.0 if n, incx<=0.
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_isamin(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    rocblas_int *result);
+ROCBLAS_EXPORT rocblas_status rocblas_isamin(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_idamin(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    rocblas_int *result);
+ROCBLAS_EXPORT rocblas_status rocblas_idamin(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -501,11 +470,11 @@ rocblas_idzamin(rocblas_handle handle,
     rocblas_int *result);
 */
 
-    /*
-     * ===========================================================================
-     *    level 2 BLAS
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    level 2 BLAS
+ * ===========================================================================
+ */
 
 /*! \brief BLAS Level 2 API
 
@@ -549,25 +518,31 @@ rocblas_idzamin(rocblas_handle handle,
               specifies the increment for the elements of y.
 
     ********************************************************************/
-ROCBLAS_EXPORT rocblas_status
-rocblas_sgemv(rocblas_handle handle,
-                 rocblas_operation trans,
-                 rocblas_int m, rocblas_int n,
-                 const float *alpha,
-                 const float *A, rocblas_int lda,
-                 const float *x, rocblas_int incx,
-                 const float *beta,
-                 float *y, rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_sgemv(rocblas_handle handle,
+                                            rocblas_operation trans,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            const float* alpha,
+                                            const float* A,
+                                            rocblas_int lda,
+                                            const float* x,
+                                            rocblas_int incx,
+                                            const float* beta,
+                                            float* y,
+                                            rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dgemv(rocblas_handle handle,
-                 rocblas_operation trans,
-                 rocblas_int m, rocblas_int n,
-                 const double *alpha,
-                 const double *A, rocblas_int lda,
-                 const double *x, rocblas_int incx,
-                 const double *beta,
-                 double *y, rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_dgemv(rocblas_handle handle,
+                                            rocblas_operation trans,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            const double* alpha,
+                                            const double* A,
+                                            rocblas_int lda,
+                                            const double* x,
+                                            rocblas_int incx,
+                                            const double* beta,
+                                            double* y,
+                                            rocblas_int incy);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -590,7 +565,6 @@ rocblas_zgemv(rocblas_handle handle,
                  const rocblas_double_complex *beta,
                  rocblas_double_complex *y, rocblas_int incy);
 */
-
 
 /*! \brief BLAS Level 2 API
 
@@ -713,21 +687,27 @@ rocblas_zhemv(rocblas_handle handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_sger(rocblas_handle handle,
-                 rocblas_int m, rocblas_int n,
-                 const float *alpha,
-                 const float *x, rocblas_int incx,
-                 const float *y, rocblas_int incy,
-                       float *A, rocblas_int lda);
+ROCBLAS_EXPORT rocblas_status rocblas_sger(rocblas_handle handle,
+                                           rocblas_int m,
+                                           rocblas_int n,
+                                           const float* alpha,
+                                           const float* x,
+                                           rocblas_int incx,
+                                           const float* y,
+                                           rocblas_int incy,
+                                           float* A,
+                                           rocblas_int lda);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dger(rocblas_handle handle,
-                 rocblas_int m, rocblas_int n,
-                 const double *alpha,
-                 const double *x, rocblas_int incx,
-                 const double *y, rocblas_int incy,
-                       double *A, rocblas_int lda);
+ROCBLAS_EXPORT rocblas_status rocblas_dger(rocblas_handle handle,
+                                           rocblas_int m,
+                                           rocblas_int n,
+                                           const double* alpha,
+                                           const double* x,
+                                           rocblas_int incx,
+                                           const double* y,
+                                           rocblas_int incy,
+                                           double* A,
+                                           rocblas_int lda);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -788,20 +768,23 @@ rocblas_zger(rocblas_handle handle,
 
 ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_strtri(rocblas_handle handle,
-    rocblas_fill uplo, rocblas_diagonal diag,
-    rocblas_int n,
-    float *A, rocblas_int lda,
-    float *invA, rocblas_int ldinvA);
+ROCBLAS_EXPORT rocblas_status rocblas_strtri(rocblas_handle handle,
+                                             rocblas_fill uplo,
+                                             rocblas_diagonal diag,
+                                             rocblas_int n,
+                                             float* A,
+                                             rocblas_int lda,
+                                             float* invA,
+                                             rocblas_int ldinvA);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dtrtri(rocblas_handle handle,
-    rocblas_fill uplo, rocblas_diagonal diag,
-    rocblas_int n,
-    double *A, rocblas_int lda,
-    double *invA, rocblas_int ldinvA);
-
+ROCBLAS_EXPORT rocblas_status rocblas_dtrtri(rocblas_handle handle,
+                                             rocblas_fill uplo,
+                                             rocblas_diagonal diag,
+                                             rocblas_int n,
+                                             double* A,
+                                             rocblas_int lda,
+                                             double* invA,
+                                             rocblas_int ldinvA);
 
 /*! \brief BLAS Level 3 API
 
@@ -843,26 +826,29 @@ rocblas_dtrtri(rocblas_handle handle,
               numbers of matrices in the batch
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_strtri_batched(rocblas_handle handle,
-    rocblas_fill uplo,
-    rocblas_diagonal diag,
-    rocblas_int n,
-    float *A, rocblas_int lda, rocblas_int bsa,
-    float *invA, rocblas_int ldinvA, rocblas_int bsinvA,
-    rocblas_int batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_strtri_batched(rocblas_handle handle,
+                                                     rocblas_fill uplo,
+                                                     rocblas_diagonal diag,
+                                                     rocblas_int n,
+                                                     float* A,
+                                                     rocblas_int lda,
+                                                     rocblas_int bsa,
+                                                     float* invA,
+                                                     rocblas_int ldinvA,
+                                                     rocblas_int bsinvA,
+                                                     rocblas_int batch_count);
 
-
-ROCBLAS_EXPORT rocblas_status
-rocblas_dtrtri_batched(rocblas_handle handle,
-    rocblas_fill uplo,
-    rocblas_diagonal diag,
-    rocblas_int n,
-    double *A, rocblas_int lda, rocblas_int bsa,
-    double *invA, rocblas_int ldinvA, rocblas_int bsinvA,
-    rocblas_int batch_count);
-
-
+ROCBLAS_EXPORT rocblas_status rocblas_dtrtri_batched(rocblas_handle handle,
+                                                     rocblas_fill uplo,
+                                                     rocblas_diagonal diag,
+                                                     rocblas_int n,
+                                                     double* A,
+                                                     rocblas_int lda,
+                                                     rocblas_int bsa,
+                                                     double* invA,
+                                                     rocblas_int ldinvA,
+                                                     rocblas_int bsinvA,
+                                                     rocblas_int batch_count);
 
 /*! \brief BLAS Level 3 API
 
@@ -940,25 +926,31 @@ rocblas_dtrtri_batched(rocblas_handle handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_strsm(rocblas_handle handle,
-    rocblas_side side, rocblas_fill uplo,
-    rocblas_operation transA, rocblas_diagonal diag,
-    rocblas_int m, rocblas_int n,
-    const float* alpha,
-    float* A, rocblas_int lda,
-    float* B, rocblas_int ldb);
+ROCBLAS_EXPORT rocblas_status rocblas_strsm(rocblas_handle handle,
+                                            rocblas_side side,
+                                            rocblas_fill uplo,
+                                            rocblas_operation transA,
+                                            rocblas_diagonal diag,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            const float* alpha,
+                                            float* A,
+                                            rocblas_int lda,
+                                            float* B,
+                                            rocblas_int ldb);
 
-
-ROCBLAS_EXPORT rocblas_status
-rocblas_dtrsm(rocblas_handle handle,
-    rocblas_side side, rocblas_fill uplo,
-    rocblas_operation transA, rocblas_diagonal diag,
-    rocblas_int m, rocblas_int n,
-    const double* alpha,
-    double* A, rocblas_int lda,
-    double* B, rocblas_int ldb);
-
+ROCBLAS_EXPORT rocblas_status rocblas_dtrsm(rocblas_handle handle,
+                                            rocblas_side side,
+                                            rocblas_fill uplo,
+                                            rocblas_operation transA,
+                                            rocblas_diagonal diag,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            const double* alpha,
+                                            double* A,
+                                            rocblas_int lda,
+                                            double* B,
+                                            rocblas_int ldb);
 
 /*! \brief BLAS Level 3 API
 
@@ -1025,27 +1017,35 @@ rocblas_hgemm(
           rocblas_half *C, rocblas_int ldc);
 */
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_sgemm(
-    rocblas_handle handle,
-    rocblas_operation transa, rocblas_operation transb,
-    rocblas_int m, rocblas_int n, rocblas_int k,
-    const float *alpha,
-    const float *A, rocblas_int lda,
-    const float *B, rocblas_int ldb,
-    const float *beta,
-          float *C, rocblas_int ldc);
+ROCBLAS_EXPORT rocblas_status rocblas_sgemm(rocblas_handle handle,
+                                            rocblas_operation transa,
+                                            rocblas_operation transb,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            rocblas_int k,
+                                            const float* alpha,
+                                            const float* A,
+                                            rocblas_int lda,
+                                            const float* B,
+                                            rocblas_int ldb,
+                                            const float* beta,
+                                            float* C,
+                                            rocblas_int ldc);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dgemm(
-    rocblas_handle handle,
-    rocblas_operation transa, rocblas_operation transb,
-    rocblas_int m, rocblas_int n, rocblas_int k,
-    const double *alpha,
-    const double *A, rocblas_int lda,
-    const double *B, rocblas_int ldb,
-    const double *beta,
-          double *C, rocblas_int ldc);
+ROCBLAS_EXPORT rocblas_status rocblas_dgemm(rocblas_handle handle,
+                                            rocblas_operation transa,
+                                            rocblas_operation transb,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            rocblas_int k,
+                                            const double* alpha,
+                                            const double* A,
+                                            rocblas_int lda,
+                                            const double* B,
+                                            rocblas_int ldb,
+                                            const double* beta,
+                                            double* C,
+                                            rocblas_int ldc);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -1084,7 +1084,6 @@ rocblas_zgemm(
           rocblas_double_complex *C, rocblas_int ldc);
 */
 
-
 /***************************************************************************
  * batched
  * bsa - "batch stride a": stride from the start of one "A" matrix to the next
@@ -1106,29 +1105,43 @@ rocblas_hgemm_strided_batched(
     rocblas_int batch_count );
 */
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_sgemm_strided_batched(
-    rocblas_handle handle,
-    rocblas_operation transa, rocblas_operation transb,
-    rocblas_int m, rocblas_int n, rocblas_int k,
-    const float *alpha,
-    const float *A, rocblas_int lda, rocblas_int bsa,
-    const float *B, rocblas_int ldb, rocblas_int bsb,
-    const float *beta,
-          float *C, rocblas_int ldc, rocblas_int bsc,
-    rocblas_int batch_count );
+ROCBLAS_EXPORT rocblas_status rocblas_sgemm_strided_batched(rocblas_handle handle,
+                                                            rocblas_operation transa,
+                                                            rocblas_operation transb,
+                                                            rocblas_int m,
+                                                            rocblas_int n,
+                                                            rocblas_int k,
+                                                            const float* alpha,
+                                                            const float* A,
+                                                            rocblas_int lda,
+                                                            rocblas_int bsa,
+                                                            const float* B,
+                                                            rocblas_int ldb,
+                                                            rocblas_int bsb,
+                                                            const float* beta,
+                                                            float* C,
+                                                            rocblas_int ldc,
+                                                            rocblas_int bsc,
+                                                            rocblas_int batch_count);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dgemm_strided_batched(
-    rocblas_handle handle,
-    rocblas_operation transa, rocblas_operation transb,
-    rocblas_int m, rocblas_int n, rocblas_int k,
-    const double *alpha,
-    const double *A, rocblas_int lda, rocblas_int bsa,
-    const double *B, rocblas_int ldb, rocblas_int bsb,
-    const double *beta,
-          double *C, rocblas_int ldc, rocblas_int bsc,
-    rocblas_int batch_count );
+ROCBLAS_EXPORT rocblas_status rocblas_dgemm_strided_batched(rocblas_handle handle,
+                                                            rocblas_operation transa,
+                                                            rocblas_operation transb,
+                                                            rocblas_int m,
+                                                            rocblas_int n,
+                                                            rocblas_int k,
+                                                            const double* alpha,
+                                                            const double* A,
+                                                            rocblas_int lda,
+                                                            rocblas_int bsa,
+                                                            const double* B,
+                                                            rocblas_int ldb,
+                                                            rocblas_int bsb,
+                                                            const double* beta,
+                                                            double* C,
+                                                            rocblas_int ldc,
+                                                            rocblas_int bsc,
+                                                            rocblas_int batch_count);
 
 /* not implemented
 ROCBLAS_EXPORT rocblas_status
@@ -1221,31 +1234,36 @@ rocblas_zgemm_strided_batched(
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_sgeam(
-    rocblas_handle handle,
-    rocblas_operation transa, rocblas_operation transb,
-    rocblas_int m, rocblas_int n,
-    const float *alpha,
-    const float *A, rocblas_int lda,
-    const float *beta,
-    const float *B, rocblas_int ldb,
-          float *C, rocblas_int ldc);
+ROCBLAS_EXPORT rocblas_status rocblas_sgeam(rocblas_handle handle,
+                                            rocblas_operation transa,
+                                            rocblas_operation transb,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            const float* alpha,
+                                            const float* A,
+                                            rocblas_int lda,
+                                            const float* beta,
+                                            const float* B,
+                                            rocblas_int ldb,
+                                            float* C,
+                                            rocblas_int ldc);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dgeam(
-    rocblas_handle handle,
-    rocblas_operation transa, rocblas_operation transb,
-    rocblas_int m, rocblas_int n,
-    const double *alpha,
-    const double *A, rocblas_int lda,
-    const double *beta,
-    const double *B, rocblas_int ldb,
-          double *C, rocblas_int ldc);
-
+ROCBLAS_EXPORT rocblas_status rocblas_dgeam(rocblas_handle handle,
+                                            rocblas_operation transa,
+                                            rocblas_operation transb,
+                                            rocblas_int m,
+                                            rocblas_int n,
+                                            const double* alpha,
+                                            const double* A,
+                                            rocblas_int lda,
+                                            const double* beta,
+                                            const double* B,
+                                            rocblas_int ldb,
+                                            double* C,
+                                            rocblas_int ldc);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* _ROCBLAS_FUNCTIONS_H_ */
+#endif /* _ROCBLAS_FUNCTIONS_H_ */

--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -15,103 +15,96 @@
 #include <stdint.h>
 #include <hip/hip_vector_types.h>
 
-
 // integer type
 /*! \brief To specify whether int32 or int64 is used
  */
-#if defined( rocblas_ILP64 )
+#if defined(rocblas_ILP64)
 typedef int64_t rocblas_int;
 #else
 typedef int32_t rocblas_int;
 #endif
 // complex type
-typedef float2  rocblas_float_complex;
+typedef float2 rocblas_float_complex;
 typedef double2 rocblas_double_complex;
 // half type TODO put name of half here
 typedef uint16_t rocblas_half;
-typedef float2   rocblas_half_complex;
+typedef float2 rocblas_half_complex;
 
-typedef struct _rocblas_handle * rocblas_handle;
+typedef struct _rocblas_handle* rocblas_handle;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-    /* ============================================================================================ */
+/* ============================================================================================ */
 
-    /*! parameter constants.
-     *  numbering is consistent with CBLAS, ACML and most standard C BLAS libraries
-     */
+/*! parameter constants.
+ *  numbering is consistent with CBLAS, ACML and most standard C BLAS libraries
+ */
 
-    /*! \brief Used to specify whether the matrix is to be transposed or not. */
-    typedef enum rocblas_operation_ {
-        rocblas_operation_none                = 111, /**< Operate with the matrix. */
-        rocblas_operation_transpose           = 112, /**< Operate with the transpose of the matrix. */
-        rocblas_operation_conjugate_transpose = 113  /**< Operate with the conjugate transpose of the matrix. */
-    } rocblas_operation;
+/*! \brief Used to specify whether the matrix is to be transposed or not. */
+typedef enum rocblas_operation_ {
+    rocblas_operation_none      = 111, /**< Operate with the matrix. */
+    rocblas_operation_transpose = 112, /**< Operate with the transpose of the matrix. */
+    rocblas_operation_conjugate_transpose =
+        113 /**< Operate with the conjugate transpose of the matrix. */
+} rocblas_operation;
 
-    /*! \brief Used by the Hermitian, symmetric and triangular matrix
-     * routines to specify whether the upper or lower triangle is being referenced.
-     */
-    typedef enum rocblas_fill_ {
-        rocblas_fill_upper = 121,               /**< Upper triangle. */
-        rocblas_fill_lower = 122,               /**< Lower triangle. */
-        rocblas_fill_full  = 123
-    } rocblas_fill;
+/*! \brief Used by the Hermitian, symmetric and triangular matrix
+ * routines to specify whether the upper or lower triangle is being referenced.
+ */
+typedef enum rocblas_fill_ {
+    rocblas_fill_upper = 121, /**< Upper triangle. */
+    rocblas_fill_lower = 122, /**< Lower triangle. */
+    rocblas_fill_full  = 123
+} rocblas_fill;
 
+/*! \brief It is used by the triangular matrix routines to specify whether the
+ * matrix is unit triangular.
+ */
+typedef enum rocblas_diagonal_ {
+    rocblas_diagonal_non_unit = 131, /**< Non-unit triangular. */
+    rocblas_diagonal_unit     = 132, /**< Unit triangular. */
+} rocblas_diagonal;
 
-    /*! \brief It is used by the triangular matrix routines to specify whether the
-     * matrix is unit triangular.
-     */
-    typedef enum rocblas_diagonal_ {
-        rocblas_diagonal_non_unit  = 131,           /**< Non-unit triangular. */
-        rocblas_diagonal_unit      = 132,          /**< Unit triangular. */
-    } rocblas_diagonal;
+/*! \brief Indicates the side matrix A is located relative to matrix B during multiplication. */
+typedef enum rocblas_side_ {
+    rocblas_side_left = 141,  /**< Multiply general matrix by symmetric,
+                        Hermitian or triangular matrix on the left. */
+    rocblas_side_right = 142, /**< Multiply general matrix by symmetric,
+                        Hermitian or triangular matrix on the right. */
+    rocblas_side_both = 143
+} rocblas_side;
 
+/* ============================================================================================ */
+/**
+ *   @brief rocblas status codes definition
+ */
+typedef enum rocblas_status_ {
+    rocblas_status_success         = 0, /**< success */
+    rocblas_status_invalid_handle  = 1, /**< handle not initialized, invalid or null */
+    rocblas_status_not_implemented = 2, /**< function is not implemented */
+    rocblas_status_invalid_pointer = 3, /**< invalid pointer parameter */
+    rocblas_status_invalid_size    = 4, /**< invalid size parameter */
+    rocblas_status_memory_error    = 5, /**< failed internal memory allocation, copy or dealloc */
+    rocblas_status_internal_error  = 6, /**< other internal library failure */
+} rocblas_status;
 
-    /*! \brief Indicates the side matrix A is located relative to matrix B during multiplication. */
-    typedef enum rocblas_side_ {
-        rocblas_side_left  = 141,        /**< Multiply general matrix by symmetric,
-                                   Hermitian or triangular matrix on the left. */
-        rocblas_side_right = 142,        /**< Multiply general matrix by symmetric,
-                                   Hermitian or triangular matrix on the right. */
-        rocblas_side_both  = 143
-    } rocblas_side;
+/*! \brief Indicates the precision width of data stored in a blas type. */
+typedef enum rocblas_precision_ {
+    rocblas_precision_half           = 150,
+    rocblas_precision_single         = 151,
+    rocblas_precision_double         = 152,
+    rocblas_precision_complex_half   = 153,
+    rocblas_precision_complex_single = 154,
+    rocblas_precision_complex_double = 155
+} rocblas_precision;
 
-
-
-
-    /* ============================================================================================ */
-    /**
-     *   @brief rocblas status codes definition
-     */
-    typedef enum rocblas_status_ {
-        rocblas_status_success          = 0, /**< success */
-        rocblas_status_invalid_handle   = 1, /**< handle not initialized, invalid or null */
-        rocblas_status_not_implemented  = 2, /**< function is not implemented */
-        rocblas_status_invalid_pointer  = 3, /**< invalid pointer parameter */
-        rocblas_status_invalid_size     = 4, /**< invalid size parameter */
-        rocblas_status_memory_error     = 5, /**< failed internal memory allocation, copy or dealloc */
-        rocblas_status_internal_error   = 6, /**< other internal library failure */
-    } rocblas_status;
-
-
-    /*! \brief Indicates the precision width of data stored in a blas type. */
-    typedef enum rocblas_precision_ {
-      rocblas_precision_half            = 150,
-      rocblas_precision_single          = 151,
-      rocblas_precision_double          = 152,
-      rocblas_precision_complex_half    = 153,
-      rocblas_precision_complex_single  = 154,
-      rocblas_precision_complex_double  = 155
-    } rocblas_precision;
-
-
-    /*! \brief Indicates the pointer is device pointer or host pointer */
-    typedef enum rocblas_pointer_mode_ {
-      rocblas_pointer_mode_host   = 0,
-      rocblas_pointer_mode_device = 1
-    } rocblas_pointer_mode;
+/*! \brief Indicates the pointer is device pointer or host pointer */
+typedef enum rocblas_pointer_mode_ {
+    rocblas_pointer_mode_host   = 0,
+    rocblas_pointer_mode_device = 1
+} rocblas_pointer_mode;
 
 #ifdef __cplusplus
 }

--- a/library/include/rocblas-version.h.in
+++ b/library/include/rocblas-version.h.in
@@ -4,7 +4,7 @@
 
 /* the configured version and settings
  */
-#define rocblasVersionMajor @rocblas_VERSION_MAJOR@
-#define rocblaseVersionMinor @rocblas_VERSION_MINOR@
-#define rocblasVersionPatch @rocblas_VERSION_PATCH@
-#define rocblasVersionTweak @rocblas_VERSION_TWEAK@
+#define rocblasVersionMajor @rocblas_VERSION_MAJOR @
+#define rocblaseVersionMinor @rocblas_VERSION_MINOR @
+#define rocblasVersionPatch @rocblas_VERSION_PATCH @
+#define rocblasVersionTweak @rocblas_VERSION_TWEAK @

--- a/library/src/blas1/device_template.h
+++ b/library/src/blas1/device_template.h
@@ -1,10 +1,9 @@
 
-    /*
-     * ===========================================================================
-     *    This file provide common device function used in various BLAS routines
-     * ===========================================================================
-     */
-
+/*
+ * ===========================================================================
+ *    This file provide common device function used in various BLAS routines
+ * ===========================================================================
+ */
 
 /*! \brief parallel reduction: sum
 
@@ -19,22 +18,91 @@
               usually x is stored in shared memory;
               x[0] store the final result.
     ********************************************************************/
-template< rocblas_int n, typename T >
-__device__ void
-rocblas_sum_reduce(rocblas_int tx, T* x )
+template <rocblas_int n, typename T>
+__device__ void rocblas_sum_reduce(rocblas_int tx, T* x)
 {
     __syncthreads();
-    if ( n >  512 ) { if ( tx <  512 && tx +  512 < n ) { x[tx] += x[tx+ 512]; }  __syncthreads(); }
-    if ( n >  256 ) { if ( tx <  256 && tx +  256 < n ) { x[tx] += x[tx+ 256]; }  __syncthreads(); }
-    if ( n >  128 ) { if ( tx <  128 && tx +  128 < n ) { x[tx] += x[tx+ 128]; }  __syncthreads(); }
+    if(n > 512)
+    {
+        if(tx < 512 && tx + 512 < n)
+        {
+            x[tx] += x[tx + 512];
+        }
+        __syncthreads();
+    }
+    if(n > 256)
+    {
+        if(tx < 256 && tx + 256 < n)
+        {
+            x[tx] += x[tx + 256];
+        }
+        __syncthreads();
+    }
+    if(n > 128)
+    {
+        if(tx < 128 && tx + 128 < n)
+        {
+            x[tx] += x[tx + 128];
+        }
+        __syncthreads();
+    }
 
-    if ( n >   64 ) { if ( tx <   64 && tx +   64 < n ) { x[tx] += x[tx+  64]; }  __syncthreads(); }
-    if ( n >   32 ) { if ( tx <   32 && tx +   32 < n ) { x[tx] += x[tx+  32]; }  __syncthreads(); }
-    if ( n >   16 ) { if ( tx <   16 && tx +   16 < n ) { x[tx] += x[tx+  16]; }  __syncthreads(); }
-    if ( n >    8 ) { if ( tx <    8 && tx +    8 < n ) { x[tx] += x[tx+   8]; }  __syncthreads(); }
-    if ( n >    4 ) { if ( tx <    4 && tx +    4 < n ) { x[tx] += x[tx+   4]; }  __syncthreads(); }
-    if ( n >    2 ) { if ( tx <    2 && tx +    2 < n ) { x[tx] += x[tx+   2]; }  __syncthreads(); }
-    if ( n >    1 ) { if ( tx <    1 && tx +    1 < n ) { x[tx] += x[tx+   1]; }  __syncthreads(); }
+    if(n > 64)
+    {
+        if(tx < 64 && tx + 64 < n)
+        {
+            x[tx] += x[tx + 64];
+        }
+        __syncthreads();
+    }
+    if(n > 32)
+    {
+        if(tx < 32 && tx + 32 < n)
+        {
+            x[tx] += x[tx + 32];
+        }
+        __syncthreads();
+    }
+    if(n > 16)
+    {
+        if(tx < 16 && tx + 16 < n)
+        {
+            x[tx] += x[tx + 16];
+        }
+        __syncthreads();
+    }
+    if(n > 8)
+    {
+        if(tx < 8 && tx + 8 < n)
+        {
+            x[tx] += x[tx + 8];
+        }
+        __syncthreads();
+    }
+    if(n > 4)
+    {
+        if(tx < 4 && tx + 4 < n)
+        {
+            x[tx] += x[tx + 4];
+        }
+        __syncthreads();
+    }
+    if(n > 2)
+    {
+        if(tx < 2 && tx + 2 < n)
+        {
+            x[tx] += x[tx + 2];
+        }
+        __syncthreads();
+    }
+    if(n > 1)
+    {
+        if(tx < 1 && tx + 1 < n)
+        {
+            x[tx] += x[tx + 1];
+        }
+        __syncthreads();
+    }
 }
 // end sum_reduce
 
@@ -52,22 +120,91 @@ rocblas_sum_reduce(rocblas_int tx, T* x )
               x[0] store the final result.
     ********************************************************************/
 
-template< rocblas_int n, typename T >
-__device__ void
-rocblas_min_reduce(rocblas_int tx, T* x )
+template <rocblas_int n, typename T>
+__device__ void rocblas_min_reduce(rocblas_int tx, T* x)
 {
     __syncthreads();
-    if ( n >  512 ) { if ( tx <  512 && tx +  512 < n ) { x[tx] = min( x[tx], x[tx+ 512] ); }  __syncthreads(); }
-    if ( n >  256 ) { if ( tx <  256 && tx +  256 < n ) { x[tx] = min( x[tx], x[tx+ 256] ); }  __syncthreads(); }
-    if ( n >  128 ) { if ( tx <  128 && tx +  128 < n ) { x[tx] = min( x[tx], x[tx+ 128] ); }  __syncthreads(); }
+    if(n > 512)
+    {
+        if(tx < 512 && tx + 512 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 512]);
+        }
+        __syncthreads();
+    }
+    if(n > 256)
+    {
+        if(tx < 256 && tx + 256 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 256]);
+        }
+        __syncthreads();
+    }
+    if(n > 128)
+    {
+        if(tx < 128 && tx + 128 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 128]);
+        }
+        __syncthreads();
+    }
 
-    if ( n >   64 ) { if ( tx <   64 && tx +   64 < n ) { x[tx] = min( x[tx], x[tx+  64] ); }  __syncthreads(); }
-    if ( n >   32 ) { if ( tx <   32 && tx +   32 < n ) { x[tx] = min( x[tx], x[tx+  32] ); }  __syncthreads(); }
-    if ( n >   16 ) { if ( tx <   16 && tx +   16 < n ) { x[tx] = min( x[tx], x[tx+  16] ); }  __syncthreads(); }
-    if ( n >    8 ) { if ( tx <    8 && tx +    8 < n ) { x[tx] = min( x[tx], x[tx+   8] ); }  __syncthreads(); }
-    if ( n >    4 ) { if ( tx <    4 && tx +    4 < n ) { x[tx] = min( x[tx], x[tx+   4] ); }  __syncthreads(); }
-    if ( n >    2 ) { if ( tx <    2 && tx +    2 < n ) { x[tx] = min( x[tx], x[tx+   2] ); }  __syncthreads(); }
-    if ( n >    1 ) { if ( tx <    1 && tx +    1 < n ) { x[tx] = min( x[tx], x[tx+   1] ); }  __syncthreads(); }
+    if(n > 64)
+    {
+        if(tx < 64 && tx + 64 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 64]);
+        }
+        __syncthreads();
+    }
+    if(n > 32)
+    {
+        if(tx < 32 && tx + 32 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 32]);
+        }
+        __syncthreads();
+    }
+    if(n > 16)
+    {
+        if(tx < 16 && tx + 16 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 16]);
+        }
+        __syncthreads();
+    }
+    if(n > 8)
+    {
+        if(tx < 8 && tx + 8 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 8]);
+        }
+        __syncthreads();
+    }
+    if(n > 4)
+    {
+        if(tx < 4 && tx + 4 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 4]);
+        }
+        __syncthreads();
+    }
+    if(n > 2)
+    {
+        if(tx < 2 && tx + 2 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 2]);
+        }
+        __syncthreads();
+    }
+    if(n > 1)
+    {
+        if(tx < 1 && tx + 1 < n)
+        {
+            x[tx] = min(x[tx], x[tx + 1]);
+        }
+        __syncthreads();
+    }
 }
 // end min_reduce
 
@@ -84,25 +221,93 @@ rocblas_min_reduce(rocblas_int tx, T* x )
               usually x is stored in shared memory;
               x[0] store the final result.
     ********************************************************************/
-template< rocblas_int n, typename T >
-__device__ void
-rocblas_max_reduce(rocblas_int tx, T* x)
+template <rocblas_int n, typename T>
+__device__ void rocblas_max_reduce(rocblas_int tx, T* x)
 {
     __syncthreads();
-    if ( n >  512 ) { if ( tx <  512 && tx +  512 < n ) { x[tx] = max( x[tx], x[tx+ 512] ); }  __syncthreads(); }
-    if ( n >  256 ) { if ( tx <  256 && tx +  256 < n ) { x[tx] = max( x[tx], x[tx+ 256] ); }  __syncthreads(); }
-    if ( n >  128 ) { if ( tx <  128 && tx +  128 < n ) { x[tx] = max( x[tx], x[tx+ 128] ); }  __syncthreads(); }
+    if(n > 512)
+    {
+        if(tx < 512 && tx + 512 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 512]);
+        }
+        __syncthreads();
+    }
+    if(n > 256)
+    {
+        if(tx < 256 && tx + 256 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 256]);
+        }
+        __syncthreads();
+    }
+    if(n > 128)
+    {
+        if(tx < 128 && tx + 128 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 128]);
+        }
+        __syncthreads();
+    }
 
-    if ( n >   64 ) { if ( tx <   64 && tx +   64 < n ) { x[tx] = max( x[tx], x[tx+  64] ); }  __syncthreads(); }
-    if ( n >   32 ) { if ( tx <   32 && tx +   32 < n ) { x[tx] = max( x[tx], x[tx+  32] ); }  __syncthreads(); }
-    if ( n >   16 ) { if ( tx <   16 && tx +   16 < n ) { x[tx] = max( x[tx], x[tx+  16] ); }  __syncthreads(); }
-    if ( n >    8 ) { if ( tx <    8 && tx +    8 < n ) { x[tx] = max( x[tx], x[tx+   8] ); }  __syncthreads(); }
-    if ( n >    4 ) { if ( tx <    4 && tx +    4 < n ) { x[tx] = max( x[tx], x[tx+   4] ); }  __syncthreads(); }
-    if ( n >    2 ) { if ( tx <    2 && tx +    2 < n ) { x[tx] = max( x[tx], x[tx+   2] ); }  __syncthreads(); }
-    if ( n >    1 ) { if ( tx <    1 && tx +    1 < n ) { x[tx] = max( x[tx], x[tx+   1] ); }  __syncthreads(); }
+    if(n > 64)
+    {
+        if(tx < 64 && tx + 64 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 64]);
+        }
+        __syncthreads();
+    }
+    if(n > 32)
+    {
+        if(tx < 32 && tx + 32 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 32]);
+        }
+        __syncthreads();
+    }
+    if(n > 16)
+    {
+        if(tx < 16 && tx + 16 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 16]);
+        }
+        __syncthreads();
+    }
+    if(n > 8)
+    {
+        if(tx < 8 && tx + 8 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 8]);
+        }
+        __syncthreads();
+    }
+    if(n > 4)
+    {
+        if(tx < 4 && tx + 4 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 4]);
+        }
+        __syncthreads();
+    }
+    if(n > 2)
+    {
+        if(tx < 2 && tx + 2 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 2]);
+        }
+        __syncthreads();
+    }
+    if(n > 1)
+    {
+        if(tx < 1 && tx + 1 < n)
+        {
+            x[tx] = max(x[tx], x[tx + 1]);
+        }
+        __syncthreads();
+    }
 }
 // end max_reduce
-
 
 /*! \brief parallel reduction: minid
 
@@ -125,53 +330,181 @@ rocblas_max_reduce(rocblas_int tx, T* x)
               index[0] stores the final result
 
     ********************************************************************/
-template< rocblas_int n, typename T>
-__device__ void
-rocblas_minid_reduce(rocblas_int tx, T* x, rocblas_int* index)
+template <rocblas_int n, typename T>
+__device__ void rocblas_minid_reduce(rocblas_int tx, T* x, rocblas_int* index)
 {
     __syncthreads();
-    if ( n >  512 ) { if ( tx <  512 && tx +  512 < n ) {
-        if ( x[tx] == x[tx+ 512] ) { index[tx] = min(index[tx], index[tx+512]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+ 512] ) { index[tx] = index[tx+ 512]; x[tx] = x[tx+ 512]; } }  __syncthreads(); }
+    if(n > 512)
+    {
+        if(tx < 512 && tx + 512 < n)
+        {
+            if(x[tx] == x[tx + 512])
+            {
+                index[tx] = min(index[tx], index[tx + 512]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 512])
+            {
+                index[tx] = index[tx + 512];
+                x[tx]     = x[tx + 512];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >  256 ) { if ( tx <  256 && tx +  256 < n ) {
-        if ( x[tx] == x[tx+ 256] ) { index[tx] = min(index[tx], index[tx+256]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+ 256] ) { index[tx] = index[tx+ 256]; x[tx] = x[tx+ 256]; } }  __syncthreads(); }
+    if(n > 256)
+    {
+        if(tx < 256 && tx + 256 < n)
+        {
+            if(x[tx] == x[tx + 256])
+            {
+                index[tx] = min(index[tx], index[tx + 256]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 256])
+            {
+                index[tx] = index[tx + 256];
+                x[tx]     = x[tx + 256];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >  128 ) { if ( tx <  128 && tx +  128 < n ) {
-        if ( x[tx] == x[tx+ 128] ) { index[tx] = min(index[tx], index[tx+128]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+ 128] ) { index[tx] = index[tx+ 128]; x[tx] = x[tx+ 128]; } }  __syncthreads(); }
+    if(n > 128)
+    {
+        if(tx < 128 && tx + 128 < n)
+        {
+            if(x[tx] == x[tx + 128])
+            {
+                index[tx] = min(index[tx], index[tx + 128]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 128])
+            {
+                index[tx] = index[tx + 128];
+                x[tx]     = x[tx + 128];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   64 ) { if ( tx <   64 && tx +   64 < n ) {
-        if ( x[tx] == x[tx+ 64] ) { index[tx] = min(index[tx], index[tx+64]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+  64] ) { index[tx] = index[tx+  64]; x[tx] = x[tx+  64]; } }  __syncthreads(); }
+    if(n > 64)
+    {
+        if(tx < 64 && tx + 64 < n)
+        {
+            if(x[tx] == x[tx + 64])
+            {
+                index[tx] = min(index[tx], index[tx + 64]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 64])
+            {
+                index[tx] = index[tx + 64];
+                x[tx]     = x[tx + 64];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   32 ) { if ( tx <   32 && tx +   32 < n ) {
-        if ( x[tx] == x[tx+ 32] ) { index[tx] = min(index[tx], index[tx+32]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+  32] ) { index[tx] = index[tx+  32]; x[tx] = x[tx+  32]; } }  __syncthreads(); }
+    if(n > 32)
+    {
+        if(tx < 32 && tx + 32 < n)
+        {
+            if(x[tx] == x[tx + 32])
+            {
+                index[tx] = min(index[tx], index[tx + 32]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 32])
+            {
+                index[tx] = index[tx + 32];
+                x[tx]     = x[tx + 32];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   16 ) { if ( tx <   16 && tx +   16 < n ) {
-        if ( x[tx] == x[tx+ 16] ) { index[tx] = min(index[tx], index[tx+16]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+  16] ) { index[tx] = index[tx+  16]; x[tx] = x[tx+  16]; } }  __syncthreads(); }
+    if(n > 16)
+    {
+        if(tx < 16 && tx + 16 < n)
+        {
+            if(x[tx] == x[tx + 16])
+            {
+                index[tx] = min(index[tx], index[tx + 16]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 16])
+            {
+                index[tx] = index[tx + 16];
+                x[tx]     = x[tx + 16];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   8 ) { if ( tx <   8 && tx +   8 < n ) {
-        if ( x[tx] == x[tx+ 8] ) { index[tx] = min(index[tx], index[tx+8]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+  8] ) { index[tx] = index[tx+  8]; x[tx] = x[tx+  8]; } }  __syncthreads(); }
+    if(n > 8)
+    {
+        if(tx < 8 && tx + 8 < n)
+        {
+            if(x[tx] == x[tx + 8])
+            {
+                index[tx] = min(index[tx], index[tx + 8]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 8])
+            {
+                index[tx] = index[tx + 8];
+                x[tx]     = x[tx + 8];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   4 ) { if ( tx <   4 && tx +   4 < n ) {
-        if ( x[tx] == x[tx+ 4] ) { index[tx] = min(index[tx], index[tx+4]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+  4] ) { index[tx] = index[tx+  4]; x[tx] = x[tx+  4]; } }  __syncthreads(); }
+    if(n > 4)
+    {
+        if(tx < 4 && tx + 4 < n)
+        {
+            if(x[tx] == x[tx + 4])
+            {
+                index[tx] = min(index[tx], index[tx + 4]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 4])
+            {
+                index[tx] = index[tx + 4];
+                x[tx]     = x[tx + 4];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   2 ) { if ( tx <   2 && tx +   2 < n ) {
-        if ( x[tx] == x[tx+ 2] ) { index[tx] = min(index[tx], index[tx+2]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+  2] ) { index[tx] = index[tx+  2]; x[tx] = x[tx+  2]; } }  __syncthreads(); }
+    if(n > 2)
+    {
+        if(tx < 2 && tx + 2 < n)
+        {
+            if(x[tx] == x[tx + 2])
+            {
+                index[tx] = min(index[tx], index[tx + 2]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 2])
+            {
+                index[tx] = index[tx + 2];
+                x[tx]     = x[tx + 2];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   1 ) { if ( tx <   1 && tx +   1 < n ) {
-        if ( x[tx] == x[tx+ 1] ) { index[tx] = min(index[tx], index[tx+1]);}// if equal take the smaller index
-        else if ( x[tx] > x[tx+  1] ) { index[tx] = index[tx+  1]; x[tx] = x[tx+  1]; } }  __syncthreads(); }
+    if(n > 1)
+    {
+        if(tx < 1 && tx + 1 < n)
+        {
+            if(x[tx] == x[tx + 1])
+            {
+                index[tx] = min(index[tx], index[tx + 1]);
+            } // if equal take the smaller index
+            else if(x[tx] > x[tx + 1])
+            {
+                index[tx] = index[tx + 1];
+                x[tx]     = x[tx + 1];
+            }
+        }
+        __syncthreads();
+    }
 }
 // end minid_reduce
-
 
 /*! \brief parallel reduction: maxid
 
@@ -194,49 +527,178 @@ rocblas_minid_reduce(rocblas_int tx, T* x, rocblas_int* index)
               index[0] stores the final result
 
     ********************************************************************/
-template< rocblas_int n, typename T>
-__device__ void
-rocblas_maxid_reduce(rocblas_int tx, T* x, rocblas_int* index)
+template <rocblas_int n, typename T>
+__device__ void rocblas_maxid_reduce(rocblas_int tx, T* x, rocblas_int* index)
 {
     __syncthreads();
-    if ( n >  512 ) { if ( tx <  512 && tx +  512 < n ) {
-        if ( x[tx] == x[tx+ 512] ) { index[tx] = min(index[tx], index[tx+512]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+ 512] ) { index[tx] = index[tx+ 512]; x[tx] = x[tx+ 512]; } }  __syncthreads(); }
+    if(n > 512)
+    {
+        if(tx < 512 && tx + 512 < n)
+        {
+            if(x[tx] == x[tx + 512])
+            {
+                index[tx] = min(index[tx], index[tx + 512]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 512])
+            {
+                index[tx] = index[tx + 512];
+                x[tx]     = x[tx + 512];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >  256 ) { if ( tx <  256 && tx +  256 < n ) {
-        if ( x[tx] == x[tx+ 256] ) { index[tx] = min(index[tx], index[tx+256]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+ 256] ) { index[tx] = index[tx+ 256]; x[tx] = x[tx+ 256]; } }  __syncthreads(); }
+    if(n > 256)
+    {
+        if(tx < 256 && tx + 256 < n)
+        {
+            if(x[tx] == x[tx + 256])
+            {
+                index[tx] = min(index[tx], index[tx + 256]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 256])
+            {
+                index[tx] = index[tx + 256];
+                x[tx]     = x[tx + 256];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >  128 ) { if ( tx <  128 && tx +  128 < n ) {
-        if ( x[tx] == x[tx+ 128] ) { index[tx] = min(index[tx], index[tx+128]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+ 128] ) { index[tx] = index[tx+ 128]; x[tx] = x[tx+ 128]; } }  __syncthreads(); }
+    if(n > 128)
+    {
+        if(tx < 128 && tx + 128 < n)
+        {
+            if(x[tx] == x[tx + 128])
+            {
+                index[tx] = min(index[tx], index[tx + 128]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 128])
+            {
+                index[tx] = index[tx + 128];
+                x[tx]     = x[tx + 128];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   64 ) { if ( tx <   64 && tx +   64 < n ) {
-        if ( x[tx] == x[tx+ 64] ) { index[tx] = min(index[tx], index[tx+64]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+  64] ) { index[tx] = index[tx+  64]; x[tx] = x[tx+  64]; } }  __syncthreads(); }
+    if(n > 64)
+    {
+        if(tx < 64 && tx + 64 < n)
+        {
+            if(x[tx] == x[tx + 64])
+            {
+                index[tx] = min(index[tx], index[tx + 64]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 64])
+            {
+                index[tx] = index[tx + 64];
+                x[tx]     = x[tx + 64];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   32 ) { if ( tx <   32 && tx +   32 < n ) {
-        if ( x[tx] == x[tx+ 32] ) { index[tx] = min(index[tx], index[tx+32]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+  32] ) { index[tx] = index[tx+  32]; x[tx] = x[tx+  32]; } }  __syncthreads(); }
+    if(n > 32)
+    {
+        if(tx < 32 && tx + 32 < n)
+        {
+            if(x[tx] == x[tx + 32])
+            {
+                index[tx] = min(index[tx], index[tx + 32]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 32])
+            {
+                index[tx] = index[tx + 32];
+                x[tx]     = x[tx + 32];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   16 ) { if ( tx <   16 && tx +   16 < n ) {
-        if ( x[tx] == x[tx+ 16] ) { index[tx] = min(index[tx], index[tx+16]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+  16] ) { index[tx] = index[tx+  16]; x[tx] = x[tx+  16]; } }  __syncthreads(); }
+    if(n > 16)
+    {
+        if(tx < 16 && tx + 16 < n)
+        {
+            if(x[tx] == x[tx + 16])
+            {
+                index[tx] = min(index[tx], index[tx + 16]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 16])
+            {
+                index[tx] = index[tx + 16];
+                x[tx]     = x[tx + 16];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   8 ) { if ( tx <   8 && tx +   8 < n ) {
-        if ( x[tx] == x[tx+ 8] ) { index[tx] = min(index[tx], index[tx+8]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+  8] ) { index[tx] = index[tx+  8]; x[tx] = x[tx+  8]; } }  __syncthreads(); }
+    if(n > 8)
+    {
+        if(tx < 8 && tx + 8 < n)
+        {
+            if(x[tx] == x[tx + 8])
+            {
+                index[tx] = min(index[tx], index[tx + 8]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 8])
+            {
+                index[tx] = index[tx + 8];
+                x[tx]     = x[tx + 8];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   4 ) { if ( tx <   4 && tx +   4 < n ) {
-        if ( x[tx] == x[tx+ 4] ) { index[tx] = min(index[tx], index[tx+4]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+  4] ) { index[tx] = index[tx+  4]; x[tx] = x[tx+  4]; } }  __syncthreads(); }
+    if(n > 4)
+    {
+        if(tx < 4 && tx + 4 < n)
+        {
+            if(x[tx] == x[tx + 4])
+            {
+                index[tx] = min(index[tx], index[tx + 4]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 4])
+            {
+                index[tx] = index[tx + 4];
+                x[tx]     = x[tx + 4];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   2 ) { if ( tx <   2 && tx +   2 < n ) {
-        if ( x[tx] == x[tx+ 2] ) { index[tx] = min(index[tx], index[tx+2]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+  2] ) { index[tx] = index[tx+  2]; x[tx] = x[tx+  2]; } }  __syncthreads(); }
+    if(n > 2)
+    {
+        if(tx < 2 && tx + 2 < n)
+        {
+            if(x[tx] == x[tx + 2])
+            {
+                index[tx] = min(index[tx], index[tx + 2]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 2])
+            {
+                index[tx] = index[tx + 2];
+                x[tx]     = x[tx + 2];
+            }
+        }
+        __syncthreads();
+    }
 
-    if ( n >   1 ) { if ( tx <   1 && tx +   1 < n ) {
-        if ( x[tx] == x[tx+ 1] ) { index[tx] = min(index[tx], index[tx+1]);}// if equal take the smaller index
-        else if ( x[tx] < x[tx+  1] ) { index[tx] = index[tx+  1]; x[tx] = x[tx+  1]; } }  __syncthreads(); }
+    if(n > 1)
+    {
+        if(tx < 1 && tx + 1 < n)
+        {
+            if(x[tx] == x[tx + 1])
+            {
+                index[tx] = min(index[tx], index[tx + 1]);
+            } // if equal take the smaller index
+            else if(x[tx] < x[tx + 1])
+            {
+                index[tx] = index[tx + 1];
+                x[tx]     = x[tx + 1];
+            }
+        }
+        __syncthreads();
+    }
 }
 // end maxid_reduce

--- a/library/src/blas1/fetch_template.cpp
+++ b/library/src/blas1/fetch_template.cpp
@@ -1,72 +1,60 @@
 /* ************************************************************************
  * Copyright 2016 Advanced Micro Devices, Inc.
  * ************************************************************************ */
-    /*
+/*
 
-     * ===========================================================================
-     *    This file provide common device function used in various BLAS routines
-     * ===========================================================================
-     */
-
+ * ===========================================================================
+ *    This file provide common device function used in various BLAS routines
+ * ===========================================================================
+ */
 
 #include "rocblas.h"
 #include "fetch_template.h"
 
-template<>
- __device__ float
-fetch_real<float, float>(float A)
+template <>
+__device__ float fetch_real<float, float>(float A)
 {
     return A;
 }
 
-template<>
- __device__ float
-fetch_imag<float, float>(float A)
+template <>
+__device__ float fetch_imag<float, float>(float A)
 {
     return 0.0;
 }
 
-
-template<>
- __device__ double
-fetch_real<double, double>(double A)
+template <>
+__device__ double fetch_real<double, double>(double A)
 {
     return A;
 }
 
-template<>
- __device__ double
-fetch_imag<double, double>(double A)
+template <>
+__device__ double fetch_imag<double, double>(double A)
 {
     return 0.0;
 }
 
-
-template<>
-__device__ float
-fetch_real<rocblas_float_complex, float>(rocblas_float_complex A)
+template <>
+__device__ float fetch_real<rocblas_float_complex, float>(rocblas_float_complex A)
 {
     return A.x;
 }
 
-template<>
-__device__ float
-fetch_imag<rocblas_float_complex, float>(rocblas_float_complex A)
+template <>
+__device__ float fetch_imag<rocblas_float_complex, float>(rocblas_float_complex A)
 {
     return A.y;
 }
 
-
-template<>
-__device__ double
-fetch_real<rocblas_double_complex, double>(rocblas_double_complex A)
+template <>
+__device__ double fetch_real<rocblas_double_complex, double>(rocblas_double_complex A)
 {
     return A.x;
 }
 
-template<>
-__device__ double
-fetch_imag<rocblas_double_complex, double>(rocblas_double_complex A)
+template <>
+__device__ double fetch_imag<rocblas_double_complex, double>(rocblas_double_complex A)
 {
     return A.y;
 }

--- a/library/src/blas1/fetch_template.h
+++ b/library/src/blas1/fetch_template.h
@@ -1,21 +1,18 @@
 
-    /*
-     * ===========================================================================
-     *    This file provide common device function used in various BLAS routines
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    This file provide common device function used in various BLAS routines
+ * ===========================================================================
+ */
 
 #pragma once
 #ifndef _FETCH_TEMPLATE_
 #define _FETCH_TEMPLATE_
 
-template<typename T1, typename T2>
-__device__ T2
-fetch_real(T1 A);
+template <typename T1, typename T2>
+__device__ T2 fetch_real(T1 A);
 
-template<typename T1, typename T2>
-__device__ T2
-fetch_imag(T1 A);
-
+template <typename T1, typename T2>
+__device__ T2 fetch_imag(T1 A);
 
 #endif

--- a/library/src/blas1/rocblas_amax.cpp
+++ b/library/src/blas1/rocblas_amax.cpp
@@ -4,7 +4,7 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
@@ -12,13 +12,13 @@
 #include "rocblas_unique_ptr.hpp"
 #include "handle.h"
 
-template<typename T1, typename T2, rocblas_int NB>
-__global__ void
-iamax_kernel_part1(hipLaunchParm lp,
-    rocblas_int n,
-    const T1* x, rocblas_int incx,
-    T2* workspace,
-    rocblas_int* workspace_index)
+template <typename T1, typename T2, rocblas_int NB>
+__global__ void iamax_kernel_part1(hipLaunchParm lp,
+                                   rocblas_int n,
+                                   const T1* x,
+                                   rocblas_int incx,
+                                   T2* workspace,
+                                   rocblas_int* workspace_index)
 {
     rocblas_int tx  = hipThreadIdx_x;
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -26,57 +26,55 @@ iamax_kernel_part1(hipLaunchParm lp,
     __shared__ T2 shared_tep[NB];
     __shared__ rocblas_int index[NB];
 
-    //bound
-    if (tid < n) 
+    // bound
+    if(tid < n)
     {
-        T2 real = fetch_real<T1, T2>(x[tid * incx]);
-        T2 imag = fetch_imag<T1, T2>(x[tid * incx]);
-        shared_tep[tx] =  fabs(real) + fabs(imag);
-        index[tx] = tid;
+        T2 real        = fetch_real<T1, T2>(x[tid * incx]);
+        T2 imag        = fetch_imag<T1, T2>(x[tid * incx]);
+        shared_tep[tx] = fabs(real) + fabs(imag);
+        index[tx]      = tid;
     }
     else
-    {   //pad with zero
-        shared_tep[tx] =  0.0;
-        index[tx] = -1;
+    { // pad with zero
+        shared_tep[tx] = 0.0;
+        index[tx]      = -1;
     }
 
     rocblas_maxid_reduce<NB, T2>(tx, shared_tep, index);
 
-    if (tx == 0) 
+    if(tx == 0)
     {
-        workspace[hipBlockIdx_x] = shared_tep[0];
+        workspace[hipBlockIdx_x]       = shared_tep[0];
         workspace_index[hipBlockIdx_x] = index[0];
     }
 }
 
-
-template<typename T, rocblas_int NB, rocblas_int flag>
-__global__ void
-iamax_kernel_part2(hipLaunchParm lp,
-    rocblas_int n,
-    T* workspace,
-    rocblas_int* workspace_index,
-    rocblas_int* result)
+template <typename T, rocblas_int NB, rocblas_int flag>
+__global__ void iamax_kernel_part2(hipLaunchParm lp,
+                                   rocblas_int n,
+                                   T* workspace,
+                                   rocblas_int* workspace_index,
+                                   rocblas_int* result)
 {
-    rocblas_int tx  = hipThreadIdx_x;
+    rocblas_int tx = hipThreadIdx_x;
 
     __shared__ T shared_tep[NB];
     __shared__ rocblas_int index[NB];
 
     shared_tep[tx] = 0.0;
-    index[tx] = -1;
+    index[tx]      = -1;
 
-    //bound, loop
-    for(rocblas_int i=tx; i<n; i+=NB)
+    // bound, loop
+    for(rocblas_int i = tx; i < n; i += NB)
     {
-        if( shared_tep[tx] == workspace[i] )
+        if(shared_tep[tx] == workspace[i])
         {
-            index[tx] = min(index[tx], workspace_index[i]); //if equal take the smaller index
+            index[tx] = min(index[tx], workspace_index[i]); // if equal take the smaller index
         }
-        else if (shared_tep[tx] < workspace[i])             // if smaller, then take the bigger one
-        { 
+        else if(shared_tep[tx] < workspace[i]) // if smaller, then take the bigger one
+        {
             shared_tep[tx] = workspace[i];
-            index[tx] = workspace_index[i];
+            index[tx]      = workspace_index[i];
         }
     }
 
@@ -88,37 +86,39 @@ iamax_kernel_part2(hipLaunchParm lp,
     {
         if(flag)
         {
-            //flag == 1, write the result on device memory
+            // flag == 1, write the result on device memory
             // return Fortran 1 based index as in BLAS standard, not C zero based index
-            *result = index[0] + 1; //result[0] works, too
+            *result = index[0] + 1; // result[0] works, too
         }
-        else  //if flag == 0, cannot write to result which is in host memory, instead write to worksapce
-        { 
+        else // if flag == 0, cannot write to result which is in host memory, instead write to
+             // worksapce
+        {
             workspace_index[0] = index[0];
         }
     }
 }
 
-
-//HIP support up to 1024 threads/work itmes per thread block/work group
+// HIP support up to 1024 threads/work itmes per thread block/work group
 #define NB_X 1024
 
-//assume workspace has already been allocated, recommened for repeated calling of iamax product routine
-template<typename T1, typename T2>
-rocblas_status
-rocblas_iamax_template_workspace(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    rocblas_int *result,
-    T2 *workspace,
-    rocblas_int *workspace_index,
-    rocblas_int lworkspace)
+// assume workspace has already been allocated, recommened for repeated calling of iamax product
+// routine
+template <typename T1, typename T2>
+rocblas_status rocblas_iamax_template_workspace(rocblas_handle handle,
+                                                rocblas_int n,
+                                                const T1* x,
+                                                rocblas_int incx,
+                                                rocblas_int* result,
+                                                T2* workspace,
+                                                rocblas_int* workspace_index,
+                                                rocblas_int lworkspace)
 {
-    rocblas_int blocks = (n-1)/ NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
-    //At least two kernels are needed to finish the reduction
-    //kennel 1 write partial result per thread block in workspace, number of partial result is blocks
-    //kernel 2 gather all the partial result in workspace and finish the final reduction.
+    // At least two kernels are needed to finish the reduction
+    // kennel 1 write partial result per thread block in workspace, number of partial result is
+    // blocks
+    // kernel 2 gather all the partial result in workspace and finish the final reduction.
 
     if(lworkspace < blocks)
     {
@@ -132,27 +132,51 @@ rocblas_iamax_template_workspace(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    hipLaunchKernel(HIP_KERNEL_NAME(iamax_kernel_part1<T1, T2, NB_X>), dim3(grid), dim3(threads), 0, rocblas_stream,
-                                                                      n, x, incx, workspace, workspace_index);
+    hipLaunchKernel(HIP_KERNEL_NAME(iamax_kernel_part1<T1, T2, NB_X>),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    n,
+                    x,
+                    incx,
+                    workspace,
+                    workspace_index);
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        //the last argument 1 indicate the result is a device pointer, not memcpy is required
-        hipLaunchKernel(HIP_KERNEL_NAME(iamax_kernel_part2<T2, NB_X, 1>), dim3(1,1,1), dim3(threads), 0, rocblas_stream,
-                                                                         blocks, workspace, workspace_index, result);
+        // the last argument 1 indicate the result is a device pointer, not memcpy is required
+        hipLaunchKernel(HIP_KERNEL_NAME(iamax_kernel_part2<T2, NB_X, 1>),
+                        dim3(1, 1, 1),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        blocks,
+                        workspace,
+                        workspace_index,
+                        result);
     }
     else
     {
-        //the last argument 0 indicate the result is a host pointer
-        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory copy is required
-        //printf("it is a host pointer\n");
+        // the last argument 0 indicate the result is a host pointer
+        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory
+        // copy is required
+        // printf("it is a host pointer\n");
         // only for blocks > 1, otherwise the final result is already reduced in workspace[0]
-        if ( blocks > 1) 
+        if(blocks > 1)
         {
-            hipLaunchKernel(HIP_KERNEL_NAME(iamax_kernel_part2<T2, NB_X, 0>), dim3(1,1,1), dim3(threads), 0, rocblas_stream,
-                                                                                          blocks, workspace, workspace_index, result);
+            hipLaunchKernel(HIP_KERNEL_NAME(iamax_kernel_part2<T2, NB_X, 0>),
+                            dim3(1, 1, 1),
+                            dim3(threads),
+                            0,
+                            rocblas_stream,
+                            blocks,
+                            workspace,
+                            workspace_index,
+                            result);
         }
-        RETURN_IF_HIP_ERROR(hipMemcpy(result, workspace_index, sizeof(rocblas_int), hipMemcpyDeviceToHost));
+        RETURN_IF_HIP_ERROR(
+            hipMemcpy(result, workspace_index, sizeof(rocblas_int), hipMemcpyDeviceToHost));
 
         // return Fortran 1 based index as in the BLAS standard, not C zero based index
         *result += 1;
@@ -166,7 +190,8 @@ rocblas_iamax_template_workspace(rocblas_handle handle,
 
     \details
     iamax finds the first index of the element of maximum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex vector
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+   vector
 
     @param[in]
     handle    rocblas_handle.
@@ -185,27 +210,24 @@ rocblas_iamax_template_workspace(rocblas_handle handle,
               (Fortran) is used, not 0 based indexing (C).
     ********************************************************************/
 
-//allocate workspace inside this API
-template<typename T1, typename T2>
-rocblas_status
-rocblas_iamax_template(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    rocblas_int *result)
+// allocate workspace inside this API
+template <typename T1, typename T2>
+rocblas_status rocblas_iamax_template(
+    rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, rocblas_int* result)
 {
-    if ( nullptr == x )
+    if(nullptr == x)
         return rocblas_status_invalid_pointer;
-    else if ( nullptr == result )
+    else if(nullptr == result)
         return rocblas_status_invalid_pointer;
-    else if( nullptr == handle )
+    else if(nullptr == handle)
         return rocblas_status_invalid_handle;
 
     /*
      * Quick return if possible.
      */
-    if ( n <= 0 || incx <= 0)
+    if(n <= 0 || incx <= 0)
     {
-        if (rocblas_pointer_mode_device == handle->pointer_mode)
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
         {
             RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(rocblas_int)));
         }
@@ -216,70 +238,68 @@ rocblas_iamax_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    rocblas_int blocks = (n-1) / NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
     rocblas_status status;
 
-    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
+    auto workspace =
+        rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks), rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    auto workspace_index = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
+    auto workspace_index = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),
+                                              rocblas::device_free};
     if(!workspace_index)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_iamax_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), (rocblas_int*)workspace_index.get(), blocks);
+    status = rocblas_iamax_template_workspace<T1, T2>(handle,
+                                                      n,
+                                                      x,
+                                                      incx,
+                                                      result,
+                                                      (T2*)workspace.get(),
+                                                      (rocblas_int*)workspace_index.get(),
+                                                      blocks);
 
     return status;
 }
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-
-extern "C"
-rocblas_status
-rocblas_isamax(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_isamax(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
 {
     return rocblas_iamax_template<float, float>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_idamax(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_idamax(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
 {
     return rocblas_iamax_template<double, double>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_iscamax(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_iscamax(rocblas_handle handle,
+                                          rocblas_int n,
+                                          const rocblas_float_complex* x,
+                                          rocblas_int incx,
+                                          rocblas_int* result)
 {
     return rocblas_iamax_template<rocblas_float_complex, float>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_idzamax(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_idzamax(rocblas_handle handle,
+                                          rocblas_int n,
+                                          const rocblas_double_complex* x,
+                                          rocblas_int incx,
+                                          rocblas_int* result)
 {
     return rocblas_iamax_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }

--- a/library/src/blas1/rocblas_amin.cpp
+++ b/library/src/blas1/rocblas_amin.cpp
@@ -4,7 +4,7 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
@@ -12,13 +12,13 @@
 #include "rocblas_unique_ptr.hpp"
 #include "handle.h"
 
-template<typename T1, typename T2, rocblas_int NB>
-__global__ void
-iamin_kernel_part1(hipLaunchParm lp,
-    rocblas_int n,
-    const T1* x, rocblas_int incx,
-    T2* workspace,
-    rocblas_int* workspace_index)
+template <typename T1, typename T2, rocblas_int NB>
+__global__ void iamin_kernel_part1(hipLaunchParm lp,
+                                   rocblas_int n,
+                                   const T1* x,
+                                   rocblas_int incx,
+                                   T2* workspace,
+                                   rocblas_int* workspace_index)
 {
     rocblas_int tx  = hipThreadIdx_x;
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -26,56 +26,55 @@ iamin_kernel_part1(hipLaunchParm lp,
     __shared__ T2 shared_tep[NB];
     __shared__ rocblas_int index[NB];
 
-    //bound
-    if ( tid < n )
+    // bound
+    if(tid < n)
     {
-        T2 real = fetch_real<T1, T2>(x[tid * incx]);
-        T2 imag = fetch_imag<T1, T2>(x[tid * incx]);
-        shared_tep[tx] =  fabs(real) + fabs(imag);
-        index[tx] = tid;
+        T2 real        = fetch_real<T1, T2>(x[tid * incx]);
+        T2 imag        = fetch_imag<T1, T2>(x[tid * incx]);
+        shared_tep[tx] = fabs(real) + fabs(imag);
+        index[tx]      = tid;
     }
     else
-    {   //pad with zero
-        shared_tep[tx] =  0.0;
-        index[tx] = -1;
+    { // pad with zero
+        shared_tep[tx] = 0.0;
+        index[tx]      = -1;
     }
 
     rocblas_maxid_reduce<NB, T2>(tx, shared_tep, index);
 
     if(tx == 0)
     {
-        workspace[hipBlockIdx_x] = shared_tep[0];
+        workspace[hipBlockIdx_x]       = shared_tep[0];
         workspace_index[hipBlockIdx_x] = index[0];
     }
 }
 
-template<typename T, rocblas_int NB, rocblas_int flag>
-__global__ void
-iamin_kernel_part2(hipLaunchParm lp,
-    rocblas_int n,
-    T* workspace,
-    rocblas_int* workspace_index,
-    rocblas_int* result)
+template <typename T, rocblas_int NB, rocblas_int flag>
+__global__ void iamin_kernel_part2(hipLaunchParm lp,
+                                   rocblas_int n,
+                                   T* workspace,
+                                   rocblas_int* workspace_index,
+                                   rocblas_int* result)
 {
-    rocblas_int tx  = hipThreadIdx_x;
+    rocblas_int tx = hipThreadIdx_x;
 
     __shared__ T shared_tep[NB];
     __shared__ rocblas_int index[NB];
 
     shared_tep[tx] = 0.0;
-    index[tx] = -1;
+    index[tx]      = -1;
 
-    //bound, loop
-    for(rocblas_int i=tx; i<n; i+=NB)
+    // bound, loop
+    for(rocblas_int i = tx; i < n; i += NB)
     {
-        if( shared_tep[tx] == workspace[i] )
+        if(shared_tep[tx] == workspace[i])
         {
-            index[tx] = min(index[tx], workspace_index[i]); //if equal take the smaller index
+            index[tx] = min(index[tx], workspace_index[i]); // if equal take the smaller index
         }
-        else if (shared_tep[tx] < workspace[i]) // if smaller, then take the bigger one
+        else if(shared_tep[tx] < workspace[i]) // if smaller, then take the bigger one
         {
             shared_tep[tx] = workspace[i];
-            index[tx] = workspace_index[i];
+            index[tx]      = workspace_index[i];
         }
     }
 
@@ -87,39 +86,41 @@ iamin_kernel_part2(hipLaunchParm lp,
     {
         if(flag)
         {
-            //flag == 1, write the result on device memory
-            *result = index[0]; //result[0] works, too
+            // flag == 1, write the result on device memory
+            *result = index[0]; // result[0] works, too
         }
-        else //if flag == 0, cannot write to result which is in host memory, instead write to worksapce
+        else // if flag == 0, cannot write to result which is in host memory, instead write to
+             // worksapce
         {
             workspace_index[0] = index[0];
         }
     }
 }
 
-
-//HIP support up to 1024 threads/work itmes per thread block/work group
+// HIP support up to 1024 threads/work itmes per thread block/work group
 #define NB_X 1024
 
-//assume workspace has already been allocated, recommened for repeated calling of iamin product routine
-template<typename T1, typename T2>
-rocblas_status
-rocblas_iamin_template_workspace(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    rocblas_int *result,
-    T2 *workspace,
-    rocblas_int *workspace_index,
-    rocblas_int lworkspace)
+// assume workspace has already been allocated, recommened for repeated calling of iamin product
+// routine
+template <typename T1, typename T2>
+rocblas_status rocblas_iamin_template_workspace(rocblas_handle handle,
+                                                rocblas_int n,
+                                                const T1* x,
+                                                rocblas_int incx,
+                                                rocblas_int* result,
+                                                T2* workspace,
+                                                rocblas_int* workspace_index,
+                                                rocblas_int lworkspace)
 {
 
-    rocblas_int blocks = (n-1)/ NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
-    //At least two kernels are needed to finish the reduction
-    //kennel 1 write partial result per thread block in workspace, number of partial result is blocks
-    //kernel 2 gather all the partial result in workspace and finish the final reduction.
+    // At least two kernels are needed to finish the reduction
+    // kennel 1 write partial result per thread block in workspace, number of partial result is
+    // blocks
+    // kernel 2 gather all the partial result in workspace and finish the final reduction.
 
-    if (lworkspace < blocks)
+    if(lworkspace < blocks)
     {
         printf("size of workspace = %d is too small, allocate at least %d", lworkspace, blocks);
         return rocblas_status_not_implemented;
@@ -131,24 +132,49 @@ rocblas_iamin_template_workspace(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    hipLaunchKernel(HIP_KERNEL_NAME(iamin_kernel_part1<T1, T2, NB_X>), dim3(grid), dim3(threads), 0, rocblas_stream,
-                                                                      n, x, incx, workspace, workspace_index);
+    hipLaunchKernel(HIP_KERNEL_NAME(iamin_kernel_part1<T1, T2, NB_X>),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    n,
+                    x,
+                    incx,
+                    workspace,
+                    workspace_index);
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        //the last argument 1 indicate the result is a device pointer, not memcpy is required
-        hipLaunchKernel(HIP_KERNEL_NAME(iamin_kernel_part2<T2, NB_X, 1>), dim3(1,1,1), dim3(threads), 0, rocblas_stream,
-                                                                         blocks, workspace, workspace_index, result);
+        // the last argument 1 indicate the result is a device pointer, not memcpy is required
+        hipLaunchKernel(HIP_KERNEL_NAME(iamin_kernel_part2<T2, NB_X, 1>),
+                        dim3(1, 1, 1),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        blocks,
+                        workspace,
+                        workspace_index,
+                        result);
     }
     else
     {
-        //the last argument 0 indicate the result is a host pointer
-        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory copy is required
-        //printf("it is a host pointer\n");
+        // the last argument 0 indicate the result is a host pointer
+        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory
+        // copy is required
+        // printf("it is a host pointer\n");
         // only for blocks > 1, otherwise the final result is already reduced in workspace[0]
-        if ( blocks > 1) hipLaunchKernel(HIP_KERNEL_NAME(iamin_kernel_part2<T2, NB_X, 0>), dim3(1,1,1), dim3(threads), 0, rocblas_stream,
-                                                                                          blocks, workspace, workspace_index, result);
-        RETURN_IF_HIP_ERROR(hipMemcpy(result, workspace_index, sizeof(rocblas_int), hipMemcpyDeviceToHost));
+        if(blocks > 1)
+            hipLaunchKernel(HIP_KERNEL_NAME(iamin_kernel_part2<T2, NB_X, 0>),
+                            dim3(1, 1, 1),
+                            dim3(threads),
+                            0,
+                            rocblas_stream,
+                            blocks,
+                            workspace,
+                            workspace_index,
+                            result);
+        RETURN_IF_HIP_ERROR(
+            hipMemcpy(result, workspace_index, sizeof(rocblas_int), hipMemcpyDeviceToHost));
     }
 
     return rocblas_status_success;
@@ -160,7 +186,8 @@ rocblas_iamin_template_workspace(rocblas_handle handle,
 
     \details
     iamin finds the first index of the element of minimum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex vector
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+   vector
 
     @param[in]
     handle    rocblas_handle.
@@ -179,27 +206,24 @@ rocblas_iamin_template_workspace(rocblas_handle handle,
               (Fortran) is used, not 0 based indexing (C).
     ********************************************************************/
 
-//allocate workspace inside this API
-template<typename T1, typename T2>
-rocblas_status
-rocblas_iamin_template(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    rocblas_int *result)
+// allocate workspace inside this API
+template <typename T1, typename T2>
+rocblas_status rocblas_iamin_template(
+    rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, rocblas_int* result)
 {
     if(handle == nullptr)
         return rocblas_status_invalid_handle;
-    else if ( x == nullptr )
+    else if(x == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( result == nullptr )
+    else if(result == nullptr)
         return rocblas_status_invalid_pointer;
 
     /*
      * Quick return if possible.
      */
-    if (n <= 0 || incx <= 0)
+    if(n <= 0 || incx <= 0)
     {
-        if (rocblas_pointer_mode_device == handle->pointer_mode)
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
         {
             RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(T2)));
         }
@@ -210,72 +234,68 @@ rocblas_iamin_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    rocblas_int blocks = (n-1) / NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
     rocblas_status status;
 
-    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
+    auto workspace =
+        rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks), rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    auto workspace_index = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),rocblas::device_free};
+    auto workspace_index = rocblas_unique_ptr{rocblas::device_malloc(sizeof(rocblas_int) * blocks),
+                                              rocblas::device_free};
     if(!workspace_index)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_iamin_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), (rocblas_int*)workspace_index.get(), blocks);
+    status = rocblas_iamin_template_workspace<T1, T2>(handle,
+                                                      n,
+                                                      x,
+                                                      incx,
+                                                      result,
+                                                      (T2*)workspace.get(),
+                                                      (rocblas_int*)workspace_index.get(),
+                                                      blocks);
 
     return status;
 }
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-
-extern "C"
-rocblas_status
-rocblas_isamin(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_isamin(
+    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
 {
     return rocblas_iamin_template<float, float>(handle, n, x, incx, result);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_idamin(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_idamin(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
 {
     return rocblas_iamin_template<double, double>(handle, n, x, incx, result);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_iscamin(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_iscamin(rocblas_handle handle,
+                                          rocblas_int n,
+                                          const rocblas_float_complex* x,
+                                          rocblas_int incx,
+                                          rocblas_int* result)
 {
     return rocblas_iamin_template<rocblas_float_complex, float>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_idzamin(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    rocblas_int *result)
+extern "C" rocblas_status rocblas_idzamin(rocblas_handle handle,
+                                          rocblas_int n,
+                                          const rocblas_double_complex* x,
+                                          rocblas_int incx,
+                                          rocblas_int* result)
 {
     return rocblas_iamin_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -4,7 +4,7 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
@@ -12,49 +12,42 @@
 #include "rocblas_unique_ptr.hpp"
 #include "handle.h"
 
-template<typename T1, typename T2, rocblas_int NB>
+template <typename T1, typename T2, rocblas_int NB>
 __global__ void
-asum_kernel_part1(hipLaunchParm lp,
-    rocblas_int n,
-    const T1* x, rocblas_int incx,
-    T2* workspace)
+asum_kernel_part1(hipLaunchParm lp, rocblas_int n, const T1* x, rocblas_int incx, T2* workspace)
 {
     rocblas_int tx  = hipThreadIdx_x;
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
     __shared__ T2 shared_tep[NB];
-    //bound
-    if (tid < n)
+    // bound
+    if(tid < n)
     {
-        T2 real = fetch_real<T1, T2>(x[tid * incx]);
-        T2 imag = fetch_imag<T1, T2>(x[tid * incx]);
-        shared_tep[tx] =  fabs(real) + fabs(imag);
+        T2 real        = fetch_real<T1, T2>(x[tid * incx]);
+        T2 imag        = fetch_imag<T1, T2>(x[tid * incx]);
+        shared_tep[tx] = fabs(real) + fabs(imag);
     }
     else
-    {   //pad with zero
-        shared_tep[tx] =  0.0;
+    { // pad with zero
+        shared_tep[tx] = 0.0;
     }
 
     rocblas_sum_reduce<NB, T2>(tx, shared_tep);
 
-    if (tx == 0) workspace[hipBlockIdx_x] = shared_tep[0];
+    if(tx == 0)
+        workspace[hipBlockIdx_x] = shared_tep[0];
 }
 
-
-template<typename T, rocblas_int NB, rocblas_int flag>
-__global__ void
-asum_kernel_part2(hipLaunchParm lp,
-    rocblas_int n,
-    T* workspace,
-    T* result)
+template <typename T, rocblas_int NB, rocblas_int flag>
+__global__ void asum_kernel_part2(hipLaunchParm lp, rocblas_int n, T* workspace, T* result)
 {
-    rocblas_int tx  = hipThreadIdx_x;
+    rocblas_int tx = hipThreadIdx_x;
 
     __shared__ T shared_tep[NB];
 
     shared_tep[tx] = 0.0;
 
-    //bound, loop
+    // bound, loop
     for(rocblas_int i = tx; i < n; i += NB)
     {
         shared_tep[i] += workspace[i];
@@ -62,7 +55,7 @@ asum_kernel_part2(hipLaunchParm lp,
 
     __syncthreads();
 
-    if (n < 32)
+    if(n < 32)
     {
         // no need parallel reduction
         if(tx == 0)
@@ -75,16 +68,16 @@ asum_kernel_part2(hipLaunchParm lp,
     }
     else
     {
-            //parallel reduction, TODO bug
-            rocblas_sum_reduce<NB, T>(tx, shared_tep);
+        // parallel reduction, TODO bug
+        rocblas_sum_reduce<NB, T>(tx, shared_tep);
     }
 
-    if (tx == 0)
+    if(tx == 0)
     {
-        if (flag)
+        if(flag)
         {
-            //flag == 1, write to result of device memory
-            *result = shared_tep[0]; //result[0] works, too
+            // flag == 1, write to result of device memory
+            *result = shared_tep[0]; // result[0] works, too
         }
         else
         {
@@ -93,22 +86,27 @@ asum_kernel_part2(hipLaunchParm lp,
     }
 }
 
-//HIP support up to 1024 threads/work itmes per thread block/work group
+// HIP support up to 1024 threads/work itmes per thread block/work group
 #define NB_X 1024
 
-//assume workspace has already been allocated, recommened for repeated calling of asum product routine
-template<typename T1, typename T2>
-rocblas_status
-rocblas_asum_template_workspace(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    T2* result, T2* workspace, rocblas_int lworkspace)
+// assume workspace has already been allocated, recommened for repeated calling of asum product
+// routine
+template <typename T1, typename T2>
+rocblas_status rocblas_asum_template_workspace(rocblas_handle handle,
+                                               rocblas_int n,
+                                               const T1* x,
+                                               rocblas_int incx,
+                                               T2* result,
+                                               T2* workspace,
+                                               rocblas_int lworkspace)
 {
-    rocblas_int blocks = (n-1) / NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
-    //At least two kernels are needed to finish the reduction
-    //kennel 1 write partial result per thread block in workspace, number of partial result is blocks
-    //kernel 2 gather all the partial result in workspace and finish the final reduction. number of threads (NB_X) loop blocks
+    // At least two kernels are needed to finish the reduction
+    // kennel 1 write partial result per thread block in workspace, number of partial result is
+    // blocks
+    // kernel 2 gather all the partial result in workspace and finish the final reduction. number of
+    // threads (NB_X) loop blocks
 
     if(lworkspace < blocks)
     {
@@ -122,20 +120,44 @@ rocblas_asum_template_workspace(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    hipLaunchKernel(HIP_KERNEL_NAME(asum_kernel_part1<T1, T2, NB_X>), dim3(grid), dim3(threads), 0, rocblas_stream, n, x, incx, workspace);
+    hipLaunchKernel(HIP_KERNEL_NAME(asum_kernel_part1<T1, T2, NB_X>),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    n,
+                    x,
+                    incx,
+                    workspace);
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        //the last argument 1 indicate the result is on device, not memcpy is required
-        hipLaunchKernel(HIP_KERNEL_NAME(asum_kernel_part2<T2, NB_X, 1>), dim3(1,1,1), dim3(threads), 0, rocblas_stream, blocks, workspace, result);
+        // the last argument 1 indicate the result is on device, not memcpy is required
+        hipLaunchKernel(HIP_KERNEL_NAME(asum_kernel_part2<T2, NB_X, 1>),
+                        dim3(1, 1, 1),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        blocks,
+                        workspace,
+                        result);
     }
     else
     {
-        //the last argument 0 indicate the result is on host
-        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory copy is required
-        //printf("it is a host pointer\n");
+        // the last argument 0 indicate the result is on host
+        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory
+        // copy is required
+        // printf("it is a host pointer\n");
         // only for blocks > 1, otherwise the final result is already reduced in workspace[0]
-        if (blocks > 1) hipLaunchKernel(HIP_KERNEL_NAME(asum_kernel_part2<T2, NB_X, 0>), dim3(1,1,1), dim3(threads), 0, rocblas_stream, blocks, workspace, result);
+        if(blocks > 1)
+            hipLaunchKernel(HIP_KERNEL_NAME(asum_kernel_part2<T2, NB_X, 0>),
+                            dim3(1, 1, 1),
+                            dim3(threads),
+                            0,
+                            rocblas_stream,
+                            blocks,
+                            workspace,
+                            result);
         RETURN_IF_HIP_ERROR(hipMemcpy(result, workspace, sizeof(T2), hipMemcpyDeviceToHost));
     }
 
@@ -148,7 +170,8 @@ rocblas_asum_template_workspace(rocblas_handle handle,
 
     \details
     asum computes the sum of the absolute values of elements of a real vector x,
-         or the sum of absolute values of the real and imaginary parts of elements if x is a complex vector
+         or the sum of absolute values of the real and imaginary parts of elements if x is a complex
+   vector
 
     @param[in]
     handle    rocblas_handle.
@@ -166,19 +189,16 @@ rocblas_asum_template_workspace(rocblas_handle handle,
               result is 0.0 if n <= 0 or incx <= 0.
     ********************************************************************/
 
-//allocate workspace inside this API
-template<typename T1, typename T2>
-rocblas_status
-rocblas_asum_template(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    T2 *result)
+// allocate workspace inside this API
+template <typename T1, typename T2>
+rocblas_status rocblas_asum_template(
+    rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, T2* result)
 {
-    if (nullptr == x)
+    if(nullptr == x)
     {
         return rocblas_status_invalid_pointer;
     }
-    else if (nullptr == result)
+    else if(nullptr == result)
     {
         return rocblas_status_invalid_pointer;
     }
@@ -190,9 +210,9 @@ rocblas_asum_template(rocblas_handle handle,
     /*
      * Quick return if possible.
      */
-    if (n <= 0 || incx <= 0)
+    if(n <= 0 || incx <= 0)
     {
-        if (rocblas_pointer_mode_device == handle->pointer_mode)
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
         {
             RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(T2)));
         }
@@ -203,63 +223,55 @@ rocblas_asum_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    rocblas_int blocks = (n-1) / NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
     rocblas_status status;
 
-    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
+    auto workspace =
+        rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks), rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_asum_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), blocks);
+    status = rocblas_asum_template_workspace<T1, T2>(
+        handle, n, x, incx, result, (T2*)workspace.get(), blocks);
 
     return status;
 }
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-extern "C"
-rocblas_status
-rocblas_sasum(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    float *result)
+extern "C" rocblas_status
+rocblas_sasum(rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result)
 {
     return rocblas_asum_template<float, float>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_dasum(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    double *result)
+extern "C" rocblas_status rocblas_dasum(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result)
 {
-    return rocblas_asum_template<double,double>(handle, n, x, incx, result);
+    return rocblas_asum_template<double, double>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_scasum(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    float *result)
+extern "C" rocblas_status rocblas_scasum(rocblas_handle handle,
+                                         rocblas_int n,
+                                         const rocblas_float_complex* x,
+                                         rocblas_int incx,
+                                         float* result)
 {
     return rocblas_asum_template<rocblas_float_complex, float>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_dzasum(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    double *result)
+extern "C" rocblas_status rocblas_dzasum(rocblas_handle handle,
+                                         rocblas_int n,
+                                         const rocblas_double_complex* x,
+                                         rocblas_int incx,
+                                         double* result)
 {
     return rocblas_asum_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -8,108 +8,110 @@
 
 #define NB_X 256
 
-template<typename T>
-__global__ void
-axpy_kernel_host_scalar(hipLaunchParm lp,
-    rocblas_int n,
-    const T alpha,
-    const T *x, rocblas_int incx,
-    T *y,  rocblas_int incy)
+template <typename T>
+__global__ void axpy_kernel_host_scalar(hipLaunchParm lp,
+                                        rocblas_int n,
+                                        const T alpha,
+                                        const T* x,
+                                        rocblas_int incx,
+                                        T* y,
+                                        rocblas_int incy)
 {
     int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
     if(incx >= 0 && incy >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[tid*incy] +=  (alpha) * x[tid * incx];
+            y[tid * incy] += (alpha)*x[tid * incx];
         }
     }
     else if(incx < 0 && incy < 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[(1 - n + tid) * incy] +=  (alpha) * x[(1 - n + tid) * incx];
+            y[(1 - n + tid) * incy] += (alpha)*x[(1 - n + tid) * incx];
         }
     }
-    else if (incx >=0)
+    else if(incx >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[(1 - n + tid) * incy] +=  (alpha) * x[tid * incx];
+            y[(1 - n + tid) * incy] += (alpha)*x[tid * incx];
         }
     }
     else
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[tid * incy] +=  (alpha) * x[(1 - n + tid) * incx];
+            y[tid * incy] += (alpha)*x[(1 - n + tid) * incx];
         }
     }
 }
 
-template<typename T>
-__global__ void
-axpy_kernel_device_scalar(hipLaunchParm lp,
-    rocblas_int n,
-    const T *alpha,
-    const T *x, rocblas_int incx,
-    T *y,  rocblas_int incy)
+template <typename T>
+__global__ void axpy_kernel_device_scalar(hipLaunchParm lp,
+                                          rocblas_int n,
+                                          const T* alpha,
+                                          const T* x,
+                                          rocblas_int incx,
+                                          T* y,
+                                          rocblas_int incy)
 {
     int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    //bound
-    if (incx >= 0 && incy >= 0)
+    // bound
+    if(incx >= 0 && incy >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[tid*incy] +=  (*alpha) * x[tid * incx];
+            y[tid * incy] += (*alpha) * x[tid * incx];
         }
     }
-    else if (incx < 0 && incy < 0)
+    else if(incx < 0 && incy < 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[(1 - n + tid) * incy] +=  (*alpha) * x[(1 - n + tid) * incx];
+            y[(1 - n + tid) * incy] += (*alpha) * x[(1 - n + tid) * incx];
         }
     }
-    else if (incx >=0)
+    else if(incx >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[(1 - n + tid) * incy] +=  (*alpha) * x[tid * incx];
+            y[(1 - n + tid) * incy] += (*alpha) * x[tid * incx];
         }
     }
     else
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[tid * incy] +=  (*alpha) * x[(1 - n + tid) * incx];
+            y[tid * incy] += (*alpha) * x[(1 - n + tid) * incx];
         }
     }
 }
 
-__global__ void
-haxpy_mod_8_device_scalar(int n, const __fp16 *alpha, const __fp16 *x, __fp16 *y)
+__global__ void haxpy_mod_8_device_scalar(int n, const __fp16* alpha, const __fp16* x, __fp16* y)
 {
     int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
     int index = ((n / 8) * 8) + tid;
 
-    if (index < n) y[index] = (*alpha) * x[index] + y[index];
+    if(index < n)
+        y[index] = (*alpha) * x[index] + y[index];
 }
 
-__global__ void
-haxpy_mod_8_host_scalar(int n, const __fp16 alpha, const __fp16 *x, __fp16 *y)
+__global__ void haxpy_mod_8_host_scalar(int n, const __fp16 alpha, const __fp16* x, __fp16* y)
 {
     int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
     int index = ((n / 8) * 8) + tid;
 
-    if (index < n) y[index] = alpha * x[index] + y[index];
+    if(index < n)
+        y[index] = alpha * x[index] + y[index];
 }
 
 __global__ void
-haxpy_mlt_8_device_scalar(int n_mlt_8, const __fp16 *alpha, const half8 *x, half8 *y)
+haxpy_mlt_8_device_scalar(int n_mlt_8, const __fp16* alpha, const half8* x, half8* y)
 {
     int tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 
@@ -121,7 +123,7 @@ haxpy_mlt_8_device_scalar(int n_mlt_8, const __fp16 *alpha, const half8 *x, half
     half2 x0, x1, x2, x3;
     half2 z0, z1, z2, z3;
 
-    if (tid*8 < n_mlt_8)
+    if(tid * 8 < n_mlt_8)
     {
         y0[0] = y[tid][0];
         y0[1] = y[tid][1];
@@ -157,8 +159,7 @@ haxpy_mlt_8_device_scalar(int n_mlt_8, const __fp16 *alpha, const half8 *x, half
     }
 }
 
-__global__ void
-haxpy_mlt_8_host_scalar(int n_mlt_8, const half2 alpha, const half8 *x, half8 *y)
+__global__ void haxpy_mlt_8_host_scalar(int n_mlt_8, const half2 alpha, const half8* x, half8* y)
 {
     int tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 
@@ -166,7 +167,7 @@ haxpy_mlt_8_host_scalar(int n_mlt_8, const half2 alpha, const half8 *x, half8 *y
     half2 x0, x1, x2, x3;
     half2 z0, z1, z2, z3;
 
-    if(tid*8 < n_mlt_8)
+    if(tid * 8 < n_mlt_8)
     {
         y0[0] = y[tid][0];
         y0[1] = y[tid][1];
@@ -202,7 +203,6 @@ haxpy_mlt_8_host_scalar(int n_mlt_8, const half2 alpha, const half8 *x, half8 *y
     }
 }
 
-
 /*! \brief BLAS Level 1 API
 
     \details
@@ -229,29 +229,30 @@ haxpy_mlt_8_host_scalar(int n_mlt_8, const half2 alpha, const half8 *x, half8 *y
 
     ********************************************************************/
 
-template<class T>
-rocblas_status
-rocblas_axpy_template(rocblas_handle handle,
-    rocblas_int n,
-    const T *alpha,
-    const T *x, rocblas_int incx,
-    T *y,  rocblas_int incy)
+template <class T>
+rocblas_status rocblas_axpy_template(rocblas_handle handle,
+                                     rocblas_int n,
+                                     const T* alpha,
+                                     const T* x,
+                                     rocblas_int incx,
+                                     T* y,
+                                     rocblas_int incy)
 {
-    if (nullptr == alpha)
+    if(nullptr == alpha)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == x)
+    else if(nullptr == x)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == y)
+    else if(nullptr == y)
         return rocblas_status_invalid_pointer;
     else if(nullptr == handle)
         return rocblas_status_invalid_handle;
 
-    if (n <= 0) // Quick return if possible. Not Argument error
+    if(n <= 0) // Quick return if possible. Not Argument error
     {
         return rocblas_status_success;
     }
 
-    int blocks = ((n-1) / NB_X) + 1;
+    int blocks = ((n - 1) / NB_X) + 1;
 
     dim3 grid(blocks, 1, 1);
     dim3 threads(NB_X, 1, 1);
@@ -259,45 +260,62 @@ rocblas_axpy_template(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
         hipLaunchKernel(HIP_KERNEL_NAME(axpy_kernel_device_scalar),
-                dim3(blocks), dim3(threads), 0, rocblas_stream,
-                n, alpha, x, incx, y, incy);
+                        dim3(blocks),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        n,
+                        alpha,
+                        x,
+                        incx,
+                        y,
+                        incy);
     }
     else // alpha is on host
     {
         T scalar = *alpha;
-        if (0.0 == scalar)
+        if(0.0 == scalar)
         {
             return rocblas_status_success;
         }
 
         hipLaunchKernel(HIP_KERNEL_NAME(axpy_kernel_host_scalar),
-                dim3(blocks), dim3(threads), 0, rocblas_stream,
-                n, scalar, x, incx, y, incy);
+                        dim3(blocks),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        n,
+                        scalar,
+                        x,
+                        incx,
+                        y,
+                        incy);
     }
 
     return rocblas_status_success;
 }
 
-template<class T>
-rocblas_status
-rocblas_axpy_half(rocblas_handle handle,
-    rocblas_int n,
-    const T *alpha,
-    const T *x, rocblas_int incx,
-    T *y,  rocblas_int incy)
+template <class T>
+rocblas_status rocblas_axpy_half(rocblas_handle handle,
+                                 rocblas_int n,
+                                 const T* alpha,
+                                 const T* x,
+                                 rocblas_int incx,
+                                 T* y,
+                                 rocblas_int incy)
 {
-    if (nullptr == alpha)
+    if(nullptr == alpha)
     {
         return rocblas_status_invalid_pointer;
     }
-    else if (nullptr == x)
+    else if(nullptr == x)
     {
         return rocblas_status_invalid_pointer;
     }
-    else if (nullptr == y)
+    else if(nullptr == y)
     {
         return rocblas_status_invalid_pointer;
     }
@@ -306,12 +324,12 @@ rocblas_axpy_half(rocblas_handle handle,
         return rocblas_status_invalid_handle;
     }
 
-    if (n <= 0) // Quick return if possible. Not Argument error
+    if(n <= 0) // Quick return if possible. Not Argument error
     {
         return rocblas_status_success;
     }
 
-    if (1 != incx || 1 != incy) // slow code, no half8 or half2
+    if(1 != incx || 1 != incy) // slow code, no half8 or half2
     {
         int blocks = ((n - 1) / NB_X) + 1;
 
@@ -321,69 +339,109 @@ rocblas_axpy_half(rocblas_handle handle,
         hipStream_t rocblas_stream;
         RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-        if (rocblas_pointer_mode_device == handle->pointer_mode)
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
         {
             hipLaunchKernel(HIP_KERNEL_NAME(axpy_kernel_device_scalar),
-                            dim3(blocks), dim3(threads), 0, rocblas_stream,
-                            n, (const __fp16 *)alpha, (const __fp16 *)x, incx, (__fp16 *)y, incy);
+                            dim3(blocks),
+                            dim3(threads),
+                            0,
+                            rocblas_stream,
+                            n,
+                            (const __fp16*)alpha,
+                            (const __fp16*)x,
+                            incx,
+                            (__fp16*)y,
+                            incy);
         }
         else // alpha is on host
         {
-            if (0 == *alpha)
+            if(0 == *alpha)
             {
                 return rocblas_status_success;
             }
 
-            const __fp16 f16_alpha = *reinterpret_cast<const __fp16 *>(alpha);
+            const __fp16 f16_alpha = *reinterpret_cast<const __fp16*>(alpha);
             hipLaunchKernel(HIP_KERNEL_NAME(axpy_kernel_host_scalar),
-                            dim3(blocks), dim3(threads), 0, rocblas_stream,
-                            n, f16_alpha, (const __fp16 *)x, incx, (__fp16 *)y, incy);
+                            dim3(blocks),
+                            dim3(threads),
+                            0,
+                            rocblas_stream,
+                            n,
+                            f16_alpha,
+                            (const __fp16*)x,
+                            incx,
+                            (__fp16*)y,
+                            incy);
         }
     }
-    else  // half8 load-store and half2 arithmetic
+    else // half8 load-store and half2 arithmetic
     {
-        rocblas_int n_mlt_8 = (n / 8) * 8;  // multiple of 8
-        rocblas_int n_mod_8 = n - n_mlt_8;  // n mod 8
+        rocblas_int n_mlt_8 = (n / 8) * 8; // multiple of 8
+        rocblas_int n_mod_8 = n - n_mlt_8; // n mod 8
 
-        int blocks = (((n/8)-1) / NB_X) + 1;
+        int blocks = (((n / 8) - 1) / NB_X) + 1;
 
         dim3 grid(blocks, 1, 1);
         dim3 threads(NB_X, 1, 1);
 
-        if (rocblas_pointer_mode_device == handle->pointer_mode)
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
         {
             hipLaunchKernelGGL(haxpy_mlt_8_device_scalar,
-                               dim3(grid), dim3(threads), 0, 0,
-                               n_mlt_8, (const __fp16 *)alpha, (const half8 *)x, (half8 *)y);
+                               dim3(grid),
+                               dim3(threads),
+                               0,
+                               0,
+                               n_mlt_8,
+                               (const __fp16*)alpha,
+                               (const half8*)x,
+                               (half8*)y);
 
-            if (0 != n_mod_8) // cleanup non-multiple of 8
+            if(0 != n_mod_8) // cleanup non-multiple of 8
             {
                 hipLaunchKernelGGL(haxpy_mod_8_device_scalar,
-                                   dim3(1, 1, 1), dim3(n_mod_8, 1, 1),
-                                   0, 0, n, (const __fp16 *)alpha, (const __fp16 *)x, (__fp16*)y);
+                                   dim3(1, 1, 1),
+                                   dim3(n_mod_8, 1, 1),
+                                   0,
+                                   0,
+                                   n,
+                                   (const __fp16*)alpha,
+                                   (const __fp16*)x,
+                                   (__fp16*)y);
             }
         }
-        else  // alpha is on host
+        else // alpha is on host
         {
-            if (0 == *alpha)
+            if(0 == *alpha)
             {
                 return rocblas_status_success;
             }
 
             half2 half2_alpha;
-            half2_alpha[0] = *reinterpret_cast<const __fp16 *>(alpha);
-            half2_alpha[1] = *reinterpret_cast<const __fp16 *>(alpha);
+            half2_alpha[0] = *reinterpret_cast<const __fp16*>(alpha);
+            half2_alpha[1] = *reinterpret_cast<const __fp16*>(alpha);
 
             hipLaunchKernelGGL(haxpy_mlt_8_host_scalar,
-                dim3(grid), dim3(threads), 0, 0,
-                n_mlt_8, half2_alpha, (const half8*)x, (half8*)y);
+                               dim3(grid),
+                               dim3(threads),
+                               0,
+                               0,
+                               n_mlt_8,
+                               half2_alpha,
+                               (const half8*)x,
+                               (half8*)y);
 
-            if (0 != n_mod_8) // cleanup non-multiple of 8
+            if(0 != n_mod_8) // cleanup non-multiple of 8
             {
-                const __fp16 f16_alpha = *reinterpret_cast<const __fp16 *>(alpha);
+                const __fp16 f16_alpha = *reinterpret_cast<const __fp16*>(alpha);
                 hipLaunchKernelGGL(haxpy_mod_8_host_scalar,
-                                   dim3(1, 1, 1), dim3(n_mod_8, 1, 1),
-                                   0, 0, n, f16_alpha, (const __fp16 *)x, (__fp16 *)y);
+                                   dim3(1, 1, 1),
+                                   dim3(n_mod_8, 1, 1),
+                                   0,
+                                   0,
+                                   n,
+                                   f16_alpha,
+                                   (const __fp16*)x,
+                                   (__fp16*)y);
             }
         }
     }
@@ -392,66 +450,65 @@ rocblas_axpy_half(rocblas_handle handle,
 
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    C89 wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C89 wrapper
+ * ===========================================================================
+ */
 
-extern "C"
-rocblas_status
-rocblas_haxpy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_half *alpha,
-    const rocblas_half *x, rocblas_int incx,
-    rocblas_half *y,  rocblas_int incy)
+extern "C" rocblas_status rocblas_haxpy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_half* alpha,
+                                        const rocblas_half* x,
+                                        rocblas_int incx,
+                                        rocblas_half* y,
+                                        rocblas_int incy)
 {
     return rocblas_axpy_half<rocblas_half>(handle, n, alpha, x, incx, y, incy);
 }
 
-extern "C"
-rocblas_status
-rocblas_saxpy(rocblas_handle handle,
-    rocblas_int n,
-    const float *alpha,
-    const float *x, rocblas_int incx,
-    float *y,  rocblas_int incy)
+extern "C" rocblas_status rocblas_saxpy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const float* alpha,
+                                        const float* x,
+                                        rocblas_int incx,
+                                        float* y,
+                                        rocblas_int incy)
 {
     return rocblas_axpy_template<float>(handle, n, alpha, x, incx, y, incy);
 }
 
-extern "C"
-rocblas_status
-rocblas_daxpy(rocblas_handle handle,
-    rocblas_int n,
-    const double *alpha,
-    const double *x, rocblas_int incx,
-    double *y,  rocblas_int incy)
+extern "C" rocblas_status rocblas_daxpy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const double* alpha,
+                                        const double* x,
+                                        rocblas_int incx,
+                                        double* y,
+                                        rocblas_int incy)
 {
     return rocblas_axpy_template<double>(handle, n, alpha, x, incx, y, incy);
 }
 
-extern "C"
-rocblas_status
-rocblas_caxpy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *alpha,
-    const rocblas_float_complex *x, rocblas_int incx,
-    rocblas_float_complex *y,  rocblas_int incy)
+extern "C" rocblas_status rocblas_caxpy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_float_complex* alpha,
+                                        const rocblas_float_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_float_complex* y,
+                                        rocblas_int incy)
 {
     return rocblas_axpy_template<rocblas_float_complex>(handle, n, alpha, x, incx, y, incy);
 }
 
-extern "C"
-rocblas_status
-rocblas_zaxpy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *alpha,
-    const rocblas_double_complex *x, rocblas_int incx,
-    rocblas_double_complex *y,  rocblas_int incy)
+extern "C" rocblas_status rocblas_zaxpy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_double_complex* alpha,
+                                        const rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
 {
     return rocblas_axpy_template<rocblas_double_complex>(handle, n, alpha, x, incx, y, incy);
 }
-
 
 /* ============================================================================================ */

--- a/library/src/blas1/rocblas_copy.cpp
+++ b/library/src/blas1/rocblas_copy.cpp
@@ -4,50 +4,46 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "definitions.h"
 
 #define NB_X 256
 
-template<typename T>
+template <typename T>
 __global__ void
-copy_kernel(hipLaunchParm lp,
-    rocblas_int n,
-    const T *x, rocblas_int incx,
-    T* y,  rocblas_int incy)
+copy_kernel(hipLaunchParm lp, rocblas_int n, const T* x, rocblas_int incx, T* y, rocblas_int incy)
 {
     int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    //bound
+    // bound
     if(incx >= 0 && incy >= 0)
     {
-        if ( tid < n ) 
+        if(tid < n)
         {
-            y[tid*incy] =  x[tid * incx];
+            y[tid * incy] = x[tid * incx];
         }
     }
     else if(incx < 0 && incy < 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[(1 - n + tid) * incy] =  x[(1 - n + tid) * incx];
+            y[(1 - n + tid) * incy] = x[(1 - n + tid) * incx];
         }
     }
-    else if (incx >=0)
+    else if(incx >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[(1 - n + tid) * incy] =  x[tid * incx];
+            y[(1 - n + tid) * incy] = x[tid * incx];
         }
     }
     else
     {
-        if (tid < n)
+        if(tid < n)
         {
-            y[tid * incy] =  x[(1 - n + tid) * incx];
+            y[tid * incy] = x[(1 - n + tid) * incx];
         }
     }
 }
-
 
 /*! \brief BLAS Level 1 API
 
@@ -74,16 +70,13 @@ copy_kernel(hipLaunchParm lp,
 
     ********************************************************************/
 
-template<class T>
-rocblas_status
-rocblas_copy_template(rocblas_handle handle,
-    rocblas_int n,
-    const T *x, rocblas_int incx,
-    T* y,       rocblas_int incy)
+template <class T>
+rocblas_status rocblas_copy_template(
+    rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, T* y, rocblas_int incy)
 {
-    if ( x == nullptr )
+    if(x == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( y == nullptr )
+    else if(y == nullptr)
         return rocblas_status_invalid_pointer;
     else if(handle == nullptr)
         return rocblas_status_invalid_handle;
@@ -91,73 +84,81 @@ rocblas_copy_template(rocblas_handle handle,
     /*
      * Quick return if possible.
      */
-    if ( n <= 0)
+    if(n <= 0)
         return rocblas_status_success;
 
-    int blocks = (n-1)/ NB_X + 1;
+    int blocks = (n - 1) / NB_X + 1;
 
-    dim3 grid( blocks, 1, 1 );
-    dim3 threads( NB_X, 1, 1 );
+    dim3 grid(blocks, 1, 1);
+    dim3 threads(NB_X, 1, 1);
 
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    hipLaunchKernel(HIP_KERNEL_NAME(copy_kernel), dim3(grid), dim3(threads), 0, rocblas_stream, n, x, incx, y, incy);
+    hipLaunchKernel(HIP_KERNEL_NAME(copy_kernel),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    n,
+                    x,
+                    incx,
+                    y,
+                    incy);
 
     return rocblas_status_success;
 }
 
-
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-
-extern "C"
-rocblas_status
-rocblas_scopy(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    float* y,       rocblas_int incy){
+extern "C" rocblas_status rocblas_scopy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const float* x,
+                                        rocblas_int incx,
+                                        float* y,
+                                        rocblas_int incy)
+{
 
     return rocblas_copy_template<float>(handle, n, x, incx, y, incy);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_dcopy(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    double* y,       rocblas_int incy){
+extern "C" rocblas_status rocblas_dcopy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const double* x,
+                                        rocblas_int incx,
+                                        double* y,
+                                        rocblas_int incy)
+{
 
     return rocblas_copy_template<double>(handle, n, x, incx, y, incy);
 }
 
-extern "C"
-rocblas_status
-rocblas_ccopy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    rocblas_float_complex* y,       rocblas_int incy){
+extern "C" rocblas_status rocblas_ccopy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_float_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_float_complex* y,
+                                        rocblas_int incy)
+{
 
     return rocblas_copy_template<rocblas_float_complex>(handle, n, x, incx, y, incy);
 }
 
-extern "C"
-rocblas_status
-rocblas_zcopy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    rocblas_double_complex* y,       rocblas_int incy){
+extern "C" rocblas_status rocblas_zcopy(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
+{
 
     return rocblas_copy_template<rocblas_double_complex>(handle, n, x, incx, y, incy);
 }
-
-
 
 /* ============================================================================================ */

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -4,104 +4,101 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
 #include "rocblas_unique_ptr.hpp"
 #include "handle.h"
 
-template<typename T, rocblas_int NB>
-__global__ void
-dot_kernel_part1(hipLaunchParm lp,
-    rocblas_int n,
-    const T* x, rocblas_int incx,
-    const T* y, rocblas_int incy,
-    T* workspace)
+template <typename T, rocblas_int NB>
+__global__ void dot_kernel_part1(hipLaunchParm lp,
+                                 rocblas_int n,
+                                 const T* x,
+                                 rocblas_int incx,
+                                 const T* y,
+                                 rocblas_int incy,
+                                 T* workspace)
 {
     rocblas_int tx  = hipThreadIdx_x;
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
     __shared__ T shared_tep[NB];
-    //bound
-    if (incx >= 0 && incy >= 0)
+    // bound
+    if(incx >= 0 && incy >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            shared_tep[tx] = y[tid*incy] * x[tid * incx];
+            shared_tep[tx] = y[tid * incy] * x[tid * incx];
         }
         else
-        {   //pad with zero
+        { // pad with zero
             shared_tep[tx] = 0.0;
         }
     }
     else if(incx < 0 && incy < 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
             shared_tep[tx] = y[(1 - n + tid) * incy] * x[(1 - n + tid) * incx];
         }
         else
-        {   //pad with zero
+        { // pad with zero
             shared_tep[tx] = 0.0;
         }
     }
-    else if (incx >=0)
+    else if(incx >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
             shared_tep[tx] = y[(1 - n + tid) * incy] * x[tid * incx];
         }
         else
-        {   //pad with zero
+        { // pad with zero
             shared_tep[tx] = 0.0;
         }
     }
     else
     {
-        if (tid < n)
+        if(tid < n)
         {
             shared_tep[tx] = y[tid * incy] * x[(1 - n + tid) * incx];
         }
         else
-        {   //pad with zero
+        { // pad with zero
             shared_tep[tx] = 0.0;
         }
     }
 
-
     rocblas_sum_reduce<NB, T>(tx, shared_tep);
 
-    if (tx == 0) workspace[hipBlockIdx_x] = shared_tep[0];
+    if(tx == 0)
+        workspace[hipBlockIdx_x] = shared_tep[0];
 }
 
-template<typename T, rocblas_int NB, rocblas_int flag>
-__global__ void
-dot_kernel_part2(hipLaunchParm lp,
-    rocblas_int n,
-    T* workspace,
-    T* result)
+template <typename T, rocblas_int NB, rocblas_int flag>
+__global__ void dot_kernel_part2(hipLaunchParm lp, rocblas_int n, T* workspace, T* result)
 {
 
-    rocblas_int tx  = hipThreadIdx_x;
+    rocblas_int tx = hipThreadIdx_x;
 
     __shared__ T shared_tep[NB];
 
     shared_tep[tx] = 0.0;
 
-    //bound, loop
-    for (rocblas_int i=tx; i<n; i+=NB)
+    // bound, loop
+    for(rocblas_int i = tx; i < n; i += NB)
     {
         shared_tep[i] += workspace[i];
     }
     __syncthreads();
 
-    if (n < 32)
+    if(n < 32)
     {
         // no need parallel reduction
-        if (tx == 0)
+        if(tx == 0)
         {
-            for (rocblas_int i=1;i<n;i++)
+            for(rocblas_int i = 1; i < n; i++)
             {
                 shared_tep[0] += shared_tep[i];
             }
@@ -109,16 +106,16 @@ dot_kernel_part2(hipLaunchParm lp,
     }
     else
     {
-        //parallel reduction, TODO bug
+        // parallel reduction, TODO bug
         rocblas_sum_reduce<NB, T>(tx, shared_tep);
     }
 
-    if (tx == 0)
+    if(tx == 0)
     {
-        if (flag)
+        if(flag)
         {
-            //flag == 1, write to result of device memory
-            *result = shared_tep[0]; //result[0] works, too
+            // flag == 1, write to result of device memory
+            *result = shared_tep[0]; // result[0] works, too
         }
         else
         {
@@ -127,26 +124,31 @@ dot_kernel_part2(hipLaunchParm lp,
     }
 }
 
-
-//HIP support up to 1024 threads/work itmes per thread block/work group
+// HIP support up to 1024 threads/work itmes per thread block/work group
 #define NB_X 1024
 
-//assume workspace has already been allocated, recommened for repeated calling of dot product routine
-template<typename T>
-rocblas_status
-rocblas_dot_template_workspace(rocblas_handle handle,
-    rocblas_int n,
-    const T *x, rocblas_int incx,
-    const T *y, rocblas_int incy,
-    T* result, T* workspace, rocblas_int lworkspace)
+// assume workspace has already been allocated, recommened for repeated calling of dot product
+// routine
+template <typename T>
+rocblas_status rocblas_dot_template_workspace(rocblas_handle handle,
+                                              rocblas_int n,
+                                              const T* x,
+                                              rocblas_int incx,
+                                              const T* y,
+                                              rocblas_int incy,
+                                              T* result,
+                                              T* workspace,
+                                              rocblas_int lworkspace)
 {
-    rocblas_int blocks = (n-1)/ NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
-    //At least two kernels are needed to finish the reduction
-    //kennel 1 write partial result per thread block in workspace, number of partial result is blocks
-    //kernel 2 gather all the partial result in workspace and finish the final reduction. number of threads (NB_X) loop blocks
+    // At least two kernels are needed to finish the reduction
+    // kennel 1 write partial result per thread block in workspace, number of partial result is
+    // blocks
+    // kernel 2 gather all the partial result in workspace and finish the final reduction. number of
+    // threads (NB_X) loop blocks
 
-    if (lworkspace < blocks)
+    if(lworkspace < blocks)
     {
         printf("size workspace = %d is too small, allocate at least %d", lworkspace, blocks);
         return rocblas_status_not_implemented;
@@ -158,20 +160,46 @@ rocblas_dot_template_workspace(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    hipLaunchKernel(HIP_KERNEL_NAME(dot_kernel_part1<T, NB_X>), dim3(grid), dim3(threads), 0, rocblas_stream, n, x, incx, y, incy, workspace);
+    hipLaunchKernel(HIP_KERNEL_NAME(dot_kernel_part1<T, NB_X>),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    n,
+                    x,
+                    incx,
+                    y,
+                    incy,
+                    workspace);
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        //the last argument 1 indicate the result is on device, not memcpy is required
-        hipLaunchKernel(HIP_KERNEL_NAME(dot_kernel_part2<T, NB_X, 1>), dim3(1,1,1), dim3(threads), 0, rocblas_stream, blocks, workspace, result);
+        // the last argument 1 indicate the result is on device, not memcpy is required
+        hipLaunchKernel(HIP_KERNEL_NAME(dot_kernel_part2<T, NB_X, 1>),
+                        dim3(1, 1, 1),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        blocks,
+                        workspace,
+                        result);
     }
     else
     {
-        //the last argument 0 indicate the result is on host
-        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory copy is required
-        //printf("it is a host pointer\n");
+        // the last argument 0 indicate the result is on host
+        // workspace[0] has a copy of the final result, if the result pointer is on host, a memory
+        // copy is required
+        // printf("it is a host pointer\n");
         // only for blocks > 1, otherwise the final result is already reduced in workspace[0]
-        if ( blocks > 1) hipLaunchKernel(HIP_KERNEL_NAME(dot_kernel_part2<T, NB_X, 0>), dim3(1,1,1), dim3(threads), 0, rocblas_stream, blocks, workspace, result);
+        if(blocks > 1)
+            hipLaunchKernel(HIP_KERNEL_NAME(dot_kernel_part2<T, NB_X, 0>),
+                            dim3(1, 1, 1),
+                            dim3(threads),
+                            0,
+                            rocblas_stream,
+                            blocks,
+                            workspace,
+                            result);
         RETURN_IF_HIP_ERROR(hipMemcpy(result, workspace, sizeof(T), hipMemcpyDeviceToHost));
     }
 
@@ -208,20 +236,21 @@ rocblas_dot_template_workspace(rocblas_handle handle,
 
     ********************************************************************/
 
-//allocate workspace inside this API
-template<typename T>
-rocblas_status
-rocblas_dot_template(rocblas_handle handle,
-    rocblas_int n,
-    const T *x, rocblas_int incx,
-    const T *y, rocblas_int incy,
-    T *result)
+// allocate workspace inside this API
+template <typename T>
+rocblas_status rocblas_dot_template(rocblas_handle handle,
+                                    rocblas_int n,
+                                    const T* x,
+                                    rocblas_int incx,
+                                    const T* y,
+                                    rocblas_int incy,
+                                    T* result)
 {
-    if (nullptr == x)
+    if(nullptr == x)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == y)
+    else if(nullptr == y)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == result)
+    else if(nullptr == result)
         return rocblas_status_invalid_pointer;
     else if(nullptr == handle)
         return rocblas_status_invalid_handle;
@@ -229,9 +258,9 @@ rocblas_dot_template(rocblas_handle handle,
     /*
      * Quick return if possible.
      */
-    if (n <= 0)
+    if(n <= 0)
     {
-        if (rocblas_pointer_mode_device == handle->pointer_mode)
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
         {
             RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(T)));
         }
@@ -242,21 +271,22 @@ rocblas_dot_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    rocblas_int blocks = (n-1) / NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
     rocblas_status status;
 
-    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * blocks),rocblas::device_free};
+    auto workspace =
+        rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * blocks), rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_dot_template_workspace<T>(handle, n, x, incx, y, incy, result, (T*)workspace.get(), blocks);
+    status = rocblas_dot_template_workspace<T>(
+        handle, n, x, incx, y, incy, result, (T*)workspace.get(), blocks);
 
     return status;
 }
-
 
 /*
  * ===========================================================================
@@ -264,47 +294,46 @@ rocblas_dot_template(rocblas_handle handle,
  * ===========================================================================
  */
 
-
-extern "C"
-rocblas_status
-rocblas_sdot(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    const float *y, rocblas_int incy,
-    float *result)
+extern "C" rocblas_status rocblas_sdot(rocblas_handle handle,
+                                       rocblas_int n,
+                                       const float* x,
+                                       rocblas_int incx,
+                                       const float* y,
+                                       rocblas_int incy,
+                                       float* result)
 {
     return rocblas_dot_template<float>(handle, n, x, incx, y, incy, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_ddot(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    const double *y, rocblas_int incy,
-    double *result)
+extern "C" rocblas_status rocblas_ddot(rocblas_handle handle,
+                                       rocblas_int n,
+                                       const double* x,
+                                       rocblas_int incx,
+                                       const double* y,
+                                       rocblas_int incy,
+                                       double* result)
 {
     return rocblas_dot_template<double>(handle, n, x, incx, y, incy, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_cdotu(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    const rocblas_float_complex *y, rocblas_int incy,
-    rocblas_float_complex *result)
+extern "C" rocblas_status rocblas_cdotu(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_float_complex* x,
+                                        rocblas_int incx,
+                                        const rocblas_float_complex* y,
+                                        rocblas_int incy,
+                                        rocblas_float_complex* result)
 {
     return rocblas_dot_template<rocblas_float_complex>(handle, n, x, incx, y, incy, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_zdotu(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    const rocblas_double_complex *y, rocblas_int incy,
-    rocblas_double_complex *result)
+extern "C" rocblas_status rocblas_zdotu(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        const rocblas_double_complex* y,
+                                        rocblas_int incy,
+                                        rocblas_double_complex* result)
 {
     return rocblas_dot_template<rocblas_double_complex>(handle, n, x, incx, y, incy, result);
 }

--- a/library/src/blas1/rocblas_nrm2.cpp
+++ b/library/src/blas1/rocblas_nrm2.cpp
@@ -4,7 +4,7 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "status.h"
 #include "definitions.h"
 #include "device_template.h"
@@ -12,61 +12,54 @@
 #include "rocblas_unique_ptr.hpp"
 #include "handle.h"
 
-template<typename T1, typename T2, rocblas_int NB>
+template <typename T1, typename T2, rocblas_int NB>
 __global__ void
-nrm2_kernel_part1(hipLaunchParm lp,
-    rocblas_int n,
-    const T1* x, rocblas_int incx,
-    T2* workspace)
+nrm2_kernel_part1(hipLaunchParm lp, rocblas_int n, const T1* x, rocblas_int incx, T2* workspace)
 {
     rocblas_int tx  = hipThreadIdx_x;
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
     __shared__ T2 shared_tep[NB];
-    //bound
-    if ( tid < n )
+    // bound
+    if(tid < n)
     {
-        T2 real = fetch_real<T1, T2>(x[tid * incx]);
-        T2 imag = fetch_imag<T1, T2>(x[tid * incx]);
-        shared_tep[tx] =  real*real + imag*imag;
+        T2 real        = fetch_real<T1, T2>(x[tid * incx]);
+        T2 imag        = fetch_imag<T1, T2>(x[tid * incx]);
+        shared_tep[tx] = real * real + imag * imag;
     }
     else
-    {   //pad with zero
-        shared_tep[tx] =  0.0;
+    { // pad with zero
+        shared_tep[tx] = 0.0;
     }
 
     rocblas_sum_reduce<NB, T2>(tx, shared_tep);
 
-    if(tx == 0) workspace[hipBlockIdx_x] = shared_tep[0];
+    if(tx == 0)
+        workspace[hipBlockIdx_x] = shared_tep[0];
 }
 
-
-template<typename T, rocblas_int NB, rocblas_int flag>
-__global__ void
-nrm2_kernel_part2(hipLaunchParm lp,
-    rocblas_int n,
-    T* workspace,
-    T* result)
+template <typename T, rocblas_int NB, rocblas_int flag>
+__global__ void nrm2_kernel_part2(hipLaunchParm lp, rocblas_int n, T* workspace, T* result)
 {
-    rocblas_int tx  = hipThreadIdx_x;
+    rocblas_int tx = hipThreadIdx_x;
 
     __shared__ T shared_tep[NB];
 
     shared_tep[tx] = 0.0;
 
-    //bound, loop
-    for (rocblas_int i=tx; i<n; i+=NB)
+    // bound, loop
+    for(rocblas_int i = tx; i < n; i += NB)
     {
         shared_tep[i] += workspace[i];
     }
     __syncthreads();
 
-    if (n < 32)
+    if(n < 32)
     {
         // no need parallel reduction
-        if (tx == 0)
+        if(tx == 0)
         {
-            for (rocblas_int i=1;i<n;i++)
+            for(rocblas_int i = 1; i < n; i++)
             {
                 shared_tep[0] += shared_tep[i];
             }
@@ -74,16 +67,16 @@ nrm2_kernel_part2(hipLaunchParm lp,
     }
     else
     {
-            //parallel reduction, TODO bug
-            rocblas_sum_reduce<NB, T>(tx, shared_tep);
+        // parallel reduction, TODO bug
+        rocblas_sum_reduce<NB, T>(tx, shared_tep);
     }
 
     if(tx == 0)
     {
         if(flag)
         {
-            //flag == 1, write to result of device memory
-            *result = sqrt(shared_tep[0]); //result[0] works, too
+            // flag == 1, write to result of device memory
+            *result = sqrt(shared_tep[0]); // result[0] works, too
         }
         else
         {
@@ -92,25 +85,29 @@ nrm2_kernel_part2(hipLaunchParm lp,
     }
 }
 
-
-//HIP support up to 1024 threads/work itmes per thread block/work group
+// HIP support up to 1024 threads/work itmes per thread block/work group
 #define NB_X 1024
 
-//assume workspace has already been allocated, recommened for repeated calling of nrm2 product routine
-template<typename T1, typename T2>
-rocblas_status
-rocblas_nrm2_template_workspace(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    T2* result, T2* workspace, rocblas_int lworkspace)
+// assume workspace has already been allocated, recommened for repeated calling of nrm2 product
+// routine
+template <typename T1, typename T2>
+rocblas_status rocblas_nrm2_template_workspace(rocblas_handle handle,
+                                               rocblas_int n,
+                                               const T1* x,
+                                               rocblas_int incx,
+                                               T2* result,
+                                               T2* workspace,
+                                               rocblas_int lworkspace)
 {
-    rocblas_int blocks = (n-1)/ NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
-    //At least two kernels are needed to finish the reduction
-    //kennel 1 write partial result per thread block in workspace, number of partial result is blocks
-    //kernel 2 gather all the partial result in workspace and finish the final reduction. number of threads (NB_X) loop blocks
+    // At least two kernels are needed to finish the reduction
+    // kennel 1 write partial result per thread block in workspace, number of partial result is
+    // blocks
+    // kernel 2 gather all the partial result in workspace and finish the final reduction. number of
+    // threads (NB_X) loop blocks
 
-    if (lworkspace < blocks)
+    if(lworkspace < blocks)
     {
         printf("size workspace = %d is too small, allocate at least %d", lworkspace, blocks);
         return rocblas_status_not_implemented;
@@ -122,20 +119,43 @@ rocblas_nrm2_template_workspace(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    hipLaunchKernel(HIP_KERNEL_NAME(nrm2_kernel_part1<T1, T2, NB_X>), dim3(grid), dim3(threads), 0, rocblas_stream, n, x, incx, workspace);
+    hipLaunchKernel(HIP_KERNEL_NAME(nrm2_kernel_part1<T1, T2, NB_X>),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    n,
+                    x,
+                    incx,
+                    workspace);
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        //the last argument 1 in <> indicate the result is on device, not memcpy is required
-        hipLaunchKernel(HIP_KERNEL_NAME(nrm2_kernel_part2<T2, NB_X, 1>), dim3(1,1,1), dim3(threads), 0, rocblas_stream, blocks, workspace, result);
+        // the last argument 1 in <> indicate the result is on device, not memcpy is required
+        hipLaunchKernel(HIP_KERNEL_NAME(nrm2_kernel_part2<T2, NB_X, 1>),
+                        dim3(1, 1, 1),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        blocks,
+                        workspace,
+                        result);
     }
     else
     {
-        //the last argument 0 in <> indicate the result is on host
-        // workspace[0] does not has a copy of the final result since not sqrt yet, if the result pointer is on host, a memory copy is required
-        //printf("it is a host pointer\n");
+        // the last argument 0 in <> indicate the result is on host
+        // workspace[0] does not has a copy of the final result since not sqrt yet, if the result
+        // pointer is on host, a memory copy is required
+        // printf("it is a host pointer\n");
         // the second kernel is required to perform sqrt,
-        hipLaunchKernel(HIP_KERNEL_NAME(nrm2_kernel_part2<T2, NB_X, 0>), dim3(1,1,1), dim3(threads), 0, rocblas_stream, blocks, workspace, result);
+        hipLaunchKernel(HIP_KERNEL_NAME(nrm2_kernel_part2<T2, NB_X, 0>),
+                        dim3(1, 1, 1),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        blocks,
+                        workspace,
+                        result);
         RETURN_IF_HIP_ERROR(hipMemcpy(result, workspace, sizeof(T2), hipMemcpyDeviceToHost));
     }
 
@@ -167,17 +187,14 @@ rocblas_nrm2_template_workspace(rocblas_handle handle,
               return is 0.0 if n <= 0 or incx <= 0.
     ********************************************************************/
 
-//allocate workspace inside this API
-template<typename T1, typename T2>
-rocblas_status
-rocblas_nrm2_template(rocblas_handle handle,
-    rocblas_int n,
-    const T1 *x, rocblas_int incx,
-    T2 *result)
+// allocate workspace inside this API
+template <typename T1, typename T2>
+rocblas_status rocblas_nrm2_template(
+    rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, T2* result)
 {
-    if (nullptr == x)
+    if(nullptr == x)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == result)
+    else if(nullptr == result)
         return rocblas_status_invalid_pointer;
     else if(nullptr == handle)
         return rocblas_status_invalid_handle;
@@ -185,9 +202,9 @@ rocblas_nrm2_template(rocblas_handle handle,
     /*
      * Quick return if possible.
      */
-    if (n <= 0 || incx <= 0)
+    if(n <= 0 || incx <= 0)
     {
-        if (rocblas_pointer_mode_device == handle->pointer_mode)
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
         {
             RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(T2)));
         }
@@ -198,71 +215,57 @@ rocblas_nrm2_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    rocblas_int blocks = (n-1)/ NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
     rocblas_status status;
 
-    auto workspace = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks),rocblas::device_free};
+    auto workspace =
+        rocblas_unique_ptr{rocblas::device_malloc(sizeof(T2) * blocks), rocblas::device_free};
     if(!workspace)
     {
         return rocblas_status_memory_error;
     }
 
-    status = rocblas_nrm2_template_workspace<T1, T2>(handle, n, x, incx, result, (T2*)workspace.get(), blocks);
+    status = rocblas_nrm2_template_workspace<T1, T2>(
+        handle, n, x, incx, result, (T2*)workspace.get(), blocks);
 
     return status;
 }
 
-
-
-
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-
-extern "C"
-rocblas_status
-rocblas_snrm2(rocblas_handle handle,
-    rocblas_int n,
-    const float *x, rocblas_int incx,
-    float *result)
+extern "C" rocblas_status
+rocblas_snrm2(rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result)
 {
     return rocblas_nrm2_template<float, float>(handle, n, x, incx, result);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_dnrm2(rocblas_handle handle,
-    rocblas_int n,
-    const double *x, rocblas_int incx,
-    double *result)
+extern "C" rocblas_status rocblas_dnrm2(
+    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result)
 {
     return rocblas_nrm2_template<double, double>(handle, n, x, incx, result);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_scnrm2(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    float *result)
+extern "C" rocblas_status rocblas_scnrm2(rocblas_handle handle,
+                                         rocblas_int n,
+                                         const rocblas_float_complex* x,
+                                         rocblas_int incx,
+                                         float* result)
 {
     return rocblas_nrm2_template<rocblas_float_complex, float>(handle, n, x, incx, result);
 }
 
-extern "C"
-rocblas_status
-rocblas_dznrm2(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    double *result)
+extern "C" rocblas_status rocblas_dznrm2(rocblas_handle handle,
+                                         rocblas_int n,
+                                         const rocblas_double_complex* x,
+                                         rocblas_int incx,
+                                         double* result)
 {
     return rocblas_nrm2_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -4,39 +4,33 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "definitions.h"
 #include "handle.h"
 
 #define NB_X 256
 
-template<typename T>
+template <typename T>
 __global__ void
-scal_kernel_host_scalar(hipLaunchParm lp,
-    rocblas_int n,
-    const T alpha,
-    T *x, rocblas_int incx)
+scal_kernel_host_scalar(hipLaunchParm lp, rocblas_int n, const T alpha, T* x, rocblas_int incx)
 {
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    //bound
-    if (tid < n) 
+    // bound
+    if(tid < n)
     {
-        x[tid * incx] =  (alpha) * (x[tid * incx]);
+        x[tid * incx] = (alpha) * (x[tid * incx]);
     }
 }
 
-template<typename T>
+template <typename T>
 __global__ void
-scal_kernel_device_scalar(hipLaunchParm lp,
-    rocblas_int n,
-    const T *alpha,
-    T *x, rocblas_int incx)
+scal_kernel_device_scalar(hipLaunchParm lp, rocblas_int n, const T* alpha, T* x, rocblas_int incx)
 {
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    //bound
-    if (tid < n)
+    // bound
+    if(tid < n)
     {
-        x[tid * incx] =  (*alpha) * (x[tid * incx]);
+        x[tid * incx] = (*alpha) * (x[tid * incx]);
     }
 }
 
@@ -64,16 +58,13 @@ scal_kernel_device_scalar(hipLaunchParm lp,
 
     ********************************************************************/
 
-template<class T>
+template <class T>
 rocblas_status
-rocblas_scal_template(rocblas_handle handle,
-    rocblas_int n,
-    const T *alpha,
-    T *x, rocblas_int incx)
+rocblas_scal_template(rocblas_handle handle, rocblas_int n, const T* alpha, T* x, rocblas_int incx)
 {
-    if (nullptr == x)
+    if(nullptr == x)
         return rocblas_status_invalid_pointer;
-    if (nullptr == alpha)
+    if(nullptr == alpha)
         return rocblas_status_invalid_pointer;
     else if(nullptr == handle)
         return rocblas_status_invalid_handle;
@@ -81,74 +72,78 @@ rocblas_scal_template(rocblas_handle handle,
     /*
      * Quick return if possible. Not Argument error
      */
-    if (n <= 0 || incx <= 0)
+    if(n <= 0 || incx <= 0)
         return rocblas_status_success;
 
-    rocblas_int blocks = (n-1) / NB_X + 1;
+    rocblas_int blocks = (n - 1) / NB_X + 1;
 
-    dim3 grid( blocks, 1, 1 );
+    dim3 grid(blocks, 1, 1);
     dim3 threads(NB_X, 1, 1);
 
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        hipLaunchKernel(HIP_KERNEL_NAME(scal_kernel_device_scalar), dim3(blocks), dim3(threads), 0, rocblas_stream, n, alpha, x, incx);
+        hipLaunchKernel(HIP_KERNEL_NAME(scal_kernel_device_scalar),
+                        dim3(blocks),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        n,
+                        alpha,
+                        x,
+                        incx);
     }
     else // alpha is on host
     {
         T scalar = *alpha;
-        hipLaunchKernel(HIP_KERNEL_NAME(scal_kernel_host_scalar), dim3(blocks), dim3(threads), 0, rocblas_stream, n, scalar, x, incx);
+        hipLaunchKernel(HIP_KERNEL_NAME(scal_kernel_host_scalar),
+                        dim3(blocks),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        n,
+                        scalar,
+                        x,
+                        incx);
     }
 
     return rocblas_status_success;
 }
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-
-extern "C"
-rocblas_status
-rocblas_sscal(rocblas_handle handle,
-    rocblas_int n,
-    const float *alpha,
-    float *x, rocblas_int incx)
+extern "C" rocblas_status
+rocblas_sscal(rocblas_handle handle, rocblas_int n, const float* alpha, float* x, rocblas_int incx)
 {
     return rocblas_scal_template<float>(handle, n, alpha, x, incx);
 }
 
-extern "C"
-rocblas_status
-rocblas_dscal(rocblas_handle handle,
-    rocblas_int n,
-    const double *alpha,
-    double *x, rocblas_int incx)
+extern "C" rocblas_status rocblas_dscal(
+    rocblas_handle handle, rocblas_int n, const double* alpha, double* x, rocblas_int incx)
 {
     return rocblas_scal_template<double>(handle, n, alpha, x, incx);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_cscal(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *alpha,
-    rocblas_float_complex *x, rocblas_int incx)
+extern "C" rocblas_status rocblas_cscal(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_float_complex* alpha,
+                                        rocblas_float_complex* x,
+                                        rocblas_int incx)
 {
     return rocblas_scal_template<rocblas_float_complex>(handle, n, alpha, x, incx);
 }
 
-extern "C"
-rocblas_status
-rocblas_zscal(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *alpha,
-    rocblas_double_complex *x, rocblas_int incx)
+extern "C" rocblas_status rocblas_zscal(rocblas_handle handle,
+                                        rocblas_int n,
+                                        const rocblas_double_complex* alpha,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx)
 {
     return rocblas_scal_template<rocblas_double_complex>(handle, n, alpha, x, incx);
 }

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -4,59 +4,55 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
- 
+
 #include "definitions.h"
 
 #define NB_X 256
 
-template<typename T>
+template <typename T>
 __global__ void
-swap_kernel(hipLaunchParm lp,
-    rocblas_int n,
-    T *x, rocblas_int incx,
-    T* y,  rocblas_int incy)
+swap_kernel(hipLaunchParm lp, rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
 {
     int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
     T tmp;
     if(incx >= 0 && incy >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            tmp = y[tid*incy];
-            y[tid*incy] =  x[tid * incx];
-            x[tid*incx] =  tmp;
+            tmp           = y[tid * incy];
+            y[tid * incy] = x[tid * incx];
+            x[tid * incx] = tmp;
         }
     }
     else if(incx < 0 && incy < 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            tmp = y[(1 - n + tid) * incy];
-            y[(1 - n + tid) * incy] =  x[(1 - n + tid) * incx];
-            x[(1 - n + tid) * incx] =  tmp;
+            tmp                     = y[(1 - n + tid) * incy];
+            y[(1 - n + tid) * incy] = x[(1 - n + tid) * incx];
+            x[(1 - n + tid) * incx] = tmp;
         }
     }
-    else if (incx >=0)
+    else if(incx >= 0)
     {
-        if (tid < n)
+        if(tid < n)
         {
-            tmp = y[(1 - n + tid) * incy];
-            y[(1 - n + tid) * incy] =  x[tid * incx];
-            x[tid * incx] =  tmp;
+            tmp                     = y[(1 - n + tid) * incy];
+            y[(1 - n + tid) * incy] = x[tid * incx];
+            x[tid * incx]           = tmp;
         }
     }
     else
     {
-        if (tid < n)
+        if(tid < n)
         {
-            tmp = y[tid * incy];
-            y[tid * incy] =  x[(1 - n + tid) * incx];
-            x[(1 - n + tid) * incx] =  tmp;
+            tmp                     = y[tid * incy];
+            y[tid * incy]           = x[(1 - n + tid) * incx];
+            x[(1 - n + tid) * incx] = tmp;
         }
     }
 }
-
 
 /*! \brief BLAS Level 1 API
 
@@ -83,16 +79,13 @@ swap_kernel(hipLaunchParm lp,
 
     ********************************************************************/
 
-template<class T>
-rocblas_status
-rocblas_swap_template(rocblas_handle handle,
-    rocblas_int n,
-    T *x, rocblas_int incx,
-    T* y, rocblas_int incy)
+template <class T>
+rocblas_status rocblas_swap_template(
+    rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
 {
-    if ( x == nullptr )
+    if(x == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( y == nullptr )
+    else if(y == nullptr)
         return rocblas_status_invalid_pointer;
     if(handle == nullptr)
         return rocblas_status_invalid_handle;
@@ -100,70 +93,71 @@ rocblas_swap_template(rocblas_handle handle,
     /*
      * Quick return if possible.
      */
-    if ( n <= 0)
+    if(n <= 0)
         return rocblas_status_success;
 
-    int blocks = (n-1)/ NB_X + 1;
+    int blocks = (n - 1) / NB_X + 1;
 
-    dim3 grid( blocks, 1, 1 );
-    dim3 threads( NB_X, 1, 1 );
+    dim3 grid(blocks, 1, 1);
+    dim3 threads(NB_X, 1, 1);
 
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    hipLaunchKernel(HIP_KERNEL_NAME(swap_kernel), dim3(grid), dim3(threads), 0, rocblas_stream, n, x, incx, y, incy);
+    hipLaunchKernel(HIP_KERNEL_NAME(swap_kernel),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    n,
+                    x,
+                    incx,
+                    y,
+                    incy);
 
     return rocblas_status_success;
 }
 
-
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-
-extern "C"
-rocblas_status
-rocblas_sswap(rocblas_handle handle,
-    rocblas_int n,
-    float *x, rocblas_int incx,
-    float* y, rocblas_int incy){
+extern "C" rocblas_status rocblas_sswap(
+    rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy)
+{
 
     return rocblas_swap_template<float>(handle, n, x, incx, y, incy);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_dswap(rocblas_handle handle,
-    rocblas_int n,
-    double *x, rocblas_int incx,
-    double* y, rocblas_int incy){
+extern "C" rocblas_status rocblas_dswap(
+    rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy)
+{
 
     return rocblas_swap_template<double>(handle, n, x, incx, y, incy);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_cswap(rocblas_handle handle,
-    rocblas_int n,
-    rocblas_float_complex *x, rocblas_int incx,
-    rocblas_float_complex* y, rocblas_int incy){
+extern "C" rocblas_status rocblas_cswap(rocblas_handle handle,
+                                        rocblas_int n,
+                                        rocblas_float_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_float_complex* y,
+                                        rocblas_int incy)
+{
 
     return rocblas_swap_template<rocblas_float_complex>(handle, n, x, incx, y, incy);
 }
 
-extern "C"
-rocblas_status
-rocblas_zswap(rocblas_handle handle,
-    rocblas_int n,
-    rocblas_double_complex *x, rocblas_int incx,
-    rocblas_double_complex* y, rocblas_int incy){
+extern "C" rocblas_status rocblas_zswap(rocblas_handle handle,
+                                        rocblas_int n,
+                                        rocblas_double_complex* x,
+                                        rocblas_int incx,
+                                        rocblas_double_complex* y,
+                                        rocblas_int incy)
+{
 
     return rocblas_swap_template<rocblas_double_complex>(handle, n, x, incx, y, incy);
 }

--- a/library/src/blas2/gemv_device.h
+++ b/library/src/blas2/gemv_device.h
@@ -1,26 +1,29 @@
-    /*
-     * ===========================================================================
-     *    This file provide common device function for gemv routines
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    This file provide common device function for gemv routines
+ * ===========================================================================
+ */
 
 /* ============================================================================================ */
 
 #include "../blas1/device_template.h"
 
-template<typename T, const rocblas_int DIM_X, const rocblas_int DIM_Y>
-static __device__ void
-gemvn_device(
-    rocblas_int m, rocblas_int n,
-    T alpha,
-    const T * __restrict__ A, rocblas_int lda,
-    const T * __restrict__ x, rocblas_int incx,
-    T beta,
-    T       * y, rocblas_int incy)
+template <typename T, const rocblas_int DIM_X, const rocblas_int DIM_Y>
+static __device__ void gemvn_device(rocblas_int m,
+                                    rocblas_int n,
+                                    T alpha,
+                                    const T* __restrict__ A,
+                                    rocblas_int lda,
+                                    const T* __restrict__ x,
+                                    rocblas_int incx,
+                                    T beta,
+                                    T* y,
+                                    rocblas_int incy)
 {
     rocblas_int num_threads = hipBlockDim_x * hipBlockDim_y * hipBlockDim_z;
 
-    if (DIM_X * DIM_Y != num_threads) return; // need to launch exactly the same number of threads as template parameters indicate
+    if(DIM_X * DIM_Y != num_threads)
+        return; // need to launch exactly the same number of threads as template parameters indicate
 
     rocblas_int thread_id = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x;
 
@@ -32,7 +35,7 @@ gemvn_device(
 
     __shared__ T sdata[DIM_X * 4 * DIM_Y];
 
-    T res_A[4]; //micor tile is 4 * 4
+    T res_A[4]; // micor tile is 4 * 4
     T res_x[4];
 
     res_A[0] = res_x[0] = 0.0;
@@ -40,55 +43,59 @@ gemvn_device(
     res_A[2] = res_x[0] = 0.0;
     res_A[3] = res_x[0] = 0.0;
 
-    ind = hipBlockIdx_x*DIM_X*4 + tx ;
+    ind = hipBlockIdx_x * DIM_X * 4 + tx;
 
     rocblas_int n_tail = n % (4 * DIM_Y);
-    rocblas_int col = ty * 4;
+    rocblas_int col    = ty * 4;
 
-    for (col=ty*4; col < (n - n_tail); col += 4 * DIM_Y)
+    for(col = ty * 4; col < (n - n_tail); col += 4 * DIM_Y)
     {
 
         if(incx >= 0)
         {
-            res_x[0] = x[(col+0)*incx];
-            res_x[1] = x[(col+1)*incx];
-            res_x[2] = x[(col+2)*incx];
-            res_x[3] = x[(col+3)*incx];
+            res_x[0] = x[(col + 0) * incx];
+            res_x[1] = x[(col + 1) * incx];
+            res_x[2] = x[(col + 2) * incx];
+            res_x[3] = x[(col + 3) * incx];
         }
         else
         {
-            res_x[0] = x[(col+1-n)*incx];
-            res_x[1] = x[(col+2-n)*incx];
-            res_x[2] = x[(col+3-n)*incx];
-            res_x[3] = x[(col+4-n)*incx];
+            res_x[0] = x[(col + 1 - n) * incx];
+            res_x[1] = x[(col + 2 - n) * incx];
+            res_x[2] = x[(col + 3 - n) * incx];
+            res_x[3] = x[(col + 4 - n) * incx];
         }
 
-        if(ind < m){
-            res_A[0] += A[ind + (col+0)*lda] * res_x[0];
-            res_A[0] += A[ind + (col+1)*lda] * res_x[1];
-            res_A[0] += A[ind + (col+2)*lda] * res_x[2];
-            res_A[0] += A[ind + (col+3)*lda] * res_x[3];
+        if(ind < m)
+        {
+            res_A[0] += A[ind + (col + 0) * lda] * res_x[0];
+            res_A[0] += A[ind + (col + 1) * lda] * res_x[1];
+            res_A[0] += A[ind + (col + 2) * lda] * res_x[2];
+            res_A[0] += A[ind + (col + 3) * lda] * res_x[3];
         }
 
-        if(ind + DIM_X < m){
-            res_A[1] += A[ind + DIM_X + (col+0)*lda] * res_x[0];
-            res_A[1] += A[ind + DIM_X + (col+1)*lda] * res_x[1];
-            res_A[1] += A[ind + DIM_X + (col+2)*lda] * res_x[2];
-            res_A[1] += A[ind + DIM_X + (col+3)*lda] * res_x[3];
+        if(ind + DIM_X < m)
+        {
+            res_A[1] += A[ind + DIM_X + (col + 0) * lda] * res_x[0];
+            res_A[1] += A[ind + DIM_X + (col + 1) * lda] * res_x[1];
+            res_A[1] += A[ind + DIM_X + (col + 2) * lda] * res_x[2];
+            res_A[1] += A[ind + DIM_X + (col + 3) * lda] * res_x[3];
         }
 
-        if(ind + 2 * DIM_X < m){
-            res_A[2] += A[ind + 2 * DIM_X + (col+0)*lda] * res_x[0];
-            res_A[2] += A[ind + 2 * DIM_X + (col+1)*lda] * res_x[1];
-            res_A[2] += A[ind + 2 * DIM_X + (col+2)*lda] * res_x[2];
-            res_A[2] += A[ind + 2 * DIM_X + (col+3)*lda] * res_x[3];
+        if(ind + 2 * DIM_X < m)
+        {
+            res_A[2] += A[ind + 2 * DIM_X + (col + 0) * lda] * res_x[0];
+            res_A[2] += A[ind + 2 * DIM_X + (col + 1) * lda] * res_x[1];
+            res_A[2] += A[ind + 2 * DIM_X + (col + 2) * lda] * res_x[2];
+            res_A[2] += A[ind + 2 * DIM_X + (col + 3) * lda] * res_x[3];
         }
 
-        if(ind + 3 * DIM_X < m){
-            res_A[3] += A[ind + 3 * DIM_X + (col+0)*lda] * res_x[0];
-            res_A[3] += A[ind + 3 * DIM_X + (col+1)*lda] * res_x[1];
-            res_A[3] += A[ind + 3 * DIM_X + (col+2)*lda] * res_x[2];
-            res_A[3] += A[ind + 3 * DIM_X + (col+3)*lda] * res_x[3];
+        if(ind + 3 * DIM_X < m)
+        {
+            res_A[3] += A[ind + 3 * DIM_X + (col + 0) * lda] * res_x[0];
+            res_A[3] += A[ind + 3 * DIM_X + (col + 1) * lda] * res_x[1];
+            res_A[3] += A[ind + 3 * DIM_X + (col + 2) * lda] * res_x[2];
+            res_A[3] += A[ind + 3 * DIM_X + (col + 3) * lda] * res_x[3];
         }
     }
 
@@ -97,61 +104,63 @@ gemvn_device(
     {
         if(incx >= 0)
         {
-            res_x[0] = (col     < n) ? x[(col+0)*incx] : 0;
-            res_x[1] = (col + 1 < n) ? x[(col+1)*incx] : 0;
-            res_x[2] = (col + 2 < n) ? x[(col+2)*incx] : 0;
-            res_x[3] = (col + 3 < n) ? x[(col+3)*incx] : 0;
+            res_x[0] = (col < n) ? x[(col + 0) * incx] : 0;
+            res_x[1] = (col + 1 < n) ? x[(col + 1) * incx] : 0;
+            res_x[2] = (col + 2 < n) ? x[(col + 2) * incx] : 0;
+            res_x[3] = (col + 3 < n) ? x[(col + 3) * incx] : 0;
         }
         else
         {
-            res_x[0] = (col     < n) ? x[(col+1-n)*incx] : 0;
-            res_x[1] = (col + 1 < n) ? x[(col+2-n)*incx] : 0;
-            res_x[2] = (col + 2 < n) ? x[(col+3-n)*incx] : 0;
-            res_x[3] = (col + 3 < n) ? x[(col+4-n)*incx] : 0;
+            res_x[0] = (col < n) ? x[(col + 1 - n) * incx] : 0;
+            res_x[1] = (col + 1 < n) ? x[(col + 2 - n) * incx] : 0;
+            res_x[2] = (col + 2 < n) ? x[(col + 3 - n) * incx] : 0;
+            res_x[3] = (col + 3 < n) ? x[(col + 4 - n) * incx] : 0;
         }
 
-        if(ind < m){
-            res_A[0] += A[ind + (col+0)*lda*(col+0 < n)] * res_x[0];
-            res_A[0] += A[ind + (col+1)*lda*(col+1 < n)] * res_x[1];
-            res_A[0] += A[ind + (col+2)*lda*(col+2 < n)] * res_x[2];
-            res_A[0] += A[ind + (col+3)*lda*(col+3 < n)] * res_x[3];
+        if(ind < m)
+        {
+            res_A[0] += A[ind + (col + 0) * lda * (col + 0 < n)] * res_x[0];
+            res_A[0] += A[ind + (col + 1) * lda * (col + 1 < n)] * res_x[1];
+            res_A[0] += A[ind + (col + 2) * lda * (col + 2 < n)] * res_x[2];
+            res_A[0] += A[ind + (col + 3) * lda * (col + 3 < n)] * res_x[3];
         }
 
-
-        if(ind + DIM_X < m){
-            res_A[1] += A[ind + DIM_X + (col+0)*lda*(col+0 < n)] * res_x[0];
-            res_A[1] += A[ind + DIM_X + (col+1)*lda*(col+1 < n)] * res_x[1];
-            res_A[1] += A[ind + DIM_X + (col+2)*lda*(col+2 < n)] * res_x[2];
-            res_A[1] += A[ind + DIM_X + (col+3)*lda*(col+3 < n)] * res_x[3];
+        if(ind + DIM_X < m)
+        {
+            res_A[1] += A[ind + DIM_X + (col + 0) * lda * (col + 0 < n)] * res_x[0];
+            res_A[1] += A[ind + DIM_X + (col + 1) * lda * (col + 1 < n)] * res_x[1];
+            res_A[1] += A[ind + DIM_X + (col + 2) * lda * (col + 2 < n)] * res_x[2];
+            res_A[1] += A[ind + DIM_X + (col + 3) * lda * (col + 3 < n)] * res_x[3];
         }
 
-        if(ind + 2 * DIM_X < m){
-            res_A[2] += A[ind + 2 * DIM_X + (col+0)*lda*(col+0 < n)] * res_x[0];
-            res_A[2] += A[ind + 2 * DIM_X + (col+1)*lda*(col+1 < n)] * res_x[1];
-            res_A[2] += A[ind + 2 * DIM_X + (col+2)*lda*(col+2 < n)] * res_x[2];
-            res_A[2] += A[ind + 2 * DIM_X + (col+3)*lda*(col+3 < n)] * res_x[3];
+        if(ind + 2 * DIM_X < m)
+        {
+            res_A[2] += A[ind + 2 * DIM_X + (col + 0) * lda * (col + 0 < n)] * res_x[0];
+            res_A[2] += A[ind + 2 * DIM_X + (col + 1) * lda * (col + 1 < n)] * res_x[1];
+            res_A[2] += A[ind + 2 * DIM_X + (col + 2) * lda * (col + 2 < n)] * res_x[2];
+            res_A[2] += A[ind + 2 * DIM_X + (col + 3) * lda * (col + 3 < n)] * res_x[3];
         }
 
-        if(ind + 3 * DIM_X < m){
-            res_A[3] += A[ind + 3 * DIM_X + (col+0)*lda*(col+0 < n)] * res_x[0];
-            res_A[3] += A[ind + 3 * DIM_X + (col+1)*lda*(col+1 < n)] * res_x[1];
-            res_A[3] += A[ind + 3 * DIM_X + (col+2)*lda*(col+2 < n)] * res_x[2];
-            res_A[3] += A[ind + 3 * DIM_X + (col+3)*lda*(col+3 < n)] * res_x[3];
+        if(ind + 3 * DIM_X < m)
+        {
+            res_A[3] += A[ind + 3 * DIM_X + (col + 0) * lda * (col + 0 < n)] * res_x[0];
+            res_A[3] += A[ind + 3 * DIM_X + (col + 1) * lda * (col + 1 < n)] * res_x[1];
+            res_A[3] += A[ind + 3 * DIM_X + (col + 2) * lda * (col + 2 < n)] * res_x[2];
+            res_A[3] += A[ind + 3 * DIM_X + (col + 3) * lda * (col + 3 < n)] * res_x[3];
         }
     }
 
-    sdata[ tx + ty * DIM_X * 4] = res_A[0];
-    sdata[ tx + DIM_X + ty * DIM_X * 4] = res_A[1];
-    sdata[ tx + 2 * DIM_X + ty * DIM_X * 4] = res_A[2];
-    sdata[ tx + 3 * DIM_X + ty * DIM_X * 4] = res_A[3];
+    sdata[tx + ty * DIM_X * 4]             = res_A[0];
+    sdata[tx + DIM_X + ty * DIM_X * 4]     = res_A[1];
+    sdata[tx + 2 * DIM_X + ty * DIM_X * 4] = res_A[2];
+    sdata[tx + 3 * DIM_X + ty * DIM_X * 4] = res_A[3];
 
     __syncthreads();
 
-
-    ind = hipBlockIdx_x*DIM_X*4 + thread_id ;
+    ind = hipBlockIdx_x * DIM_X * 4 + thread_id;
     if(thread_id < DIM_X * 4)
     {
-        for (rocblas_int i=1; i < DIM_Y; i++)
+        for(rocblas_int i = 1; i < DIM_Y; i++)
         {
             sdata[thread_id] += sdata[thread_id + DIM_X * 4 * i];
         }
@@ -160,31 +169,31 @@ gemvn_device(
         {
             if(incy >= 0)
             {
-                y[ind*incy] = alpha*sdata[thread_id] + beta*y[ind*incy];
+                y[ind * incy] = alpha * sdata[thread_id] + beta * y[ind * incy];
             }
             else
             {
-                y[(1 - m + ind)*incy] = alpha*sdata[thread_id] + beta*y[(1 - m + ind)*incy];
+                y[(1 - m + ind) * incy] = alpha * sdata[thread_id] + beta * y[(1 - m + ind) * incy];
             }
         }
     }
-
 }
 
-
-
-template<typename T, const rocblas_int NB_X>
-static __device__ void
-gemvc_device(
-    rocblas_int m, rocblas_int n,
-    T alpha,
-    const T * __restrict__ A, rocblas_int lda,
-    const T * __restrict__ x, rocblas_int incx,
-    T beta,
-    T       * y, rocblas_int incy)
+template <typename T, const rocblas_int NB_X>
+static __device__ void gemvc_device(rocblas_int m,
+                                    rocblas_int n,
+                                    T alpha,
+                                    const T* __restrict__ A,
+                                    rocblas_int lda,
+                                    const T* __restrict__ x,
+                                    rocblas_int incx,
+                                    T beta,
+                                    T* y,
+                                    rocblas_int incy)
 {
     rocblas_int tx = hipThreadIdx_x;
-    if (tx < m) A += tx;
+    if(tx < m)
+        A += tx;
 
     rocblas_int col = hipBlockIdx_x;
     A += col * lda;
@@ -197,44 +206,43 @@ gemvc_device(
     // partial sums
     rocblas_int m_full = (m / NB_X) * NB_X;
 
-    if(incx >= 0) 
+    if(incx >= 0)
     {
-        for (rocblas_int i=0; i < m_full; i += NB_X) 
+        for(rocblas_int i = 0; i < m_full; i += NB_X)
         {
-            res += (A[i]) * x[(tx + i)*incx];
+            res += (A[i]) * x[(tx + i) * incx];
         }
-        if ( tx + m_full < m ) 
+        if(tx + m_full < m)
         {
-            res += (A[m_full]) * x[(tx + m_full)*incx];
+            res += (A[m_full]) * x[(tx + m_full) * incx];
         }
     }
     else
     {
-        for (rocblas_int i=0; i < m_full; i += NB_X) 
+        for(rocblas_int i = 0; i < m_full; i += NB_X)
         {
-            res += (A[i]) * x[(1 - m + tx + i)*incx];
+            res += (A[i]) * x[(1 - m + tx + i) * incx];
         }
-        if ( tx + m_full < m ) 
+        if(tx + m_full < m)
         {
-            res += (A[m_full]) * x[(1 - m + tx + m_full)*incx];
+            res += (A[m_full]) * x[(1 - m + tx + m_full) * incx];
         }
     }
-
 
     sdata[tx] = res;
 
     // tree reduction of partial sums,
-    if ( NB_X > 16)
+    if(NB_X > 16)
     {
-        rocblas_sum_reduce< NB_X >( tx, sdata);
+        rocblas_sum_reduce<NB_X>(tx, sdata);
     }
     else
     {
         __syncthreads();
 
-        if (tx == 0)
+        if(tx == 0)
         {
-            for (rocblas_int i=1; i < m && i < NB_X; i++)
+            for(rocblas_int i = 1; i < m && i < NB_X; i++)
             {
                 sdata[0] += sdata[i];
             }
@@ -242,15 +250,15 @@ gemvc_device(
         __syncthreads();
     }
 
-    if ( tx == 0) 
+    if(tx == 0)
     {
         if(incy >= 0)
         {
-            y[col*incy] = alpha*sdata[0] + beta*y[col*incy];
+            y[col * incy] = alpha * sdata[0] + beta * y[col * incy];
         }
         else
         {
-            y[(1 - n + col)*incy] = alpha*sdata[0] + beta*y[(1 - n + col)*incy];
+            y[(1 - n + col) * incy] = alpha * sdata[0] + beta * y[(1 - n + col) * incy];
         }
     }
 }

--- a/library/src/blas2/ger_device.h
+++ b/library/src/blas2/ger_device.h
@@ -12,46 +12,49 @@
 
 #include "../blas1/device_template.h"
 
-template<typename T>
-static __device__ void
-ger_device(
-    rocblas_int m, rocblas_int n,
-    T alpha,
-    const T * __restrict__ x, rocblas_int incx,
-    const T * __restrict__ y, rocblas_int incy,
-          T *              A, rocblas_int lda)
+template <typename T>
+static __device__ void ger_device(rocblas_int m,
+                                  rocblas_int n,
+                                  T alpha,
+                                  const T* __restrict__ x,
+                                  rocblas_int incx,
+                                  const T* __restrict__ y,
+                                  rocblas_int incy,
+                                  T* A,
+                                  rocblas_int lda)
 {
-    if (m <= 0 || n <= 0) return;
+    if(m <= 0 || n <= 0)
+        return;
 
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     rocblas_int ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
 
     if(incx >= 0 && incy >= 0)
     {
-        if (tx < m && ty < n)
+        if(tx < m && ty < n)
         {
-            A[tx + lda*ty] += (alpha) * x[tx*incx] * y[ty*incy];
+            A[tx + lda * ty] += (alpha)*x[tx * incx] * y[ty * incy];
         }
     }
     else if(incx < 0 && incy < 0)
     {
-        if (tx < m && ty < n)
+        if(tx < m && ty < n)
         {
-            A[tx + lda*ty] += (alpha) * x[(1 - m + tx)*incx] * y[(1 - n + ty)*incy];
+            A[tx + lda * ty] += (alpha)*x[(1 - m + tx) * incx] * y[(1 - n + ty) * incy];
         }
     }
-    else if (incx >= 0)
+    else if(incx >= 0)
     {
-        if (tx < m && ty < n)
+        if(tx < m && ty < n)
         {
-            A[tx + lda*ty] += (alpha) * x[tx*incx] * y[(1 - n + ty)*incy];
+            A[tx + lda * ty] += (alpha)*x[tx * incx] * y[(1 - n + ty) * incy];
         }
     }
     else
     {
-        if (tx < m && ty < n)
+        if(tx < m && ty < n)
         {
-            A[tx + lda*ty] += (alpha) * x[(1 - m + tx)*incx] * y[ty*incy];
+            A[tx + lda * ty] += (alpha)*x[(1 - m + tx) * incx] * y[ty * incy];
         }
     }
 }

--- a/library/src/blas2/rocblas_ger.cpp
+++ b/library/src/blas2/rocblas_ger.cpp
@@ -9,30 +9,35 @@
 #include "ger_device.h"
 #include "handle.h"
 
-template<typename T>
-__global__ void
-ger_kernel_host_pointer(hipLaunchParm lp,
-    rocblas_int m, rocblas_int n,
-    const T alpha,
-    const T * __restrict__ x, rocblas_int incx,
-    const T * __restrict__ y, rocblas_int incy,
-          T *              A, rocblas_int lda)
+template <typename T>
+__global__ void ger_kernel_host_pointer(hipLaunchParm lp,
+                                        rocblas_int m,
+                                        rocblas_int n,
+                                        const T alpha,
+                                        const T* __restrict__ x,
+                                        rocblas_int incx,
+                                        const T* __restrict__ y,
+                                        rocblas_int incy,
+                                        T* A,
+                                        rocblas_int lda)
 {
     ger_device<T>(m, n, alpha, x, incx, y, incy, A, lda);
 }
 
-template<typename T>
-__global__ void
-ger_kernel_device_pointer(hipLaunchParm lp,
-    rocblas_int m, rocblas_int n,
-    const T * alpha,
-    const T * __restrict__ x, rocblas_int incx,
-    const T * __restrict__ y, rocblas_int incy,
-          T *              A, rocblas_int lda)
+template <typename T>
+__global__ void ger_kernel_device_pointer(hipLaunchParm lp,
+                                          rocblas_int m,
+                                          rocblas_int n,
+                                          const T* alpha,
+                                          const T* __restrict__ x,
+                                          rocblas_int incx,
+                                          const T* __restrict__ y,
+                                          rocblas_int incy,
+                                          T* A,
+                                          rocblas_int lda)
 {
     ger_device<T>(m, n, *alpha, x, incx, y, incy, A, lda);
 }
-
 
 /*! \brief BLAS Level 2 API
 
@@ -77,41 +82,44 @@ ger_kernel_device_pointer(hipLaunchParm lp,
 
     ********************************************************************/
 
-template<typename T>
-rocblas_status
-rocblas_ger_template(rocblas_handle handle,
-    rocblas_int m, rocblas_int n,
-    const T *alpha,
-    const T * x, rocblas_int incx,
-    const T * y, rocblas_int incy,
-          T * A, rocblas_int lda)
+template <typename T>
+rocblas_status rocblas_ger_template(rocblas_handle handle,
+                                    rocblas_int m,
+                                    rocblas_int n,
+                                    const T* alpha,
+                                    const T* x,
+                                    rocblas_int incx,
+                                    const T* y,
+                                    rocblas_int incy,
+                                    T* A,
+                                    rocblas_int lda)
 {
-    if (nullptr == alpha)
+    if(nullptr == alpha)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == x)
+    else if(nullptr == x)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == y)
+    else if(nullptr == y)
         return rocblas_status_invalid_pointer;
-    else if (nullptr == A)
+    else if(nullptr == A)
         return rocblas_status_invalid_pointer;
     else if(nullptr == handle)
         return rocblas_status_invalid_handle;
 
-    if ( m < 0 )
+    if(m < 0)
         return rocblas_status_invalid_size;
-    else if ( n < 0 )
+    else if(n < 0)
         return rocblas_status_invalid_size;
-    else if (0 == incx)
+    else if(0 == incx)
         return rocblas_status_invalid_size;
-    else if (0 == incy)
+    else if(0 == incy)
         return rocblas_status_invalid_size;
-    else if ( lda < m || lda < 1)
+    else if(lda < m || lda < 1)
         return rocblas_status_invalid_size;
 
     /*
      * Quick return if possible. Not Argument error
      */
-    if ( m == 0 || n == 0 || alpha == 0)
+    if(m == 0 || n == 0 || alpha == 0)
     {
         return rocblas_status_success;
     }
@@ -119,57 +127,85 @@ rocblas_ger_template(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    #define  GEMV_DIM_X 128
-    #define  GEMV_DIM_Y 8
-    rocblas_int blocksX = ((m-1) / GEMV_DIM_X) + 1;
-    rocblas_int blocksY = ((n-1) / GEMV_DIM_Y) + 1;
+#define GEMV_DIM_X 128
+#define GEMV_DIM_Y 8
+    rocblas_int blocksX = ((m - 1) / GEMV_DIM_X) + 1;
+    rocblas_int blocksY = ((n - 1) / GEMV_DIM_Y) + 1;
 
-    dim3 ger_grid( blocksX, blocksY, 1 );
+    dim3 ger_grid(blocksX, blocksY, 1);
     dim3 ger_threads(GEMV_DIM_X, GEMV_DIM_Y, 1);
 
-    if (rocblas_pointer_mode_device == handle->pointer_mode)
+    if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_device_pointer<T>), dim3(ger_grid), dim3(ger_threads), 0, rocblas_stream,
-                                        m, n, alpha, x, incx, y, incy, A, lda);
+        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_device_pointer<T>),
+                        dim3(ger_grid),
+                        dim3(ger_threads),
+                        0,
+                        rocblas_stream,
+                        m,
+                        n,
+                        alpha,
+                        x,
+                        incx,
+                        y,
+                        incy,
+                        A,
+                        lda);
     }
     else
     {
         T h_alpha_scalar = *alpha;
-        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_host_pointer<T>), dim3(ger_grid), dim3(ger_threads), 0, rocblas_stream,
-                                        m, n, h_alpha_scalar, x, incx, y, incy, A, lda);
+        hipLaunchKernel(HIP_KERNEL_NAME(ger_kernel_host_pointer<T>),
+                        dim3(ger_grid),
+                        dim3(ger_threads),
+                        0,
+                        rocblas_stream,
+                        m,
+                        n,
+                        h_alpha_scalar,
+                        x,
+                        incx,
+                        y,
+                        incy,
+                        A,
+                        lda);
     }
-    #undef GEMV_DIM_X
-    #undef GEMV_DIM_Y
+#undef GEMV_DIM_X
+#undef GEMV_DIM_Y
 
     return rocblas_status_success;
 }
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-extern "C"
-rocblas_status
-rocblas_sger(rocblas_handle handle,
-             rocblas_int m, rocblas_int n,
-             const float *alpha,
-             const float *x, rocblas_int incx,
-             const float *y, rocblas_int incy,
-                   float *A, rocblas_int lda)
+extern "C" rocblas_status rocblas_sger(rocblas_handle handle,
+                                       rocblas_int m,
+                                       rocblas_int n,
+                                       const float* alpha,
+                                       const float* x,
+                                       rocblas_int incx,
+                                       const float* y,
+                                       rocblas_int incy,
+                                       float* A,
+                                       rocblas_int lda)
 {
-    return   rocblas_ger_template<float>(handle, m, n, alpha, x, incx, y, incy, A, lda);
+    return rocblas_ger_template<float>(handle, m, n, alpha, x, incx, y, incy, A, lda);
 }
 
-extern "C"
-rocblas_status
-rocblas_dger(rocblas_handle handle,
-             rocblas_int m, rocblas_int n,
-             const double *alpha,
-             const double *x, rocblas_int incx,
-             const double *y, rocblas_int incy,
-                   double *A, rocblas_int lda)
+extern "C" rocblas_status rocblas_dger(rocblas_handle handle,
+                                       rocblas_int m,
+                                       rocblas_int n,
+                                       const double* alpha,
+                                       const double* x,
+                                       rocblas_int incx,
+                                       const double* y,
+                                       rocblas_int incy,
+                                       double* A,
+                                       rocblas_int lda)
 {
-    return   rocblas_ger_template<double>(handle, m, n, alpha, x, incx, y, incy, A, lda);
+    return rocblas_ger_template<double>(handle, m, n, alpha, x, incx, y, incy, A, lda);
 }

--- a/library/src/blas3/Tensile/gemm.cpp
+++ b/library/src/blas3/Tensile/gemm.cpp
@@ -10,173 +10,209 @@
 #include "definitions.h"
 #include "handle.h"
 
-
 /*******************************************************************************
  * API Args
  ******************************************************************************/
-#define ARGS(TYPE) \
-  rocblas_handle handle, \
-  rocblas_operation trans_a, \
-  rocblas_operation trans_b, \
-  rocblas_int m, \
-  rocblas_int n, \
-  rocblas_int k, \
-  const TYPE *alpha, \
-  const TYPE *A, \
-  rocblas_int ld_a, \
-  const TYPE *B, \
-  rocblas_int ld_b, \
-  const TYPE *beta, \
-  TYPE *C, \
-  rocblas_int ld_c
+#define ARGS(TYPE)                                                                              \
+    rocblas_handle handle, rocblas_operation trans_a, rocblas_operation trans_b, rocblas_int m, \
+        rocblas_int n, rocblas_int k, const TYPE *alpha, const TYPE *A, rocblas_int ld_a,       \
+        const TYPE *B, rocblas_int ld_b, const TYPE *beta, TYPE *C, rocblas_int ld_c
 
-
-
-#define ARGS_BATCHED(TYPE) \
-  rocblas_handle handle, \
-  rocblas_operation trans_a, \
-  rocblas_operation trans_b, \
-  rocblas_int m, \
-  rocblas_int n, \
-  rocblas_int k, \
-  const TYPE *alpha, \
-  const TYPE *A, \
-  rocblas_int ld_a, \
-  rocblas_int bs_a, \
-  const TYPE *B, \
-  rocblas_int ld_b, \
-  rocblas_int bs_b, \
-  const TYPE *beta, \
-  TYPE *C, \
-  rocblas_int ld_c, \
-  rocblas_int bs_c, \
-  rocblas_int b_c
-
+#define ARGS_BATCHED(TYPE)                                                                      \
+    rocblas_handle handle, rocblas_operation trans_a, rocblas_operation trans_b, rocblas_int m, \
+        rocblas_int n, rocblas_int k, const TYPE *alpha, const TYPE *A, rocblas_int ld_a,       \
+        rocblas_int bs_a, const TYPE *B, rocblas_int ld_b, rocblas_int bs_b, const TYPE *beta,  \
+        TYPE *C, rocblas_int ld_c, rocblas_int bs_c, rocblas_int b_c
 
 /*******************************************************************************
  * Preamble Code
  ******************************************************************************/
-#define PREAMBLE \
-  rocblas_int b_c = 1; \
-  rocblas_int bs_c; \
-  rocblas_int bs_a; \
-  rocblas_int bs_b; \
-  infer_batch_strides( trans_a, trans_b, m, n, k, \
-      ld_a, &bs_a, ld_b, &bs_b, ld_c, &bs_c ); \
-  rocblas_status validArgs = validateArgs( handle, trans_a, trans_b, \
-    m, n, k, alpha, A, ld_a, bs_a, B, ld_b, bs_b, beta, C, ld_c, bs_c, b_c); \
-  if (validArgs != rocblas_status_success) return validArgs; \
-  \
-  unsigned int strideC1 = static_cast<unsigned int>(ld_c); \
-  unsigned int strideC2 = static_cast<unsigned int>(bs_c); \
-  unsigned int strideA1 = static_cast<unsigned int>(ld_a); \
-  unsigned int strideA2 = static_cast<unsigned int>(bs_a); \
-  unsigned int strideB1 = static_cast<unsigned int>(ld_b); \
-  unsigned int strideB2 = static_cast<unsigned int>(bs_b); \
-  unsigned int sizeI    = static_cast<unsigned int>(m); \
-  unsigned int sizeJ    = static_cast<unsigned int>(n); \
-  unsigned int sizeK    = b_c; \
-  unsigned int sizeL    = static_cast<unsigned int>(k);
+#define PREAMBLE                                                                           \
+    rocblas_int b_c = 1;                                                                   \
+    rocblas_int bs_c;                                                                      \
+    rocblas_int bs_a;                                                                      \
+    rocblas_int bs_b;                                                                      \
+    infer_batch_strides(trans_a, trans_b, m, n, k, ld_a, &bs_a, ld_b, &bs_b, ld_c, &bs_c); \
+    rocblas_status validArgs = validateArgs(handle,                                        \
+                                            trans_a,                                       \
+                                            trans_b,                                       \
+                                            m,                                             \
+                                            n,                                             \
+                                            k,                                             \
+                                            alpha,                                         \
+                                            A,                                             \
+                                            ld_a,                                          \
+                                            bs_a,                                          \
+                                            B,                                             \
+                                            ld_b,                                          \
+                                            bs_b,                                          \
+                                            beta,                                          \
+                                            C,                                             \
+                                            ld_c,                                          \
+                                            bs_c,                                          \
+                                            b_c);                                          \
+    if(validArgs != rocblas_status_success)                                                \
+        return validArgs;                                                                  \
+                                                                                           \
+    unsigned int strideC1 = static_cast<unsigned int>(ld_c);                               \
+    unsigned int strideC2 = static_cast<unsigned int>(bs_c);                               \
+    unsigned int strideA1 = static_cast<unsigned int>(ld_a);                               \
+    unsigned int strideA2 = static_cast<unsigned int>(bs_a);                               \
+    unsigned int strideB1 = static_cast<unsigned int>(ld_b);                               \
+    unsigned int strideB2 = static_cast<unsigned int>(bs_b);                               \
+    unsigned int sizeI    = static_cast<unsigned int>(m);                                  \
+    unsigned int sizeJ    = static_cast<unsigned int>(n);                                  \
+    unsigned int sizeK    = b_c;                                                           \
+    unsigned int sizeL    = static_cast<unsigned int>(k);
 
-#define PREAMBLE_BATCHED \
-  rocblas_status validArgs = validateArgs( handle, trans_a, trans_b, \
-    m, n, k, alpha, A, ld_a, bs_a, B, ld_b, bs_b, beta, C, ld_c, bs_c, b_c); \
-  if (validArgs != rocblas_status_success) return validArgs; \
-  \
-  unsigned int strideC1 = static_cast<unsigned int>(ld_c); \
-  unsigned int strideC2 = static_cast<unsigned int>(bs_c); \
-  unsigned int strideA1 = static_cast<unsigned int>(ld_a); \
-  unsigned int strideA2 = static_cast<unsigned int>(bs_a); \
-  unsigned int strideB1 = static_cast<unsigned int>(ld_b); \
-  unsigned int strideB2 = static_cast<unsigned int>(bs_b); \
-  unsigned int sizeI    = static_cast<unsigned int>(m); \
-  unsigned int sizeJ    = static_cast<unsigned int>(n); \
-  unsigned int sizeK    = static_cast<unsigned int>(b_c); \
-  unsigned int sizeL    = static_cast<unsigned int>(k);
-
-
+#define PREAMBLE_BATCHED                                     \
+    rocblas_status validArgs = validateArgs(handle,          \
+                                            trans_a,         \
+                                            trans_b,         \
+                                            m,               \
+                                            n,               \
+                                            k,               \
+                                            alpha,           \
+                                            A,               \
+                                            ld_a,            \
+                                            bs_a,            \
+                                            B,               \
+                                            ld_b,            \
+                                            bs_b,            \
+                                            beta,            \
+                                            C,               \
+                                            ld_c,            \
+                                            bs_c,            \
+                                            b_c);            \
+    if(validArgs != rocblas_status_success)                  \
+        return validArgs;                                    \
+                                                             \
+    unsigned int strideC1 = static_cast<unsigned int>(ld_c); \
+    unsigned int strideC2 = static_cast<unsigned int>(bs_c); \
+    unsigned int strideA1 = static_cast<unsigned int>(ld_a); \
+    unsigned int strideA2 = static_cast<unsigned int>(bs_a); \
+    unsigned int strideB1 = static_cast<unsigned int>(ld_b); \
+    unsigned int strideB2 = static_cast<unsigned int>(bs_b); \
+    unsigned int sizeI    = static_cast<unsigned int>(m);    \
+    unsigned int sizeJ    = static_cast<unsigned int>(n);    \
+    unsigned int sizeK    = static_cast<unsigned int>(b_c);  \
+    unsigned int sizeL    = static_cast<unsigned int>(k);
 
 /*******************************************************************************
  * Calling Tensile
  ******************************************************************************/
 #ifndef NDEBUG
 
-#define PRINT_SOLUTION_NAME(PREC,TRANS) \
-  std::cout << "Solution Name: " << tensileGetSolutionName_ ## TRANS ## _ ## PREC ## B(  \
-      strideC1, strideC2, strideA1, strideA2, \
-      strideB1, strideB2, sizeI, sizeJ, sizeK, sizeL, \
-      handle->rocblas_stream ) << std::endl;
+#define PRINT_SOLUTION_NAME(PREC, TRANS)                                            \
+    std::cout << "Solution Name: "                                                  \
+              << tensileGetSolutionName_##TRANS##_##PREC##B(strideC1,               \
+                                                            strideC2,               \
+                                                            strideA1,               \
+                                                            strideA2,               \
+                                                            strideB1,               \
+                                                            strideB2,               \
+                                                            sizeI,                  \
+                                                            sizeJ,                  \
+                                                            sizeK,                  \
+                                                            sizeL,                  \
+                                                            handle->rocblas_stream) \
+              << std::endl;
 
-#define PRINT_RETURN_STATUS \
-  std::cout << "Return Status: " << status << std::endl;
+#define PRINT_RETURN_STATUS std::cout << "Return Status: " << status << std::endl;
 
 #else
-#define PRINT_SOLUTION_NAME(PREC,TRANS)
+#define PRINT_SOLUTION_NAME(PREC, TRANS)
 #define PRINT_RETURN_STATUS
 #endif
 
-#define CALL_TENSILE(PREC, TYPE, TRANS) \
-  PRINT_SOLUTION_NAME(PREC,TRANS) \
-  TYPE alpha_h; \
-  TYPE beta_h; \
-  if (rocblas_pointer_mode_host == handle->pointer_mode) \
-  { \
-    alpha_h = *alpha; \
-    beta_h = *beta; \
-  } \
-  else \
-  { \
-    hipMemcpy(&alpha_h, alpha, sizeof(TYPE), hipMemcpyDeviceToHost); \
-    hipMemcpy(&beta_h, beta, sizeof(TYPE), hipMemcpyDeviceToHost); \
-  } \
-  status = tensile_ ## TRANS ## _ ## PREC ## B( C, A, B, alpha_h, beta_h, \
-      0, 0, 0, strideC1, strideC2, strideA1, strideA2, \
-      strideB1, strideB2, sizeI, sizeJ, sizeK, sizeL, \
-      handle->rocblas_stream, 0, nullptr, nullptr); \
-  PRINT_RETURN_STATUS
-
+#define CALL_TENSILE(PREC, TYPE, TRANS)                                  \
+    PRINT_SOLUTION_NAME(PREC, TRANS)                                     \
+    TYPE alpha_h;                                                        \
+    TYPE beta_h;                                                         \
+    if(rocblas_pointer_mode_host == handle->pointer_mode)                \
+    {                                                                    \
+        alpha_h = *alpha;                                                \
+        beta_h  = *beta;                                                 \
+    }                                                                    \
+    else                                                                 \
+    {                                                                    \
+        hipMemcpy(&alpha_h, alpha, sizeof(TYPE), hipMemcpyDeviceToHost); \
+        hipMemcpy(&beta_h, beta, sizeof(TYPE), hipMemcpyDeviceToHost);   \
+    }                                                                    \
+    status = tensile_##TRANS##_##PREC##B(C,                              \
+                                         A,                              \
+                                         B,                              \
+                                         alpha_h,                        \
+                                         beta_h,                         \
+                                         0,                              \
+                                         0,                              \
+                                         0,                              \
+                                         strideC1,                       \
+                                         strideC2,                       \
+                                         strideA1,                       \
+                                         strideA2,                       \
+                                         strideB1,                       \
+                                         strideB2,                       \
+                                         sizeI,                          \
+                                         sizeJ,                          \
+                                         sizeK,                          \
+                                         sizeL,                          \
+                                         handle->rocblas_stream,         \
+                                         0,                              \
+                                         nullptr,                        \
+                                         nullptr);                       \
+    PRINT_RETURN_STATUS
 
 /*******************************************************************************
  * Handle Transposes
  ******************************************************************************/
-#define TENSILE_TRANSPOSES(PREC, TYPE) \
-  hipError_t status; \
-  if ( trans_a == rocblas_operation_none) { \
-    if (trans_b == rocblas_operation_none) { /*NN*/ \
-      CALL_TENSILE(PREC,TYPE,Cijk_Ailk_Bljk) \
-    } else { /*NT*/ \
-      CALL_TENSILE(PREC,TYPE,Cijk_Ailk_Bjlk) \
-    } \
-  } else { /*TN*/ \
-    if (trans_b == rocblas_operation_none) { \
-      CALL_TENSILE(PREC,TYPE,Cijk_Alik_Bljk) \
-    } else { /*TT*/ \
-      CALL_TENSILE(PREC,TYPE,Cijk_Alik_Bjlk) \
-    } \
-  } \
-  return get_rocblas_status_for_hip_status( status );
-
+#define TENSILE_TRANSPOSES(PREC, TYPE)               \
+    hipError_t status;                               \
+    if(trans_a == rocblas_operation_none)            \
+    {                                                \
+        if(trans_b == rocblas_operation_none)        \
+        { /*NN*/                                     \
+            CALL_TENSILE(PREC, TYPE, Cijk_Ailk_Bljk) \
+        }                                            \
+        else                                         \
+        { /*NT*/                                     \
+            CALL_TENSILE(PREC, TYPE, Cijk_Ailk_Bjlk) \
+        }                                            \
+    }                                                \
+    else                                             \
+    { /*TN*/                                         \
+        if(trans_b == rocblas_operation_none)        \
+        {                                            \
+            CALL_TENSILE(PREC, TYPE, Cijk_Alik_Bljk) \
+        }                                            \
+        else                                         \
+        { /*TT*/                                     \
+            CALL_TENSILE(PREC, TYPE, Cijk_Alik_Bjlk) \
+        }                                            \
+    }                                                \
+    return get_rocblas_status_for_hip_status(status);
 
 /*******************************************************************************
  * Batched vs Non
  ******************************************************************************/
-#define GEMM_API(prec, PREC, TYPE) \
-  rocblas_status rocblas_ ## prec ## gemm( ARGS(TYPE) ) { \
-    PREAMBLE \
-    TENSILE_TRANSPOSES(PREC, TYPE) \
-  }
+#define GEMM_API(prec, PREC, TYPE)                  \
+    rocblas_status rocblas_##prec##gemm(ARGS(TYPE)) \
+    {                                               \
+        PREAMBLE                                    \
+        TENSILE_TRANSPOSES(PREC, TYPE)              \
+    }
 
-#define GEMM_API_BATCHED(prec, PREC, TYPE) \
-  rocblas_status rocblas_ ## prec ## gemm_strided_batched( ARGS_BATCHED(TYPE) ) { \
-    PREAMBLE_BATCHED \
-    TENSILE_TRANSPOSES(PREC, TYPE) \
-  }
+#define GEMM_API_BATCHED(prec, PREC, TYPE)                                  \
+    rocblas_status rocblas_##prec##gemm_strided_batched(ARGS_BATCHED(TYPE)) \
+    {                                                                       \
+        PREAMBLE_BATCHED                                                    \
+        TENSILE_TRANSPOSES(PREC, TYPE)                                      \
+    }
 
 /*******************************************************************************
  * GEMM APIs
  ******************************************************************************/
-GEMM_API(s, S, float )
-GEMM_API(d, D, double )
-GEMM_API_BATCHED(s, S, float )
-GEMM_API_BATCHED(d, D, double )
-
+GEMM_API(s, S, float)
+GEMM_API(d, D, double)
+GEMM_API_BATCHED(s, S, float)
+GEMM_API_BATCHED(d, D, double)

--- a/library/src/blas3/Tensile/gemm.h
+++ b/library/src/blas3/Tensile/gemm.h
@@ -4,79 +4,91 @@
 /*******************************************************************************
  * Infer Batch Strides
  ******************************************************************************/
-inline void infer_batch_strides(
-    rocblas_operation trans_a, rocblas_operation trans_b,
-    rocblas_int m, rocblas_int n, rocblas_int k,
-    rocblas_int ld_a, rocblas_int *bs_a,
-    rocblas_int ld_b, rocblas_int *bs_b,
-    rocblas_int ld_c, rocblas_int *bs_c ) {
+inline void infer_batch_strides(rocblas_operation trans_a,
+                                rocblas_operation trans_b,
+                                rocblas_int m,
+                                rocblas_int n,
+                                rocblas_int k,
+                                rocblas_int ld_a,
+                                rocblas_int* bs_a,
+                                rocblas_int ld_b,
+                                rocblas_int* bs_b,
+                                rocblas_int ld_c,
+                                rocblas_int* bs_c)
+{
 
-  rocblas_int num_cols_c = n;
-  rocblas_int num_rows_c = m;
-  rocblas_int num_cols_a = (trans_a == rocblas_operation_none ? k : m);
-  rocblas_int num_rows_a = (trans_a == rocblas_operation_none ? m : k);
-  rocblas_int num_cols_b = (trans_b == rocblas_operation_none ? n : k);
-  rocblas_int num_rows_b = (trans_b == rocblas_operation_none ? k : n);
+    rocblas_int num_cols_c = n;
+    rocblas_int num_rows_c = m;
+    rocblas_int num_cols_a = (trans_a == rocblas_operation_none ? k : m);
+    rocblas_int num_rows_a = (trans_a == rocblas_operation_none ? m : k);
+    rocblas_int num_cols_b = (trans_b == rocblas_operation_none ? n : k);
+    rocblas_int num_rows_b = (trans_b == rocblas_operation_none ? k : n);
 
-  *bs_a = ld_a * num_cols_a;
-  *bs_b = ld_b * num_cols_b;
-  *bs_c = ld_c * num_cols_c;
+    *bs_a = ld_a * num_cols_a;
+    *bs_b = ld_b * num_cols_b;
+    *bs_c = ld_c * num_cols_c;
 
 } // infer batched strides
-
 
 /*******************************************************************************
  * Validate Arguments
  ******************************************************************************/
-inline rocblas_status validateArgs(
-    rocblas_handle handle,
-    rocblas_operation trans_a, rocblas_operation trans_b,
-    rocblas_int m, rocblas_int n, rocblas_int k,
-    const void *alpha,
-    const void *a, rocblas_int ld_a, rocblas_int bs_a,
-    const void *b, rocblas_int ld_b, rocblas_int bs_b,
-    const void *beta,
-    void *c, rocblas_int ld_c, rocblas_int bs_c, rocblas_int b_c
-    ) {
+inline rocblas_status validateArgs(rocblas_handle handle,
+                                   rocblas_operation trans_a,
+                                   rocblas_operation trans_b,
+                                   rocblas_int m,
+                                   rocblas_int n,
+                                   rocblas_int k,
+                                   const void* alpha,
+                                   const void* a,
+                                   rocblas_int ld_a,
+                                   rocblas_int bs_a,
+                                   const void* b,
+                                   rocblas_int ld_b,
+                                   rocblas_int bs_b,
+                                   const void* beta,
+                                   void* c,
+                                   rocblas_int ld_c,
+                                   rocblas_int bs_c,
+                                   rocblas_int b_c)
+{
 
-  // quick return 0 is valid in BLAS
-  if (m == 0 || n == 0 || k == 0 || b_c == 0) {
+    // quick return 0 is valid in BLAS
+    if(m == 0 || n == 0 || k == 0 || b_c == 0)
+    {
+        return rocblas_status_success;
+    }
+
+    // sizes must not be negative
+    if(m < 0 || n < 0 || k < 0 || b_c < 0)
+    {
+        return rocblas_status_invalid_size;
+    }
+
+    // handle must be valid
+    if(handle == nullptr)
+    {
+        return rocblas_status_invalid_handle;
+    }
+
+    // pointers must be valid
+    if(c == nullptr || a == nullptr || b == nullptr || alpha == nullptr || beta == nullptr)
+    {
+        return rocblas_status_invalid_pointer;
+    }
+
+    rocblas_int num_cols_c = n;
+    rocblas_int num_rows_c = m;
+    rocblas_int num_cols_a = (trans_a == rocblas_operation_none) ? k : m;
+    rocblas_int num_rows_a = (trans_a == rocblas_operation_none) ? m : k;
+    rocblas_int num_cols_b = (trans_b == rocblas_operation_none) ? n : k;
+    rocblas_int num_rows_b = (trans_b == rocblas_operation_none) ? k : n;
+
+    // leading dimensions must be valid
+    if(num_rows_a > ld_a || num_rows_b > ld_b || num_rows_c > ld_c)
+    {
+        return rocblas_status_invalid_size;
+    }
+
     return rocblas_status_success;
-  }
-
-  // sizes must not be negative
-  if (m < 0 || n < 0 || k < 0 || b_c < 0) {
-    return rocblas_status_invalid_size;
-  }
-
-  // handle must be valid
-  if (handle == nullptr) {
-    return rocblas_status_invalid_handle;
-  }
-
-  // pointers must be valid
-  if ( c == nullptr
-      || a == nullptr
-      || b == nullptr
-      || alpha == nullptr
-      || beta == nullptr ) {
-    return rocblas_status_invalid_pointer;
-  }
-
-  rocblas_int num_cols_c = n;
-  rocblas_int num_rows_c = m;
-  rocblas_int num_cols_a = (trans_a == rocblas_operation_none) ? k : m;
-  rocblas_int num_rows_a = (trans_a == rocblas_operation_none) ? m : k;
-  rocblas_int num_cols_b = (trans_b == rocblas_operation_none) ? n : k;
-  rocblas_int num_rows_b = (trans_b == rocblas_operation_none) ? k : n;
-
-  // leading dimensions must be valid
-  if( num_rows_a > ld_a
-      || num_rows_b > ld_b
-      || num_rows_c > ld_c) {
-    return rocblas_status_invalid_size;
-  }
-
-  return rocblas_status_success;
 } // validate parameters
-

--- a/library/src/blas3/geam_device.h
+++ b/library/src/blas3/geam_device.h
@@ -3,42 +3,45 @@
  * ************************************************************************ */
 
 // general case for any alpha, beta, lda, ldb, ldc
-template<typename T>
-static __device__ void
-geam_device(
-    rocblas_operation transA, rocblas_operation transB,
-    rocblas_int m, rocblas_int n,
-    T alpha,
-    const T * __restrict__ A, rocblas_int lda,
-    T beta,
-    const T * __restrict__ B, rocblas_int ldb,
-          T *              C, rocblas_int ldc)
+template <typename T>
+static __device__ void geam_device(rocblas_operation transA,
+                                   rocblas_operation transB,
+                                   rocblas_int m,
+                                   rocblas_int n,
+                                   T alpha,
+                                   const T* __restrict__ A,
+                                   rocblas_int lda,
+                                   T beta,
+                                   const T* __restrict__ B,
+                                   rocblas_int ldb,
+                                   T* C,
+                                   rocblas_int ldc)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     rocblas_int ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
 
-    if (tx < m && ty < n)
+    if(tx < m && ty < n)
     {
         int a_index;
         int b_index;
-        int c_index = tx + ldc*ty;
+        int c_index = tx + ldc * ty;
 
-        if (transA == rocblas_operation_none)
+        if(transA == rocblas_operation_none)
         {
-            a_index = tx + ty*lda;
+            a_index = tx + ty * lda;
         }
         else
         {
-            a_index = tx*lda + ty;
+            a_index = tx * lda + ty;
         }
 
-        if (transB == rocblas_operation_none)
+        if(transB == rocblas_operation_none)
         {
-            b_index = tx + ty*ldb;
+            b_index = tx + ty * ldb;
         }
         else
         {
-            b_index = tx*ldb + ty;
+            b_index = tx * ldb + ty;
         }
 
         C[c_index] = fma(beta, B[b_index], alpha * A[a_index]);
@@ -47,22 +50,23 @@ geam_device(
 
 //  special case:
 //  only one matrix contributes because   0 == alpha || 0 == beta
-template<typename T>
-static __device__ void
-geam_2matrix_device(
-    rocblas_operation transA,
-    rocblas_int m, rocblas_int n,
-    T alpha,
-    const T * __restrict__ A, rocblas_int lda,
-          T *              C, rocblas_int ldc)
+template <typename T>
+static __device__ void geam_2matrix_device(rocblas_operation transA,
+                                           rocblas_int m,
+                                           rocblas_int n,
+                                           T alpha,
+                                           const T* __restrict__ A,
+                                           rocblas_int lda,
+                                           T* C,
+                                           rocblas_int ldc)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     rocblas_int ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
 
-    if (tx < m && ty < n)
+    if(tx < m && ty < n)
     {
-        int c_index = tx + ldc*ty;
-        if (alpha == 0)
+        int c_index = tx + ldc * ty;
+        if(alpha == 0)
         {
             C[c_index] = 0;
         }
@@ -70,37 +74,31 @@ geam_2matrix_device(
         {
             int a_index;
 
-            if (transA == rocblas_operation_none)
+            if(transA == rocblas_operation_none)
             {
-                a_index = tx + ty*lda;
+                a_index = tx + ty * lda;
             }
             else
             {
-                a_index = tx*lda + ty;
+                a_index = tx * lda + ty;
             }
             C[c_index] = alpha * A[a_index];
         }
     }
 }
-                   
+
 //  special case:
 //  treat matrices as contiguous vectors because
 //  m == lda && m == ldb && m == ldc && none == transA && none == transB
-template<typename T>
-static __device__ void
-geam_1D_device(
-    rocblas_int size,
-    T alpha,
-    const T * __restrict__ A,
-    T beta,
-    const T * __restrict__ B,
-          T *              C)
+template <typename T>
+static __device__ void geam_1D_device(
+    rocblas_int size, T alpha, const T* __restrict__ A, T beta, const T* __restrict__ B, T* C)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
-    if (tx < size)
+    if(tx < size)
     {
-        if (alpha == 0 && beta == 0)
+        if(alpha == 0 && beta == 0)
         {
             C[tx] = 0;
         }
@@ -110,23 +108,20 @@ geam_1D_device(
         }
     }
 }
-                   
+
 //  special case:
 //  treat matrices as contiguous vectors, and only one matrix contributes, because
-//  m == lda && m == ldb && m == ldc && none == transA && none == transB && (0 == alpha || 0 == beta)
-template<typename T>
+//  m == lda && m == ldb && m == ldc && none == transA && none == transB && (0 == alpha || 0 ==
+//  beta)
+template <typename T>
 static __device__ void
-geam_1D_2matrix_device(
-    rocblas_int size,
-    T alpha,
-    const T * __restrict__ A,
-          T *              C)
+geam_1D_2matrix_device(rocblas_int size, T alpha, const T* __restrict__ A, T* C)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
-    if (tx < size)
+    if(tx < size)
     {
-        if (alpha == 0)
+        if(alpha == 0)
         {
             C[tx] = 0;
         }
@@ -138,39 +133,40 @@ geam_1D_2matrix_device(
 }
 // special case
 // inplace
-template<typename T>
-static __device__ void
-geam_inplace_device(
-    rocblas_operation transB,
-    rocblas_int m, rocblas_int n,
-    T alpha,
-    T beta,
-    const T * __restrict__ B, rocblas_int ldb,
-          T *              C, rocblas_int ldc)
+template <typename T>
+static __device__ void geam_inplace_device(rocblas_operation transB,
+                                           rocblas_int m,
+                                           rocblas_int n,
+                                           T alpha,
+                                           T beta,
+                                           const T* __restrict__ B,
+                                           rocblas_int ldb,
+                                           T* C,
+                                           rocblas_int ldc)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     rocblas_int ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
 
-    if (tx < m && ty < n)
+    if(tx < m && ty < n)
     {
         int b_index;
-        int c_index = tx + ldc*ty;
+        int c_index = tx + ldc * ty;
 
-        if (beta == 0)
+        if(beta == 0)
         {
             C[c_index] = alpha * C[c_index];
         }
         else
         {
-            if (transB == rocblas_operation_none)
+            if(transB == rocblas_operation_none)
             {
-                b_index = tx + ty*ldb;
+                b_index = tx + ty * ldb;
             }
             else
             {
-                b_index = tx*ldb + ty;
+                b_index = tx * ldb + ty;
             }
-            if (alpha == 0)
+            if(alpha == 0)
             {
                 C[c_index] = beta * B[b_index];
             }

--- a/library/src/blas3/gemm.hpp
+++ b/library/src/blas3/gemm.hpp
@@ -2,47 +2,59 @@
  * Copyright 2016 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-
 #pragma once
 #ifndef _GEMM_HPP_
-#define _GEMM_HPP_ 
+#define _GEMM_HPP_
 
 #include <hip/hip_runtime.h>
 
-    template<typename T>
-    rocblas_status rocblas_gemm_template(rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const T *alpha,
-        const T *A, rocblas_int lda,
-        const T *B, rocblas_int ldb,
-        const T *beta,
-        T *C, rocblas_int ldc);
+template <typename T>
+rocblas_status rocblas_gemm_template(rocblas_handle handle,
+                                     rocblas_operation transA,
+                                     rocblas_operation transB,
+                                     rocblas_int m,
+                                     rocblas_int n,
+                                     rocblas_int k,
+                                     const T* alpha,
+                                     const T* A,
+                                     rocblas_int lda,
+                                     const T* B,
+                                     rocblas_int ldb,
+                                     const T* beta,
+                                     T* C,
+                                     rocblas_int ldc);
 
-    template<typename T>
-    rocblas_status rocblas_gemm_strided_batched_template(
-        rocblas_handle handle,
-        rocblas_operation transA, rocblas_operation transB,
-        rocblas_int m, rocblas_int n, rocblas_int k,
-        const T *alpha,
-        const T *A, rocblas_int lda, rocblas_int bsa,
-        const T *B, rocblas_int ldb, rocblas_int bsb,
-        const T *beta,
-        T *C, rocblas_int ldc, rocblas_int bsc,
-        rocblas_int batch_count);
+template <typename T>
+rocblas_status rocblas_gemm_strided_batched_template(rocblas_handle handle,
+                                                     rocblas_operation transA,
+                                                     rocblas_operation transB,
+                                                     rocblas_int m,
+                                                     rocblas_int n,
+                                                     rocblas_int k,
+                                                     const T* alpha,
+                                                     const T* A,
+                                                     rocblas_int lda,
+                                                     rocblas_int bsa,
+                                                     const T* B,
+                                                     rocblas_int ldb,
+                                                     rocblas_int bsb,
+                                                     const T* beta,
+                                                     T* C,
+                                                     rocblas_int ldc,
+                                                     rocblas_int bsc,
+                                                     rocblas_int batch_count);
 
-
-#define COMPLEX  0
+#define COMPLEX 0
 
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    template interface
-     *    template specialization
-     *    call GEMM C interfaces (see gemm.cpp in the same dir)
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    template interface
+ *    template specialization
+ *    call GEMM C interfaces (see gemm.cpp in the same dir)
+ * ===========================================================================
+ */
 
 /*! \brief BLAS Level 3 API
 
@@ -97,73 +109,86 @@
 
     ********************************************************************/
 
-
-template<>
-rocblas_status
-rocblas_gemm_template<float>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const float *alpha,
-    const float *A, rocblas_int lda,
-    const float *B, rocblas_int ldb,
-    const float *beta,
-    float *C, rocblas_int ldc)
+template <>
+rocblas_status rocblas_gemm_template<float>(rocblas_handle handle,
+                                            rocblas_operation transA,
+                                            rocblas_operation transB,
+                                            rocblas_int M,
+                                            rocblas_int N,
+                                            rocblas_int K,
+                                            const float* alpha,
+                                            const float* A,
+                                            rocblas_int lda,
+                                            const float* B,
+                                            rocblas_int ldb,
+                                            const float* beta,
+                                            float* C,
+                                            rocblas_int ldc)
 {
     return rocblas_sgemm(handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
-template<>
-rocblas_status
-rocblas_gemm_template<double>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const double *alpha,
-    const double *A, rocblas_int lda,
-    const double *B, rocblas_int ldb,
-    const double *beta,
-    double *C, rocblas_int ldc)
+template <>
+rocblas_status rocblas_gemm_template<double>(rocblas_handle handle,
+                                             rocblas_operation transA,
+                                             rocblas_operation transB,
+                                             rocblas_int M,
+                                             rocblas_int N,
+                                             rocblas_int K,
+                                             const double* alpha,
+                                             const double* A,
+                                             rocblas_int lda,
+                                             const double* B,
+                                             rocblas_int ldb,
+                                             const double* beta,
+                                             double* C,
+                                             rocblas_int ldc)
 {
     return rocblas_dgemm(handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #if COMPLEX
 
-template<>
-rocblas_status
-rocblas_gemm_template<rocblas_float_complex>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const rocblas_float_complex *alpha,
-    const rocblas_float_complex *A, rocblas_int lda,
-    const rocblas_float_complex *B, rocblas_int ldb,
-    const rocblas_float_complex *beta,
-    rocblas_float_complex *C, rocblas_int ldc)
+template <>
+rocblas_status rocblas_gemm_template<rocblas_float_complex>(rocblas_handle handle,
+                                                            rocblas_operation transA,
+                                                            rocblas_operation transB,
+                                                            rocblas_int M,
+                                                            rocblas_int N,
+                                                            rocblas_int K,
+                                                            const rocblas_float_complex* alpha,
+                                                            const rocblas_float_complex* A,
+                                                            rocblas_int lda,
+                                                            const rocblas_float_complex* B,
+                                                            rocblas_int ldb,
+                                                            const rocblas_float_complex* beta,
+                                                            rocblas_float_complex* C,
+                                                            rocblas_int ldc)
 {
     return rocblas_cgemm(handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
-
-template<>
-rocblas_status
-rocblas_gemm_template<rocblas_double_complex>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const rocblas_double_complex *alpha,
-    const rocblas_double_complex *A, rocblas_int lda,
-    const rocblas_double_complex *B, rocblas_int ldb,
-    const rocblas_double_complex *beta,
-    rocblas_double_complex *C, rocblas_int ldc)
+template <>
+rocblas_status rocblas_gemm_template<rocblas_double_complex>(rocblas_handle handle,
+                                                             rocblas_operation transA,
+                                                             rocblas_operation transB,
+                                                             rocblas_int M,
+                                                             rocblas_int N,
+                                                             rocblas_int K,
+                                                             const rocblas_double_complex* alpha,
+                                                             const rocblas_double_complex* A,
+                                                             rocblas_int lda,
+                                                             const rocblas_double_complex* B,
+                                                             rocblas_int ldb,
+                                                             const rocblas_double_complex* beta,
+                                                             rocblas_double_complex* C,
+                                                             rocblas_int ldc)
 {
     return rocblas_zgemm(handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 #endif
 /* ============================================================================================ */
-
 
 /*! \brief BLAS Level 3 API
 
@@ -235,72 +260,170 @@ rocblas_gemm_template<rocblas_double_complex>(rocblas_handle handle,
 
     ********************************************************************/
 
-template<>
-rocblas_status
-rocblas_gemm_strided_batched_template<float>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const float *alpha,
-    const float *A, rocblas_int lda, rocblas_int bsa,
-    const float *B, rocblas_int ldb, rocblas_int bsb,
-    const float *beta,
-    float *C, rocblas_int ldc, rocblas_int bsc,
-    rocblas_int batch_count)
+template <>
+rocblas_status rocblas_gemm_strided_batched_template<float>(rocblas_handle handle,
+                                                            rocblas_operation transA,
+                                                            rocblas_operation transB,
+                                                            rocblas_int M,
+                                                            rocblas_int N,
+                                                            rocblas_int K,
+                                                            const float* alpha,
+                                                            const float* A,
+                                                            rocblas_int lda,
+                                                            rocblas_int bsa,
+                                                            const float* B,
+                                                            rocblas_int ldb,
+                                                            rocblas_int bsb,
+                                                            const float* beta,
+                                                            float* C,
+                                                            rocblas_int ldc,
+                                                            rocblas_int bsc,
+                                                            rocblas_int batch_count)
 {
-    return rocblas_sgemm_strided_batched(handle, transA, transB, M, N, K, alpha, A, lda, bsa, B, ldb, bsb, beta, C, ldc, bsc, batch_count);
+    return rocblas_sgemm_strided_batched(handle,
+                                         transA,
+                                         transB,
+                                         M,
+                                         N,
+                                         K,
+                                         alpha,
+                                         A,
+                                         lda,
+                                         bsa,
+                                         B,
+                                         ldb,
+                                         bsb,
+                                         beta,
+                                         C,
+                                         ldc,
+                                         bsc,
+                                         batch_count);
 }
 
-template<>
-rocblas_status
-rocblas_gemm_strided_batched_template<double>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const double *alpha,
-    const double *A, rocblas_int lda, rocblas_int bsa,
-    const double *B, rocblas_int ldb, rocblas_int bsb,
-    const double *beta,
-    double *C, rocblas_int ldc, rocblas_int bsc,
-    rocblas_int batch_count)
+template <>
+rocblas_status rocblas_gemm_strided_batched_template<double>(rocblas_handle handle,
+                                                             rocblas_operation transA,
+                                                             rocblas_operation transB,
+                                                             rocblas_int M,
+                                                             rocblas_int N,
+                                                             rocblas_int K,
+                                                             const double* alpha,
+                                                             const double* A,
+                                                             rocblas_int lda,
+                                                             rocblas_int bsa,
+                                                             const double* B,
+                                                             rocblas_int ldb,
+                                                             rocblas_int bsb,
+                                                             const double* beta,
+                                                             double* C,
+                                                             rocblas_int ldc,
+                                                             rocblas_int bsc,
+                                                             rocblas_int batch_count)
 {
-    return rocblas_dgemm_strided_batched(handle, transA, transB, M, N, K, alpha, A, lda, bsa, B, ldb, bsb, beta, C, ldc, bsc, batch_count);
+    return rocblas_dgemm_strided_batched(handle,
+                                         transA,
+                                         transB,
+                                         M,
+                                         N,
+                                         K,
+                                         alpha,
+                                         A,
+                                         lda,
+                                         bsa,
+                                         B,
+                                         ldb,
+                                         bsb,
+                                         beta,
+                                         C,
+                                         ldc,
+                                         bsc,
+                                         batch_count);
 }
 
 #if COMPLEX
 
-template<>
+template <>
 rocblas_status
 rocblas_gemm_strided_batched_template<rocblas_float_complex>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const rocblas_float_complex *alpha,
-    const rocblas_float_complex *A, rocblas_int lda, rocblas_int bsa,
-    const rocblas_float_complex *B, rocblas_int ldb, rocblas_int bsb,
-    const rocblas_float_complex *beta,
-    rocblas_float_complex *C, rocblas_int ldc, rocblas_int bsc,
-    rocblas_int batch_count)
+                                                             rocblas_operation transA,
+                                                             rocblas_operation transB,
+                                                             rocblas_int M,
+                                                             rocblas_int N,
+                                                             rocblas_int K,
+                                                             const rocblas_float_complex* alpha,
+                                                             const rocblas_float_complex* A,
+                                                             rocblas_int lda,
+                                                             rocblas_int bsa,
+                                                             const rocblas_float_complex* B,
+                                                             rocblas_int ldb,
+                                                             rocblas_int bsb,
+                                                             const rocblas_float_complex* beta,
+                                                             rocblas_float_complex* C,
+                                                             rocblas_int ldc,
+                                                             rocblas_int bsc,
+                                                             rocblas_int batch_count)
 {
-    return rocblas_cgemm_strided_batched(handle, transA, transB, M, N, K, alpha, A, lda, bsa, B, ldb, bsb, beta, C, ldc, bsc, batch_count);
+    return rocblas_cgemm_strided_batched(handle,
+                                         transA,
+                                         transB,
+                                         M,
+                                         N,
+                                         K,
+                                         alpha,
+                                         A,
+                                         lda,
+                                         bsa,
+                                         B,
+                                         ldb,
+                                         bsb,
+                                         beta,
+                                         C,
+                                         ldc,
+                                         bsc,
+                                         batch_count);
 }
 
-template<>
+template <>
 rocblas_status
 rocblas_gemm_strided_batched_template<rocblas_double_complex>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const rocblas_double_complex *alpha,
-    const rocblas_double_complex *A, rocblas_int lda, rocblas_int bsa,
-    const rocblas_double_complex *B, rocblas_int ldb, rocblas_int bsb,
-    const rocblas_double_complex *beta,
-    rocblas_double_complex *C, rocblas_int ldc, rocblas_int bsc,
-    rocblas_int batch_count)
+                                                              rocblas_operation transA,
+                                                              rocblas_operation transB,
+                                                              rocblas_int M,
+                                                              rocblas_int N,
+                                                              rocblas_int K,
+                                                              const rocblas_double_complex* alpha,
+                                                              const rocblas_double_complex* A,
+                                                              rocblas_int lda,
+                                                              rocblas_int bsa,
+                                                              const rocblas_double_complex* B,
+                                                              rocblas_int ldb,
+                                                              rocblas_int bsb,
+                                                              const rocblas_double_complex* beta,
+                                                              rocblas_double_complex* C,
+                                                              rocblas_int ldc,
+                                                              rocblas_int bsc,
+                                                              rocblas_int batch_count)
 {
-    return rocblas_zgemm_strided_batched(handle, transA, transB, M, N, K, alpha, A, lda, bsa, B, ldb, bsb, beta, C, ldc, bsc, batch_count);
+    return rocblas_zgemm_strided_batched(handle,
+                                         transA,
+                                         transB,
+                                         M,
+                                         N,
+                                         K,
+                                         alpha,
+                                         A,
+                                         lda,
+                                         bsa,
+                                         B,
+                                         ldb,
+                                         bsb,
+                                         beta,
+                                         C,
+                                         ldc,
+                                         bsc,
+                                         batch_count);
 }
 
 #endif
 
-#endif  // _GEMM_HPP_
+#endif // _GEMM_HPP_

--- a/library/src/blas3/rocblas_geam.cpp
+++ b/library/src/blas3/rocblas_geam.cpp
@@ -10,153 +10,158 @@
 #include "handle.h"
 
 // general cases for any transA, transB, alpha, beta, lda, ldb, ldc
-template<typename T>
-__global__ void
-geam_kernel_host_pointer(hipLaunchParm lp,
-    rocblas_operation transA, rocblas_operation transB,
-    rocblas_int m, rocblas_int n,
-    const T alpha,
-    const T * __restrict__ A, rocblas_int lda,
-    const T beta,
-    const T * __restrict__ B, rocblas_int ldb,
-    T *C, rocblas_int ldc)
+template <typename T>
+__global__ void geam_kernel_host_pointer(hipLaunchParm lp,
+                                         rocblas_operation transA,
+                                         rocblas_operation transB,
+                                         rocblas_int m,
+                                         rocblas_int n,
+                                         const T alpha,
+                                         const T* __restrict__ A,
+                                         rocblas_int lda,
+                                         const T beta,
+                                         const T* __restrict__ B,
+                                         rocblas_int ldb,
+                                         T* C,
+                                         rocblas_int ldc)
 {
     geam_device<T>(transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
 }
 
-template<typename T>
-__global__ void
-geam_kernel_device_pointer(hipLaunchParm lp,
-    rocblas_operation transA, rocblas_operation transB,
-    rocblas_int m, rocblas_int n,
-    const T *alpha,
-    const T * __restrict__ A, rocblas_int lda,
-    const T *beta,
-    const T * __restrict__ B, rocblas_int ldb,
-    T *C, rocblas_int ldc)
+template <typename T>
+__global__ void geam_kernel_device_pointer(hipLaunchParm lp,
+                                           rocblas_operation transA,
+                                           rocblas_operation transB,
+                                           rocblas_int m,
+                                           rocblas_int n,
+                                           const T* alpha,
+                                           const T* __restrict__ A,
+                                           rocblas_int lda,
+                                           const T* beta,
+                                           const T* __restrict__ B,
+                                           rocblas_int ldb,
+                                           T* C,
+                                           rocblas_int ldc)
 {
     geam_device<T>(transA, transB, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
 }
 
-// special cases where: lda=ldb=ldc=m && transA==transB=none so matrices 
+// special cases where: lda=ldb=ldc=m && transA==transB=none so matrices
 // are contiguous, there are no transposes, and therefore matrices
 // can be treated as contiguous vectors
-template<typename T>
-__global__ void
-geam_1D_kernel_host_pointer(hipLaunchParm lp,
-    rocblas_int size,
-    const T alpha,
-    const T * __restrict__ A,
-    const T beta,
-    const T * __restrict__ B,
-    T *C)
+template <typename T>
+__global__ void geam_1D_kernel_host_pointer(hipLaunchParm lp,
+                                            rocblas_int size,
+                                            const T alpha,
+                                            const T* __restrict__ A,
+                                            const T beta,
+                                            const T* __restrict__ B,
+                                            T* C)
 {
     geam_1D_device<T>(size, alpha, A, beta, B, C);
 }
 
-template<typename T>
-__global__ void
-geam_1D_kernel_device_pointer(hipLaunchParm lp,
-    rocblas_int size,
-    const T *alpha,
-    const T * __restrict__ A,
-    const T *beta,
-    const T * __restrict__ B,
-    T *C)
+template <typename T>
+__global__ void geam_1D_kernel_device_pointer(hipLaunchParm lp,
+                                              rocblas_int size,
+                                              const T* alpha,
+                                              const T* __restrict__ A,
+                                              const T* beta,
+                                              const T* __restrict__ B,
+                                              T* C)
 {
     geam_1D_device<T>(size, *alpha, A, *beta, B, C);
 }
 
-// special cases where: lda=ldb=ldc=m && transA==transB=none so matrices 
+// special cases where: lda=ldb=ldc=m && transA==transB=none so matrices
 // are contiguous, there are no transposes, and therefore matrices
 // can be treated as contiguous vectors.
 // Also, alpha == 0  ||  beta == 0  so only one matrix contributes
-template<typename T>
-__global__ void
-geam_1D_2matrix_kernel_host_pointer(hipLaunchParm lp,
-    rocblas_int size,
-    const T alpha,
-    const T * __restrict__ A,
-    T *C)
+template <typename T>
+__global__ void geam_1D_2matrix_kernel_host_pointer(
+    hipLaunchParm lp, rocblas_int size, const T alpha, const T* __restrict__ A, T* C)
 {
     geam_1D_2matrix_device<T>(size, alpha, A, C);
 }
 
-template<typename T>
-__global__ void
-geam_1D_2matrix_kernel_device_pointer(hipLaunchParm lp,
-    rocblas_int size,
-    const T *alpha,
-    const T * __restrict__ A,
-    T *C)
+template <typename T>
+__global__ void geam_1D_2matrix_kernel_device_pointer(
+    hipLaunchParm lp, rocblas_int size, const T* alpha, const T* __restrict__ A, T* C)
 {
     geam_1D_2matrix_device<T>(size, *alpha, A, C);
 }
 
 // special cases where: alpha == 0 || beta == 0 so only one
 // matrix contributes
-template<typename T>
-__global__ void
-geam_2matrix_kernel_host_pointer(hipLaunchParm lp,
-    rocblas_operation transA,
-    rocblas_int m, rocblas_int n,
-    const T alpha,
-    const T * __restrict__ A, rocblas_int lda,
-    T *C, rocblas_int ldc)
+template <typename T>
+__global__ void geam_2matrix_kernel_host_pointer(hipLaunchParm lp,
+                                                 rocblas_operation transA,
+                                                 rocblas_int m,
+                                                 rocblas_int n,
+                                                 const T alpha,
+                                                 const T* __restrict__ A,
+                                                 rocblas_int lda,
+                                                 T* C,
+                                                 rocblas_int ldc)
 {
     geam_2matrix_device<T>(transA, m, n, alpha, A, lda, C, ldc);
 }
 
-template<typename T>
-__global__ void
-geam_2matrix_kernel_device_pointer(hipLaunchParm lp,
-    rocblas_operation transA,
-    rocblas_int m, rocblas_int n,
-    const T *alpha,
-    const T * __restrict__ A, rocblas_int lda,
-    T *C, rocblas_int ldc)
+template <typename T>
+__global__ void geam_2matrix_kernel_device_pointer(hipLaunchParm lp,
+                                                   rocblas_operation transA,
+                                                   rocblas_int m,
+                                                   rocblas_int n,
+                                                   const T* alpha,
+                                                   const T* __restrict__ A,
+                                                   rocblas_int lda,
+                                                   T* C,
+                                                   rocblas_int ldc)
 {
     geam_2matrix_device<T>(transA, m, n, *alpha, A, lda, C, ldc);
 }
 
 // special cases where: A == C && lda == ldc && transA == none
 // this is in place case C <- alpha*C + beta*B
-template<typename T>
-__global__ void
-geam_inplace_kernel_host_pointer(hipLaunchParm lp,
-    rocblas_operation transB, 
-    rocblas_int m, rocblas_int n, 
-    const T alpha, 
-    const T beta, 
-    const T * __restrict__ B, rocblas_int ldb, 
-    T *C, rocblas_int ldc)
+template <typename T>
+__global__ void geam_inplace_kernel_host_pointer(hipLaunchParm lp,
+                                                 rocblas_operation transB,
+                                                 rocblas_int m,
+                                                 rocblas_int n,
+                                                 const T alpha,
+                                                 const T beta,
+                                                 const T* __restrict__ B,
+                                                 rocblas_int ldb,
+                                                 T* C,
+                                                 rocblas_int ldc)
 {
     geam_inplace_device(transB, m, n, alpha, beta, B, ldb, C, ldc);
 }
 
-template<typename T>
-__global__ void
-geam_inplace_kernel_device_pointer(hipLaunchParm lp,
-    rocblas_operation transB, 
-    rocblas_int m, rocblas_int n, 
-    const T *alpha, 
-    const T *beta, 
-    const T * __restrict__ B, rocblas_int ldb, 
-    T *C, rocblas_int ldc)
+template <typename T>
+__global__ void geam_inplace_kernel_device_pointer(hipLaunchParm lp,
+                                                   rocblas_operation transB,
+                                                   rocblas_int m,
+                                                   rocblas_int n,
+                                                   const T* alpha,
+                                                   const T* beta,
+                                                   const T* __restrict__ B,
+                                                   rocblas_int ldb,
+                                                   T* C,
+                                                   rocblas_int ldc)
 {
     geam_inplace_device(transB, m, n, *alpha, *beta, B, ldb, C, ldc);
 }
 
-
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    template interface
-     *    template specialization
-     *    call GEAM C interfaces (see geam.cpp in the same dir)
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    template interface
+ *    template specialization
+ *    call GEAM C interfaces (see geam.cpp in the same dir)
+ * ===========================================================================
+ */
 
 /*! \brief BLAS Level 3 API
 
@@ -209,25 +214,29 @@ geam_inplace_kernel_device_pointer(hipLaunchParm lp,
 
     ********************************************************************/
 
-template<typename T>
-rocblas_status 
-rocblas_geam_template(rocblas_handle handle,
-   rocblas_operation transA, rocblas_operation transB,
-   rocblas_int m, rocblas_int n,
-   const T *alpha,
-   const T *A, rocblas_int lda,
-   const T *beta,
-   const T *B, rocblas_int ldb,
-   T *C, rocblas_int ldc)
+template <typename T>
+rocblas_status rocblas_geam_template(rocblas_handle handle,
+                                     rocblas_operation transA,
+                                     rocblas_operation transB,
+                                     rocblas_int m,
+                                     rocblas_int n,
+                                     const T* alpha,
+                                     const T* A,
+                                     rocblas_int lda,
+                                     const T* beta,
+                                     const T* B,
+                                     rocblas_int ldb,
+                                     T* C,
+                                     rocblas_int ldc)
 {
     int dim1_A, dim2_A, dim1_B, dim2_B;
     // quick return
-    if (0 == m || 0 == n)
+    if(0 == m || 0 == n)
     {
         return rocblas_status_success;
     }
 
-    if (transA == rocblas_operation_none)
+    if(transA == rocblas_operation_none)
     {
         dim1_A = m;
         dim2_A = n;
@@ -238,7 +247,7 @@ rocblas_geam_template(rocblas_handle handle,
         dim2_A = m;
     }
 
-    if (transB == rocblas_operation_none)
+    if(transB == rocblas_operation_none)
     {
         dim1_B = m;
         dim2_B = n;
@@ -249,23 +258,23 @@ rocblas_geam_template(rocblas_handle handle,
         dim2_B = m;
     }
 
-    if (m < 0 || n < 0 || lda < dim1_A || ldb < dim1_B || ldc < m)
+    if(m < 0 || n < 0 || lda < dim1_A || ldb < dim1_B || ldc < m)
     {
         return rocblas_status_invalid_size;
     }
 
-    if (nullptr == A || nullptr == B || nullptr == C || nullptr == alpha || nullptr == beta) 
+    if(nullptr == A || nullptr == B || nullptr == C || nullptr == alpha || nullptr == beta)
     {
         return rocblas_status_invalid_pointer;
     }
 
-    if (nullptr == handle) 
+    if(nullptr == handle)
     {
         return rocblas_status_invalid_handle;
     }
 
-    if (((C == A) && ((lda != ldc) || (transA != rocblas_operation_none))) || 
-        ((C == B) && ((ldb != ldc) || (transB != rocblas_operation_none))))
+    if(((C == A) && ((lda != ldc) || (transA != rocblas_operation_none))) ||
+       ((C == B) && ((ldb != ldc) || (transB != rocblas_operation_none))))
     {
         return rocblas_status_invalid_size;
     }
@@ -273,15 +282,15 @@ rocblas_geam_template(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    if ((rocblas_pointer_mode_host == handle->pointer_mode) && (0 == *alpha) && (0 == *beta))
+    if((rocblas_pointer_mode_host == handle->pointer_mode) && (0 == *alpha) && (0 == *beta))
     {
-        // call hipMemset to set matrix C to zero because alpha and beta on host 
+        // call hipMemset to set matrix C to zero because alpha and beta on host
         // and alpha = beta = zero
 
         if(ldc == m)
         {
             // one call to hipMemset because matrix C is coniguous
-            hipMemset(C, 0, sizeof(T) * m * n);     //  unit-test-covered
+            hipMemset(C, 0, sizeof(T) * m * n); //  unit-test-covered
         }
         else
         {
@@ -289,80 +298,123 @@ rocblas_geam_template(rocblas_handle handle,
             // note that matrix C is always normal (not transpose)
             for(int i = 0; i < n; i++)
             {
-                hipMemset(&(C[i*ldc]), 0, sizeof(T) * m);    //  unit-test-covered
+                hipMemset(&(C[i * ldc]), 0, sizeof(T) * m); //  unit-test-covered
             }
         }
     }
-    else if (C == A)
+    else if(C == A)
     {
-        // C <- alpha * C + beta * B
+// C <- alpha * C + beta * B
 
-        #define  GEAM_DIM_X 16
-        #define  GEAM_DIM_Y 16
-        rocblas_int blocksX = ((m-1) / GEAM_DIM_X) + 1;
-        rocblas_int blocksY = ((n-1) / GEAM_DIM_Y) + 1;
+#define GEAM_DIM_X 16
+#define GEAM_DIM_Y 16
+        rocblas_int blocksX = ((m - 1) / GEAM_DIM_X) + 1;
+        rocblas_int blocksY = ((n - 1) / GEAM_DIM_Y) + 1;
 
-        dim3 geam_grid( blocksX, blocksY, 1 );
-        dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1 );
+        dim3 geam_grid(blocksX, blocksY, 1);
+        dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1);
 
-        if (rocblas_pointer_mode_host == handle->pointer_mode)
+        if(rocblas_pointer_mode_host == handle->pointer_mode)
         {
             T h_alpha_scalar = *alpha;
-            T h_beta_scalar = *beta;
+            T h_beta_scalar  = *beta;
             hipLaunchKernel(geam_inplace_kernel_host_pointer<T>,
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transB, m, n, h_alpha_scalar, h_beta_scalar, B, ldb, C, ldc);
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transB,
+                            m,
+                            n,
+                            h_alpha_scalar,
+                            h_beta_scalar,
+                            B,
+                            ldb,
+                            C,
+                            ldc);
         }
         else
         {
             hipLaunchKernel(geam_inplace_kernel_device_pointer<T>,
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transB, m, n, alpha, beta, B, ldb, C, ldc);
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transB,
+                            m,
+                            n,
+                            alpha,
+                            beta,
+                            B,
+                            ldb,
+                            C,
+                            ldc);
         }
-        #undef GEAM_DIM_X
-        #undef GEAM_DIM_Y
+#undef GEAM_DIM_X
+#undef GEAM_DIM_Y
     }
-    else if (C == B)
+    else if(C == B)
     {
-        // C <- alpha * A + beta * C
+// C <- alpha * A + beta * C
 
-        #define  GEAM_DIM_X 16
-        #define  GEAM_DIM_Y 16
-        rocblas_int blocksX = ((m-1) / GEAM_DIM_X) + 1;
-        rocblas_int blocksY = ((n-1) / GEAM_DIM_Y) + 1;
+#define GEAM_DIM_X 16
+#define GEAM_DIM_Y 16
+        rocblas_int blocksX = ((m - 1) / GEAM_DIM_X) + 1;
+        rocblas_int blocksY = ((n - 1) / GEAM_DIM_Y) + 1;
 
-        dim3 geam_grid( blocksX, blocksY, 1 );
-        dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1 );
+        dim3 geam_grid(blocksX, blocksY, 1);
+        dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1);
 
-        if (rocblas_pointer_mode_host == handle->pointer_mode)
+        if(rocblas_pointer_mode_host == handle->pointer_mode)
         {
             T h_alpha_scalar = *alpha;
-            T h_beta_scalar = *beta;
+            T h_beta_scalar  = *beta;
             hipLaunchKernel(geam_inplace_kernel_host_pointer<T>,
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transA, m, n, h_beta_scalar, h_alpha_scalar, A, lda, C, ldc);
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transA,
+                            m,
+                            n,
+                            h_beta_scalar,
+                            h_alpha_scalar,
+                            A,
+                            lda,
+                            C,
+                            ldc);
         }
         else
         {
             hipLaunchKernel(geam_inplace_kernel_device_pointer<T>,
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transA, m, n, beta, alpha, A, lda, C, ldc);
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transA,
+                            m,
+                            n,
+                            beta,
+                            alpha,
+                            A,
+                            lda,
+                            C,
+                            ldc);
         }
-        #undef GEAM_DIM_X
-        #undef GEAM_DIM_Y
+#undef GEAM_DIM_X
+#undef GEAM_DIM_Y
     }
-    else if ((rocblas_pointer_mode_host == handle->pointer_mode) && (0 == *beta))
+    else if((rocblas_pointer_mode_host == handle->pointer_mode) && (0 == *beta))
     {
-        if ((m == lda) && (transA == rocblas_operation_none) &&
-            (m == ldc))
+        if((m == lda) && (transA == rocblas_operation_none) && (m == ldc))
         {
-            // beta == 0
-            // special case: A, C are processed as vectors because
-            // A, C are contiguous, and A is normal (not transpose)
+// beta == 0
+// special case: A, C are processed as vectors because
+// A, C are contiguous, and A is normal (not transpose)
 
-            #define  GEAM_DIM 256
-            int size = m*n;
-            int blocks = ((size-1) / GEAM_DIM) + 1;
+#define GEAM_DIM 256
+            int size   = m * n;
+            int blocks = ((size - 1) / GEAM_DIM) + 1;
 
             dim3 geam_grid(blocks, 1, 1);
             dim3 geam_threads(GEAM_DIM, 1, 1);
@@ -370,48 +422,63 @@ rocblas_geam_template(rocblas_handle handle,
             hipStream_t rocblas_stream;
             RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-            T h_alpha_scalar = *alpha;                 // unit-test-covered
-            T h_beta_scalar = *beta;
+            T h_alpha_scalar = *alpha; // unit-test-covered
+            T h_beta_scalar  = *beta;
             hipLaunchKernel(geam_1D_2matrix_kernel_host_pointer<T>,
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                size, h_alpha_scalar, A, C);
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            size,
+                            h_alpha_scalar,
+                            A,
+                            C);
 
-            #undef GEAM_DIM
+#undef GEAM_DIM
         }
         else
         {
-            // beta == 0
-            // general case for any transA, lda, ldc
+// beta == 0
+// general case for any transA, lda, ldc
 
-            #define  GEAM_DIM_X 16
-            #define  GEAM_DIM_Y 16
-            rocblas_int blocksX = ((m-1) / GEAM_DIM_X) + 1;
-            rocblas_int blocksY = ((n-1) / GEAM_DIM_Y) + 1;
+#define GEAM_DIM_X 16
+#define GEAM_DIM_Y 16
+            rocblas_int blocksX = ((m - 1) / GEAM_DIM_X) + 1;
+            rocblas_int blocksY = ((n - 1) / GEAM_DIM_Y) + 1;
 
-            dim3 geam_grid( blocksX, blocksY, 1 );
-            dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1 );
+            dim3 geam_grid(blocksX, blocksY, 1);
+            dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1);
 
             T h_alpha_scalar = *alpha;
-            hipLaunchKernel(geam_2matrix_kernel_host_pointer<T>,            // unit-test-covered
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transA, m, n, h_alpha_scalar, A, lda, C, ldc);
+            hipLaunchKernel(geam_2matrix_kernel_host_pointer<T>, // unit-test-covered
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transA,
+                            m,
+                            n,
+                            h_alpha_scalar,
+                            A,
+                            lda,
+                            C,
+                            ldc);
 
-            #undef GEAM_DIM_X
-            #undef GEAM_DIM_Y
+#undef GEAM_DIM_X
+#undef GEAM_DIM_Y
         }
     }
-    else if ((rocblas_pointer_mode_host == handle->pointer_mode) && (0 == *alpha))
+    else if((rocblas_pointer_mode_host == handle->pointer_mode) && (0 == *alpha))
     {
-        if ((m == ldb) && (transB == rocblas_operation_none) &&
-            (m == ldc))
+        if((m == ldb) && (transB == rocblas_operation_none) && (m == ldc))
         {
-            // alpha == 0
-            // special case: B, C are processed as vectors because
-            // B, C are contiguous, and B is normal (not transpose)
+// alpha == 0
+// special case: B, C are processed as vectors because
+// B, C are contiguous, and B is normal (not transpose)
 
-            #define  GEAM_DIM 256
-            int size = m*n;
-            int blocks = ((size-1) / GEAM_DIM) + 1;
+#define GEAM_DIM 256
+            int size   = m * n;
+            int blocks = ((size - 1) / GEAM_DIM) + 1;
 
             dim3 geam_grid(blocks, 1, 1);
             dim3 geam_threads(GEAM_DIM, 1, 1);
@@ -420,44 +487,59 @@ rocblas_geam_template(rocblas_handle handle,
             RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
             T h_beta_scalar = *beta;
-            hipLaunchKernel(geam_1D_2matrix_kernel_host_pointer<T>,   // unit-test-covered
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                size, h_beta_scalar, B, C);
-            
-            #undef GEAM_DIM
+            hipLaunchKernel(geam_1D_2matrix_kernel_host_pointer<T>, // unit-test-covered
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            size,
+                            h_beta_scalar,
+                            B,
+                            C);
+
+#undef GEAM_DIM
         }
         else
         {
-            // alpha == 0
-            // general case for any transB, ldb, ldc
+// alpha == 0
+// general case for any transB, ldb, ldc
 
-            #define  GEAM_DIM_X 16
-            #define  GEAM_DIM_Y 16
-            rocblas_int blocksX = ((m-1) / GEAM_DIM_X) + 1;
-            rocblas_int blocksY = ((n-1) / GEAM_DIM_Y) + 1;
+#define GEAM_DIM_X 16
+#define GEAM_DIM_Y 16
+            rocblas_int blocksX = ((m - 1) / GEAM_DIM_X) + 1;
+            rocblas_int blocksY = ((n - 1) / GEAM_DIM_Y) + 1;
 
-            dim3 geam_grid( blocksX, blocksY, 1 );
-            dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1 );
+            dim3 geam_grid(blocksX, blocksY, 1);
+            dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1);
 
             T h_beta_scalar = *beta;
-            hipLaunchKernel(geam_2matrix_kernel_host_pointer<T>,        // unit-test-covered
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transB, m, n, h_beta_scalar, B, ldb, C, ldc);
+            hipLaunchKernel(geam_2matrix_kernel_host_pointer<T>, // unit-test-covered
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transB,
+                            m,
+                            n,
+                            h_beta_scalar,
+                            B,
+                            ldb,
+                            C,
+                            ldc);
 
-            #undef GEAM_DIM_X
-            #undef GEAM_DIM_Y
+#undef GEAM_DIM_X
+#undef GEAM_DIM_Y
         }
     }
-    else if ((m == lda) && (transA == rocblas_operation_none) &&
-             (m == ldb) && (transB == rocblas_operation_none) &&
-             (m == ldc))
+    else if((m == lda) && (transA == rocblas_operation_none) && (m == ldb) &&
+            (transB == rocblas_operation_none) && (m == ldc))
     {
-        // special case: A, B, C are processed as vectors because
-        // A, B, C are contiguous, and A and B are normal (not transpose)
+// special case: A, B, C are processed as vectors because
+// A, B, C are contiguous, and A and B are normal (not transpose)
 
-        #define  GEAM_DIM 256
-        int size = m*n;
-        int blocks = ((size-1) / GEAM_DIM) + 1;
+#define GEAM_DIM 256
+        int size   = m * n;
+        int blocks = ((size - 1) / GEAM_DIM) + 1;
 
         dim3 geam_grid(blocks, 1, 1);
         dim3 geam_threads(GEAM_DIM, 1, 1);
@@ -465,85 +547,137 @@ rocblas_geam_template(rocblas_handle handle,
         hipStream_t rocblas_stream;
         RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-        if (rocblas_pointer_mode_host == handle->pointer_mode)
+        if(rocblas_pointer_mode_host == handle->pointer_mode)
         {
             T h_alpha_scalar = *alpha;
-            T h_beta_scalar = *beta;
-            hipLaunchKernel(geam_1D_kernel_host_pointer<T>,              // unit-test-covered
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                size, h_alpha_scalar, A, h_beta_scalar, B, C);
+            T h_beta_scalar  = *beta;
+            hipLaunchKernel(geam_1D_kernel_host_pointer<T>, // unit-test-covered
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            size,
+                            h_alpha_scalar,
+                            A,
+                            h_beta_scalar,
+                            B,
+                            C);
         }
         else
         {
-            hipLaunchKernel(geam_1D_kernel_device_pointer<T>,            // unit-test-covered
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                size, alpha, A, beta, B, C);
+            hipLaunchKernel(geam_1D_kernel_device_pointer<T>, // unit-test-covered
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            size,
+                            alpha,
+                            A,
+                            beta,
+                            B,
+                            C);
         }
-        #undef GEAM_DIM
+#undef GEAM_DIM
     }
     else
     {
-        // general case, any transA, transB, lda, ldb, ldc
+// general case, any transA, transB, lda, ldb, ldc
 
-        #define  GEAM_DIM_X 16
-        #define  GEAM_DIM_Y 16
-        rocblas_int blocksX = ((m-1) / GEAM_DIM_X) + 1;
-        rocblas_int blocksY = ((n-1) / GEAM_DIM_Y) + 1;
+#define GEAM_DIM_X 16
+#define GEAM_DIM_Y 16
+        rocblas_int blocksX = ((m - 1) / GEAM_DIM_X) + 1;
+        rocblas_int blocksY = ((n - 1) / GEAM_DIM_Y) + 1;
 
-        dim3 geam_grid( blocksX, blocksY, 1 );
-        dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1 );
+        dim3 geam_grid(blocksX, blocksY, 1);
+        dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y, 1);
 
-        if (rocblas_pointer_mode_host == handle->pointer_mode)
+        if(rocblas_pointer_mode_host == handle->pointer_mode)
         {
             T h_alpha_scalar = *alpha;
-            T h_beta_scalar = *beta;
-            hipLaunchKernel(geam_kernel_host_pointer<T>,                                     // unit-test-covered
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transA, transB, m, n, h_alpha_scalar, A, lda, h_beta_scalar, B, ldb, C, ldc);
+            T h_beta_scalar  = *beta;
+            hipLaunchKernel(geam_kernel_host_pointer<T>, // unit-test-covered
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transA,
+                            transB,
+                            m,
+                            n,
+                            h_alpha_scalar,
+                            A,
+                            lda,
+                            h_beta_scalar,
+                            B,
+                            ldb,
+                            C,
+                            ldc);
         }
         else
         {
-            hipLaunchKernel(geam_kernel_device_pointer<T>,                                // unit-test-covered
-                dim3(geam_grid), dim3(geam_threads), 0, rocblas_stream,
-                transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
+            hipLaunchKernel(geam_kernel_device_pointer<T>, // unit-test-covered
+                            dim3(geam_grid),
+                            dim3(geam_threads),
+                            0,
+                            rocblas_stream,
+                            transA,
+                            transB,
+                            m,
+                            n,
+                            alpha,
+                            A,
+                            lda,
+                            beta,
+                            B,
+                            ldb,
+                            C,
+                            ldc);
         }
-        #undef GEAM_DIM_X
-        #undef GEAM_DIM_Y
+#undef GEAM_DIM_X
+#undef GEAM_DIM_Y
     }
 
     return rocblas_status_success;
 }
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
-extern "C"
-rocblas_status 
-rocblas_sgeam(rocblas_handle handle,
-   rocblas_operation transA, rocblas_operation transB,
-   rocblas_int m, rocblas_int n,
-   const float *alpha,
-   const float *A, rocblas_int lda,
-   const float *beta,
-   const float *B, rocblas_int ldb,
-   float *C, rocblas_int ldc)
+extern "C" rocblas_status rocblas_sgeam(rocblas_handle handle,
+                                        rocblas_operation transA,
+                                        rocblas_operation transB,
+                                        rocblas_int m,
+                                        rocblas_int n,
+                                        const float* alpha,
+                                        const float* A,
+                                        rocblas_int lda,
+                                        const float* beta,
+                                        const float* B,
+                                        rocblas_int ldb,
+                                        float* C,
+                                        rocblas_int ldc)
 {
-    return rocblas_geam_template<float>(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
+    return rocblas_geam_template<float>(
+        handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
 }
 
-extern "C"
-rocblas_status 
-rocblas_dgeam(rocblas_handle handle,
-   rocblas_operation transA, rocblas_operation transB,
-   rocblas_int m, rocblas_int n,
-   const double *alpha,
-   const double *A, rocblas_int lda,
-   const double *beta,
-   const double *B, rocblas_int ldb,
-   double *C, rocblas_int ldc)
+extern "C" rocblas_status rocblas_dgeam(rocblas_handle handle,
+                                        rocblas_operation transA,
+                                        rocblas_operation transB,
+                                        rocblas_int m,
+                                        rocblas_int n,
+                                        const double* alpha,
+                                        const double* A,
+                                        rocblas_int lda,
+                                        const double* beta,
+                                        const double* B,
+                                        rocblas_int ldb,
+                                        double* C,
+                                        rocblas_int ldc)
 {
-    return rocblas_geam_template<double>(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
+    return rocblas_geam_template<double>(
+        handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
 }

--- a/library/src/blas3/rocblas_trmm.cpp
+++ b/library/src/blas3/rocblas_trmm.cpp
@@ -4,82 +4,83 @@
  * ************************************************************************ */
 #include <hip/hip_runtime.h>
 
-
 #include "rocblas.h"
 #include "definitions.h"
 
-
-//do not use fma which is 50% slower than regular fmaf
+// do not use fma which is 50% slower than regular fmaf
 #define fmaf(a, b, c) (a) * (b) + (c)
 
-#define  M6x6 \
-            rA[0][0] = lA[offA + 0];				  \
-            rA[0][1] = lA[offA + 16];				  \
-            rA[0][2] = lA[offA + 32];				  \
-            rA[0][3] = lA[offA + 48];				  \
-            rA[0][4] = lA[offA + 64];				  \
-            rA[0][5] = lA[offA + 80];				  \
-            rB[0][0] = lB[offB + 0];				  \
-            rB[0][1] = lB[offB + 16];				  \
-            rB[0][2] = lB[offB + 32];				  \
-            rB[0][3] = lB[offB + 48];				  \
-            rB[0][4] = lB[offB + 64];				  \
-            rB[0][5] = lB[offB + 80];				  \
-            offA += 97;								  \
-            offB += 97;								  \
-            rC[0][0]=fmaf(rA[0][0],rB[0][0],rC[0][0]); \
-            rC[1][0]=fmaf(rA[0][1],rB[0][0],rC[1][0]); \
-            rC[2][0]=fmaf(rA[0][2],rB[0][0],rC[2][0]); \
-            rC[3][0]=fmaf(rA[0][3],rB[0][0],rC[3][0]); \
-            rC[4][0]=fmaf(rA[0][4],rB[0][0],rC[4][0]); \
-            rC[5][0]=fmaf(rA[0][5],rB[0][0],rC[5][0]); \
-            rC[0][1]=fmaf(rA[0][0],rB[0][1],rC[0][1]); \
-            rC[1][1]=fmaf(rA[0][1],rB[0][1],rC[1][1]); \
-            rC[2][1]=fmaf(rA[0][2],rB[0][1],rC[2][1]); \
-            rC[3][1]=fmaf(rA[0][3],rB[0][1],rC[3][1]); \
-            rC[4][1]=fmaf(rA[0][4],rB[0][1],rC[4][1]); \
-            rC[5][1]=fmaf(rA[0][5],rB[0][1],rC[5][1]); \
-            rC[0][2]=fmaf(rA[0][0],rB[0][2],rC[0][2]); \
-            rC[1][2]=fmaf(rA[0][1],rB[0][2],rC[1][2]); \
-            rC[2][2]=fmaf(rA[0][2],rB[0][2],rC[2][2]); \
-            rC[3][2]=fmaf(rA[0][3],rB[0][2],rC[3][2]); \
-            rC[4][2]=fmaf(rA[0][4],rB[0][2],rC[4][2]); \
-            rC[5][2]=fmaf(rA[0][5],rB[0][2],rC[5][2]); \
-            rC[0][3]=fmaf(rA[0][0],rB[0][3],rC[0][3]); \
-            rC[1][3]=fmaf(rA[0][1],rB[0][3],rC[1][3]); \
-            rC[2][3]=fmaf(rA[0][2],rB[0][3],rC[2][3]); \
-            rC[3][3]=fmaf(rA[0][3],rB[0][3],rC[3][3]); \
-            rC[4][3]=fmaf(rA[0][4],rB[0][3],rC[4][3]); \
-            rC[5][3]=fmaf(rA[0][5],rB[0][3],rC[5][3]); \
-            rC[0][4]=fmaf(rA[0][0],rB[0][4],rC[0][4]); \
-            rC[1][4]=fmaf(rA[0][1],rB[0][4],rC[1][4]); \
-            rC[2][4]=fmaf(rA[0][2],rB[0][4],rC[2][4]); \
-            rC[3][4]=fmaf(rA[0][3],rB[0][4],rC[3][4]); \
-            rC[4][4]=fmaf(rA[0][4],rB[0][4],rC[4][4]); \
-            rC[5][4]=fmaf(rA[0][5],rB[0][4],rC[5][4]); \
-            rC[0][5]=fmaf(rA[0][0],rB[0][5],rC[0][5]); \
-            rC[1][5]=fmaf(rA[0][1],rB[0][5],rC[1][5]); \
-            rC[2][5]=fmaf(rA[0][2],rB[0][5],rC[2][5]); \
-            rC[3][5]=fmaf(rA[0][3],rB[0][5],rC[3][5]); \
-            rC[4][5]=fmaf(rA[0][4],rB[0][5],rC[4][5]); \
-            rC[5][5]=fmaf(rA[0][5],rB[0][5],rC[5][5]); \
+#define M6x6                                       \
+    rA[0][0] = lA[offA + 0];                       \
+    rA[0][1] = lA[offA + 16];                      \
+    rA[0][2] = lA[offA + 32];                      \
+    rA[0][3] = lA[offA + 48];                      \
+    rA[0][4] = lA[offA + 64];                      \
+    rA[0][5] = lA[offA + 80];                      \
+    rB[0][0] = lB[offB + 0];                       \
+    rB[0][1] = lB[offB + 16];                      \
+    rB[0][2] = lB[offB + 32];                      \
+    rB[0][3] = lB[offB + 48];                      \
+    rB[0][4] = lB[offB + 64];                      \
+    rB[0][5] = lB[offB + 80];                      \
+    offA += 97;                                    \
+    offB += 97;                                    \
+    rC[0][0] = fmaf(rA[0][0], rB[0][0], rC[0][0]); \
+    rC[1][0] = fmaf(rA[0][1], rB[0][0], rC[1][0]); \
+    rC[2][0] = fmaf(rA[0][2], rB[0][0], rC[2][0]); \
+    rC[3][0] = fmaf(rA[0][3], rB[0][0], rC[3][0]); \
+    rC[4][0] = fmaf(rA[0][4], rB[0][0], rC[4][0]); \
+    rC[5][0] = fmaf(rA[0][5], rB[0][0], rC[5][0]); \
+    rC[0][1] = fmaf(rA[0][0], rB[0][1], rC[0][1]); \
+    rC[1][1] = fmaf(rA[0][1], rB[0][1], rC[1][1]); \
+    rC[2][1] = fmaf(rA[0][2], rB[0][1], rC[2][1]); \
+    rC[3][1] = fmaf(rA[0][3], rB[0][1], rC[3][1]); \
+    rC[4][1] = fmaf(rA[0][4], rB[0][1], rC[4][1]); \
+    rC[5][1] = fmaf(rA[0][5], rB[0][1], rC[5][1]); \
+    rC[0][2] = fmaf(rA[0][0], rB[0][2], rC[0][2]); \
+    rC[1][2] = fmaf(rA[0][1], rB[0][2], rC[1][2]); \
+    rC[2][2] = fmaf(rA[0][2], rB[0][2], rC[2][2]); \
+    rC[3][2] = fmaf(rA[0][3], rB[0][2], rC[3][2]); \
+    rC[4][2] = fmaf(rA[0][4], rB[0][2], rC[4][2]); \
+    rC[5][2] = fmaf(rA[0][5], rB[0][2], rC[5][2]); \
+    rC[0][3] = fmaf(rA[0][0], rB[0][3], rC[0][3]); \
+    rC[1][3] = fmaf(rA[0][1], rB[0][3], rC[1][3]); \
+    rC[2][3] = fmaf(rA[0][2], rB[0][3], rC[2][3]); \
+    rC[3][3] = fmaf(rA[0][3], rB[0][3], rC[3][3]); \
+    rC[4][3] = fmaf(rA[0][4], rB[0][3], rC[4][3]); \
+    rC[5][3] = fmaf(rA[0][5], rB[0][3], rC[5][3]); \
+    rC[0][4] = fmaf(rA[0][0], rB[0][4], rC[0][4]); \
+    rC[1][4] = fmaf(rA[0][1], rB[0][4], rC[1][4]); \
+    rC[2][4] = fmaf(rA[0][2], rB[0][4], rC[2][4]); \
+    rC[3][4] = fmaf(rA[0][3], rB[0][4], rC[3][4]); \
+    rC[4][4] = fmaf(rA[0][4], rB[0][4], rC[4][4]); \
+    rC[5][4] = fmaf(rA[0][5], rB[0][4], rC[5][4]); \
+    rC[0][5] = fmaf(rA[0][0], rB[0][5], rC[0][5]); \
+    rC[1][5] = fmaf(rA[0][1], rB[0][5], rC[1][5]); \
+    rC[2][5] = fmaf(rA[0][2], rB[0][5], rC[2][5]); \
+    rC[3][5] = fmaf(rA[0][3], rB[0][5], rC[3][5]); \
+    rC[4][5] = fmaf(rA[0][4], rB[0][5], rC[4][5]); \
+    rC[5][5] = fmaf(rA[0][5], rB[0][5], rC[5][5]);
 
-             //__threadfence_block(); \ does not compile
+//__threadfence_block(); \ does not compile
 
-
-template<typename T, rocblas_int NB>
+template <typename T, rocblas_int NB>
 __global__ void trmm_left_lower_nontrans_MX096_NX096_KX16(hipLaunchParm lp,
-    rocblas_fill uplo,
-    rocblas_operation transA,
-    rocblas_diagonal diag,
-    rocblas_int M, rocblas_int N,
-    const T *alpha,
-    const T *A, rocblas_int lda,
-    const T *B, rocblas_int ldb,
-    T *C, rocblas_int ldc)
+                                                          rocblas_fill uplo,
+                                                          rocblas_operation transA,
+                                                          rocblas_diagonal diag,
+                                                          rocblas_int M,
+                                                          rocblas_int N,
+                                                          const T* alpha,
+                                                          const T* A,
+                                                          rocblas_int lda,
+                                                          const T* B,
+                                                          rocblas_int ldb,
+                                                          T* C,
+                                                          rocblas_int ldc)
 {
 
-    T rC[6][6]  = { {(T)0} };
+    T rC[6][6] = {{(T)0}};
     T rA[1][6];
     T rB[1][6];
 
@@ -90,104 +91,88 @@ __global__ void trmm_left_lower_nontrans_MX096_NX096_KX16(hipLaunchParm lp,
 
     uint gidx = hipBlockIdx_x;
     uint gidy = hipBlockIdx_y;
-    uint idx = hipThreadIdx_x; //get_local_id(0);
-    uint idy = hipThreadIdx_y; //get_local_id(1);
+    uint idx  = hipThreadIdx_x; // get_local_id(0);
+    uint idy  = hipThreadIdx_y; // get_local_id(1);
 
-    A +=  gidx*96+ idx + idy*lda;
-    B +=  gidy*96*ldb+ idx + idy*ldb;
+    A += gidx * 96 + idx + idy * lda;
+    B += gidy * 96 * ldb + idx + idy * ldb;
 
     uint block_k = K >> 4;
-    do {
-        plA = lA + idy*97+idx;
-        plB = lB + idx*97+idy;
+    do
+    {
+        plA = lA + idy * 97 + idx;
+        plB = lB + idx * 97 + idy;
 
-        plB[0] = B[0];
-        plB[16] = B[16*ldb];
-        plB[32] = B[32*ldb];
-        plB[48] = B[48*ldb];
-        plB[64] = B[64*ldb];
-        plB[80] = B[80*ldb];
+        plB[0]  = B[0];
+        plB[16] = B[16 * ldb];
+        plB[32] = B[32 * ldb];
+        plB[48] = B[48 * ldb];
+        plB[64] = B[64 * ldb];
+        plB[80] = B[80 * ldb];
 
-	    plA[0] = A[0+0*lda];
-        plA[16] = A[16+0*lda];
-        plA[32] = A[32+0*lda];
-        plA[48] = A[48+0*lda];
-        plA[64] = A[64+0*lda];
-        plA[80] = A[80+0*lda];
-
+        plA[0]  = A[0 + 0 * lda];
+        plA[16] = A[16 + 0 * lda];
+        plA[32] = A[32 + 0 * lda];
+        plA[48] = A[48 + 0 * lda];
+        plA[64] = A[64 + 0 * lda];
+        plA[80] = A[80 + 0 * lda];
 
         __syncthreads();
 
         uint offA = idx;
         uint offB = idy;
 
-        M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
-	      M6x6
+        M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6 M6x6
 
-        A += lda<<4;
+            A += lda << 4;
         B += 16;
-	} while (--block_k > 0);
+    } while(--block_k > 0);
 
-    C+= gidx*96+idx;
-    C+= gidy*96*ldc;
-    C+= idy*ldc;
+    C += gidx * 96 + idx;
+    C += gidy * 96 * ldc;
+    C += idy * ldc;
 
-    C[0*ldc] = alpha*rC[0][0] ;
-    C[16*ldc] = alpha*rC[0][1] ;
-    C[32*ldc] = alpha*rC[0][2] ;
-    C[48*ldc] = alpha*rC[0][3] ;
-    C[64*ldc] = alpha*rC[0][4] ;
-    C[80*ldc] = alpha*rC[0][5] ;
-    C+=16;
-    C[0*ldc] = alpha*rC[1][0] ;
-    C[16*ldc] = alpha*rC[1][1] ;
-    C[32*ldc] = alpha*rC[1][2] ;
-    C[48*ldc] = alpha*rC[1][3] ;
-    C[64*ldc] = alpha*rC[1][4] ;
-    C[80*ldc] = alpha*rC[1][5] ;
-    C+=16;
-    C[0*ldc] = alpha*rC[2][0] ;
-    C[16*ldc] = alpha*rC[2][1] ;
-    C[32*ldc] = alpha*rC[2][2] ;
-    C[48*ldc] = alpha*rC[2][3] ;
-    C[64*ldc] = alpha*rC[2][4] ;
-    C[80*ldc] = alpha*rC[2][5] ;
-    C+=16;
-    C[0*ldc] = alpha*rC[3][0] ;
-    C[16*ldc] = alpha*rC[3][1] ;
-    C[32*ldc] = alpha*rC[3][2] ;
-    C[48*ldc] = alpha*rC[3][3] ;
-    C[64*ldc] = alpha*rC[3][4] ;
-    C[80*ldc] = alpha*rC[3][5] ;
-    C+=16;
-    C[0*ldc] = alpha*rC[4][0] ;
-    C[16*ldc] = alpha*rC[4][1] ;
-    C[32*ldc] = alpha*rC[4][2] ;
-    C[48*ldc] = alpha*rC[4][3] ;
-    C[64*ldc] = alpha*rC[4][4] ;
-    C[80*ldc] = alpha*rC[4][5] ;
-    C+=16;
-    C[0*ldc] = alpha*rC[5][0] ;
-    C[16*ldc] = alpha*rC[5][1];
-    C[32*ldc] = alpha*rC[5][2];
-    C[48*ldc] = alpha*rC[5][3];
-    C[64*ldc] = alpha*rC[5][4];
-    C[80*ldc] = alpha*rC[5][5];
-
+    C[0 * ldc]  = alpha * rC[0][0];
+    C[16 * ldc] = alpha * rC[0][1];
+    C[32 * ldc] = alpha * rC[0][2];
+    C[48 * ldc] = alpha * rC[0][3];
+    C[64 * ldc] = alpha * rC[0][4];
+    C[80 * ldc] = alpha * rC[0][5];
+    C += 16;
+    C[0 * ldc]  = alpha * rC[1][0];
+    C[16 * ldc] = alpha * rC[1][1];
+    C[32 * ldc] = alpha * rC[1][2];
+    C[48 * ldc] = alpha * rC[1][3];
+    C[64 * ldc] = alpha * rC[1][4];
+    C[80 * ldc] = alpha * rC[1][5];
+    C += 16;
+    C[0 * ldc]  = alpha * rC[2][0];
+    C[16 * ldc] = alpha * rC[2][1];
+    C[32 * ldc] = alpha * rC[2][2];
+    C[48 * ldc] = alpha * rC[2][3];
+    C[64 * ldc] = alpha * rC[2][4];
+    C[80 * ldc] = alpha * rC[2][5];
+    C += 16;
+    C[0 * ldc]  = alpha * rC[3][0];
+    C[16 * ldc] = alpha * rC[3][1];
+    C[32 * ldc] = alpha * rC[3][2];
+    C[48 * ldc] = alpha * rC[3][3];
+    C[64 * ldc] = alpha * rC[3][4];
+    C[80 * ldc] = alpha * rC[3][5];
+    C += 16;
+    C[0 * ldc]  = alpha * rC[4][0];
+    C[16 * ldc] = alpha * rC[4][1];
+    C[32 * ldc] = alpha * rC[4][2];
+    C[48 * ldc] = alpha * rC[4][3];
+    C[64 * ldc] = alpha * rC[4][4];
+    C[80 * ldc] = alpha * rC[4][5];
+    C += 16;
+    C[0 * ldc]  = alpha * rC[5][0];
+    C[16 * ldc] = alpha * rC[5][1];
+    C[32 * ldc] = alpha * rC[5][2];
+    C[48 * ldc] = alpha * rC[5][3];
+    C[64 * ldc] = alpha * rC[5][4];
+    C[80 * ldc] = alpha * rC[5][5];
 }
 
 /*! \brief BLAS Level 3 API
@@ -273,55 +258,59 @@ __global__ void trmm_left_lower_nontrans_MX096_NX096_KX16(hipLaunchParm lp,
 
 #define NB_X 16
 
-template<typename T>
-rocblas_status
-rocblas_trmm_template(rocblas_handle handle,
-    rocblas_side side,
-    rocblas_fill uplo,
-    rocblas_operation transA,
-    rocblas_diagonal diag,
-    rocblas_int M, rocblas_int N,
-    const T *alpha,
-    const T *A, rocblas_int lda,
-    const T *B, rocblas_int ldb,
-    T *C, rocblas_int ldc)
+template <typename T>
+rocblas_status rocblas_trmm_template(rocblas_handle handle,
+                                     rocblas_side side,
+                                     rocblas_fill uplo,
+                                     rocblas_operation transA,
+                                     rocblas_diagonal diag,
+                                     rocblas_int M,
+                                     rocblas_int N,
+                                     const T* alpha,
+                                     const T* A,
+                                     rocblas_int lda,
+                                     const T* B,
+                                     rocblas_int ldb,
+                                     T* C,
+                                     rocblas_int ldc)
 {
-    rocblas_int A_row = ( side == rocblas_side_left ?  M : N);
+    rocblas_int A_row = (side == rocblas_side_left ? M : N);
 
     if(handle == nullptr)
         return rocblas_status_invalid_handle;
-    else if ( M < 0 )
+    else if(M < 0)
         return rocblas_status_invalid_size;
-    else if ( N < 0 )
+    else if(N < 0)
         return rocblas_status_invalid_size;
-    else if ( alpha == nullptr )
+    else if(alpha == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( A == nullptr )
+    else if(A == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( lda < A_row )
+    else if(lda < A_row)
         return rocblas_status_invalid_size;
-    else if ( B == nullptr )
+    else if(B == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( ldb < M )
+    else if(ldb < M)
         return rocblas_status_invalid_size;
-    else if ( C == nullptr )
+    else if(C == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( ldc < M )
+    else if(ldc < M)
         return rocblas_status_invalid_size;
 
     /*
      * Quick return if possible.
      */
 
-    if ( M == 0 || N == 0 )
+    if(M == 0 || N == 0)
         return rocblas_status_success;
 
-    if(transA == rocblas_operation_transpose){
+    if(transA == rocblas_operation_transpose)
+    {
         return rocblas_status_not_implemented;
     }
 
-    rocblas_int blocks_x = (M-1)/(NB_X*6) + 1;
-    rocblas_int blocks_y = (N-1)/(NB_X*6) + 1;
+    rocblas_int blocks_x = (M - 1) / (NB_X * 6) + 1;
+    rocblas_int blocks_y = (N - 1) / (NB_X * 6) + 1;
 
     dim3 grid(blocks_x, blocks_y, 1);
     dim3 threads(NB_X, NB_X, 1);
@@ -330,60 +319,78 @@ rocblas_trmm_template(rocblas_handle handle,
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
     T alpha_scalar = *alpha;
 
-    hipLaunchKernel(HIP_KERNEL_NAME(trmm_Col_NN_B1_MX096_NX096_KX16<T, NB_X>), dim3(grid), dim3(threads), 0, rocblas_stream, M, N, K, alpha_scalar, A, lda, B, ldb, C, ldc);
+    hipLaunchKernel(HIP_KERNEL_NAME(trmm_Col_NN_B1_MX096_NX096_KX16<T, NB_X>),
+                    dim3(grid),
+                    dim3(threads),
+                    0,
+                    rocblas_stream,
+                    M,
+                    N,
+                    K,
+                    alpha_scalar,
+                    A,
+                    lda,
+                    B,
+                    ldb,
+                    C,
+                    ldc);
 
     return rocblas_status_success;
-
-}
-
-
-/* ============================================================================================ */
-
-    /*
-     * ===========================================================================
-     *    template interface
-     *    template specialization
-     * ===========================================================================
-     */
-
-
-template<>
-rocblas_status
-rocblas_trmm<float>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const float *alpha,
-    const float *A, rocblas_int lda,
-    const float *B, rocblas_int ldb,
-    float *C, rocblas_int ldc)
-{
-    return rocblas_trmm_template<float>(handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, C, ldc);
-}
-
-template<>
-rocblas_status
-rocblas_trmm<double>(rocblas_handle handle,
-    rocblas_operation transA,
-    rocblas_operation transB,
-    rocblas_int M, rocblas_int N, rocblas_int K,
-    const double *alpha,
-    const double *A, rocblas_int lda,
-    const double *B, rocblas_int ldb,
-    double *C, rocblas_int ldc)
-{
-    return rocblas_trmm_template<double>(handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, C, ldc);
 }
 
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    C wrapper
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    template interface
+ *    template specialization
+ * ===========================================================================
+ */
 
+template <>
+rocblas_status rocblas_trmm<float>(rocblas_handle handle,
+                                   rocblas_operation transA,
+                                   rocblas_operation transB,
+                                   rocblas_int M,
+                                   rocblas_int N,
+                                   rocblas_int K,
+                                   const float* alpha,
+                                   const float* A,
+                                   rocblas_int lda,
+                                   const float* B,
+                                   rocblas_int ldb,
+                                   float* C,
+                                   rocblas_int ldc)
+{
+    return rocblas_trmm_template<float>(
+        handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, C, ldc);
+}
 
+template <>
+rocblas_status rocblas_trmm<double>(rocblas_handle handle,
+                                    rocblas_operation transA,
+                                    rocblas_operation transB,
+                                    rocblas_int M,
+                                    rocblas_int N,
+                                    rocblas_int K,
+                                    const double* alpha,
+                                    const double* A,
+                                    rocblas_int lda,
+                                    const double* B,
+                                    rocblas_int ldb,
+                                    double* C,
+                                    rocblas_int ldc)
+{
+    return rocblas_trmm_template<double>(
+        handle, transA, transB, M, N, K, alpha, A, lda, B, ldb, C, ldc);
+}
 
+/* ============================================================================================ */
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
 
 /* ============================================================================================ */

--- a/library/src/blas3/rocblas_trtri.cpp
+++ b/library/src/blas3/rocblas_trtri.cpp
@@ -5,43 +5,45 @@
 #include <hip/hip_runtime.h>
 
 #include "rocblas.h"
-namespace trtri{ //must use namespace to avoid multply definiton 
-    #include "trtri.hpp" 
+namespace trtri { // must use namespace to avoid multply definiton
+#include "trtri.hpp"
 }
 
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    C interface
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C interface
+ * ===========================================================================
+ */
 
+// because of shared memory size, the IB must be <= 64, typically 64 for s, d, c, but 32 for z
+// typically, only a small matrix A is inverted by trtri, so if n is too big, trtri is not
+// implemented
+// trtri is usually called by trsm
 
-
-
-//because of shared memory size, the IB must be <= 64, typically 64 for s, d, c, but 32 for z
-//typically, only a small matrix A is inverted by trtri, so if n is too big, trtri is not implemented
-//trtri is usually called by trsm
-
-extern "C"
-rocblas_status
-rocblas_strtri(rocblas_handle handle,
-    rocblas_fill uplo, rocblas_diagonal diag,
-    rocblas_int n,
-    float *A, rocblas_int lda,
-    float *invA, rocblas_int ldinvA){
+extern "C" rocblas_status rocblas_strtri(rocblas_handle handle,
+                                         rocblas_fill uplo,
+                                         rocblas_diagonal diag,
+                                         rocblas_int n,
+                                         float* A,
+                                         rocblas_int lda,
+                                         float* invA,
+                                         rocblas_int ldinvA)
+{
 
     return trtri::rocblas_trtri_template<float, 64>(handle, uplo, diag, n, A, lda, invA, ldinvA);
 }
 
-extern "C"
-rocblas_status
-rocblas_dtrtri(rocblas_handle handle,
-    rocblas_fill uplo, rocblas_diagonal diag,
-    rocblas_int n,
-    double *A, rocblas_int lda,
-    double *invA, rocblas_int ldinvA){
+extern "C" rocblas_status rocblas_dtrtri(rocblas_handle handle,
+                                         rocblas_fill uplo,
+                                         rocblas_diagonal diag,
+                                         rocblas_int n,
+                                         double* A,
+                                         rocblas_int lda,
+                                         double* invA,
+                                         rocblas_int ldinvA)
+{
 
     return trtri::rocblas_trtri_template<double, 64>(handle, uplo, diag, n, A, lda, invA, ldinvA);
 }

--- a/library/src/blas3/rocblas_trtri_batched.cpp
+++ b/library/src/blas3/rocblas_trtri_batched.cpp
@@ -7,42 +7,43 @@
 #include "rocblas.h"
 #include "trtri_batched.hpp"
 
-
-
 /* ============================================================================================ */
 
-    /*
-     * ===========================================================================
-     *    C interface
-     *    This function is called by trsm
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    C interface
+ *    This function is called by trsm
+ * ===========================================================================
+ */
 
-
-extern "C"
-rocblas_status
-rocblas_strtri_batched(rocblas_handle handle,
-    rocblas_fill uplo,
-    rocblas_diagonal diag,
-    rocblas_int n,
-    float *A, rocblas_int lda, rocblas_int bsa,
-    float *invA, rocblas_int ldinvA, rocblas_int bsinvA,
-    rocblas_int batch_count)
+extern "C" rocblas_status rocblas_strtri_batched(rocblas_handle handle,
+                                                 rocblas_fill uplo,
+                                                 rocblas_diagonal diag,
+                                                 rocblas_int n,
+                                                 float* A,
+                                                 rocblas_int lda,
+                                                 rocblas_int bsa,
+                                                 float* invA,
+                                                 rocblas_int ldinvA,
+                                                 rocblas_int bsinvA,
+                                                 rocblas_int batch_count)
 {
-    return rocblas_trtri_batched_template<float>(handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
+    return rocblas_trtri_batched_template<float>(
+        handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
 }
 
-
-extern "C"
-rocblas_status
-rocblas_dtrtri_batched(rocblas_handle handle,
-    rocblas_fill uplo,
-    rocblas_diagonal diag,
-    rocblas_int n,
-    double *A, rocblas_int lda, rocblas_int bsa,
-    double *invA, rocblas_int ldinvA, rocblas_int bsinvA,
-    rocblas_int batch_count)
+extern "C" rocblas_status rocblas_dtrtri_batched(rocblas_handle handle,
+                                                 rocblas_fill uplo,
+                                                 rocblas_diagonal diag,
+                                                 rocblas_int n,
+                                                 double* A,
+                                                 rocblas_int lda,
+                                                 rocblas_int bsa,
+                                                 double* invA,
+                                                 rocblas_int ldinvA,
+                                                 rocblas_int bsinvA,
+                                                 rocblas_int batch_count)
 {
-    return rocblas_trtri_batched_template<double>(handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
+    return rocblas_trtri_batched_template<double>(
+        handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
 }
-

--- a/library/src/blas3/trtri_device.h
+++ b/library/src/blas3/trtri_device.h
@@ -3,16 +3,15 @@
  *
  * ************************************************************************ */
 
-
 #pragma once
 #ifndef _TRTRI_DEVICE_H_
 #define _TRTRI_DEVICE_H_
 
-    /*
-     * ===========================================================================
-     *    This file provide common device function for trtri routines
-     * ===========================================================================
-     */
+/*
+ * ===========================================================================
+ *    This file provide common device function for trtri routines
+ * ===========================================================================
+ */
 
 /* ============================================================================================ */
 
@@ -47,108 +46,134 @@
 
     ********************************************************************/
 
-template<typename T, rocblas_int NB, rocblas_int flag>
-__device__ void
-trtri_device(rocblas_fill uplo,
-    rocblas_diagonal diag,
-    rocblas_int n,
-    T *A, rocblas_int lda,
-    T *invA, rocblas_int ldinvA)
+template <typename T, rocblas_int NB, rocblas_int flag>
+__device__ void trtri_device(rocblas_fill uplo,
+                             rocblas_diagonal diag,
+                             rocblas_int n,
+                             T* A,
+                             rocblas_int lda,
+                             T* invA,
+                             rocblas_int ldinvA)
 {
 
-    //quick return
-    if (n <=0 ) return ;
+    // quick return
+    if(n <= 0)
+        return;
 
-    int tx  = hipThreadIdx_x;
+    int tx = hipThreadIdx_x;
 
     __shared__ T sA[NB * NB];
 
-    //read matrix A into shared memory, only need to read lower part
-    //its inverse will overwrite the shared memory
+    // read matrix A into shared memory, only need to read lower part
+    // its inverse will overwrite the shared memory
 
-    if (tx < n){
-        if(uplo == rocblas_fill_lower){
-            //compute only diagonal element
-            for(int i=0;i<=tx;i++){
+    if(tx < n)
+    {
+        if(uplo == rocblas_fill_lower)
+        {
+            // compute only diagonal element
+            for(int i = 0; i <= tx; i++)
+            {
                 sA[tx + i * n] = A[tx + i * lda];
             }
         }
-        else{ // transpose A in sA if upper
-            for(int i=n-1;i>=tx;i--){
-                sA[(n-1-tx) + (n-1-i) * n] = A[tx + i * lda];
+        else
+        { // transpose A in sA if upper
+            for(int i = n - 1; i >= tx; i--)
+            {
+                sA[(n - 1 - tx) + (n - 1 - i) * n] = A[tx + i * lda];
             }
         }
     }
     __syncthreads(); // if NB < 64, this synch can be avoided
 
-    //invert the diagonal element
-    if (tx < n){
-        //compute only diagonal element
-        if (diag == rocblas_diagonal_unit){
+    // invert the diagonal element
+    if(tx < n)
+    {
+        // compute only diagonal element
+        if(diag == rocblas_diagonal_unit)
+        {
             sA[tx + tx * n] = 1.0;
         }
-        else{//inverse the diagonal
-            if(sA[tx + tx * n] == 0.0){ // notice this does not apply for complex
+        else
+        { // inverse the diagonal
+            if(sA[tx + tx * n] == 0.0)
+            {                          // notice this does not apply for complex
                 sA[tx + tx * n] = 1.0; // means the matrix is singular
             }
-            else{
-                sA[tx + tx * n] = 1.0/sA[tx + tx * n];
+            else
+            {
+                sA[tx + tx * n] = 1.0 / sA[tx + tx * n];
             }
         }
     }
     __syncthreads(); // if NB < 64, this synch can be avoided on AMD Fiji
 
-    // solve the inverse of A column by column, each inverse(A)' column will overwrite sA'column which store A
+    // solve the inverse of A column by column, each inverse(A)' column will overwrite sA'column
+    // which store A
     // this operation is safe
-    for(int col=0; col<n; col++){
+    for(int col = 0; col < n; col++)
+    {
 
         T reg = 0;
-        //use the diagonal one to update current column
-        if(tx > col) reg += sA[tx + col * n] * sA[col + col * n];
+        // use the diagonal one to update current column
+        if(tx > col)
+            reg += sA[tx + col * n] * sA[col + col * n];
 
         __syncthreads(); // if NB < 64, this synch can be avoided on AMD Fiji
 
         // in each column, it solves step, each step solve an inverse(A)[step][col]
-        for(int step=col+1;step<n;step++){
+        for(int step = col + 1; step < n; step++)
+        {
 
             // only tx == step solve off-diagonal
-            if(tx == step) {
-                //solve the step row, off-diagonal elements, notice sA[tx][tx] is already inversed, so multiply
+            if(tx == step)
+            {
+                // solve the step row, off-diagonal elements, notice sA[tx][tx] is already inversed,
+                // so multiply
                 sA[tx + col * n] = (0 - reg) * sA[tx + tx * n];
             }
 
             __syncthreads(); // if NB < 64, this synch can be avoided on AMD Fiji
 
-            //tx > step  update with (tx = step)'s result
-            if(tx > step){
-                reg +=  sA[tx + step * n] * sA[step + col * n];
+            // tx > step  update with (tx = step)'s result
+            if(tx > step)
+            {
+                reg += sA[tx + step * n] * sA[step + col * n];
             }
             __syncthreads(); // if NB < 64, this synch can be avoided on AMD Fiji
         }
         __syncthreads();
     }
 
-
-    //if flag 0, then A will be overwritten by sA, invA is not touched
-    T* output; int ldoutput;
-    if(flag == 0){
-        output = A;
+    // if flag 0, then A will be overwritten by sA, invA is not touched
+    T* output;
+    int ldoutput;
+    if(flag == 0)
+    {
+        output   = A;
         ldoutput = lda;
     }
-    else{ //else invA will be overwritten by sA, A is not touched
-        output = invA;
+    else
+    { // else invA will be overwritten by sA, A is not touched
+        output   = invA;
         ldoutput = ldinvA;
     }
 
-    if (tx < n){
-        if(uplo == rocblas_fill_lower){
-            for(int i=0;i<=tx;i++){
+    if(tx < n)
+    {
+        if(uplo == rocblas_fill_lower)
+        {
+            for(int i = 0; i <= tx; i++)
+            {
                 output[tx + i * ldoutput] = sA[tx + i * n];
             }
         }
-        else{ // transpose back to A from sA if upper
-            for(int i=n-1;i>=tx;i--){
-                output[tx + i * ldoutput] = sA[(n-1-tx) + (n-1-i) * n];
+        else
+        { // transpose back to A from sA if upper
+            for(int i = n - 1; i >= tx; i--)
+            {
+                output[tx + i * ldoutput] = sA[(n - 1 - tx) + (n - 1 - i) * n];
             }
         }
     }
@@ -157,4 +182,4 @@ trtri_device(rocblas_fill uplo,
 #define STRSM_BLOCK 192
 #define DTRSM_BLOCK 128
 
-#endif  // _TRTRI_DEVICE_H_
+#endif // _TRTRI_DEVICE_H_

--- a/library/src/blas3/trtri_trsm.hpp
+++ b/library/src/blas3/trtri_trsm.hpp
@@ -5,10 +5,10 @@
 
 #pragma once
 #ifndef __TRTRI_TRSM_HPP__
-#define __TRTRI_TRSM_HPP__  
+#define __TRTRI_TRSM_HPP__
 
 #include <hip/hip_runtime.h>
- 
+
 #include "definitions.h"
 #include "status.h"
 #include "trtri.hpp"
@@ -26,32 +26,36 @@
         [    IB ]
 
 */
-template<typename T, rocblas_int NB>
-__global__ void
-trtri_trsm_kernel(hipLaunchParm lp,
-    rocblas_fill uplo,
-    rocblas_diagonal diag,
-    rocblas_int n,
-    T *A, rocblas_int lda,
-    T *invA)
+template <typename T, rocblas_int NB>
+__global__ void trtri_trsm_kernel(hipLaunchParm lp,
+                                  rocblas_fill uplo,
+                                  rocblas_diagonal diag,
+                                  rocblas_int n,
+                                  T* A,
+                                  rocblas_int lda,
+                                  T* invA)
 {
-    //get the individual matrix which is processed by device function
-    //device function only see one matrix
+    // get the individual matrix which is processed by device function
+    // device function only see one matrix
 
     // each hip thread Block compute a inverse of a IB * IB diagonal block of A
 
-    T *individual_invA;
-    individual_invA = invA + hipBlockIdx_x/2 * NB * NB;
+    T* individual_invA;
+    individual_invA = invA + hipBlockIdx_x / 2 * NB * NB;
     // the odd thread block makes a shift
-    if( hipBlockIdx_x % 2 == 1 ){
-        individual_invA += NB * (NB/2) + (NB/2);
+    if(hipBlockIdx_x % 2 == 1)
+    {
+        individual_invA += NB * (NB / 2) + (NB / 2);
     }
 
-    trtri_device<T, NB/2, 1>(uplo, diag, (NB/2), A+hipBlockIdx_x * (NB/2) * lda + hipBlockIdx_x * (NB/2), lda, individual_invA, NB);
-
+    trtri_device<T, NB / 2, 1>(uplo,
+                               diag,
+                               (NB / 2),
+                               A + hipBlockIdx_x * (NB / 2) * lda + hipBlockIdx_x * (NB / 2),
+                               lda,
+                               individual_invA,
+                               NB);
 }
-
-
 
 /* ============================================================================================ */
 
@@ -95,36 +99,35 @@ trtri_trsm_kernel(hipLaunchParm lp,
 
     ********************************************************************/
 
-//assume invA has already been allocated, and leading dimension of invA is NB
-//assume IB is exactly half of NB
-template<typename T, rocblas_int NB>
-rocblas_status
-rocblas_trtri_trsm_template(rocblas_handle handle,
-    rocblas_fill uplo,
-    rocblas_diagonal diag,
-    rocblas_int n,
-    T *A, rocblas_int lda,
-    T *invA)
+// assume invA has already been allocated, and leading dimension of invA is NB
+// assume IB is exactly half of NB
+template <typename T, rocblas_int NB>
+rocblas_status rocblas_trtri_trsm_template(rocblas_handle handle,
+                                           rocblas_fill uplo,
+                                           rocblas_diagonal diag,
+                                           rocblas_int n,
+                                           T* A,
+                                           rocblas_int lda,
+                                           T* invA)
 {
     if(handle == nullptr)
         return rocblas_status_invalid_handle;
-    else if ( uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
+    else if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
         return rocblas_status_not_implemented;
-    else if ( n < 0 )
+    else if(n < 0)
         return rocblas_status_invalid_size;
-    else if ( A == nullptr )
+    else if(A == nullptr)
         return rocblas_status_invalid_pointer;
-    else if ( lda < n )
+    else if(lda < n)
         return rocblas_status_invalid_size;
-    else if ( invA == nullptr )
+    else if(invA == nullptr)
         return rocblas_status_invalid_pointer;
-
 
     /*
      * Quick return if possible.
      */
 
-    if ( n == 0 )
+    if(n == 0)
         return rocblas_status_success;
 
     rocblas_status status;
@@ -135,13 +138,14 @@ rocblas_trtri_trsm_template(rocblas_handle handle,
     /* blocks is number of divisible NB*NB blocks, but 2 * blocks of IB*IB blocks.
        if n < NB. Then blocks = 0; the trtri_trsm and batched gemm are diabled */
 
-    rocblas_int  blocks =  n / NB; 
+    rocblas_int blocks = n / NB;
 
-    if(blocks > 0){
+    if(blocks > 0)
+    {
 
-        rocblas_int  IB = NB/2;
+        rocblas_int IB = NB / 2;
         dim3 grid(blocks * 2, 1, 1);
-        dim3 threads(IB, 1, 1 );
+        dim3 threads(IB, 1, 1);
 
         /*
            Algorithm:
@@ -154,7 +158,8 @@ rocblas_trtri_trsm_template(rocblas_handle handle,
 
                 A11*invA11 = I                 ->  invA11 =  A11^{-1}, by trtri directly
                 A22*invA22 = I                 ->  invA22 =  A22^{-1}, by trtri directly
-                A21*invA11 +  A22*invA21 = 0 ->  invA21 = -A22^{-1}*A21*invA11 = -invA22*A21*invA11, by gemm
+                A21*invA11 +  A22*invA21 = 0 ->  invA21 = -A22^{-1}*A21*invA11 = -invA22*A21*invA11,
+           by gemm
 
 
             If A is a upper triangular matrix, to compute the invA
@@ -165,86 +170,128 @@ rocblas_trtri_trsm_template(rocblas_handle handle,
 
                 A11*invA11 = I                 ->  invA11 =  A11^{-1}, by trtri directly
                 A22*invA22 = I                 ->  invA22 =  A22^{-1}, by trtri directly
-                A11*invA12 + A12*invA22    = 0 ->  invA12 =  -A11^{-1}*A12*invA22 = -invA11*A12*invA22, by gemm
+                A11*invA12 + A12*invA22    = 0 ->  invA12 =  -A11^{-1}*A12*invA22 =
+           -invA11*A12*invA22, by gemm
 
         */
 
-        //invert IB * IB diagoanl blocks of A and write the result of invA11 and invA22 in invA
+        // invert IB * IB diagoanl blocks of A and write the result of invA11 and invA22 in invA
 
-        hipLaunchKernel(HIP_KERNEL_NAME(trtri_trsm_kernel<T, NB>), dim3(grid), dim3(threads), 0, rocblas_stream,
-                                            uplo, diag, (blocks)*NB, A, lda, invA);
+        hipLaunchKernel(HIP_KERNEL_NAME(trtri_trsm_kernel<T, NB>),
+                        dim3(grid),
+                        dim3(threads),
+                        0,
+                        rocblas_stream,
+                        uplo,
+                        diag,
+                        (blocks)*NB,
+                        A,
+                        lda,
+                        invA);
 
-        T one = 1;  T zero = 0; T negative_one = -1;
+        T one          = 1;
+        T zero         = 0;
+        T negative_one = -1;
 
-        auto C = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * IB * IB * blocks),rocblas::device_free};
+        auto C = rocblas_unique_ptr{rocblas::device_malloc(sizeof(T) * IB * IB * blocks),
+                                    rocblas::device_free};
         if(!C)
         {
             return rocblas_status_memory_error;
         }
 
-        rocblas_int stride_A = NB*lda + NB;
-        rocblas_int stride_invA = NB*NB;
-        rocblas_int stride_C = IB*IB;
+        rocblas_int stride_A    = NB * lda + NB;
+        rocblas_int stride_invA = NB * NB;
+        rocblas_int stride_C    = IB * IB;
 
         rocblas_int A12_A21_offset, invA11_offset, invA22_offset, invA21_invA12_offset;
 
-//                A21*invA11 + invA22*invA21 = 0 ->  invA21 = -A22^{-1}*A21*invA11 = -invA22*A21*invA11, by gemm
+        //                A21*invA11 + invA22*invA21 = 0 ->  invA21 = -A22^{-1}*A21*invA11 =
+        //                -invA22*A21*invA11, by gemm
 
-        if (uplo == rocblas_fill_lower){
-            A12_A21_offset = IB; //A21
-            invA11_offset =  0; //invA11 in lower
-            invA21_invA12_offset = IB; //invA21
-            invA22_offset = IB*NB+IB;//invA22 in lower
+        if(uplo == rocblas_fill_lower)
+        {
+            A12_A21_offset       = IB;           // A21
+            invA11_offset        = 0;            // invA11 in lower
+            invA21_invA12_offset = IB;           // invA21
+            invA22_offset        = IB * NB + IB; // invA22 in lower
         }
         else
         {
-            A12_A21_offset = IB*NB; //A12
-            invA11_offset =  NB*IB+IB; //invA22 in upper
-            invA21_invA12_offset = IB*NB; //invA12
-            invA22_offset =  0; // A11 in upper
+            A12_A21_offset       = IB * NB;      // A12
+            invA11_offset        = NB * IB + IB; // invA22 in upper
+            invA21_invA12_offset = IB * NB;      // invA12
+            invA22_offset        = 0;            // A11 in upper
         }
 
-
-        #ifndef NDEBUG
+#ifndef NDEBUG
         printf("first batched gemm\n");
-        #endif
+#endif
         // first batched gemm compute C = A21*invA11 (lower) or C = A12*invA22 (upper)
-        // distance between each invA11 or invA22 is stride_invA,  stride_A for each A21 or A12, C of size IB * IB
-        status = rocblas_gemm_strided_batched_template<T>(handle, rocblas_operation_none, rocblas_operation_none,
-                                        IB, IB, IB,
-                                        &one,
-                                        (const T*)(A + ((uplo == rocblas_fill_lower) ? IB : IB*lda) ), lda, stride_A,
-                                        (const T*)(invA +  ((uplo == rocblas_fill_lower) ? 0 : IB*NB+IB) ) , NB, stride_invA,
-                                        &zero,
-                                        (T*)C.get(), IB, stride_C,
-                                        blocks );
+        // distance between each invA11 or invA22 is stride_invA,  stride_A for each A21 or A12, C
+        // of size IB * IB
+        status = rocblas_gemm_strided_batched_template<T>(
+            handle,
+            rocblas_operation_none,
+            rocblas_operation_none,
+            IB,
+            IB,
+            IB,
+            &one,
+            (const T*)(A + ((uplo == rocblas_fill_lower) ? IB : IB * lda)),
+            lda,
+            stride_A,
+            (const T*)(invA + ((uplo == rocblas_fill_lower) ? 0 : IB * NB + IB)),
+            NB,
+            stride_invA,
+            &zero,
+            (T*)C.get(),
+            IB,
+            stride_C,
+            blocks);
 
-        #ifndef NDEBUG
+#ifndef NDEBUG
         printf("second batched gemm\n");
-        #endif
+#endif
         // second batched gemm compute  invA21 = -invA22 * C (lower) or invA12 = -invA11*C (upper)
         // distance between each invA21 or invA12 is stride_invA,
-        status = rocblas_gemm_strided_batched_template<T>(handle, rocblas_operation_none, rocblas_operation_none,
-                                        IB, IB, IB,
-                                        &negative_one,
-                                        (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB*NB+IB : 0)), NB, stride_invA,
-                                        (const T*)C.get(), IB, stride_C,
-                                        &zero,
-                                        (invA + ((uplo == rocblas_fill_lower) ? IB : IB*NB)), NB, stride_invA,
-                                        blocks );
+        status = rocblas_gemm_strided_batched_template<T>(
+            handle,
+            rocblas_operation_none,
+            rocblas_operation_none,
+            IB,
+            IB,
+            IB,
+            &negative_one,
+            (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * NB + IB : 0)),
+            NB,
+            stride_invA,
+            (const T*)C.get(),
+            IB,
+            stride_C,
+            &zero,
+            (invA + ((uplo == rocblas_fill_lower) ? IB : IB * NB)),
+            NB,
+            stride_invA,
+            blocks);
 
-    }//end if
-    
-    //the last digaonal block is handled seperately if n is not divisible by NB, or if there is only one block
-    if(n % NB != 0 || blocks == 0){
-        status = rocblas_trtri_template<T, NB/2>(handle, uplo, diag, n-blocks*NB, A + blocks*NB*lda + blocks*NB, lda, invA + blocks*NB*NB, NB);
+    } // end if
+
+    // the last digaonal block is handled seperately if n is not divisible by NB, or if there is
+    // only one block
+    if(n % NB != 0 || blocks == 0)
+    {
+        status = rocblas_trtri_template<T, NB / 2>(handle,
+                                                   uplo,
+                                                   diag,
+                                                   n - blocks * NB,
+                                                   A + blocks * NB * lda + blocks * NB,
+                                                   lda,
+                                                   invA + blocks * NB * NB,
+                                                   NB);
     }
 
-
     return rocblas_status_success;
-
 }
 
-
-
-#endif  // __TRTRI_TRSM_HPP__
+#endif // __TRTRI_TRSM_HPP__

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -7,45 +7,46 @@
 /*******************************************************************************
  * constructor
  ******************************************************************************/
-_rocblas_handle::_rocblas_handle() {
+_rocblas_handle::_rocblas_handle()
+{
 
     // default device is active device
-    THROW_IF_HIP_ERROR( hipGetDevice(&device) );
-    THROW_IF_HIP_ERROR( hipGetDeviceProperties(&device_properties, device) );
+    THROW_IF_HIP_ERROR(hipGetDevice(&device));
+    THROW_IF_HIP_ERROR(hipGetDeviceProperties(&device_properties, device));
 
     // rocblas by default take the system default stream 0 users cannot create
-
 }
 
 /*******************************************************************************
  * destructor
  ******************************************************************************/
-_rocblas_handle::~_rocblas_handle() {
-    //rocblas by default take the system default stream which user cannot destory
+_rocblas_handle::~_rocblas_handle()
+{
+    // rocblas by default take the system default stream which user cannot destory
 }
 
 /*******************************************************************************
  * Exactly like CUBLAS, ROCBLAS only uses one stream for one API routine
  ******************************************************************************/
 
-
 /*******************************************************************************
  * set stream:
    This API assumes user has already created a valid stream
    Associate the following rocblas API call with this user provided stream
  ******************************************************************************/
-rocblas_status _rocblas_handle::set_stream( hipStream_t user_stream ) {
+rocblas_status _rocblas_handle::set_stream(hipStream_t user_stream)
+{
 
-    //TODO: check the user_stream valid or not
+    // TODO: check the user_stream valid or not
     rocblas_stream = user_stream;
     return rocblas_status_success;
 }
 
-
 /*******************************************************************************
  * get stream
  ******************************************************************************/
-rocblas_status _rocblas_handle::get_stream( hipStream_t *stream ) const {
+rocblas_status _rocblas_handle::get_stream(hipStream_t* stream) const
+{
     *stream = rocblas_stream;
     return rocblas_status_success;
 }

--- a/library/src/include/definitions.h
+++ b/library/src/include/definitions.h
@@ -19,49 +19,71 @@ typedef __fp16 half8 __attribute__((ext_vector_type(8)));
 typedef __fp16 half2 __attribute__((ext_vector_type(2)));
 extern "C" half2 llvm_fma_v2f16(half2, half2, half2) __asm("llvm.fma.v2f16");
 
-__device__ inline half2
-rocblas_fmadd_half2(half2 multiplier, half2 multiplicand, half2 addend)
+__device__ inline half2 rocblas_fmadd_half2(half2 multiplier, half2 multiplicand, half2 addend)
 {
     return llvm_fma_v2f16(multiplier, multiplicand, addend);
 };
 
-#define RETURN_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK) { \
-    hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != hipSuccess ) { \
-        return get_rocblas_status_for_hip_status(TMP_STATUS_FOR_CHECK); \
-} }
+#define RETURN_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                         \
+    {                                                                       \
+        hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK;           \
+        if(TMP_STATUS_FOR_CHECK != hipSuccess)                              \
+        {                                                                   \
+            return get_rocblas_status_for_hip_status(TMP_STATUS_FOR_CHECK); \
+        }                                                                   \
+    }
 
-#define RETURN_IF_ROCBLAS_ERROR(INPUT_STATUS_FOR_CHECK) { \
-    rocblas_status TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != rocblas_status_success) { \
-        return TMP_STATUS_FOR_CHECK; \
-} }
+#define RETURN_IF_ROCBLAS_ERROR(INPUT_STATUS_FOR_CHECK)               \
+    {                                                                 \
+        rocblas_status TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != rocblas_status_success)            \
+        {                                                             \
+            return TMP_STATUS_FOR_CHECK;                              \
+        }                                                             \
+    }
 
-#define THROW_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK) { \
-    hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != hipSuccess ) { \
-        throw get_rocblas_status_for_hip_status(TMP_STATUS_FOR_CHECK); \
-} }
+#define THROW_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                         \
+    {                                                                      \
+        hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK;          \
+        if(TMP_STATUS_FOR_CHECK != hipSuccess)                             \
+        {                                                                  \
+            throw get_rocblas_status_for_hip_status(TMP_STATUS_FOR_CHECK); \
+        }                                                                  \
+    }
 
-#define THROW_IF_ROCBLAS_ERROR(INPUT_STATUS_FOR_CHECK) { \
-    rocblas_status TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != rocblas_status_success) { \
-        throw TMP_STATUS_FOR_CHECK; \
-} }
+#define THROW_IF_ROCBLAS_ERROR(INPUT_STATUS_FOR_CHECK)                \
+    {                                                                 \
+        rocblas_status TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != rocblas_status_success)            \
+        {                                                             \
+            throw TMP_STATUS_FOR_CHECK;                               \
+        }                                                             \
+    }
 
-#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK) {\
-    hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != hipSuccess) { \
-        fprintf(stderr, "hip error code: %d at %s:%d\n",  TMP_STATUS_FOR_CHECK,__FILE__, __LINE__); \
-} }
+#define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
+    {                                                             \
+        hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != hipSuccess)                    \
+        {                                                         \
+            fprintf(stderr,                                       \
+                    "hip error code: %d at %s:%d\n",              \
+                    TMP_STATUS_FOR_CHECK,                         \
+                    __FILE__,                                     \
+                    __LINE__);                                    \
+        }                                                         \
+    }
 
+#define PRINT_IF_ROCBLAS_ERROR(INPUT_STATUS_FOR_CHECK)                \
+    {                                                                 \
+        rocblas_status TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
+        if(TMP_STATUS_FOR_CHECK != rocblas_status_success)            \
+        {                                                             \
+            fprintf(stderr,                                           \
+                    "rocblas error code: %d at %s:%d\n",              \
+                    TMP_STATUS_FOR_CHECK,                             \
+                    __FILE__,                                         \
+                    __LINE__);                                        \
+        }                                                             \
+    }
 
-#define PRINT_IF_ROCBLAS_ERROR(INPUT_STATUS_FOR_CHECK) {\
-    rocblas_status TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \
-    if (TMP_STATUS_FOR_CHECK != rocblas_status_success) { \
-        fprintf(stderr, "rocblas error code: %d at %s:%d\n",  TMP_STATUS_FOR_CHECK,__FILE__, __LINE__); \
-} }
-
-
-
-#endif //DEFINITIONS_H
+#endif // DEFINITIONS_H

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -15,23 +15,23 @@
  * It should be destroyed at the end using rocblas_destroy_handle().
  * Exactly like CUBLAS, ROCBLAS only uses one stream for one API routine
 ******************************************************************************/
-struct _rocblas_handle{
+struct _rocblas_handle
+{
 
-  _rocblas_handle();
-  ~_rocblas_handle();
+    _rocblas_handle();
+    ~_rocblas_handle();
 
-  rocblas_status set_stream( hipStream_t stream );
-  rocblas_status get_stream( hipStream_t *stream ) const;
+    rocblas_status set_stream(hipStream_t stream);
+    rocblas_status get_stream(hipStream_t* stream) const;
 
-  rocblas_int device;
-  hipDeviceProp_t device_properties;
+    rocblas_int device;
+    hipDeviceProp_t device_properties;
 
-  // rocblas by default take the system default stream 0 users cannot create
-  hipStream_t rocblas_stream = 0; 
+    // rocblas by default take the system default stream 0 users cannot create
+    hipStream_t rocblas_stream = 0;
 
-  // default pointer_mode is on host
-  rocblas_pointer_mode pointer_mode = rocblas_pointer_mode_host;
-
+    // default pointer_mode is on host
+    rocblas_pointer_mode pointer_mode = rocblas_pointer_mode_host;
 };
 
 #endif

--- a/library/src/include/rocblas_unique_ptr.hpp
+++ b/library/src/include/rocblas_unique_ptr.hpp
@@ -3,24 +3,20 @@
 
 #include <memory>
 
-namespace rocblas
+namespace rocblas {
+// device_malloc wraps hipMalloc and provides same API as malloc
+static void* device_malloc(size_t byte_size)
 {
-    // device_malloc wraps hipMalloc and provides same API as malloc
-    static void* device_malloc(size_t byte_size)
-    {
-        void *pointer;
-        PRINT_IF_HIP_ERROR(hipMalloc(&pointer, byte_size));
-        return pointer;
-    }
+    void* pointer;
+    PRINT_IF_HIP_ERROR(hipMalloc(&pointer, byte_size));
+    return pointer;
+}
 
-    // device_free wraps hipFree and provides same API as free
-    static void device_free(void *ptr)
-    {   
-        PRINT_IF_HIP_ERROR(hipFree(ptr));
-    }
+// device_free wraps hipFree and provides same API as free
+static void device_free(void* ptr) { PRINT_IF_HIP_ERROR(hipFree(ptr)); }
 
 } // namespace rocblas
 
-using rocblas_unique_ptr = std::unique_ptr<void, void(*)(void*)>;
+using rocblas_unique_ptr = std::unique_ptr<void, void (*)(void*)>;
 
 #endif

--- a/library/src/include/status.h
+++ b/library/src/include/status.h
@@ -3,17 +3,14 @@
  *
  * ************************************************************************ */
 
-
 #ifndef STATUS_H
 #define STATUS_H
 
 #include "rocblas.h"
 
-
 /*******************************************************************************
  * \brief convert hipError_t to rocblas_status
  ******************************************************************************/
-rocblas_status
-get_rocblas_status_for_hip_status( hipError_t status );
+rocblas_status get_rocblas_status_for_hip_status(hipError_t status);
 
 #endif

--- a/library/src/rocblas_auxiliary.cpp
+++ b/library/src/rocblas_auxiliary.cpp
@@ -11,113 +11,116 @@
 #include "rocblas_unique_ptr.hpp"
 #include "rocblas-auxiliary.h"
 
-    /* ============================================================================================ */
+/* ============================================================================================ */
 
 /*******************************************************************************
  * ! \brief  indicates whether the pointer is on the host or device.
  * currently HIP API can only recoginize the input ptr on deive or not
  *  can not recoginize it is on host or not
  ******************************************************************************/
-rocblas_pointer_mode rocblas_pointer_to_mode(void *ptr){
+rocblas_pointer_mode rocblas_pointer_to_mode(void* ptr)
+{
     hipPointerAttribute_t attribute;
     hipPointerGetAttributes(&attribute, ptr);
-    if (ptr == attribute.devicePointer) {
+    if(ptr == attribute.devicePointer)
+    {
         return rocblas_pointer_mode_device;
-    } else {
+    }
+    else
+    {
         return rocblas_pointer_mode_host;
     }
 }
 
-
 /*******************************************************************************
  * ! \brief get pointer mode, can be host or device
  ******************************************************************************/
-extern "C"
-rocblas_status rocblas_get_pointer_mode(rocblas_handle handle, rocblas_pointer_mode *mode)
+extern "C" rocblas_status rocblas_get_pointer_mode(rocblas_handle handle,
+                                                   rocblas_pointer_mode* mode)
 {
     // if handle not valid
-    if (handle == nullptr) {
+    if(handle == nullptr)
+    {
         return rocblas_status_invalid_pointer;
     }
     *mode = handle->pointer_mode;
-    return rocblas_status_success; 
+    return rocblas_status_success;
 }
-
 
 /*******************************************************************************
  * ! \brief set pointer mode to host or device
  ******************************************************************************/
-extern "C"
-rocblas_status rocblas_set_pointer_mode(rocblas_handle handle, rocblas_pointer_mode mode)
+extern "C" rocblas_status rocblas_set_pointer_mode(rocblas_handle handle, rocblas_pointer_mode mode)
 {
     // if handle not valid
-    if (handle == nullptr) {
+    if(handle == nullptr)
+    {
         return rocblas_status_invalid_pointer;
     }
     handle->pointer_mode = mode;
-    return rocblas_status_success; 
+    return rocblas_status_success;
 }
-
 
 /*******************************************************************************
  * ! \brief create rocblas handle called before any rocblas library routines
  ******************************************************************************/
-extern "C"
-rocblas_status rocblas_create_handle(rocblas_handle *handle){
+extern "C" rocblas_status rocblas_create_handle(rocblas_handle* handle)
+{
 
     // if handle not valid
-    if (handle == nullptr) {
+    if(handle == nullptr)
+    {
         return rocblas_status_invalid_pointer;
     }
 
     // allocate on heap
-    try {
-      *handle = new _rocblas_handle();
-    } catch (rocblas_status status) {
+    try
+    {
+        *handle = new _rocblas_handle();
+    }
+    catch(rocblas_status status)
+    {
         return status;
     }
 
     return rocblas_status_success;
 }
-
 
 /*******************************************************************************
  *! \brief release rocblas handle, will implicitly synchronize host and device
  ******************************************************************************/
-extern "C"
-rocblas_status rocblas_destroy_handle(rocblas_handle handle){
+extern "C" rocblas_status rocblas_destroy_handle(rocblas_handle handle)
+{
     // call destructor
-    try {
+    try
+    {
         delete handle;
-    } catch (rocblas_status status) {
+    }
+    catch(rocblas_status status)
+    {
         return status;
     }
     return rocblas_status_success;
 }
-
 
 /*******************************************************************************
  *! \brief   set rocblas stream used for all subsequent library function calls.
  *   If not set, all hip kernels will take the default NULL stream.
  *   stream_id must be created before this call
  ******************************************************************************/
-extern "C"
-rocblas_status
-rocblas_set_stream(rocblas_handle handle, hipStream_t stream_id){
-    return handle->set_stream( stream_id );
+extern "C" rocblas_status rocblas_set_stream(rocblas_handle handle, hipStream_t stream_id)
+{
+    return handle->set_stream(stream_id);
 }
-
 
 /*******************************************************************************
  *! \brief   get rocblas stream used for all subsequent library function calls.
  *   If not set, all hip kernels will take the default NULL stream.
  ******************************************************************************/
-extern "C"
-rocblas_status
-rocblas_get_stream(rocblas_handle handle, hipStream_t *stream_id){
-    return handle->get_stream( stream_id );
+extern "C" rocblas_status rocblas_get_stream(rocblas_handle handle, hipStream_t* stream_id)
+{
+    return handle->get_stream(stream_id);
 }
-
 
 /*******************************************************************************
  *! \brief  Non-unit stride vector copy on device. Vectors are void pointers
@@ -127,282 +130,335 @@ rocblas_get_stream(rocblas_handle handle, hipStream_t *stream_id){
 #define VEC_BUFF_MAX_BYTES 1048576
 #define NB_X 256
 
-__global__ void
-copy_void_ptr_vector_kernel(hipLaunchParm lp,
-    rocblas_int n, rocblas_int elem_size,
-    const void *x, rocblas_int incx,
-    void *y,  rocblas_int incy)
+__global__ void copy_void_ptr_vector_kernel(hipLaunchParm lp,
+                                            rocblas_int n,
+                                            rocblas_int elem_size,
+                                            const void* x,
+                                            rocblas_int incx,
+                                            void* y,
+                                            rocblas_int incy)
 {
     int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    if ( tid < n ) 
+    if(tid < n)
     {
-        memcpy((void *)((size_t)y + (size_t)(tid * incy * elem_size)), 
-               (void *)((size_t)x + (size_t)(tid * incx * elem_size)), elem_size);
+        memcpy((void*)((size_t)y + (size_t)(tid * incy * elem_size)),
+               (void*)((size_t)x + (size_t)(tid * incx * elem_size)),
+               elem_size);
     }
 }
 
 /*******************************************************************************
- *! \brief   copies void* vector x with stride incx on host to void* vector 
+ *! \brief   copies void* vector x with stride incx on host to void* vector
      y with stride incy on device. Vectors have n elements of size elem_size.
  ******************************************************************************/
-extern "C"
-rocblas_status
-rocblas_set_vector(rocblas_int n, rocblas_int elem_size, 
-    const void *x_h, rocblas_int incx, 
-    void *y_d, rocblas_int incy)
+extern "C" rocblas_status rocblas_set_vector(rocblas_int n,
+                                             rocblas_int elem_size,
+                                             const void* x_h,
+                                             rocblas_int incx,
+                                             void* y_d,
+                                             rocblas_int incy)
 {
-    if ( n == 0 )   //quick return
+    if(n == 0) // quick return
         return rocblas_status_success;
-    if ( n < 0 ) 
+    if(n < 0)
         return rocblas_status_invalid_size;
-    if ( incx <= 0 ) 
+    if(incx <= 0)
         return rocblas_status_invalid_size;
-    if ( incy <= 0 ) 
+    if(incy <= 0)
         return rocblas_status_invalid_size;
-    if ( elem_size <= 0 ) 
+    if(elem_size <= 0)
         return rocblas_status_invalid_size;
-    if ( x_h == nullptr )
+    if(x_h == nullptr)
         return rocblas_status_invalid_pointer;
-    if ( y_d == nullptr )
+    if(y_d == nullptr)
         return rocblas_status_invalid_pointer;
 
-    try  // trap any exceptions
+    try // trap any exceptions
     {
 
-    if ( incx == 1 && incy == 1)  // contiguous host vector -> contiguous device vector
-    {
-        PRINT_IF_HIP_ERROR(hipMemcpy(y_d, x_h, elem_size * n, hipMemcpyHostToDevice));
-    }
-    else                          // either non-contiguous host vector or non-contiguous device vector
-    {
-        int temp_byte_size = elem_size * n < VEC_BUFF_MAX_BYTES ? elem_size * n : VEC_BUFF_MAX_BYTES;
-        int n_elem = temp_byte_size / elem_size; // number of elements in buffer
-        int n_copy = ((n - 1) / n_elem) + 1;     // number of times buffer is copied
-
-        int blocks = (n_elem-1)/ NB_X + 1;       // parameters for device kernel
-        dim3 grid( blocks, 1, 1 );
-        dim3 threads( NB_X, 1, 1 );
-
-        hipStream_t rocblas_stream;
-        if (incy != 1)
+        if(incx == 1 && incy == 1) // contiguous host vector -> contiguous device vector
         {
-            rocblas_handle handle;
-            rocblas_create_handle(&handle);
-            RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+            PRINT_IF_HIP_ERROR(hipMemcpy(y_d, x_h, elem_size * n, hipMemcpyHostToDevice));
         }
-        
-        size_t x_h_byte_stride = (size_t) elem_size * (size_t) incx;
-        size_t y_d_byte_stride = (size_t) elem_size * (size_t) incy;
-        size_t t_h_byte_stride = (size_t) elem_size;
-
-        for (int i_copy = 0; i_copy < n_copy; i_copy++)
+        else // either non-contiguous host vector or non-contiguous device vector
         {
-            int i_start = i_copy * n_elem;
-            int n_elem_max =  n - i_start < n_elem ? n - i_start : n_elem;
-            int contig_size = n_elem_max * elem_size;
-            void *y_d_start = (void *)((size_t)y_d + ((size_t) i_start * y_d_byte_stride));
-            void *x_h_start = (void *)((size_t)x_h + ((size_t) i_start * x_h_byte_stride));
+            int temp_byte_size =
+                elem_size * n < VEC_BUFF_MAX_BYTES ? elem_size * n : VEC_BUFF_MAX_BYTES;
+            int n_elem = temp_byte_size / elem_size; // number of elements in buffer
+            int n_copy = ((n - 1) / n_elem) + 1;     // number of times buffer is copied
 
-            if((incx != 1) && (incy != 1))
+            int blocks = (n_elem - 1) / NB_X + 1; // parameters for device kernel
+            dim3 grid(blocks, 1, 1);
+            dim3 threads(NB_X, 1, 1);
+
+            hipStream_t rocblas_stream;
+            if(incy != 1)
             {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // non-contiguous host vector -> host buffer
-                for (int i_b = 0, i_x = i_start; i_b < n_elem_max; i_b++, i_x++)
-                {
-                    memcpy((void *)((size_t)t_h + ((size_t) i_b * t_h_byte_stride)),
-                           (void *)((size_t)x_h + ((size_t) i_x * x_h_byte_stride)), elem_size);
-                }
-                // host buffer -> device buffer 
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_d, t_h, contig_size, hipMemcpyHostToDevice));
-                // device buffer -> non-contiguous device vector
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, n_elem_max, elem_size, t_d, 1, y_d_start, incy);
+                rocblas_handle handle;
+                rocblas_create_handle(&handle);
+                RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
             }
-            else if (incx == 1 && incy != 1)
+
+            size_t x_h_byte_stride = (size_t)elem_size * (size_t)incx;
+            size_t y_d_byte_stride = (size_t)elem_size * (size_t)incy;
+            size_t t_h_byte_stride = (size_t)elem_size;
+
+            for(int i_copy = 0; i_copy < n_copy; i_copy++)
             {
-                // used unique_ptr to avoid memory leak
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
+                int i_start     = i_copy * n_elem;
+                int n_elem_max  = n - i_start < n_elem ? n - i_start : n_elem;
+                int contig_size = n_elem_max * elem_size;
+                void* y_d_start = (void*)((size_t)y_d + ((size_t)i_start * y_d_byte_stride));
+                void* x_h_start = (void*)((size_t)x_h + ((size_t)i_start * x_h_byte_stride));
+
+                if((incx != 1) && (incy != 1))
                 {
-                    return rocblas_status_memory_error;
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous host vector -> host buffer
+                    for(int i_b = 0, i_x = i_start; i_b < n_elem_max; i_b++, i_x++)
+                    {
+                        memcpy((void*)((size_t)t_h + ((size_t)i_b * t_h_byte_stride)),
+                               (void*)((size_t)x_h + ((size_t)i_x * x_h_byte_stride)),
+                               elem_size);
+                    }
+                    // host buffer -> device buffer
+                    PRINT_IF_HIP_ERROR(hipMemcpy(t_d, t_h, contig_size, hipMemcpyHostToDevice));
+                    // device buffer -> non-contiguous device vector
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    n_elem_max,
+                                    elem_size,
+                                    t_d,
+                                    1,
+                                    y_d_start,
+                                    incy);
                 }
-                // contiguous host vector -> device buffer
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_d, x_h_start, contig_size, hipMemcpyHostToDevice));
-                // device buffer -> non-contiguous device vector
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, n_elem_max, elem_size, t_d, 1, y_d_start, incy);
-            }
-            else if (incx != 1 && incy == 1)
-            {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
+                else if(incx == 1 && incy != 1)
                 {
-                    return rocblas_status_memory_error;
+                    // used unique_ptr to avoid memory leak
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // contiguous host vector -> device buffer
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(t_d, x_h_start, contig_size, hipMemcpyHostToDevice));
+                    // device buffer -> non-contiguous device vector
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    n_elem_max,
+                                    elem_size,
+                                    t_d,
+                                    1,
+                                    y_d_start,
+                                    incy);
                 }
-                // non-contiguous host vector -> host buffer
-                for (int i_b = 0, i_x = i_start; i_b < n_elem_max; i_b++, i_x++)
+                else if(incx != 1 && incy == 1)
                 {
-                    memcpy((void *)((size_t)t_h + ((size_t) i_b * t_h_byte_stride)),
-                           (void *)((size_t)x_h + ((size_t) i_x * x_h_byte_stride)), elem_size);
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous host vector -> host buffer
+                    for(int i_b = 0, i_x = i_start; i_b < n_elem_max; i_b++, i_x++)
+                    {
+                        memcpy((void*)((size_t)t_h + ((size_t)i_b * t_h_byte_stride)),
+                               (void*)((size_t)x_h + ((size_t)i_x * x_h_byte_stride)),
+                               elem_size);
+                    }
+                    // host buffer -> contiguous device vector
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(y_d_start, t_h, contig_size, hipMemcpyHostToDevice));
                 }
-                // host buffer -> contiguous device vector
-                PRINT_IF_HIP_ERROR(hipMemcpy(y_d_start, t_h, contig_size, hipMemcpyHostToDevice));
             }
         }
+        return rocblas_status_success;
     }
-    return rocblas_status_success;
-
-    }
-    catch(...)    // catch all exceptions
+    catch(...) // catch all exceptions
     {
         return rocblas_status_internal_error;
     }
 }
 
 /*******************************************************************************
- *! \brief   copies void* vector x with stride incx on device to void* vector 
+ *! \brief   copies void* vector x with stride incx on device to void* vector
      y with stride incy on host. Vectors have n elements of size elem_size.
  ******************************************************************************/
-extern "C"
-rocblas_status
-rocblas_get_vector(rocblas_int n, rocblas_int elem_size, 
-    const void *x_d, rocblas_int incx, 
-    void *y_h, rocblas_int incy)
+extern "C" rocblas_status rocblas_get_vector(rocblas_int n,
+                                             rocblas_int elem_size,
+                                             const void* x_d,
+                                             rocblas_int incx,
+                                             void* y_h,
+                                             rocblas_int incy)
 {
-    if ( n == 0 )   // quick return
+    if(n == 0) // quick return
         return rocblas_status_success;
-    if ( n < 0 ) 
+    if(n < 0)
         return rocblas_status_invalid_size;
-    if ( incx <= 0 ) 
+    if(incx <= 0)
         return rocblas_status_invalid_size;
-    if ( incy <= 0 ) 
+    if(incy <= 0)
         return rocblas_status_invalid_size;
-    if ( elem_size <= 0 ) 
+    if(elem_size <= 0)
         return rocblas_status_invalid_size;
-    if ( x_d == nullptr )
+    if(x_d == nullptr)
         return rocblas_status_invalid_pointer;
-    if ( y_h == nullptr )
+    if(y_h == nullptr)
         return rocblas_status_invalid_pointer;
 
-    try  // trap any exceptions
+    try // trap any exceptions
     {
 
-    if ( incx == 1 && incy == 1)  // congiguous device vector -> congiguous host vector
-    {
-        PRINT_IF_HIP_ERROR(hipMemcpy(y_h, x_d, elem_size * n, hipMemcpyDeviceToHost));
-    }
-    else                          // either device or host vector is non-contiguous 
-    {
-        int temp_byte_size = elem_size * n < VEC_BUFF_MAX_BYTES ? elem_size * n : VEC_BUFF_MAX_BYTES;
-        int n_elem = temp_byte_size / elem_size; // number elements in buffer
-        int n_copy = ((n - 1) / n_elem) + 1;     // number of times buffer is copied
-
-        int blocks = (n_elem-1)/ NB_X + 1;       // parameters for device kernel
-        dim3 grid( blocks, 1, 1 );
-        dim3 threads( NB_X, 1, 1 );
-        
-        hipStream_t rocblas_stream;
-        if (incx != 1)
+        if(incx == 1 && incy == 1) // congiguous device vector -> congiguous host vector
         {
-            rocblas_handle handle;
-            rocblas_create_handle(&handle);
-            RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+            PRINT_IF_HIP_ERROR(hipMemcpy(y_h, x_d, elem_size * n, hipMemcpyDeviceToHost));
         }
-        
-        size_t x_d_byte_stride = (size_t) elem_size * (size_t) incx;
-        size_t y_h_byte_stride = (size_t) elem_size * (size_t) incy;
-        size_t t_h_byte_stride = (size_t) elem_size;
-
-        for (int i_copy = 0; i_copy < n_copy; i_copy++)
+        else // either device or host vector is non-contiguous
         {
-            int i_start = i_copy * n_elem;
-            int n_elem_max = n - (n_elem * i_copy) < n_elem ? n - (n_elem * i_copy) : n_elem;
-            int contig_size = elem_size * n_elem_max;
-            void *x_d_start = (void *)((size_t)x_d + ((size_t)i_start * x_d_byte_stride));
-            void *y_h_start = (void *)((size_t)y_h + ((size_t)i_start * y_h_byte_stride));
-                     
-            if (incx !=1 && incy != 1)
-            {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // non-contiguous device vector -> device buffer
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, n_elem_max, elem_size, x_d_start, incx, t_d, 1);
-                // device buffer -> host buffer
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_h, t_d, contig_size, hipMemcpyDeviceToHost));
-                // host buffer -> non-contiguous host vector
-                for (int i_b = 0, i_y = i_start; i_b < n_elem_max; i_b++, i_y++)
-                {
-                    memcpy((void *)((size_t)y_h + ((size_t)i_y * y_h_byte_stride)),
-                           (void *)((size_t)t_h + ((size_t)i_b * t_h_byte_stride)), elem_size);
-                }
-            }
-            else if (incx == 1 && incy != 1)
-            {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // congiguous device vector -> host buffer
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_h, x_d_start, contig_size, hipMemcpyDeviceToHost));
+            int temp_byte_size =
+                elem_size * n < VEC_BUFF_MAX_BYTES ? elem_size * n : VEC_BUFF_MAX_BYTES;
+            int n_elem = temp_byte_size / elem_size; // number elements in buffer
+            int n_copy = ((n - 1) / n_elem) + 1;     // number of times buffer is copied
 
-                // host buffer -> non-contiguous host vector
-                for (int i_b = 0, i_y = i_start; i_b < n_elem_max; i_b++, i_y++)
-                {
-                    memcpy((void *)((size_t)y_h + ((size_t)i_y * y_h_byte_stride)),
-                           (void *)((size_t)t_h + ((size_t)i_b * t_h_byte_stride)), elem_size);
-                }
-            }
-            else if (incx != 1 && incy == 1)
+            int blocks = (n_elem - 1) / NB_X + 1; // parameters for device kernel
+            dim3 grid(blocks, 1, 1);
+            dim3 threads(NB_X, 1, 1);
+
+            hipStream_t rocblas_stream;
+            if(incx != 1)
             {
-                // used unique_ptr to avoid memory leak
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
+                rocblas_handle handle;
+                rocblas_create_handle(&handle);
+                RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+            }
+
+            size_t x_d_byte_stride = (size_t)elem_size * (size_t)incx;
+            size_t y_h_byte_stride = (size_t)elem_size * (size_t)incy;
+            size_t t_h_byte_stride = (size_t)elem_size;
+
+            for(int i_copy = 0; i_copy < n_copy; i_copy++)
+            {
+                int i_start     = i_copy * n_elem;
+                int n_elem_max  = n - (n_elem * i_copy) < n_elem ? n - (n_elem * i_copy) : n_elem;
+                int contig_size = elem_size * n_elem_max;
+                void* x_d_start = (void*)((size_t)x_d + ((size_t)i_start * x_d_byte_stride));
+                void* y_h_start = (void*)((size_t)y_h + ((size_t)i_start * y_h_byte_stride));
+
+                if(incx != 1 && incy != 1)
                 {
-                    return rocblas_status_memory_error;
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous device vector -> device buffer
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    n_elem_max,
+                                    elem_size,
+                                    x_d_start,
+                                    incx,
+                                    t_d,
+                                    1);
+                    // device buffer -> host buffer
+                    PRINT_IF_HIP_ERROR(hipMemcpy(t_h, t_d, contig_size, hipMemcpyDeviceToHost));
+                    // host buffer -> non-contiguous host vector
+                    for(int i_b = 0, i_y = i_start; i_b < n_elem_max; i_b++, i_y++)
+                    {
+                        memcpy((void*)((size_t)y_h + ((size_t)i_y * y_h_byte_stride)),
+                               (void*)((size_t)t_h + ((size_t)i_b * t_h_byte_stride)),
+                               elem_size);
+                    }
                 }
-                // non-contiguous device vector -> device buffer
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, n_elem_max, elem_size, x_d_start, incx, t_d, 1);
-                // device buffer -> contiguous host vector
-                PRINT_IF_HIP_ERROR(hipMemcpy(y_h_start, t_d, contig_size, hipMemcpyDeviceToHost));
+                else if(incx == 1 && incy != 1)
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // congiguous device vector -> host buffer
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(t_h, x_d_start, contig_size, hipMemcpyDeviceToHost));
+
+                    // host buffer -> non-contiguous host vector
+                    for(int i_b = 0, i_y = i_start; i_b < n_elem_max; i_b++, i_y++)
+                    {
+                        memcpy((void*)((size_t)y_h + ((size_t)i_y * y_h_byte_stride)),
+                               (void*)((size_t)t_h + ((size_t)i_b * t_h_byte_stride)),
+                               elem_size);
+                    }
+                }
+                else if(incx != 1 && incy == 1)
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous device vector -> device buffer
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_vector_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    n_elem_max,
+                                    elem_size,
+                                    x_d_start,
+                                    incx,
+                                    t_d,
+                                    1);
+                    // device buffer -> contiguous host vector
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(y_h_start, t_d, contig_size, hipMemcpyDeviceToHost));
+                }
             }
         }
+        return rocblas_status_success;
     }
-    return rocblas_status_success;
-
-    }
-    catch(...)    // catch all exceptions
+    catch(...) // catch all exceptions
     {
         return rocblas_status_internal_error;
     }
@@ -417,329 +473,391 @@ rocblas_get_vector(rocblas_int n, rocblas_int elem_size,
 #define MATRIX_DIM_X 128
 #define MATRIX_DIM_Y 8
 
-__global__ void
-copy_void_ptr_matrix_kernel(hipLaunchParm lp,
-    rocblas_int rows, rocblas_int cols, rocblas_int elem_size,
-    const void *a, rocblas_int lda,
-    void *b, rocblas_int ldb)
+__global__ void copy_void_ptr_matrix_kernel(hipLaunchParm lp,
+                                            rocblas_int rows,
+                                            rocblas_int cols,
+                                            rocblas_int elem_size,
+                                            const void* a,
+                                            rocblas_int lda,
+                                            void* b,
+                                            rocblas_int ldb)
 {
     rocblas_int tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     rocblas_int ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
 
-    if (tx < rows && ty < cols) 
+    if(tx < rows && ty < cols)
     {
-        memcpy((void *)((size_t)b + (size_t)((tx + ldb*ty) * elem_size)), 
-               (void *)((size_t)a + (size_t)((tx + lda*ty) * elem_size)), elem_size);
+        memcpy((void*)((size_t)b + (size_t)((tx + ldb * ty) * elem_size)),
+               (void*)((size_t)a + (size_t)((tx + lda * ty) * elem_size)),
+               elem_size);
     }
 }
 
 /*******************************************************************************
- *! \brief   copies void* matrix a_h with leading dimentsion lda on host to 
-     void* matrix b_d with leading dimension ldb on device. Matrices have 
+ *! \brief   copies void* matrix a_h with leading dimentsion lda on host to
+     void* matrix b_d with leading dimension ldb on device. Matrices have
      size rows * cols with element size elem_size.
  ******************************************************************************/
 
-extern "C"
-rocblas_status
-rocblas_set_matrix(rocblas_int rows, rocblas_int cols, rocblas_int elem_size, 
-    const void *a_h, rocblas_int lda, 
-    void *b_d, rocblas_int ldb)
+extern "C" rocblas_status rocblas_set_matrix(rocblas_int rows,
+                                             rocblas_int cols,
+                                             rocblas_int elem_size,
+                                             const void* a_h,
+                                             rocblas_int lda,
+                                             void* b_d,
+                                             rocblas_int ldb)
 {
-    if ( rows == 0 || cols == 0 )  // quick return
+    if(rows == 0 || cols == 0) // quick return
         return rocblas_status_success;
-    if ( rows < 0 ) 
+    if(rows < 0)
         return rocblas_status_invalid_size;
-    if ( cols < 0 ) 
+    if(cols < 0)
         return rocblas_status_invalid_size;
-    if ( lda <= 0 ) 
+    if(lda <= 0)
         return rocblas_status_invalid_size;
-    if ( ldb <= 0 ) 
+    if(ldb <= 0)
         return rocblas_status_invalid_size;
-    if ( rows > lda ) 
+    if(rows > lda)
         return rocblas_status_invalid_size;
-    if ( rows > ldb ) 
+    if(rows > ldb)
         return rocblas_status_invalid_size;
-    if ( elem_size <= 0 ) 
+    if(elem_size <= 0)
         return rocblas_status_invalid_size;
-    if ( a_h == nullptr )
+    if(a_h == nullptr)
         return rocblas_status_invalid_pointer;
-    if ( b_d == nullptr )
+    if(b_d == nullptr)
         return rocblas_status_invalid_pointer;
 
-    try  // trap any exceptions
+    try // trap any exceptions
     {
 
-    // contiguous host matrix -> contiguous device matrix
-    if ( lda == rows && ldb == rows)
-    {
-        PRINT_IF_HIP_ERROR(hipMemcpy(b_d, a_h, elem_size * rows * cols, hipMemcpyHostToDevice));
-    }
-    // matrix colums too large to fit in temp buffer, copy matrix col by col 
-    else if (rows * elem_size > MAT_BUFF_MAX_BYTES)
-    {
-        for (int i = 0; i < cols; i++)
+        // contiguous host matrix -> contiguous device matrix
+        if(lda == rows && ldb == rows)
         {
-            PRINT_IF_HIP_ERROR(hipMemcpy(
-                (void *)((size_t) b_d + (size_t)(ldb * i * elem_size)),
-                (void *)((size_t) a_h + (size_t)(lda * i * elem_size)),
-                elem_size * rows, hipMemcpyHostToDevice));
+            PRINT_IF_HIP_ERROR(hipMemcpy(b_d, a_h, elem_size * rows * cols, hipMemcpyHostToDevice));
         }
-    }
-    // columns fit in temp buffer, pack columns in buffer, hipMemcpy host->device, unpack columns
-    else
-    {
-        int temp_byte_size = elem_size * rows * cols < MAT_BUFF_MAX_BYTES ? elem_size * rows * cols : MAT_BUFF_MAX_BYTES;
-        int n_cols = temp_byte_size / (elem_size * rows);      // number of columns in buffer
-        int n_copy = ((cols - 1) / n_cols) + 1;                // number of times buffer is copied
-
-        rocblas_int blocksX = ((rows-1) / MATRIX_DIM_X) + 1;   // parameters for device kernel
-        rocblas_int blocksY = ((n_cols-1) / MATRIX_DIM_Y) + 1;
-        dim3 grid(blocksX, blocksY, 1);
-        dim3 threads(MATRIX_DIM_X, MATRIX_DIM_Y, 1);
-
-        hipStream_t rocblas_stream;
-        if (ldb != rows)
+        // matrix colums too large to fit in temp buffer, copy matrix col by col
+        else if(rows * elem_size > MAT_BUFF_MAX_BYTES)
         {
-            rocblas_handle handle;
-            rocblas_create_handle(&handle);
-            RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
-        }
-        
-        size_t lda_h_byte = (size_t) elem_size * (size_t) lda;
-        size_t ldb_d_byte = (size_t) elem_size * (size_t) ldb;
-        size_t ldt_h_byte = (size_t) elem_size * (size_t) rows;
-
-        for (int i_copy = 0; i_copy < n_copy; i_copy++)
-        {
-            int i_start = i_copy * n_cols;
-            int n_cols_max = cols - i_start < n_cols ? cols - i_start : n_cols;
-            int contig_size = elem_size * rows * n_cols_max;
-            void *b_d_start = (void *)((size_t)b_d + ((size_t) i_start * ldb_d_byte));
-            void *a_h_start = (void *)((size_t)a_h + ((size_t) i_start * lda_h_byte));
-
-            if((lda != rows) && (ldb != rows))
+            for(int i = 0; i < cols; i++)
             {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // non-contiguous host matrix -> host buffer
-                for (int i_t = 0, i_a = i_start; i_t < n_cols_max; i_t++, i_a++)
-                {
-                    memcpy((void *)((size_t)t_h + ((size_t)i_t * ldt_h_byte)),
-                           (void *)((size_t)a_h + ((size_t)i_a * lda_h_byte)), ldt_h_byte);
-                }
-                // host buffer -> device buffer 
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_d, t_h, contig_size, hipMemcpyHostToDevice));
-                // device buffer -> non-contiguous device matrix
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, rows, n_cols_max, elem_size, t_d, rows, b_d_start, ldb);
-            }
-            else if (lda == rows && ldb != rows)
-            {
-                // used unique_ptr to avoid memory leak
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // contiguous host matrix -> device buffer
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_d, a_h_start, contig_size, hipMemcpyHostToDevice));
-                // device buffer -> non-contiguous device matrix
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, rows, n_cols_max, elem_size, t_d, rows, b_d_start, ldb);
-            }
-            else if (lda != rows && ldb == rows)
-            {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // non-contiguous host matrix -> host buffer
-                for (int i_t = 0, i_a = i_start; i_t < n_cols_max; i_t++, i_a++)
-                {
-                    memcpy((void *)((size_t)t_h + ((size_t) i_t * ldt_h_byte)),
-                           (void *)((size_t)a_h + ((size_t) i_a * lda_h_byte)), ldt_h_byte);
-                }
-                // host buffer -> contiguous device matrix
-                PRINT_IF_HIP_ERROR(hipMemcpy(b_d_start, t_h, contig_size, hipMemcpyHostToDevice));
+                PRINT_IF_HIP_ERROR(hipMemcpy((void*)((size_t)b_d + (size_t)(ldb * i * elem_size)),
+                                             (void*)((size_t)a_h + (size_t)(lda * i * elem_size)),
+                                             elem_size * rows,
+                                             hipMemcpyHostToDevice));
             }
         }
-    }
-    return rocblas_status_success;
+        // columns fit in temp buffer, pack columns in buffer, hipMemcpy host->device, unpack
+        // columns
+        else
+        {
+            int temp_byte_size = elem_size * rows * cols < MAT_BUFF_MAX_BYTES
+                                     ? elem_size * rows * cols
+                                     : MAT_BUFF_MAX_BYTES;
+            int n_cols = temp_byte_size / (elem_size * rows); // number of columns in buffer
+            int n_copy = ((cols - 1) / n_cols) + 1;           // number of times buffer is copied
 
+            rocblas_int blocksX = ((rows - 1) / MATRIX_DIM_X) + 1; // parameters for device kernel
+            rocblas_int blocksY = ((n_cols - 1) / MATRIX_DIM_Y) + 1;
+            dim3 grid(blocksX, blocksY, 1);
+            dim3 threads(MATRIX_DIM_X, MATRIX_DIM_Y, 1);
+
+            hipStream_t rocblas_stream;
+            if(ldb != rows)
+            {
+                rocblas_handle handle;
+                rocblas_create_handle(&handle);
+                RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+            }
+
+            size_t lda_h_byte = (size_t)elem_size * (size_t)lda;
+            size_t ldb_d_byte = (size_t)elem_size * (size_t)ldb;
+            size_t ldt_h_byte = (size_t)elem_size * (size_t)rows;
+
+            for(int i_copy = 0; i_copy < n_copy; i_copy++)
+            {
+                int i_start     = i_copy * n_cols;
+                int n_cols_max  = cols - i_start < n_cols ? cols - i_start : n_cols;
+                int contig_size = elem_size * rows * n_cols_max;
+                void* b_d_start = (void*)((size_t)b_d + ((size_t)i_start * ldb_d_byte));
+                void* a_h_start = (void*)((size_t)a_h + ((size_t)i_start * lda_h_byte));
+
+                if((lda != rows) && (ldb != rows))
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous host matrix -> host buffer
+                    for(int i_t = 0, i_a = i_start; i_t < n_cols_max; i_t++, i_a++)
+                    {
+                        memcpy((void*)((size_t)t_h + ((size_t)i_t * ldt_h_byte)),
+                               (void*)((size_t)a_h + ((size_t)i_a * lda_h_byte)),
+                               ldt_h_byte);
+                    }
+                    // host buffer -> device buffer
+                    PRINT_IF_HIP_ERROR(hipMemcpy(t_d, t_h, contig_size, hipMemcpyHostToDevice));
+                    // device buffer -> non-contiguous device matrix
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    rows,
+                                    n_cols_max,
+                                    elem_size,
+                                    t_d,
+                                    rows,
+                                    b_d_start,
+                                    ldb);
+                }
+                else if(lda == rows && ldb != rows)
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // contiguous host matrix -> device buffer
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(t_d, a_h_start, contig_size, hipMemcpyHostToDevice));
+                    // device buffer -> non-contiguous device matrix
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    rows,
+                                    n_cols_max,
+                                    elem_size,
+                                    t_d,
+                                    rows,
+                                    b_d_start,
+                                    ldb);
+                }
+                else if(lda != rows && ldb == rows)
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous host matrix -> host buffer
+                    for(int i_t = 0, i_a = i_start; i_t < n_cols_max; i_t++, i_a++)
+                    {
+                        memcpy((void*)((size_t)t_h + ((size_t)i_t * ldt_h_byte)),
+                               (void*)((size_t)a_h + ((size_t)i_a * lda_h_byte)),
+                               ldt_h_byte);
+                    }
+                    // host buffer -> contiguous device matrix
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(b_d_start, t_h, contig_size, hipMemcpyHostToDevice));
+                }
+            }
+        }
+        return rocblas_status_success;
     }
-    catch(...)    // catch all exceptions
+    catch(...) // catch all exceptions
     {
         return rocblas_status_internal_error;
     }
 }
 
 /*******************************************************************************
- *! \brief   copies void* matrix a_h with leading dimentsion lda on host to 
-     void* matrix b_d with leading dimension ldb on device. Matrices have 
+ *! \brief   copies void* matrix a_h with leading dimentsion lda on host to
+     void* matrix b_d with leading dimension ldb on device. Matrices have
      size rows * cols with element size elem_size.
  ******************************************************************************/
 
-extern "C"
-rocblas_status
-rocblas_get_matrix(rocblas_int rows, rocblas_int cols, rocblas_int elem_size, 
-    const void *a_d, rocblas_int lda, 
-    void *b_h, rocblas_int ldb)
+extern "C" rocblas_status rocblas_get_matrix(rocblas_int rows,
+                                             rocblas_int cols,
+                                             rocblas_int elem_size,
+                                             const void* a_d,
+                                             rocblas_int lda,
+                                             void* b_h,
+                                             rocblas_int ldb)
 {
-    if ( rows == 0 || cols == 0 )   // quick return
+    if(rows == 0 || cols == 0) // quick return
         return rocblas_status_success;
-    if ( rows < 0 ) 
+    if(rows < 0)
         return rocblas_status_invalid_size;
-    if ( cols < 0 ) 
+    if(cols < 0)
         return rocblas_status_invalid_size;
-    if ( lda <= 0 ) 
+    if(lda <= 0)
         return rocblas_status_invalid_size;
-    if ( ldb <= 0 ) 
+    if(ldb <= 0)
         return rocblas_status_invalid_size;
-    if ( rows > lda ) 
+    if(rows > lda)
         return rocblas_status_invalid_size;
-    if ( rows > ldb ) 
+    if(rows > ldb)
         return rocblas_status_invalid_size;
-    if ( elem_size <= 0 ) 
+    if(elem_size <= 0)
         return rocblas_status_invalid_size;
-    if ( a_d == nullptr )
+    if(a_d == nullptr)
         return rocblas_status_invalid_pointer;
-    if ( b_h == nullptr )
+    if(b_h == nullptr)
         return rocblas_status_invalid_pointer;
 
-    try  // trap any exceptions
+    try // trap any exceptions
     {
 
-    // congiguous device matrix -> congiguous host matrix
-    if (lda == rows && ldb == rows)
-    {
-        PRINT_IF_HIP_ERROR(hipMemcpy(b_h, a_d, elem_size * rows * cols, hipMemcpyDeviceToHost));
-    }
-    // columns too large for temp buffer, hipMemcpy column by column 
-    else if (rows * elem_size > MAT_BUFF_MAX_BYTES)
-    {
-        for (int i = 0; i < cols; i++)
+        // congiguous device matrix -> congiguous host matrix
+        if(lda == rows && ldb == rows)
         {
-            PRINT_IF_HIP_ERROR(hipMemcpy(
-                (void *)((size_t)b_h + (size_t)(i * ldb * elem_size)),
-                (void *)((size_t)a_d + (size_t)(i * lda * elem_size)),
-                elem_size * rows, hipMemcpyDeviceToHost));
+            PRINT_IF_HIP_ERROR(hipMemcpy(b_h, a_d, elem_size * rows * cols, hipMemcpyDeviceToHost));
         }
-    }
-    // columns fit in temp buffer, pack columns in buffer, hipMemcpy device->host, unpack columns
-    else
-    {
-        int temp_byte_size = elem_size * rows * cols < MAT_BUFF_MAX_BYTES ? 
-            elem_size * rows * cols : MAT_BUFF_MAX_BYTES;
-        int n_cols = temp_byte_size / (elem_size * rows);      // number of columns in buffer
-        int n_copy = ((cols - 1) / n_cols) + 1;                // number times buffer copied
-
-        rocblas_int blocksX = ((rows-1) / MATRIX_DIM_X) + 1;   // parameters for device kernel
-        rocblas_int blocksY = ((n_cols-1) / MATRIX_DIM_Y) + 1;
-        dim3 grid( blocksX, blocksY, 1 );
-        dim3 threads(MATRIX_DIM_X, MATRIX_DIM_Y, 1 );
-        
-        hipStream_t rocblas_stream;
-        if (lda != rows)
+        // columns too large for temp buffer, hipMemcpy column by column
+        else if(rows * elem_size > MAT_BUFF_MAX_BYTES)
         {
-            rocblas_handle handle;
-            rocblas_create_handle(&handle);
-            RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
-        }
-        
-        size_t lda_d_byte = (size_t) elem_size * (size_t) lda;
-        size_t ldb_h_byte = (size_t) elem_size * (size_t) ldb;
-        size_t ldt_h_byte = (size_t) elem_size * (size_t) rows;
-
-        for (int i_copy = 0; i_copy < n_copy; i_copy++)
-        {
-            int i_start = i_copy * n_cols;
-            int n_cols_max = cols - i_start < n_cols ? cols - i_start : n_cols;
-            int contig_size = elem_size * rows * n_cols_max;
-            void *a_d_start = (void *)((size_t)a_d + (size_t)(i_start * lda_d_byte));
-            void *b_h_start = (void *)((size_t)b_h + (size_t)(i_start * ldb_h_byte));
-            if (lda !=rows && ldb != rows)
+            for(int i = 0; i < cols; i++)
             {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // non-contiguous device matrix -> device buffer
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, rows, n_cols_max, elem_size, a_d_start, lda, t_d, rows);
-                // device buffer -> host buffer
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_h, t_d, contig_size, hipMemcpyDeviceToHost));
-                // host buffer -> non-contiguous host matrix
-                for (int i_t = 0, i_b = i_start; i_t < n_cols_max; i_t++, i_b++)
-                {
-                    memcpy((void *)((size_t)b_h + (size_t)(i_b * ldb_h_byte)),
-                           (void *)((size_t)t_h + (size_t)(i_t * ldt_h_byte)), ldt_h_byte);
-                }
-            }
-            else if (lda == rows && ldb != rows)
-            {
-                // used unique_ptr to avoid memory leak
-                auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size),free};
-                void *t_h = t_h_managed.get();
-                if(!t_h) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // congiguous device matrix -> host buffer
-                PRINT_IF_HIP_ERROR(hipMemcpy(t_h, a_d_start, contig_size, hipMemcpyDeviceToHost));
-                // host buffer -> non-contiguous host matrix
-                for (int i_t = 0, i_b = i_start; i_t < n_cols_max; i_t++, i_b++)
-                {
-                    memcpy((void *)((size_t)b_h + (size_t)(i_b * ldb_h_byte)),
-                           (void *)((size_t)t_h + (size_t)(i_t * ldt_h_byte)), ldt_h_byte);
-                }
-            }
-            else if (lda != rows && ldb == rows)
-            {
-                // used unique_ptr to avoid memory leak
-                auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),rocblas::device_free};
-                void *t_d = t_d_managed.get();
-                if(!t_d) 
-                {
-                    return rocblas_status_memory_error;
-                }
-                // non-contiguous device matrix -> device buffer
-                hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel), dim3(grid), dim3(threads), 0,
-                    rocblas_stream, rows, n_cols_max, elem_size, a_d_start, lda, t_d, rows);
-                // device temp buffer -> contiguous host matrix
-                PRINT_IF_HIP_ERROR(hipMemcpy(b_h_start, t_d, contig_size, hipMemcpyDeviceToHost));
+                PRINT_IF_HIP_ERROR(hipMemcpy((void*)((size_t)b_h + (size_t)(i * ldb * elem_size)),
+                                             (void*)((size_t)a_d + (size_t)(i * lda * elem_size)),
+                                             elem_size * rows,
+                                             hipMemcpyDeviceToHost));
             }
         }
-    }
-    return rocblas_status_success;
+        // columns fit in temp buffer, pack columns in buffer, hipMemcpy device->host, unpack
+        // columns
+        else
+        {
+            int temp_byte_size = elem_size * rows * cols < MAT_BUFF_MAX_BYTES
+                                     ? elem_size * rows * cols
+                                     : MAT_BUFF_MAX_BYTES;
+            int n_cols = temp_byte_size / (elem_size * rows); // number of columns in buffer
+            int n_copy = ((cols - 1) / n_cols) + 1;           // number times buffer copied
 
+            rocblas_int blocksX = ((rows - 1) / MATRIX_DIM_X) + 1; // parameters for device kernel
+            rocblas_int blocksY = ((n_cols - 1) / MATRIX_DIM_Y) + 1;
+            dim3 grid(blocksX, blocksY, 1);
+            dim3 threads(MATRIX_DIM_X, MATRIX_DIM_Y, 1);
+
+            hipStream_t rocblas_stream;
+            if(lda != rows)
+            {
+                rocblas_handle handle;
+                rocblas_create_handle(&handle);
+                RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+            }
+
+            size_t lda_d_byte = (size_t)elem_size * (size_t)lda;
+            size_t ldb_h_byte = (size_t)elem_size * (size_t)ldb;
+            size_t ldt_h_byte = (size_t)elem_size * (size_t)rows;
+
+            for(int i_copy = 0; i_copy < n_copy; i_copy++)
+            {
+                int i_start     = i_copy * n_cols;
+                int n_cols_max  = cols - i_start < n_cols ? cols - i_start : n_cols;
+                int contig_size = elem_size * rows * n_cols_max;
+                void* a_d_start = (void*)((size_t)a_d + (size_t)(i_start * lda_d_byte));
+                void* b_h_start = (void*)((size_t)b_h + (size_t)(i_start * ldb_h_byte));
+                if(lda != rows && ldb != rows)
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous device matrix -> device buffer
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    rows,
+                                    n_cols_max,
+                                    elem_size,
+                                    a_d_start,
+                                    lda,
+                                    t_d,
+                                    rows);
+                    // device buffer -> host buffer
+                    PRINT_IF_HIP_ERROR(hipMemcpy(t_h, t_d, contig_size, hipMemcpyDeviceToHost));
+                    // host buffer -> non-contiguous host matrix
+                    for(int i_t = 0, i_b = i_start; i_t < n_cols_max; i_t++, i_b++)
+                    {
+                        memcpy((void*)((size_t)b_h + (size_t)(i_b * ldb_h_byte)),
+                               (void*)((size_t)t_h + (size_t)(i_t * ldt_h_byte)),
+                               ldt_h_byte);
+                    }
+                }
+                else if(lda == rows && ldb != rows)
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_h_managed = rocblas_unique_ptr{malloc(temp_byte_size), free};
+                    void* t_h        = t_h_managed.get();
+                    if(!t_h)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // congiguous device matrix -> host buffer
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(t_h, a_d_start, contig_size, hipMemcpyDeviceToHost));
+                    // host buffer -> non-contiguous host matrix
+                    for(int i_t = 0, i_b = i_start; i_t < n_cols_max; i_t++, i_b++)
+                    {
+                        memcpy((void*)((size_t)b_h + (size_t)(i_b * ldb_h_byte)),
+                               (void*)((size_t)t_h + (size_t)(i_t * ldt_h_byte)),
+                               ldt_h_byte);
+                    }
+                }
+                else if(lda != rows && ldb == rows)
+                {
+                    // used unique_ptr to avoid memory leak
+                    auto t_d_managed = rocblas_unique_ptr{rocblas::device_malloc(temp_byte_size),
+                                                          rocblas::device_free};
+                    void* t_d = t_d_managed.get();
+                    if(!t_d)
+                    {
+                        return rocblas_status_memory_error;
+                    }
+                    // non-contiguous device matrix -> device buffer
+                    hipLaunchKernel(HIP_KERNEL_NAME(copy_void_ptr_matrix_kernel),
+                                    dim3(grid),
+                                    dim3(threads),
+                                    0,
+                                    rocblas_stream,
+                                    rows,
+                                    n_cols_max,
+                                    elem_size,
+                                    a_d_start,
+                                    lda,
+                                    t_d,
+                                    rows);
+                    // device temp buffer -> contiguous host matrix
+                    PRINT_IF_HIP_ERROR(
+                        hipMemcpy(b_h_start, t_d, contig_size, hipMemcpyDeviceToHost));
+                }
+            }
+        }
+        return rocblas_status_success;
     }
-    catch(...)    // catch all exceptions
+    catch(...) // catch all exceptions
     {
         return rocblas_status_internal_error;
     }
 }
-

--- a/library/src/status.cpp
+++ b/library/src/status.cpp
@@ -3,7 +3,6 @@
  *
  * ************************************************************************ */
 
-
 #include <hip/hip_runtime_api.h>
 #include "rocblas.h"
 #include "status.h"
@@ -12,35 +11,35 @@
  * \brief convert hipError_t to rocblas_status
  * TODO - enumerate library calls to hip runtime, enumerate possible errors from those calls
  ******************************************************************************/
-rocblas_status
-get_rocblas_status_for_hip_status( hipError_t status ) {
-    switch(status) {
-        // success
-        case hipSuccess:
-            return rocblas_status_success;
+rocblas_status get_rocblas_status_for_hip_status(hipError_t status)
+{
+    switch(status)
+    {
+    // success
+    case hipSuccess:
+        return rocblas_status_success;
 
-        // internal hip memory allocation
-        case hipErrorMemoryAllocation:
-        case hipErrorLaunchOutOfResources:
-            return rocblas_status_memory_error;
+    // internal hip memory allocation
+    case hipErrorMemoryAllocation:
+    case hipErrorLaunchOutOfResources:
+        return rocblas_status_memory_error;
 
-        // user-allocated hip memory
-        case hipErrorInvalidDevicePointer: // hip memory
-            return rocblas_status_invalid_pointer;
+    // user-allocated hip memory
+    case hipErrorInvalidDevicePointer: // hip memory
+        return rocblas_status_invalid_pointer;
 
-        // user-allocated device, stream, event
-        case hipErrorInvalidDevice:
-        case hipErrorInvalidResourceHandle:
-            return rocblas_status_invalid_handle;
+    // user-allocated device, stream, event
+    case hipErrorInvalidDevice:
+    case hipErrorInvalidResourceHandle:
+        return rocblas_status_invalid_handle;
 
-        // library using hip incorrectly
-        case hipErrorInvalidValue:
-            return rocblas_status_internal_error;
+    // library using hip incorrectly
+    case hipErrorInvalidValue:
+        return rocblas_status_internal_error;
 
-        // hip runtime failing
-        case hipErrorNoDevice: // no hip devices
-        case hipErrorUnknown:
-        default:
-            return rocblas_status_internal_error;
+    // hip runtime failing
+    case hipErrorNoDevice: // no hip devices
+    case hipErrorUnknown:
+    default: return rocblas_status_internal_error;
     }
 }


### PR DESCRIPTION
Add clang-format consistently with clang-format in MIOpen.

Jenkins runs clang-format runs against pull request and the pull request will fail if any files do not comply with the specified format in .clang-format.

At this stage the user can
* format files individually with: clang-format-3.8 -style=file -i <filename>. This will format the files in place. Commit the changed files. The pull request should now pass
* Run the following and it will cause files to be formatted in place before they are committed: ./.githooks/install . Pull requests containing already formatted commits should pass the format check.
*  ignore the failure and merge the pull request