### PR TITLE
comment out blas1 complex template functions

### DIFF
--- a/library/src/blas1/rocblas_amax.cpp
+++ b/library/src/blas1/rocblas_amax.cpp
@@ -285,6 +285,7 @@ extern "C" rocblas_status rocblas_idamax(
     return rocblas_iamax_template<double, double>(handle, n, x, incx, result);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_iscamax(rocblas_handle handle,
                                           rocblas_int n,
                                           const rocblas_float_complex* x,
@@ -302,3 +303,4 @@ extern "C" rocblas_status rocblas_idzamax(rocblas_handle handle,
 {
     return rocblas_iamax_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }
+*/

--- a/library/src/blas1/rocblas_amin.cpp
+++ b/library/src/blas1/rocblas_amin.cpp
@@ -281,6 +281,7 @@ extern "C" rocblas_status rocblas_idamin(
     return rocblas_iamin_template<double, double>(handle, n, x, incx, result);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_iscamin(rocblas_handle handle,
                                           rocblas_int n,
                                           const rocblas_float_complex* x,
@@ -298,3 +299,4 @@ extern "C" rocblas_status rocblas_idzamin(rocblas_handle handle,
 {
     return rocblas_iamin_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }
+*/

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -261,6 +261,7 @@ extern "C" rocblas_status rocblas_dasum(
     return rocblas_asum_template<double, double>(handle, n, x, incx, result);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_scasum(rocblas_handle handle,
                                          rocblas_int n,
                                          const rocblas_float_complex* x,
@@ -278,3 +279,4 @@ extern "C" rocblas_status rocblas_dzasum(rocblas_handle handle,
 {
     return rocblas_asum_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }
+*/

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -518,6 +518,7 @@ extern "C" rocblas_status rocblas_daxpy(rocblas_handle handle,
     return rocblas_axpy_template<double>(handle, n, alpha, x, incx, y, incy);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_caxpy(rocblas_handle handle,
                                         rocblas_int n,
                                         const rocblas_float_complex* alpha,
@@ -539,5 +540,4 @@ extern "C" rocblas_status rocblas_zaxpy(rocblas_handle handle,
 {
     return rocblas_axpy_template<rocblas_double_complex>(handle, n, alpha, x, incx, y, incy);
 }
-
-/* ============================================================================================ */
+*/

--- a/library/src/blas1/rocblas_copy.cpp
+++ b/library/src/blas1/rocblas_copy.cpp
@@ -146,6 +146,7 @@ extern "C" rocblas_status rocblas_dcopy(rocblas_handle handle,
     return rocblas_copy_template<double>(handle, n, x, incx, y, incy);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_ccopy(rocblas_handle handle,
                                         rocblas_int n,
                                         const rocblas_float_complex* x,
@@ -167,5 +168,4 @@ extern "C" rocblas_status rocblas_zcopy(rocblas_handle handle,
 
     return rocblas_copy_template<rocblas_double_complex>(handle, n, x, incx, y, incy);
 }
-
-/* ============================================================================================ */
+*/

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -326,6 +326,7 @@ extern "C" rocblas_status rocblas_ddot(rocblas_handle handle,
     return rocblas_dot_template<double>(handle, n, x, incx, y, incy, result);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_cdotu(rocblas_handle handle,
                                         rocblas_int n,
                                         const rocblas_float_complex* x,
@@ -347,3 +348,4 @@ extern "C" rocblas_status rocblas_zdotu(rocblas_handle handle,
 {
     return rocblas_dot_template<rocblas_double_complex>(handle, n, x, incx, y, incy, result);
 }
+*/

--- a/library/src/blas1/rocblas_nrm2.cpp
+++ b/library/src/blas1/rocblas_nrm2.cpp
@@ -257,6 +257,7 @@ extern "C" rocblas_status rocblas_dnrm2(
     return rocblas_nrm2_template<double, double>(handle, n, x, incx, result);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_scnrm2(rocblas_handle handle,
                                          rocblas_int n,
                                          const rocblas_float_complex* x,
@@ -274,3 +275,4 @@ extern "C" rocblas_status rocblas_dznrm2(rocblas_handle handle,
 {
     return rocblas_nrm2_template<rocblas_double_complex, double>(handle, n, x, incx, result);
 }
+*/

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -148,6 +148,7 @@ extern "C" rocblas_status rocblas_dscal(
     return rocblas_scal_template<double>(handle, n, alpha, x, incx);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_cscal(rocblas_handle handle,
                                         rocblas_int n,
                                         const rocblas_float_complex* alpha,
@@ -165,3 +166,4 @@ extern "C" rocblas_status rocblas_zscal(rocblas_handle handle,
 {
     return rocblas_scal_template<rocblas_double_complex>(handle, n, alpha, x, incx);
 }
+*/

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -147,6 +147,7 @@ extern "C" rocblas_status rocblas_dswap(
     return rocblas_swap_template<double>(handle, n, x, incx, y, incy);
 }
 
+/* complex not supported
 extern "C" rocblas_status rocblas_cswap(rocblas_handle handle,
                                         rocblas_int n,
                                         rocblas_float_complex* x,
@@ -168,5 +169,4 @@ extern "C" rocblas_status rocblas_zswap(rocblas_handle handle,
 
     return rocblas_swap_template<rocblas_double_complex>(handle, n, x, incx, y, incy);
 }
-
-/* ============================================================================================ */
+*/


### PR DESCRIPTION
**resolves SWDEV 155606**

- compile errors arise from the Boolean conditional  (complex_float == 0).
- These errors started occurring after recent changes in HIP [ https://github.com/ROCm-Developer-Tools/HIP/pull/466]. 
- Comment out blas1 complex template functions to remove compile error. Complex is currently not implemented in rocBLAS, when it is implemented the complex template functions can be added back.
