### PR TITLE
Disable fedora builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -520,41 +520,39 @@ rocm_ubuntu:
 
     build_pipeline( hcc_compiler_args, hcc_docker_args, rocblas_paths, print_version_closure )
   }
-},
-rocm_fedora:
-{
-  node( 'docker && rocm && !dkms')
-  {
-    def hcc_docker_args = new docker_data(
-        from_image:'rocm/dev-fedora-24:latest',
-        build_docker_file:'dockerfile-build-fedora',
-        install_docker_file:'dockerfile-install-fedora',
-        docker_run_args:'--device=/dev/kfd',
-        docker_build_args:' --pull' )
+} //,
+// rocm_fedora:
+// {
+//   node( 'docker && rocm && !dkms')
+//   {
+//     def hcc_docker_args = new docker_data(
+//         from_image:'rocm/dev-fedora-24:latest',
+//         build_docker_file:'dockerfile-build-fedora',
+//         install_docker_file:'dockerfile-install-fedora',
+//         docker_run_args:'--device=/dev/kfd',
+//         docker_build_args:' --pull' )
 
-    def hcc_compiler_args = new compiler_data(
-        compiler_name:'hcc-rocm-fedora',
-        build_config:'Release',
-        compiler_path:'/opt/rocm/bin/hcc' )
+//     def hcc_compiler_args = new compiler_data(
+//         compiler_name:'hcc-rocm-fedora',
+//         build_config:'Release',
+//         compiler_path:'/opt/rocm/bin/hcc' )
 
-    def rocblas_paths = new project_paths(
-        project_name:'rocblas-fedora',
-        src_prefix:'src',
-        build_prefix:'src',
-        build_command: './install.sh -c' )
+//     def rocblas_paths = new project_paths(
+//         project_name:'rocblas-fedora',
+//         src_prefix:'src',
+//         build_prefix:'src',
+//         build_command: './install.sh -c' )
 
-    def print_version_closure = {
-      sh  """
-          set -x
-          /opt/rocm/bin/rocm_agent_enumerator -t ALL
-          /opt/rocm/bin/hcc --version
-        """
-    }
+//     def print_version_closure = {
+//       sh  """
+//           set -x
+//           /opt/rocm/bin/rocm_agent_enumerator -t ALL
+//           /opt/rocm/bin/hcc --version
+//         """
+//     }
 
-    build_pipeline( hcc_compiler_args, hcc_docker_args, rocblas_paths, print_version_closure )
-  }
-}
-
+//     build_pipeline( hcc_compiler_args, hcc_docker_args, rocblas_paths, print_version_closure )
+//   }
 // },
 // nvcc:
 // {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -212,7 +212,6 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
                     -o -iname \'*.h.in\' \
                     -o -iname \'*.hpp.in\' \
                     -o -iname \'*.cpp.in\' \
-                    -o -iname \'*.cl\' \
                 | grep -v 'build/' \
                 | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'
             '''
@@ -239,8 +238,8 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
 ////////////////////////////////////////////////////////////////////////
 // This builds a fresh docker image FROM a clean base image, with no build dependencies included
 // Uploads the new docker image to internal artifactory
-// String docker_upload_artifactory( String hcc_ver, String artifactory_org, String from_image, String rocblas_src_rel, String build_dir_rel )
-String docker_upload_artifactory( compiler_data compiler_args, docker_data docker_args, project_paths rocblas_paths, String job_name )
+// String docker_test_install( String hcc_ver, String artifactory_org, String from_image, String rocblas_src_rel, String build_dir_rel )
+String docker_test_install( compiler_data compiler_args, docker_data docker_args, project_paths rocblas_paths, String job_name )
 {
   def rocblas_install_image = null
   String image_name = "rocblas-hip-${compiler_args.compiler_name}-ubuntu-16.04"
@@ -434,16 +433,14 @@ def build_pipeline( compiler_data compiler_args, docker_data docker_args, projec
       docker_build_inside_image( rocblas_build_image, compiler_args, docker_args, rocblas_paths )
     }
 
-    // After a successful build, upload a docker image of the results
-    String job_name = env.JOB_NAME.toLowerCase( )
-    String rocblas_image_name = docker_upload_artifactory( compiler_args, docker_args, rocblas_paths, job_name )
+    if( !rocblas_paths.project_name.equalsIgnoreCase( 'rocblas-hcc-ctu' ) )
+    {
+      // After a successful build, upload a docker image of the results
+      String job_name = env.JOB_NAME.toLowerCase( )
+      String rocblas_image_name = docker_test_install( compiler_args, docker_args, rocblas_paths, job_name )
 
-    // if( params.push_image_to_docker_hub )
-    // {
-    //   docker_upload_dockerhub( job_name, rocblas_image_name, 'rocm' )
-    //   docker_clean_images( 'rocm', rocblas_image_name )
-    // }
-    docker_clean_images( job_name, rocblas_image_name )
+      docker_clean_images( job_name, rocblas_image_name )
+    }
   }
 }
 
@@ -458,7 +455,7 @@ parallel hcc_ctu:
           from_image:'compute-artifactory:5001/rocm-developer-tools/hip/master/hip-hcc-ctu-ubuntu-16.04:latest',
           build_docker_file:'dockerfile-build-ubuntu',
           install_docker_file:'dockerfile-install-ubuntu',
-          docker_run_args:'--device=/dev/kfd',
+          docker_run_args:'--device=/dev/kfd --device=/dev/dri --group-add=video',
           docker_build_args:' --pull' )
 
       def compiler_args = new compiler_data(
@@ -496,7 +493,7 @@ rocm_ubuntu:
         from_image:'rocm/dev-ubuntu-16.04:latest',
         build_docker_file:'dockerfile-build-ubuntu',
         install_docker_file:'dockerfile-install-ubuntu',
-        docker_run_args:'--device=/dev/kfd',
+        docker_run_args:'--device=/dev/kfd --device=/dev/dri --group-add=video',
         docker_build_args:' --pull' )
 
     def hcc_compiler_args = new compiler_data(

--- a/docker/dockerfile-build-fedora
+++ b/docker/dockerfile-build-fedora
@@ -12,6 +12,7 @@ ARG user_uid
 # * tensile: python34, PyYAML
 # * rocblas-test: gcc-gfortran, googletest
 # * rocblas-bench: boost-devel
+# * libhsakmt.so: libnuma1
 RUN dnf -y update && dnf install -y \
     sudo \
     ca-certificates \

--- a/docker/dockerfile-build-ubuntu
+++ b/docker/dockerfile-build-ubuntu
@@ -12,6 +12,7 @@ ARG user_uid
 # * tensile: python2.7, python-yaml
 # * rocblas-test: gfortran, googletest
 # * rocblas-bench: libboost-program-options-dev
+# * libhsakmt.so: libnuma1
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sudo \
     ca-certificates \
@@ -24,6 +25,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python-yaml \
     gfortran \
     libboost-program-options-dev \
+    libnuma1 \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -110,19 +110,24 @@ set( INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} )
 add_subdirectory( src )
 
 # The following code is setting variables to control the behavior of CPack to generate our
-if( WIN32 )
-    set( CPACK_SOURCE_GENERATOR "ZIP" )
-    set( CPACK_GENERATOR "ZIP" )
-else( )
-    set( CPACK_SOURCE_GENERATOR "TGZ" )
-    set( CPACK_GENERATOR "DEB;RPM" CACHE STRING "cpack list: 7Z, DEB, IFW, NSIS, NSIS64, RPM, STGZ, TBZ2, TGZ, TXZ, TZ, ZIP" )
-    # set( CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON )
-endif( )
+# if( WIN32 )
+#     set( CPACK_SOURCE_GENERATOR "ZIP" )
+#     set( CPACK_GENERATOR "ZIP" )
+# else( )
+#     set( CPACK_SOURCE_GENERATOR "TGZ" )
+#     set( CPACK_GENERATOR "DEB;RPM" CACHE STRING "cpack list: 7Z, DEB, IFW, NSIS, NSIS64, RPM, STGZ, TBZ2, TGZ, TXZ, TZ, ZIP" )
+#     # set( CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON )
+# endif( )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.0.17174)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.0.17174" )
+set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3)" )
+set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
+
+if( NOT CPACK_PACKAGING_INSTALL_PREFIX )
+  set( CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" )
+endif( )
+
 set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" )
 
 # Give rocblas compiled for CUDA backend a different name


### PR DESCRIPTION
Summary of proposed changes:
-  There are no fedora builds with ROCm v1.7; disable the fedora builds until they are available
-  Update the hip dependency version
-  
