### PR TITLE
lint errors in ctu and swdev-153306

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -488,7 +488,7 @@ parallel hcc_ctu:
 {
   try
   {
-    node( 'docker && rocm && jenkins-rocm-0')
+    node( 'docker && rocm && gfx900')
     {
       def docker_args = new docker_data(
           from_image:'compute-artifactory:5001/rocm-developer-tools/hip/master/hip-hcc-ctu-ubuntu-16.04:latest',

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -55,7 +55,7 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     rocblas_int bsc = ldc * N * 2;
 
     // check here to prevent undefined memory allocation error
-    if(M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 || batch_count < 0)
+    if(M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 || batch_count <= 0)
     {
         auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
                                              rocblas_test::device_free};
@@ -101,9 +101,9 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
 
     T rocblas_error = 0.0;
 
-    rocblas_int size_A = bsa * batch_count;
-    rocblas_int size_B = bsb * batch_count;
-    rocblas_int size_C = bsc * batch_count;
+    size_t size_A = static_cast<size_t>(bsa) * static_cast<size_t>(batch_count);
+    size_t size_B = static_cast<size_t>(bsb) * static_cast<size_t>(batch_count);
+    size_t size_C = static_cast<size_t>(bsc) * static_cast<size_t>(batch_count);
 
     // allocate memory on device
     auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -7,6 +7,7 @@
 #define _TESTING_UTILITY_H_
 
 #include <stdio.h>
+#include <iostream>
 #include <stdlib.h>
 #include <vector>
 #include <sys/time.h>

--- a/clients/samples/example_openmp.cpp
+++ b/clients/samples/example_openmp.cpp
@@ -23,6 +23,7 @@
 #include <omp.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <iostream>
 #include <vector>
 
 #include "rocblas.hpp"

--- a/clients/samples/example_scal_template.cpp
+++ b/clients/samples/example_scal_template.cpp
@@ -9,6 +9,7 @@
 
 #include "rocblas.hpp"
 #include "utility.h"
+#include <iostream>
 
 using namespace std;
 

--- a/clients/samples/example_sgemm.cpp
+++ b/clients/samples/example_sgemm.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <limits>
 #include "rocblas.h"
+#include <iostream>
 
 using namespace std;
 

--- a/clients/samples/example_sgemm_strided_batched.cpp
+++ b/clients/samples/example_sgemm_strided_batched.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <vector>
 #include <limits>
+#include <iostream>
 #include "rocblas.h"
 
 using namespace std;

--- a/clients/samples/example_sscal.cpp
+++ b/clients/samples/example_sscal.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <vector>
+#include <iostream>
 
 #include "rocblas.h"
 #include "utility.h"

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -6,6 +6,7 @@
 #ifndef LOGGING_H
 #define LOGGING_H
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <unistd.h>
 #include <sys/param.h>

--- a/library/src/utility.cpp
+++ b/library/src/utility.cpp
@@ -2,6 +2,8 @@
  * Copyright 2016 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
+#include <string>
+#include <iostream>
 #include "rocblas.h"
 
 // return letter N,T,C in place of rocblas_operation enum


### PR DESCRIPTION
Clang Tot Upgrade has lint type errors. Adding include files to aim to remove errors
