### PR TITLE
add Vega 64 support

### DIFF
--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.4.0}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.5.1}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_lite/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 3.3.5}
 - vega10
 - gfx900
-- [Device 6863,Device 6862]
+- [Device 6863,Device 6862,Device 687f]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
-  Add Device 687f (alongside 6863) to all 24 vega10 yaml files.

Tests run:
- pre-checkin tests were run and passed on Vega 64