### PR TITLE
Correct gemm test matrix initialization

### DIFF
--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -330,9 +330,9 @@ rocblas_status testing_gemm(Arguments argus)
     rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
     rocblas_init<T>(hC_1, M, N, ldc);
 
-    rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
-    rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);
-    rocblas_init<T>(hC_1, M, N, ldc, 1.0);
+    //  rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
+    //  rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);
+    //  rocblas_init<T>(hC_1, M, N, ldc, 1.0);
 
     //  std::cout << "------------------------------------------------" << std::endl;
     //  for(int i = 0; i < size_A; i++){ cout << half_to_float(hA[i]) << "  "; }

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -106,36 +106,37 @@ inline float half_to_float(rocblas_half val)
 /* ============================================================================================ */
 /* generate random number :*/
 
-/*! \brief  generate a random number between [0, 0.999...] . */
+/*! \brief  generate a random number in range [1,2,3,4,5,6,7,8,9,10] */
 template <typename T>
 T random_generator()
 {
     // return rand()/( (T)RAND_MAX + 1);
-    return (T)(rand() % 10 + 1); // generate a integer number between [1, 10]
+    return (T)(rand() % 10 + 1);
 };
 
 // for rocblas_half, generate float, and convert to rocblas_half
+/*! \brief  generate a random number in range [1,2,3] */
 template <>
 inline rocblas_half random_generator<rocblas_half>()
 {
     return float_to_half(
-        static_cast<float>((rand() % 3 + 1))); // generate a integer number between [1, 5]
+        static_cast<float>((rand() % 3 + 1))); // generate a integer number in range [1,2,3]
 };
 
-/*! \brief  generate a random number between [0, 0.999...] . */
+/*! \brief  generate a random number in range [-1,-2,-3,-4,-5,-6,-7,-8,-9,-10] */
 template <typename T>
 T random_generator_negative()
 {
     // return rand()/( (T)RAND_MAX + 1);
-    return -(T)(rand() % 10 + 1); // generate a integer number between [1, 10]
+    return -(T)(rand() % 10 + 1);
 };
 
 // for rocblas_half, generate float, and convert to rocblas_half
+/*! \brief  generate a random number in range [-1,-2,-3] */
 template <>
 inline rocblas_half random_generator_negative<rocblas_half>()
 {
-    return float_to_half(
-        -static_cast<float>((rand() % 5 + 1))); // generate a integer number between [1, 5]
+    return float_to_half(-static_cast<float>((rand() % 3 + 1)));
 };
 
 /* ============================================================================================ */


### PR DESCRIPTION
- In testing_gem.hpp matrices were incorrectly initialized to have all values equal to 1. Change to initialize matrices with random values.
- Correct rocblas_half random values so they are in range (1,2,3) for positive values, and (-1,-2,-3) for negative values.
- Separate rocblas_half known failures for small and tiny matrices.
