### PR TITLE
in set_get_pointer_mode_gtest use unique_ptr for rocblas_handle

### DIFF
--- a/clients/gtest/set_get_pointer_mode_gtest.cpp
+++ b/clients/gtest/set_get_pointer_mode_gtest.cpp
@@ -7,6 +7,8 @@
 #include <stdexcept>
 #include "rocblas.hpp"
 #include "utility.h"
+#include "arg_check.h"
+#include "rocblas_test_unique_ptr.hpp"
 
 using namespace std;
 
@@ -27,8 +29,8 @@ TEST(checkin_auxilliary, set_pointer_mode_get_pointer_mode)
     rocblas_status status     = rocblas_status_success;
     rocblas_pointer_mode mode = rocblas_pointer_mode_device;
 
-    rocblas_handle handle;
-    rocblas_create_handle(&handle);
+    std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
+    rocblas_handle handle = unique_ptr_handle->handle;
 
     status = rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
     EXPECT_EQ(status, rocblas_status_success);
@@ -45,6 +47,4 @@ TEST(checkin_auxilliary, set_pointer_mode_get_pointer_mode)
     EXPECT_EQ(status, rocblas_status_success);
 
     EXPECT_EQ(rocblas_pointer_mode_host, mode);
-
-    rocblas_destroy_handle(handle);
 }


### PR DESCRIPTION
rocblas tests were refactored to use unique_ptr for rocblas_handle. The code in set_get_pointer_mode_gtest was not refactored when it should have been refactored. This pull request contains the required refactor for set_get_pointer_mode_gtest. 
