### PR TITLE
Modify cmake to detect rocm device to compile for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ if( BUILD_WITH_TENSILE )
   set( tensile_tag "v3.5.1" CACHE STRING "Tensile tag to download" )
   file( DOWNLOAD https://github.com/ROCmSoftwarePlatform/Tensile/archive/${tensile_tag}.tar.gz
     ${PROJECT_EXTERN_DIR}/tensile-${tensile_tag}.tar.gz
+    STATUS status LOG log
     EXPECTED_HASH SHA256=6b83f7b9b9837821df879137a0eeac50460a0d156d4f0c2171147f6679b72ca9
   )
 
@@ -170,9 +171,49 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
 endif( )
 
-# CMake list of machine targets
-set( AMDGPU_TARGETS gfx900 CACHE STRING "List of specific machine types for library to target" )
-#set( AMDGPU_TARGETS gfx803;gfx900 CACHE STRING "List of specific machine types for library to target" )
+# Determine what rocm device to compile kernels for, the default is to use a utility to inspect the parts
+# of the users machine
+# First, try to use rocminfo which does not pull in an additional dependency on python
+# Second, try rocm_agent_enumerator but this implies a dependency on python
+find_program( ROCM_INFO rocminfo PATHS /opt/rocm/bin )
+if( ROCM_INFO )
+  execute_process(
+      COMMAND ${ROCM_INFO}
+      RESULT_VARIABLE rocm_info_result
+      OUTPUT_VARIABLE rocm_info_output
+  )
+  if( rocm_info_result )
+    message( FATAL_ERROR "Found rocminfo, but could not execute" )
+  endif( )
+else()
+  # This is for older installations of ROCm primarily
+  find_program( ROCM_INFO rocm_agent_enumerator PATHS /opt/rocm/bin )
+  if( ROCM_INFO )
+    execute_process(
+        COMMAND ${ROCM_INFO} -t GPU
+        RESULT_VARIABLE rocm_info_result
+        OUTPUT_VARIABLE rocm_info_output
+    )
+    if( rocm_info_result )
+      message( FATAL_ERROR "Found rocm_agent_enumerator, but could not execute" )
+    endif( )
+  else()
+    message( WARNING "Could not find either rocminfo or rocm_agent_enumerator" )
+    message( STATUS "Statically assigning gfx device of gfx900" )
+    set( info_gfx "gfx900" )
+  endif()
+endif()
+
+string( REGEX MATCHALL "gfx[0-9]+" info_gfx ${rocm_info_output} )
+# string( REGEX REPLACE "Name:[\\r\\n\\t ]*(gfx[0-9]+)" "\\1" info_gfx ${rocm_info_output} )
+# list( LENGTH info_gfx info_gfx_length )
+list( REMOVE_DUPLICATES info_gfx )
+
+# message( "RESULT_VARIABLE: ${rocm_info_result}" )
+# message( "OUTPUT_VARIABLE: \n${rocm_info_output}" )
+# message( "INFO_GRAPHICS: \n${info_gfx}" )
+
+set( AMDGPU_TARGETS ${info_gfx} CACHE STRING "List of specific machine types for library to target" )
 
 add_subdirectory( library )
 


### PR DESCRIPTION
Summary of proposed changes:
-  Fixed a bug in recognizing cached copies of Tensile
- CMake now calls out to an external utility to determine the hardware on the clients machine.  This allows tensile to tune appropriately for the developers hardware.  The old 'fat binary' approach is still valid, and a list of devices can be passed through AMDGPU_TARGETS