### PR TITLE
rocblas_strided_batched tests correction for stride_a==0

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -91,19 +91,19 @@ int main(int argc, char* argv[])
          "Specific leading dimension of matrix C, is only applicable to BLAS-2 & "
          "BLAS-3: the number of rows.")
 
-        ("bsa",
-         po::value<rocblas_int>(&argus.bsa)->default_value(128*128),
+        ("stride_a",
+         po::value<rocblas_int>(&argus.stride_a)->default_value(128*128),
+         "Specific stride of strided_batched matrix A, is only applicable to strided batched"
+         "BLAS-2 and BLAS-3: second dimension * leading dimension.")
+
+        ("stride_b",
+         po::value<rocblas_int>(&argus.stride_b)->default_value(128*128),
          "Specific stride of strided_batched matrix B, is only applicable to strided batched"
          "BLAS-2 and BLAS-3: second dimension * leading dimension.")
 
-        ("bsb",
-         po::value<rocblas_int>(&argus.bsb)->default_value(128*128),
-         "Specific stride of strided_batched matrix B, is only applicable to strided batched"
-         "BLAS-2 and BLAS-3: second dimension * leading dimension.")
-
-        ("bsc",
-         po::value<rocblas_int>(&argus.bsc)->default_value(128*128),
-         "Specific stride of strided_batched matrix B, is only applicable to strided batched"
+        ("stride_c",
+         po::value<rocblas_int>(&argus.stride_c)->default_value(128*128),
+         "Specific stride of strided_batched matrix C, is only applicable to strided batched"
          "BLAS-2 and BLAS-3: second dimension * leading dimension.")
 
         ("incx",
@@ -378,25 +378,32 @@ int main(int argc, char* argv[])
             argus.ldc = min_ldc;
         }
 
-        rocblas_int min_bsa =
-            argus.transA_option == 'N' ? argus.K * argus.lda : argus.M * argus.lda;
-        rocblas_int min_bsb =
-            argus.transB_option == 'N' ? argus.N * argus.ldb : argus.K * argus.ldb;
-        rocblas_int min_bsc = argus.ldc * argus.N;
-        if(argus.bsa < min_bsa)
+        //      rocblas_int min_stride_a =
+        //          argus.transA_option == 'N' ? argus.K * argus.lda : argus.M * argus.lda;
+        //      rocblas_int min_stride_b =
+        //          argus.transB_option == 'N' ? argus.N * argus.ldb : argus.K * argus.ldb;
+        //      rocblas_int min_stride_a =
+        //          argus.transA_option == 'N' ? argus.K * argus.lda : argus.M * argus.lda;
+        //      rocblas_int min_stride_b =
+        //          argus.transB_option == 'N' ? argus.N * argus.ldb : argus.K * argus.ldb;
+        rocblas_int min_stride_c = argus.ldc * argus.N;
+        //      if(argus.stride_a < min_stride_a)
+        //      {
+        //          std::cout << "rocblas-bench INFO: stride_a < min_stride_a, set stride_a = " <<
+        //          min_stride_a << std::endl;
+        //          argus.stride_a = min_stride_a;
+        //      }
+        //      if(argus.stride_b < min_stride_b)
+        //      {
+        //          std::cout << "rocblas-bench INFO: stride_b < min_stride_b, set stride_b = " <<
+        //          min_stride_b << std::endl;
+        //          argus.stride_b = min_stride_b;
+        //      }
+        if(argus.stride_c < min_stride_c)
         {
-            std::cout << "rocblas-bench INFO: bsa < min_bsa, set bsa = " << min_bsa << std::endl;
-            argus.bsa = min_bsa;
-        }
-        if(argus.bsb < min_bsb)
-        {
-            std::cout << "rocblas-bench INFO: bsb < min_bsb, set bsb = " << min_bsb << std::endl;
-            argus.bsb = min_bsb;
-        }
-        if(argus.bsc < min_bsc)
-        {
-            std::cout << "rocblas-bench INFO: bsc < min_bsc, set bsc = " << min_bsc << std::endl;
-            argus.bsc = min_bsc;
+            std::cout << "rocblas-bench INFO: stride_c < min_stride_c, set stride_c = "
+                      << min_stride_c << std::endl;
+            argus.stride_c = min_stride_c;
         }
 
         if(precision == 'h')
@@ -457,25 +464,28 @@ int main(int argc, char* argv[])
             argus.ldc = min_ldc;
         }
 
-        rocblas_int min_bsa =
-            argus.transA_option == 'N' ? argus.K * argus.lda : argus.M * argus.lda;
-        rocblas_int min_bsb =
-            argus.transB_option == 'N' ? argus.N * argus.ldb : argus.K * argus.ldb;
-        rocblas_int min_bsc = argus.ldc * argus.N;
-        if(argus.bsa < min_bsa)
+        //      rocblas_int min_stride_a =
+        //          argus.transA_option == 'N' ? argus.K * argus.lda : argus.M * argus.lda;
+        //      rocblas_int min_stride_b =
+        //          argus.transB_option == 'N' ? argus.N * argus.ldb : argus.K * argus.ldb;
+        rocblas_int min_stride_c = argus.ldc * argus.N;
+        //      if(argus.stride_a < min_stride_a)
+        //      {
+        //          std::cout << "rocblas-bench INFO: stride_a < min_stride_a, set stride_a = " <<
+        //          min_stride_a << std::endl;
+        //          argus.stride_a = min_stride_a;
+        //      }
+        //      if(argus.stride_b < min_stride_b)
+        //      {
+        //          std::cout << "rocblas-bench INFO: stride_b < min_stride_b, set stride_b = " <<
+        //          min_stride_b << std::endl;
+        //          argus.stride_b = min_stride_b;
+        //      }
+        if(argus.stride_c < min_stride_c)
         {
-            std::cout << "rocblas-bench INFO: bsa < min_bsa, set bsa = " << min_bsa << std::endl;
-            argus.bsa = min_bsa;
-        }
-        if(argus.bsb < min_bsb)
-        {
-            std::cout << "rocblas-bench INFO: bsb < min_bsb, set bsb = " << min_bsb << std::endl;
-            argus.bsb = min_bsb;
-        }
-        if(argus.bsc < min_bsc)
-        {
-            std::cout << "rocblas-bench INFO: bsc < min_bsc, set bsc = " << min_bsc << std::endl;
-            argus.bsc = min_bsc;
+            std::cout << "rocblas-bench INFO: stride_c < min_stride_c, set stride_c = "
+                      << min_stride_c << std::endl;
+            argus.stride_c = min_stride_c;
         }
 
         if(precision == 'h')

--- a/clients/common/arg_check.cpp
+++ b/clients/common/arg_check.cpp
@@ -164,6 +164,9 @@ void gemm_strided_batched_arg_check(rocblas_status status,
                                     rocblas_int lda,
                                     rocblas_int ldb,
                                     rocblas_int ldc,
+                                    rocblas_int stride_a,
+                                    rocblas_int stride_b,
+                                    rocblas_int stride_c,
                                     rocblas_int batch_count)
 {
 #ifdef GOOGLE_TEST
@@ -176,9 +179,10 @@ void gemm_strided_batched_arg_check(rocblas_status status,
         ASSERT_EQ(status, rocblas_status_invalid_size);
     }
 #else
-    std::cerr << "rocBLAS TEST ERROR in arguments M, N, K, lda, ldb, ldc, batch_count: ";
-    std::cerr << M << ',' << N << ',' << K << ',' << lda << ',' << ldb << ',' << ldc << batch_count
-              << std::endl;
+    std::cerr << "rocBLAS TEST ERROR in arguments M, N, K, lda, ldb, ldc, stride_a, stride_b, "
+                 "stride_c, batch_count: ";
+    std::cerr << M << ',' << N << ',' << K << ',' << lda << ',' << ldb << ',' << ldc << ','
+              << stride_a << ',' << stride_b << ',' << stride_c << ',' << batch_count << std::endl;
 #endif
 }
 

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -138,6 +138,144 @@ void unit_check_general(
     }
 }
 
+template <>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int batch_count,
+                        rocblas_int lda,
+                        rocblas_int strideA,
+                        rocblas_half* hCPU,
+                        rocblas_half* hGPU)
+{
+#pragma unroll
+    for(rocblas_int k = 0; k < batch_count; k++)
+    {
+#pragma unroll
+        for(rocblas_int j = 0; j < N; j++)
+        {
+#pragma unroll
+            for(rocblas_int i = 0; i < M; i++)
+            {
+#ifdef GOOGLE_TEST
+                float cpu_float = static_cast<float>(hCPU[i + j * lda + k * strideA]);
+                float gpu_float = static_cast<float>(hGPU[i + j * lda + k * strideA]);
+                ASSERT_FLOAT_EQ(cpu_float, gpu_float);
+#endif
+            }
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int batch_count,
+                        rocblas_int lda,
+                        rocblas_int strideA,
+                        float* hCPU,
+                        float* hGPU)
+{
+#pragma unroll
+    for(rocblas_int k = 0; k < batch_count; k++)
+    {
+#pragma unroll
+        for(rocblas_int j = 0; j < N; j++)
+        {
+#pragma unroll
+            for(rocblas_int i = 0; i < M; i++)
+            {
+#ifdef GOOGLE_TEST
+                ASSERT_FLOAT_EQ(hCPU[i + j * lda + k * strideA], hGPU[i + j * lda + k * strideA]);
+#endif
+            }
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int batch_count,
+                        rocblas_int lda,
+                        rocblas_int strideA,
+                        double* hCPU,
+                        double* hGPU)
+{
+#pragma unroll
+    for(rocblas_int k = 0; k < batch_count; k++)
+    {
+#pragma unroll
+        for(rocblas_int j = 0; j < N; j++)
+        {
+#pragma unroll
+            for(rocblas_int i = 0; i < M; i++)
+            {
+#ifdef GOOGLE_TEST
+                ASSERT_DOUBLE_EQ(hCPU[i + j * lda + k * strideA], hGPU[i + j * lda + k * strideA]);
+#endif
+            }
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int batch_count,
+                        rocblas_int lda,
+                        rocblas_int strideA,
+                        rocblas_float_complex* hCPU,
+                        rocblas_float_complex* hGPU)
+{
+#pragma unroll
+    for(rocblas_int k = 0; k < batch_count; k++)
+    {
+#pragma unroll
+        for(rocblas_int j = 0; j < N; j++)
+        {
+#pragma unroll
+            for(rocblas_int i = 0; i < M; i++)
+            {
+#ifdef GOOGLE_TEST
+                ASSERT_FLOAT_EQ(hCPU[i + j * lda + k * strideA].x,
+                                hGPU[i + j * lda + k * strideA].x);
+                ASSERT_FLOAT_EQ(hCPU[i + j * lda + k * strideA].y,
+                                hGPU[i + j * lda + k * strideA].y);
+#endif
+            }
+        }
+    }
+}
+
+template <>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int batch_count,
+                        rocblas_int lda,
+                        rocblas_int strideA,
+                        rocblas_double_complex* hCPU,
+                        rocblas_double_complex* hGPU)
+{
+#pragma unroll
+    for(rocblas_int k = 0; k < batch_count; k++)
+    {
+#pragma unroll
+        for(rocblas_int j = 0; j < N; j++)
+        {
+#pragma unroll
+            for(rocblas_int i = 0; i < M; i++)
+            {
+#ifdef GOOGLE_TEST
+                ASSERT_DOUBLE_EQ(hCPU[i + j * lda + k * strideA].x,
+                                 hGPU[i + j * lda + k * strideA].x);
+                ASSERT_DOUBLE_EQ(hCPU[i + j * lda + k * strideA].y,
+                                 hGPU[i + j * lda + k * strideA].y);
+#endif
+            }
+        }
+    }
+}
+
 /* ========================================Gtest Unit Check TRSM
  * ==================================================== */
 

--- a/clients/gtest/gemm_strided_batched_gtest.cpp
+++ b/clients/gtest/gemm_strided_batched_gtest.cpp
@@ -35,14 +35,14 @@ Yet, the goal of this file is to verify result correctness not argument-checkers
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
-// vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
+// vector of vector, each vector is a {M, N, K, lda, ldb, ldc, stride_a, stride_b, stride_c};
 // add/delete as a group, in batched gemm, the matrix is much smaller than standard gemm
 const vector<vector<int>> matrix_size_range = {
-    {-1, -1, -1, -1, 1, 1},
-    {31, 33, 35, 101, 102, 103},
-    {59, 61, 63, 129, 131, 137},
-    {129, 130, 131, 132, 133, 134},
-    {501, 502, 103, 504, 605, 506},
+    {-1, -1, -1, -1, 1, 1, 1, 1, 1},
+    {31, 33, 35, 101, 102, 103, 3605, 3605, 3605},
+    {59, 61, 63, 129, 131, 137, 8631, 8631, 8631},
+    {129, 130, 131, 132, 133, 134, 17554, 17554, 17554},
+    {501, 502, 103, 504, 605, 506, 340010, 340010, 340010},
 };
 
 // vector of vector, each pair is a {alpha, beta};
@@ -89,12 +89,15 @@ Arguments setup_gemm_strided_batched_arguments(gemm_strided_batched_tuple tup)
     Arguments arg;
 
     // see the comments about matrix_size_range above
-    arg.M   = matrix_size[0];
-    arg.N   = matrix_size[1];
-    arg.K   = matrix_size[2];
-    arg.lda = matrix_size[3];
-    arg.ldb = matrix_size[4];
-    arg.ldc = matrix_size[5];
+    arg.M        = matrix_size[0];
+    arg.N        = matrix_size[1];
+    arg.K        = matrix_size[2];
+    arg.lda      = matrix_size[3];
+    arg.ldb      = matrix_size[4];
+    arg.ldc      = matrix_size[5];
+    arg.stride_a = matrix_size[6];
+    arg.stride_b = matrix_size[7];
+    arg.stride_c = matrix_size[8];
 
     // the first element of alpha_beta_range is always alpha, and the second is always beta
     arg.alpha = alpha_beta[0];

--- a/clients/include/arg_check.h
+++ b/clients/include/arg_check.h
@@ -62,6 +62,9 @@ void gemm_strided_batched_arg_check(rocblas_status status,
                                     rocblas_int lda,
                                     rocblas_int ldb,
                                     rocblas_int ldc,
+                                    rocblas_int stride_a,
+                                    rocblas_int stride_b,
+                                    rocblas_int stride_c,
                                     rocblas_int batch_count);
 
 void geam_arg_check(rocblas_status status,

--- a/clients/include/norm.h
+++ b/clients/include/norm.h
@@ -20,7 +20,7 @@
 /* ========================================Norm Check
  * ==================================================== */
 
-/*! \brief  Template: norm check for general Matrix: float/doubel/complex  */
+/*! \brief  Template: norm check for general Matrix: half/float/doubel/complex  */
 
 // see check_norm.cpp for template speciliazation
 // use auto as the return type is only allowed in c++14
@@ -29,7 +29,18 @@ template <typename T>
 double
 norm_check_general(char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU);
 
-/*! \brief  Template: norm check for hermitian/symmetric Matrix: float/double/complex */
+/*! \brief  Template: norm check for strided_batched Matrix: half/float/double/complex */
+template <typename T>
+double norm_check_general(char norm_type,
+                          rocblas_int M,
+                          rocblas_int N,
+                          rocblas_int lda,
+                          rocblas_int stride_a,
+                          rocblas_int batch_count,
+                          T* hCPU,
+                          T* hGPU);
+
+/*! \brief  Template: norm check for hermitian/symmetric Matrix: half/float/double/complex */
 
 template <typename T>
 double

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -30,10 +30,15 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     T h_alpha = argus.alpha;
     T h_beta  = argus.beta;
 
-    rocblas_int lda          = argus.lda;
-    rocblas_int ldb          = argus.ldb;
-    rocblas_int ldc          = argus.ldc;
-    rocblas_int batch_count  = argus.batch_count;
+    rocblas_int lda = argus.lda;
+    rocblas_int ldb = argus.ldb;
+    rocblas_int ldc = argus.ldc;
+
+    rocblas_int stride_a    = argus.stride_a;
+    rocblas_int stride_b    = argus.stride_b;
+    rocblas_int stride_c    = argus.stride_c;
+    rocblas_int batch_count = argus.batch_count;
+
     rocblas_operation transA = char2rocblas_operation(argus.transA_option);
     rocblas_operation transB = char2rocblas_operation(argus.transB_option);
 
@@ -49,13 +54,9 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     rocblas_int B_row = transB == rocblas_operation_none ? K : N;
     rocblas_int B_col = transB == rocblas_operation_none ? N : K;
 
-    //  make bsa, bsb, bsc two times minimum size so matrices are non-contiguous
-    rocblas_int bsa = lda * A_col * 2;
-    rocblas_int bsb = ldb * B_col * 2;
-    rocblas_int bsc = ldc * N * 2;
-
     // check here to prevent undefined memory allocation error
-    if(M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 || batch_count <= 0)
+    if(M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 || batch_count <= 0 ||
+       stride_a <= 0 || stride_b <= 0 || stride_c <= 0)
     {
         auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
                                              rocblas_test::device_free};
@@ -81,17 +82,18 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
                                                  &h_alpha,
                                                  dA,
                                                  lda,
-                                                 bsa,
+                                                 stride_a,
                                                  dB,
                                                  ldb,
-                                                 bsb,
+                                                 stride_b,
                                                  &h_beta,
                                                  dC,
                                                  ldc,
-                                                 bsc,
+                                                 stride_c,
                                                  batch_count);
 
-        gemm_strided_batched_arg_check(status, M, N, K, lda, ldb, ldc, batch_count);
+        gemm_strided_batched_arg_check(
+            status, M, N, K, lda, ldb, ldc, stride_a, stride_b, stride_c, batch_count);
 
         return status;
     }
@@ -101,16 +103,27 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
 
     T rocblas_error = 0.0;
 
-    size_t size_A = static_cast<size_t>(bsa) * static_cast<size_t>(batch_count);
-    size_t size_B = static_cast<size_t>(bsb) * static_cast<size_t>(batch_count);
-    size_t size_C = static_cast<size_t>(bsc) * static_cast<size_t>(batch_count);
+    size_t size_one_a = transA == rocblas_operation_none
+                            ? static_cast<size_t>(K) * static_cast<size_t>(lda)
+                            : static_cast<size_t>(M) * static_cast<size_t>(lda);
+    size_t size_one_b = transB == rocblas_operation_none
+                            ? static_cast<size_t>(N) * static_cast<size_t>(ldb)
+                            : static_cast<size_t>(K) * static_cast<size_t>(ldb);
+    size_t size_one_c = N * ldc;
+
+    size_t size_a =
+        size_one_a + static_cast<size_t>(stride_a) * static_cast<size_t>(batch_count - 1);
+    size_t size_b =
+        size_one_b + static_cast<size_t>(stride_b) * static_cast<size_t>(batch_count - 1);
+    size_t size_c =
+        size_one_c + static_cast<size_t>(stride_c) * static_cast<size_t>(batch_count - 1);
 
     // allocate memory on device
-    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_a),
                                          rocblas_test::device_free};
-    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_b),
                                          rocblas_test::device_free};
-    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_c),
                                          rocblas_test::device_free};
     auto d_alpha_managed =
         rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
@@ -121,7 +134,7 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     T* dC      = (T*)dC_managed.get();
     T* d_alpha = (T*)d_alpha_managed.get();
     T* d_beta  = (T*)d_beta_managed.get();
-    if((!dA && (size_A != 0)) || (!dB && (size_B != 0)) || (!dC && (size_C != 0)) || !d_alpha ||
+    if((!dA && (size_a != 0)) || (!dB && (size_b != 0)) || (!dC && (size_c != 0)) || !d_alpha ||
        !d_beta)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
@@ -129,11 +142,11 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    vector<T> hA(size_A);
-    vector<T> hB(size_B);
-    vector<T> hC_1(size_C);
-    vector<T> hC_2(size_C);
-    vector<T> hC_gold(size_C);
+    vector<T> hA(size_a);
+    vector<T> hB(size_b);
+    vector<T> hC_1(size_c);
+    vector<T> hC_2(size_c);
+    vector<T> hC_gold(size_c);
 
     // Initial Data on CPU
     srand(1);
@@ -144,15 +157,15 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
     hC_gold = hC_1;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_a, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_b, hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
     {
         // ROCBLAS rocblas_pointer_mode_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T) * size_c, hipMemcpyHostToDevice));
 
         CHECK_ROCBLAS_ERROR(rocblas_gemm_strided_batched<T>(handle,
                                                             transA,
@@ -163,22 +176,22 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
                                                             &h_alpha,
                                                             dA,
                                                             lda,
-                                                            bsa,
+                                                            stride_a,
                                                             dB,
                                                             ldb,
-                                                            bsb,
+                                                            stride_b,
                                                             &h_beta,
                                                             dC,
                                                             ldc,
-                                                            bsc,
+                                                            stride_c,
                                                             batch_count));
 
-        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * size_c, hipMemcpyDeviceToHost));
 
         // ROCBLAS rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC_2.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_2.data(), sizeof(T) * size_c, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
@@ -191,17 +204,17 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
                                                             d_alpha,
                                                             dA,
                                                             lda,
-                                                            bsa,
+                                                            stride_a,
                                                             dB,
                                                             ldb,
-                                                            bsb,
+                                                            stride_b,
                                                             d_beta,
                                                             dC,
                                                             ldc,
-                                                            bsc,
+                                                            stride_c,
                                                             batch_count));
 
-        CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T) * size_c, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -213,12 +226,12 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
                           N,
                           K,
                           h_alpha,
-                          hA.data() + bsa * i,
+                          hA.data() + stride_a * i,
                           lda,
-                          hB.data() + bsb * i,
+                          hB.data() + stride_b * i,
                           ldb,
                           h_beta,
-                          hC_gold.data() + bsc * i,
+                          hC_gold.data() + stride_c * i,
                           ldc);
         }
         cpu_time_used = get_time_us() - cpu_time_used;
@@ -228,8 +241,8 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N, batch_count, ldc, bsc, hC_gold.data(), hC_1.data());
-            unit_check_general<T>(M, N, batch_count, ldc, bsc, hC_gold.data(), hC_2.data());
+            unit_check_general<T>(M, N, batch_count, ldc, stride_c, hC_gold.data(), hC_1.data());
+            unit_check_general<T>(M, N, batch_count, ldc, stride_c, hC_gold.data(), hC_2.data());
         }
 
         // if enable norm check, norm check is invasive
@@ -262,14 +275,14 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
                                             &h_alpha,
                                             dA,
                                             lda,
-                                            bsa,
+                                            stride_a,
                                             dB,
                                             ldb,
-                                            bsb,
+                                            stride_b,
                                             &h_beta,
                                             dC,
                                             ldc,
-                                            bsc,
+                                            stride_c,
                                             batch_count);
         }
 
@@ -286,21 +299,22 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
                                             &h_alpha,
                                             dA,
                                             lda,
-                                            bsa,
+                                            stride_a,
                                             dB,
                                             ldb,
-                                            bsb,
+                                            stride_b,
                                             &h_beta,
                                             dC,
                                             ldc,
-                                            bsc,
+                                            stride_c,
                                             batch_count);
         }
 
         gpu_time_used  = (get_time_us() - gpu_time_used) / number_hot_calls;
         rocblas_gflops = gemm_gflop_count<T>(M, N, K) * batch_count / gpu_time_used * 1e6;
 
-        cout << "transA,transB,M,N,K,alpha,lda,bsa,ldb,bsb,beta,ldc,bsc,Batch_Count,rocblas-Gflops,"
+        cout << "transA,transB,M,N,K,alpha,lda,stride_a,ldb,stride_b,beta,ldc,stride_c,Batch_Count,"
+                "rocblas-Gflops,"
                 "us";
 
         if(argus.norm_check)
@@ -309,9 +323,9 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
         cout << endl;
 
         cout << argus.transA_option << "," << argus.transB_option << "," << M << "," << N << ","
-             << K << "," << h_alpha << "," << lda << "," << bsa << "," << ldb << "," << bsb << ","
-             << h_beta << "," << ldc << "," << bsc << "," << batch_count << "," << rocblas_gflops
-             << "," << gpu_time_used;
+             << K << "," << h_alpha << "," << lda << "," << stride_a << "," << ldb << ","
+             << stride_b << "," << h_beta << "," << ldc << "," << stride_c << "," << batch_count
+             << "," << rocblas_gflops << "," << gpu_time_used;
 
         if(argus.norm_check)
             cout << "," << cblas_gflops << "," << cpu_time_used << "," << rocblas_error;

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -228,8 +228,8 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N * batch_count, lda, hC_gold.data(), hC_1.data());
-            unit_check_general<T>(M, N * batch_count, lda, hC_gold.data(), hC_2.data());
+            unit_check_general<T>(M, N, batch_count, ldc, bsc, hC_gold.data(), hC_1.data());
+            unit_check_general<T>(M, N, batch_count, ldc, bsc, hC_gold.data(), hC_2.data());
         }
 
         // if enable norm check, norm check is invasive

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -114,11 +114,11 @@ void testing_logging()
     rocblas_int incx         = 1;
     rocblas_int incy         = 1;
     rocblas_int lda          = 1;
-    rocblas_int bsa          = 1;
+    rocblas_int stride_a     = 1;
     rocblas_int ldb          = 1;
-    rocblas_int bsb          = 1;
+    rocblas_int stride_b     = 1;
     rocblas_int ldc          = 1;
-    rocblas_int bsc          = 1;
+    rocblas_int stride_c     = 1;
     rocblas_int batch_count  = 1;
     T alpha                  = 1.0;
     T beta                   = 1.0;
@@ -131,9 +131,9 @@ void testing_logging()
     rocblas_int safe_dim = ((m > n ? m : n) > k ? (m > n ? m : n) : k);
     rocblas_int size_x   = n * incx;
     rocblas_int size_y   = n * incy;
-    rocblas_int size_a   = (lda > bsa ? lda : bsa) * safe_dim * batch_count;
-    rocblas_int size_b   = (ldb > bsb ? ldb : bsb) * safe_dim * batch_count;
-    rocblas_int size_c   = (ldc > bsc ? ldc : bsc) * safe_dim * batch_count;
+    rocblas_int size_a   = (lda > stride_a ? lda : stride_a) * safe_dim * batch_count;
+    rocblas_int size_b   = (ldb > stride_b ? ldb : stride_b) * safe_dim * batch_count;
+    rocblas_int size_c   = (ldc > stride_c ? ldc : stride_c) * safe_dim * batch_count;
 
     // allocate memory on device
     auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
@@ -221,14 +221,14 @@ void testing_logging()
                                                      &alpha,
                                                      da,
                                                      lda,
-                                                     bsa,
+                                                     stride_a,
                                                      db,
                                                      ldb,
-                                                     bsb,
+                                                     stride_b,
                                                      &beta,
                                                      dc,
                                                      ldc,
-                                                     bsc,
+                                                     stride_c,
                                                      batch_count);
         }
 
@@ -547,26 +547,26 @@ void testing_logging()
             trace_ofs2 << "\n"
                        << replaceX<T>("rocblas_Xgemm_strided_batched") << "," << transA << ","
                        << transB << "," << m << "," << n << "," << k << "," << alpha << ","
-                       << (void*)da << "," << lda << "," << bsa << "," << (void*)db << "," << ldb
-                       << "," << bsb << "," << beta << "," << (void*)dc << "," << ldc << "," << bsc
-                       << "," << batch_count;
+                       << (void*)da << "," << lda << "," << stride_a << "," << (void*)db << ","
+                       << ldb << "," << stride_b << "," << beta << "," << (void*)dc << "," << ldc
+                       << "," << stride_c << "," << batch_count;
 
             bench_ofs2 << "\n"
                        << "./rocblas-bench -f gemm_strided_batched -r " << replaceX<T>("X")
                        << " --transposeA " << transA_letter << " --transposeB " << transB_letter
                        << " -m " << m << " -n " << n << " -k " << k << " --alpha " << alpha
-                       << " --lda " << lda << " --bsa " << bsa << " --ldb " << ldb << " --bsb "
-                       << bsb << " --beta " << beta << " --ldc " << ldc << " --bsc " << bsc
-                       << " --batch " << batch_count;
+                       << " --lda " << lda << " --stride_a " << stride_a << " --ldb " << ldb
+                       << " --stride_b " << stride_b << " --beta " << beta << " --ldc " << ldc
+                       << " --stride_c " << stride_c << " --batch " << batch_count;
         }
         else
         {
             trace_ofs2 << "\n"
                        << replaceX<T>("rocblas_Xgemm_strided_batched") << "," << transA << ","
                        << transB << "," << m << "," << n << "," << k << "," << (void*)&alpha << ","
-                       << (void*)da << "," << lda << "," << bsa << "," << (void*)db << "," << ldb
-                       << "," << bsb << "," << (void*)&beta << "," << (void*)dc << "," << ldc << ","
-                       << bsc << "," << batch_count;
+                       << (void*)da << "," << lda << "," << stride_a << "," << (void*)db << ","
+                       << ldb << "," << stride_b << "," << (void*)&beta << "," << (void*)dc << ","
+                       << ldc << "," << stride_c << "," << batch_count;
         }
     }
     // exclude trtri as it is an internal function

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -34,6 +34,15 @@ template <typename T>
 void unit_check_general(rocblas_int M, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU);
 
 template <typename T>
+void unit_check_general(rocblas_int M,
+                        rocblas_int N,
+                        rocblas_int batch_count,
+                        rocblas_int lda,
+                        rocblas_int strideA,
+                        T* hCPU,
+                        T* hGPU);
+
+template <typename T>
 void trsm_err_res_check(T max_error, rocblas_int M, T forward_tolerance, T eps);
 
 #endif

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -154,6 +154,27 @@ void rocblas_init(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
     }
 };
 
+// initialize strided_batched matrix
+template <typename T>
+void rocblas_init(vector<T>& A,
+                  rocblas_int M,
+                  rocblas_int N,
+                  rocblas_int lda,
+                  rocblas_int stride,
+                  rocblas_int batch_count)
+{
+    for(rocblas_int i_batch = 0; i_batch < batch_count; i_batch++)
+    {
+        for(rocblas_int i = 0; i < M; ++i)
+        {
+            for(rocblas_int j = 0; j < N; ++j)
+            {
+                A[i + j * lda + i_batch * stride] = random_generator<T>();
+            }
+        }
+    }
+};
+
 template <typename T>
 void rocblas_init_alternating_sign(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
 {

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -371,9 +371,9 @@ class Arguments
     rocblas_int apiCallCount = 1;
     rocblas_int batch_count  = 10;
 
-    rocblas_int bsa = 128 * 128; //  bsa > transA_option == 'N' ? lda * K : lda * M
-    rocblas_int bsb = 128 * 128; //  bsb > transB_option == 'N' ? ldb * N : ldb * K
-    rocblas_int bsc = 128 * 128; //  bsc > ldc * N
+    rocblas_int stride_a = 128 * 128; //  stride_a > transA_option == 'N' ? lda * K : lda * M
+    rocblas_int stride_b = 128 * 128; //  stride_b > transB_option == 'N' ? ldb * N : ldb * K
+    rocblas_int stride_c = 128 * 128; //  stride_c > ldc * N
 
     rocblas_int norm_check = 0;
     rocblas_int unit_check = 1;

--- a/library/src/blas3/Tensile/gemm.cpp
+++ b/library/src/blas3/Tensile/gemm.cpp
@@ -197,17 +197,17 @@
                   *alpha,                                               \
                   "--lda",                                              \
                   ld_a,                                                 \
-                  "--bsa",                                              \
+                  "--stride_a",                                         \
                   bs_a,                                                 \
                   "--ldb",                                              \
                   ld_b,                                                 \
-                  "--bsb",                                              \
+                  "--stride_b",                                         \
                   bs_b,                                                 \
                   "--beta",                                             \
                   *beta,                                                \
                   "--ldc",                                              \
                   ld_c,                                                 \
-                  "--bsc",                                              \
+                  "--stride_c",                                         \
                   bs_c,                                                 \
                   "--batch",                                            \
                   b_c);                                                 \


### PR DESCRIPTION
rocblas_Xgemm_strided_batched tests modifications for stride_a==0 || stride_b==0. The following needed modifications:
* norm_check_general
* unit_check_general
* rocblas_init

Small changes were also needed in tests to allow for stride_a==0 || stride_b==0 .