### PR TITLE
set,get_matrix use size_t for bytes_to_copy

### DIFF
--- a/clients/gtest/set_get_matrix_gtest.cpp
+++ b/clients/gtest/set_get_matrix_gtest.cpp
@@ -40,10 +40,10 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 
 // small sizes
 
-// vector of vector, each triple is a {rows, cols};
+// vector of vector, each triple is a {M, N};
 // add/delete this list in pairs, like {3, 4}
 
-const vector<vector<int>> rows_cols_range = {{3, 3}, {3, 30}, {30, 3}};
+const vector<vector<int>> M_N_range = {{3, 3}, {3, 30}, {30, 3}};
 
 // vector of vector, each triple is a {lda, ldb, ldc};
 // add/delete this list in pairs, like {3, 4, 3}
@@ -53,7 +53,7 @@ const vector<vector<int>> lda_ldb_ldc_range = {
     {3, 5, 4}, {3, 5, 5}, {5, 3, 3}, {5, 3, 4}, {5, 3, 5},    {5, 4, 3},   {5, 4, 4},
     {5, 4, 5}, {5, 5, 3}, {5, 5, 4}, {5, 5, 5}, {30, 30, 30}, {31, 32, 33}};
 
-// large sizes   {{rows, cols},{lda,ldb,ldc}}
+// large sizes   {{M, N},{lda,ldb,ldc}}
 set_get_matrix_tuple gemm_values1{{300000, 21}, {300000, 300001, 300002}};
 set_get_matrix_tuple gemm_values2{{300001, 22}, {300001, 300001, 300010}};
 set_get_matrix_tuple gemm_values3{{300002, 23}, {300002, 300020, 300002}};
@@ -74,6 +74,8 @@ set_get_matrix_tuple gemm_values18{{27, 300022}, {39, 40, 41}};
 
 set_get_matrix_tuple gemm_values21{{3, 3000222}, {4, 4, 4}};
 
+set_get_matrix_tuple gemm_values31{{16700, 16700}, {16700, 16700, 16700}};
+
 const vector<set_get_matrix_tuple> small_gemm_values_vec = {gemm_values1, gemm_values11};
 
 const vector<set_get_matrix_tuple> large_gemm_values_vec = {gemm_values1,
@@ -92,7 +94,8 @@ const vector<set_get_matrix_tuple> large_gemm_values_vec = {gemm_values1,
                                                             gemm_values16,
                                                             gemm_values17,
                                                             gemm_values18,
-                                                            gemm_values21};
+                                                            gemm_values21,
+                                                            gemm_values31};
 
 /* ===============Google Unit Test==================================================== */
 
@@ -113,13 +116,13 @@ const vector<set_get_matrix_tuple> large_gemm_values_vec = {gemm_values1,
 Arguments setup_set_get_matrix_arguments(set_get_matrix_tuple tup)
 {
 
-    vector<int> rows_cols   = std::get<0>(tup);
+    vector<int> M_N         = std::get<0>(tup);
     vector<int> lda_ldb_ldc = std::get<1>(tup);
 
     Arguments arg;
 
-    arg.rows = rows_cols[0];
-    arg.cols = rows_cols[1];
+    arg.M = M_N[0];
+    arg.N = M_N[1];
 
     arg.lda = lda_ldb_ldc[0];
     arg.ldb = lda_ldb_ldc[1];
@@ -151,11 +154,11 @@ TEST_P(parameterized_set_matrix_get_matrix, float)
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if(arg.rows < 0)
+        if(arg.M < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.cols <= 0)
+        else if(arg.N <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -171,15 +174,15 @@ TEST_P(parameterized_set_matrix_get_matrix, float)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.lda < arg.rows)
+        else if(arg.lda < arg.M)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.ldb < arg.rows)
+        else if(arg.ldb < arg.M)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.ldc < arg.rows)
+        else if(arg.ldc < arg.M)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -204,11 +207,11 @@ TEST_P(parameterized_set_matrix_get_matrix, double)
     // if not success, then the input argument is problematic, so detect the error message
     if(status != rocblas_status_success)
     {
-        if(arg.rows < 0)
+        if(arg.M < 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.cols <= 0)
+        else if(arg.N <= 0)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -224,15 +227,15 @@ TEST_P(parameterized_set_matrix_get_matrix, double)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.lda < arg.rows)
+        else if(arg.lda < arg.M)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.ldb < arg.rows)
+        else if(arg.ldb < arg.M)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
-        else if(arg.ldc < arg.rows)
+        else if(arg.ldc < arg.M)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
         }
@@ -250,7 +253,7 @@ TEST_P(parameterized_set_matrix_get_matrix, double)
 
 INSTANTIATE_TEST_CASE_P(checkin_auxilliary,
                         parameterized_set_matrix_get_matrix,
-                        Combine(ValuesIn(rows_cols_range), ValuesIn(lda_ldb_ldc_range)));
+                        Combine(ValuesIn(M_N_range), ValuesIn(lda_ldb_ldc_range)));
 
 INSTANTIATE_TEST_CASE_P(checkin_auxilliary_2,
                         parameterized_set_matrix_get_matrix,

--- a/clients/include/testing_set_get_matrix.hpp
+++ b/clients/include/testing_set_get_matrix.hpp
@@ -21,8 +21,8 @@ using namespace std;
 template <typename T>
 rocblas_status testing_set_get_matrix(Arguments argus)
 {
-    rocblas_int rows      = argus.rows;
-    rocblas_int cols      = argus.cols;
+    rocblas_int rows      = argus.M;
+    rocblas_int cols      = argus.N;
     rocblas_int lda       = argus.lda;
     rocblas_int ldb       = argus.ldb;
     rocblas_int ldc       = argus.ldc;
@@ -166,14 +166,14 @@ rocblas_status testing_set_get_matrix(Arguments argus)
         cout << "rows,cols,lda,ldb,rocblas-GB/s";
 
         if(argus.norm_check)
-            cout << ",CPU-GB/s";
+            cout << ",CPU-GB/s,Frobenius_norm_error";
 
         cout << endl;
 
         cout << rows << "," << cols << "," << lda << "," << ldb << "," << rocblas_bandwidth;
 
         if(argus.norm_check)
-            cout << "," << cpu_bandwidth;
+            cout << "," << cpu_bandwidth << "," << rocblas_error;
 
         cout << endl;
     }

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -345,9 +345,6 @@ class Arguments
     rocblas_int N = 128;
     rocblas_int K = 128;
 
-    rocblas_int rows = 128;
-    rocblas_int cols = 128;
-
     rocblas_int lda = 128;
     rocblas_int ldb = 128;
     rocblas_int ldc = 128;
@@ -380,6 +377,8 @@ class Arguments
     rocblas_int norm_check = 0;
     rocblas_int unit_check = 1;
     rocblas_int timing     = 0;
+
+    rocblas_int iters = 10;
 
     Arguments& operator=(const Arguments& rhs)
     {

--- a/library/src/rocblas_auxiliary.cpp
+++ b/library/src/rocblas_auxiliary.cpp
@@ -192,8 +192,9 @@ extern "C" rocblas_status rocblas_set_vector(rocblas_int n,
         }
         else // either non-contiguous host vector or non-contiguous device vector
         {
-            int temp_byte_size =
-                elem_size * n < VEC_BUFF_MAX_BYTES ? elem_size * n : VEC_BUFF_MAX_BYTES;
+            size_t bytes_to_copy = static_cast<size_t>(elem_size) * static_cast<size_t>(n);
+            size_t temp_byte_size =
+                bytes_to_copy < VEC_BUFF_MAX_BYTES ? bytes_to_copy : VEC_BUFF_MAX_BYTES;
             int n_elem = temp_byte_size / elem_size; // number of elements in buffer
             int n_copy = ((n - 1) / n_elem) + 1;     // number of times buffer is copied
 
@@ -350,8 +351,9 @@ extern "C" rocblas_status rocblas_get_vector(rocblas_int n,
         }
         else // either device or host vector is non-contiguous
         {
-            int temp_byte_size =
-                elem_size * n < VEC_BUFF_MAX_BYTES ? elem_size * n : VEC_BUFF_MAX_BYTES;
+            size_t bytes_to_copy = static_cast<size_t>(elem_size) * static_cast<size_t>(n);
+            size_t temp_byte_size =
+                bytes_to_copy < VEC_BUFF_MAX_BYTES ? bytes_to_copy : VEC_BUFF_MAX_BYTES;
             int n_elem = temp_byte_size / elem_size; // number elements in buffer
             int n_copy = ((n - 1) / n_elem) + 1;     // number of times buffer is copied
 
@@ -543,7 +545,9 @@ extern "C" rocblas_status rocblas_set_matrix(rocblas_int rows,
         // contiguous host matrix -> contiguous device matrix
         if(lda == rows && ldb == rows)
         {
-            PRINT_IF_HIP_ERROR(hipMemcpy(b_d, a_h, elem_size * rows * cols, hipMemcpyHostToDevice));
+            size_t bytes_to_copy = static_cast<size_t>(elem_size) * static_cast<size_t>(rows) *
+                                   static_cast<size_t>(cols);
+            PRINT_IF_HIP_ERROR(hipMemcpy(b_d, a_h, bytes_to_copy, hipMemcpyHostToDevice));
         }
         // matrix colums too large to fit in temp buffer, copy matrix col by col
         else if(rows * elem_size > MAT_BUFF_MAX_BYTES)
@@ -560,9 +564,10 @@ extern "C" rocblas_status rocblas_set_matrix(rocblas_int rows,
         // columns
         else
         {
-            int temp_byte_size = elem_size * rows * cols < MAT_BUFF_MAX_BYTES
-                                     ? elem_size * rows * cols
-                                     : MAT_BUFF_MAX_BYTES;
+            size_t bytes_to_copy = static_cast<size_t>(elem_size) * static_cast<size_t>(rows) *
+                                   static_cast<size_t>(cols);
+            size_t temp_byte_size =
+                bytes_to_copy < MAT_BUFF_MAX_BYTES ? bytes_to_copy : MAT_BUFF_MAX_BYTES;
             int n_cols = temp_byte_size / (elem_size * rows); // number of columns in buffer
             int n_copy = ((cols - 1) / n_cols) + 1;           // number of times buffer is copied
 
@@ -728,7 +733,9 @@ extern "C" rocblas_status rocblas_get_matrix(rocblas_int rows,
         // congiguous device matrix -> congiguous host matrix
         if(lda == rows && ldb == rows)
         {
-            PRINT_IF_HIP_ERROR(hipMemcpy(b_h, a_d, elem_size * rows * cols, hipMemcpyDeviceToHost));
+            size_t bytes_to_copy = static_cast<size_t>(elem_size) * static_cast<size_t>(rows) *
+                                   static_cast<size_t>(cols);
+            PRINT_IF_HIP_ERROR(hipMemcpy(b_h, a_d, bytes_to_copy, hipMemcpyDeviceToHost));
         }
         // columns too large for temp buffer, hipMemcpy column by column
         else if(rows * elem_size > MAT_BUFF_MAX_BYTES)
@@ -745,9 +752,10 @@ extern "C" rocblas_status rocblas_get_matrix(rocblas_int rows,
         // columns
         else
         {
-            int temp_byte_size = elem_size * rows * cols < MAT_BUFF_MAX_BYTES
-                                     ? elem_size * rows * cols
-                                     : MAT_BUFF_MAX_BYTES;
+            size_t bytes_to_copy = static_cast<size_t>(elem_size) * static_cast<size_t>(rows) *
+                                   static_cast<size_t>(cols);
+            size_t temp_byte_size =
+                bytes_to_copy < MAT_BUFF_MAX_BYTES ? bytes_to_copy : MAT_BUFF_MAX_BYTES;
             int n_cols = temp_byte_size / (elem_size * rows); // number of columns in buffer
             int n_copy = ((cols - 1) / n_cols) + 1;           // number times buffer copied
 


### PR DESCRIPTION
use size_t in place of int for number of bytes to copy in hipMemcpy called from rocblas_set_matrix and rocblas_get_matrix. This is required for double matrix of size 16700 x 16700 and other large matrices of byte size larger than can fit into int data type.