### PR TITLE
partial backport of Correct gemm test matrix initialization; updated hip_lite & hgemm_asm_full logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ include( ROCMInstallTargets )
 include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
-rocm_setup_version( VERSION 0.14.2.1 NO_GIT_TAG_VERSION )
+rocm_setup_version( VERSION 0.14.2.2 NO_GIT_TAG_VERSION )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -330,9 +330,9 @@ rocblas_status testing_gemm(Arguments argus)
     rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
     rocblas_init<T>(hC_1, M, N, ldc);
 
-    rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
-    rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);
-    rocblas_init<T>(hC_1, M, N, ldc, 1.0);
+    //  rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
+    //  rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);
+    //  rocblas_init<T>(hC_1, M, N, ldc, 1.0);
 
     //  std::cout << "------------------------------------------------" << std::endl;
     //  for(int i = 0; i < size_A; i++){ cout << half_to_float(hA[i]) << "  "; }

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -106,36 +106,37 @@ inline float half_to_float(rocblas_half val)
 /* ============================================================================================ */
 /* generate random number :*/
 
-/*! \brief  generate a random number between [0, 0.999...] . */
+/*! \brief  generate a random number in range [1,2,3,4,5,6,7,8,9,10] */
 template <typename T>
 T random_generator()
 {
     // return rand()/( (T)RAND_MAX + 1);
-    return (T)(rand() % 10 + 1); // generate a integer number between [1, 10]
+    return (T)(rand() % 10 + 1);
 };
 
 // for rocblas_half, generate float, and convert to rocblas_half
+/*! \brief  generate a random number in range [1,2,3] */
 template <>
 inline rocblas_half random_generator<rocblas_half>()
 {
     return float_to_half(
-        static_cast<float>((rand() % 3 + 1))); // generate a integer number between [1, 5]
+        static_cast<float>((rand() % 3 + 1))); // generate a integer number in range [1,2,3]
 };
 
-/*! \brief  generate a random number between [0, 0.999...] . */
+/*! \brief  generate a random number in range [-1,-2,-3,-4,-5,-6,-7,-8,-9,-10] */
 template <typename T>
 T random_generator_negative()
 {
     // return rand()/( (T)RAND_MAX + 1);
-    return -(T)(rand() % 10 + 1); // generate a integer number between [1, 10]
+    return -(T)(rand() % 10 + 1);
 };
 
 // for rocblas_half, generate float, and convert to rocblas_half
+/*! \brief  generate a random number in range [-1,-2,-3] */
 template <>
 inline rocblas_half random_generator_negative<rocblas_half>()
 {
-    return float_to_half(
-        -static_cast<float>((rand() % 5 + 1))); // generate a integer number between [1, 5]
+    return float_to_half(-static_cast<float>((rand() % 3 + 1)));
 };
 
 /* ============================================================================================ */
@@ -150,6 +151,27 @@ void rocblas_init(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
         for(rocblas_int j = 0; j < N; ++j)
         {
             A[i + j * lda] = random_generator<T>();
+        }
+    }
+};
+
+// initialize strided_batched matrix
+template <typename T>
+void rocblas_init(vector<T>& A,
+                  rocblas_int M,
+                  rocblas_int N,
+                  rocblas_int lda,
+                  rocblas_int stride,
+                  rocblas_int batch_count)
+{
+    for(rocblas_int i_batch = 0; i_batch < batch_count; i_batch++)
+    {
+        for(rocblas_int i = 0; i < M; ++i)
+        {
+            for(rocblas_int j = 0; j < N; ++j)
+            {
+                A[i + j * lda + i_batch * stride] = random_generator<T>();
+            }
         }
     }
 };

--- a/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Ailk_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Ailk_Bjlk_HB.yaml
@@ -179,6 +179,145 @@
     BufferLoad: false
     BufferStore: true
     CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 8
+    LSPB: 4
+    LVCA: 32
+    LVCB: 64
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 3584
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 2560
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x128x08_PGR1_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
     DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
@@ -291,7 +430,7 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 1
+    SolutionIndex: 2
     SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
@@ -311,150 +450,15 @@
     WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
 - [2, 3, 0, 1]
 - []
 - - - -1
     - - - 1
         - - - -1
-            - - [-1, 2]
+            - - [-1, 1]
       - - -1
         - - - 1
-            - - [-1, 1]
+            - - [-1, 2]
           - - -1
-            - - [1, 1]
+            - - [1, 2]
               - [-1, 0]

--- a/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Ailk_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Ailk_Bljk_HB.yaml
@@ -115,7 +115,7 @@
     PersistentKernel: 0
     PreciseBoundsCheck: false
     PrefetchGlobalRead: false
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -153,7 +153,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x16_PGR0_PLR1_TT08_08
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x16_PGR0_PLR0_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -318,14 +318,14 @@
     BufferLoad: false
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 4
+    DepthU: 8
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
     FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthA: 2
     GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
@@ -340,17 +340,17 @@
     GlobalWriteVectorWidth: 1
     InnerUnroll: 1
     KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
+    LSCA: 128
+    LSCB: 8
     LSPA: 4
-    LSPB: 128
+    LSPB: 64
     LVCA: 64
-    LVCB: 2
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 819
+    LVCB: 4
+    LVPA: 2
+    LVPB: 32
+    LdsNumElements: 2048
     LdsOffsetA: 0
-    LdsOffsetB: 256
+    LdsOffsetB: 1024
     LdsPadA: 0
     LdsPadB: 0
     LocalRead2A: true
@@ -362,10 +362,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
+    LoopUnroll: 8
+    MacroTile0: 128
     MacroTile1: 128
-    MacroTileA: 64
+    MacroTileA: 128
     MacroTileB: 128
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -374,14 +374,14 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 1
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 64
+    NumLoadsA: 2
+    NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
     NumThreads: 256
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
@@ -427,15 +427,15 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x04_PGR0_PLR1_TT04_08
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x08_PGR0_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
+    ThreadTile: [8, 8]
+    ThreadTile0: 8
     ThreadTile1: 8
-    ThreadTileA: 4
+    ThreadTileA: 8
     ThreadTileB: 8
     UnrollMemFence: false
     UseSgprForGRO: 0

--- a/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Alik_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Alik_Bjlk_HB.yaml
@@ -115,7 +115,7 @@
     PersistentKernel: 0
     PreciseBoundsCheck: false
     PrefetchGlobalRead: false
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -153,7 +153,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 0
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x08_PGR0_PLR1_TT04_08
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x08_PGR0_PLR0_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -169,6 +169,141 @@
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: -8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 16
+    LSCB: 128
+    LSPA: 32
+    LSPB: 4
+    LVCA: 8
+    LVCB: 64
+    LVPA: 16
+    LVPB: 2
+    LdsNumElements: 4096
+    LdsOffsetA: 0
+    LdsOffsetB: 2048
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 64
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT128x128x16_PGR0_PLR1_TT08_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [8, 8]
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
     WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
@@ -291,7 +426,7 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 1
+    SolutionIndex: 2
     SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x064x08_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
@@ -311,150 +446,15 @@
     WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 4
-    LVCA: 4
-    LVCB: 64
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
 - [2, 3, 0, 1]
 - []
 - - - -1
     - - - 1
         - - - -1
-            - - [-1, 2]
+            - - [-1, 1]
       - - -1
         - - - 1
-            - - [-1, 1]
+            - - [-1, 2]
           - - -1
-            - - [1, 1]
+            - - [1, 2]
               - [-1, 0]

--- a/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Alik_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/hip_Cijk_Alik_Bljk_HB.yaml
@@ -250,7 +250,7 @@
     PersistentKernel: 0
     PreciseBoundsCheck: false
     PrefetchGlobalRead: false
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -288,7 +288,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 1
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x128x04_PGR0_PLR1_TT04_08
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x128x04_PGR0_PLR0_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HB.yaml
@@ -37,22 +37,22 @@
   TransposeB: true
   UseBeta: true
   UseInitialStrides: false
-- - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
+- - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
+    BufferLoad: true
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 8
+    DepthU: 64
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
-    FractionalLoad: false
+    FractionalLoad: 0
     GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
@@ -65,22 +65,22 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
     InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 32
+    KernelLanguage: Assembly
+    LSCA: 64
     LSCB: 16
     LSPA: 8
-    LSPB: 8
-    LVCA: 16
-    LVCB: 16
+    LSPB: 32
+    LVCA: 32
+    LVCB: 8
     LVPA: 4
-    LVPB: 8
-    LdsNumElements: 896
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 128
+    LVPB: 16
+    LdsNumElements: 13312
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 1024
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
     LdsPadA: 0
     LdsPadB: 0
     LocalRead2A: true
@@ -92,10 +92,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
+    LoopUnroll: 64
+    MacroTile0: 64
     MacroTile1: 16
-    MacroTileA: 32
+    MacroTileA: 64
     MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -106,18 +106,18 @@
     NonTemporalC: 0
     NumElementsPerThread: 4
     NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
+    NumLoadsA: 8
+    NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
     PersistentKernel: 0
-    PreciseBoundsCheck: false
+    PreciseBoundsCheck: true
     PrefetchGlobalRead: true
     PrefetchLocalRead: true
     ProblemType:
@@ -157,10 +157,10 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT032x016x08_GRVW02_PBC0_TT02_02_USFGRO00_VW02_WG16_08_01
-    SubGroup0: 16
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x016x64_PGR1_PLR1_TT02_02
+    SubGroup0: 32
     SubGroup1: 8
-    SubGroupA: 16
+    SubGroupA: 32
     SubGroupB: 8
     ThreadTile: [2, 2]
     ThreadTile0: 2
@@ -168,152 +168,13 @@
     ThreadTileA: 2
     ThreadTileB: 2
     UnrollMemFence: false
-    UseSgprForGRO: 0
+    UseSgprForGRO: 1
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 16
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 819
-    LdsNumElementsAlignedA: 128
-    LdsNumElementsAlignedB: 128
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 256
-    LdsOffsetB: 128
-    LdsOffsetB_Blk: 384
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT016x016x08_GRVW02_PBC0_TT02_02_USFGRO00_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
     AssertSummationElementMultiple: 2
@@ -434,8 +295,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT032x016x16_GRVW02_PBC1_TT02_02_USFGRO01_VW02_WG16_08_01
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT032x016x16_PGR1_PLR1_TT02_02
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
@@ -573,8 +434,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 3
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x016x64_GRVW02_PBC1_TT02_02_USFGRO01_VW02_WG32_08_01
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x016x64_PGR1_PLR1_TT02_02
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -591,145 +452,6 @@
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 16
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: true
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT016x016x32_GRVW02_PBC1_TT02_02_USFGRO01_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -851,8 +573,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 5
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x08_GRVW08_PBC0_TT08_08_USFGRO00_VW08_WG08_08_01
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x08_PGR1_PLR1_TT08_08
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -869,701 +591,6 @@
     VectorStore: true
     VectorWidth: 8
     WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 16
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: true
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 6
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT032x016x32_GRVW02_PBC1_TT02_02_USFGRO01_VW02_WG16_08_01
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 16
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: true
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT016x016x16_GRVW02_PBC1_TT02_02_USFGRO01_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT128x064x08_GRVW04_PBC0_TT08_04_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 9
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x16_GRVW04_PBC0_TT04_04_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x32_GRVW04_PBC0_TT04_04_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -1685,8 +712,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x128x16_GRVW04_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 4
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x128x16_PGR1_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -1824,8 +851,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 12
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT128x064x16_GRVW04_PBC0_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 5
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT128x064x16_PGR1_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -1963,8 +990,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 13
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x16_GRVW04_PBC0_TT04_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 6
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -2102,8 +1129,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 14
-    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT128x128x16_GRVW08_PBC0_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 7
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT128x128x16_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -2122,645 +1149,1814 @@
     WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 8
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x32_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 8
+    LSPB: 4
+    LVCA: 32
+    LVCB: 64
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 1536
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 9
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x128x08_PGR0_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 10
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x08_PGR0_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 11
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x08_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 12
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x08_PGR0_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 13
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x16_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 14
+    SolutionNameMin: Cijk_Ailk_Bjlk_HB_MT064x064x04_PGR0_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
 - [2, 3, 0, 1]
 - - - [4096, 7133, 1, 4096]
-    - [14, 19051.2]
+    - [7, 19077.9]
   - - [512, 16, 1, 512]
-    - [7, 299.593]
+    - [1, 297.88]
   - - [2048, 7133, 1, 2048]
-    - [14, 18735.9]
+    - [7, 18702.2]
   - - [2560, 7133, 1, 2560]
-    - [12, 18675.2]
+    - [5, 18676.4]
   - - [1024, 1024, 1, 1024]
-    - [12, 14278.3]
+    - [5, 14263.1]
   - - [3072, 7435, 1, 1024]
-    - [5, 18546.7]
+    - [3, 18565.6]
   - - [1024, 32, 1, 512]
-    - [3, 1226.4]
+    - [0, 1226.4]
   - - [1760, 7133, 1, 1760]
-    - [11, 17778.3]
+    - [5, 17782.9]
   - - [7680, 5481, 1, 2560]
-    - [14, 18834.0]
+    - [7, 18833.0]
   - - [1024, 16, 1, 512]
-    - [2, 579.324]
+    - [1, 592.416]
   - - [512, 32, 1, 512]
-    - [6, 639.376]
+    - [2, 631.649]
 - - - -1
-    - - - 128
-        - - - 4
-            - - [-1, 1]
-          - - 64
-            - - [4, 1]
-              - [64, 0]
-              - [128, 1]
-              - [704, 0]
-              - [1024, 1]
-              - [2944, 0]
-              - [3584, 1]
-              - [4288, 9]
-              - [5888, 0]
-              - [-1, 9]
-          - - 128
-            - - [64, 1]
-              - [256, 0]
-              - [448, 1]
-              - [704, 0]
-              - [1408, 1]
-              - [1856, 0]
-              - [2368, 9]
-              - [2944, 0]
-              - [5888, 9]
-              - [-1, 8]
-          - - 256
-            - - [4, 1]
-              - [64, 0]
-              - [448, 1]
-              - [-1, 9]
-          - - 448
-            - - [4, 1]
-              - [64, 0]
-              - [128, 1]
-              - [448, 0]
-              - [2368, 9]
-              - [2944, 8]
-              - [-1, 9]
-          - - 704
-            - - [128, 1]
-              - [704, 9]
-              - [1024, 8]
-              - [1408, 9]
-              - [1856, 8]
-              - [-1, 9]
-          - - 1024
-            - - [64, 1]
-              - [128, 0]
-              - [704, 9]
-              - [1024, 8]
-              - [2944, 9]
-              - [3584, 8]
-              - [4288, 9]
-              - [-1, 8]
-          - - 1408
-            - - [128, 1]
-              - [1408, 9]
-              - [1856, 8]
-              - [4288, 9]
-              - [-1, 8]
-          - - 1856
-            - - [64, 1]
-              - [128, 0]
-              - [-1, 9]
-          - - 2368
-            - - [64, 1]
-              - [-1, 9]
-          - - 2944
-            - - [4, 1]
-              - [128, 0]
-              - [256, 9]
-              - [448, 8]
-              - [1408, 9]
-              - [2368, 8]
-              - [3584, 9]
-              - [5888, 8]
-              - [-1, 9]
-          - - 3584
-            - - [4, 1]
-              - [64, 0]
-              - [2368, 9]
-              - [-1, 8]
-          - - 4288
-            - - [4, 1]
-              - [64, 0]
-              - [1024, 9]
-              - [1408, 8]
-              - [2944, 9]
-              - [-1, 8]
-          - - 5056
-            - - [4, 1]
-              - [64, 0]
-              - [128, 9]
-              - [256, 8]
-              - [448, 9]
-              - [704, 8]
-              - [1024, 9]
-              - [1408, 8]
-              - [2944, 9]
-              - [-1, 8]
-          - - 5888
-            - - [4, 1]
-              - [64, 0]
-              - [128, 9]
-              - [256, 8]
-              - [448, 9]
-              - [704, 8]
-              - [1024, 9]
-              - [-1, 8]
-          - - -1
-            - - [4, 1]
-              - [1408, 9]
-              - [-1, 8]
-      - - 256
-        - - - 4
-            - - [4, 7]
-              - [64, 4]
-              - [128, 7]
-              - [704, 4]
-              - [-1, 7]
-          - - 64
-            - - [64, 7]
-              - [1024, 2]
-              - [1408, 4]
-              - [1856, 2]
-              - [2368, 6]
-              - [3584, 7]
-              - [-1, 13]
-          - - 128
-            - - [4, 4]
-              - [1024, 2]
-              - [1408, 7]
-              - [1856, 2]
-              - [5888, 13]
-              - [-1, 10]
-          - - 256
-            - - [4, 4]
-              - [448, 2]
-              - [2944, 13]
-              - [3584, 10]
-              - [-1, 13]
-          - - 448
-            - - [4, 4]
-              - [64, 7]
-              - [256, 2]
-              - [448, 6]
-              - [2368, 13]
-              - [2944, 11]
-              - [3584, 13]
-              - [4288, 11]
-              - [5888, 13]
-              - [-1, 11]
-          - - 704
-            - - [4, 4]
-              - [64, 3]
-              - [128, 2]
-              - [1024, 13]
-              - [1408, 10]
-              - [2368, 13]
-              - [5056, 11]
-              - [-1, 5]
-          - - 1024
-            - - [4, 7]
-              - [64, 6]
-              - [128, 2]
-              - [1408, 13]
-              - [2944, 12]
-              - [4288, 13]
-              - [-1, 14]
-          - - 1408
-            - - [4, 7]
-              - [64, 2]
-              - [128, 7]
-              - [704, 13]
-              - [1856, 12]
-              - [2368, 13]
-              - [3584, 14]
-              - [4288, 5]
-              - [5056, 14]
-              - [5888, 5]
-              - [-1, 12]
-          - - 1856
-            - - [4, 7]
-              - [64, 2]
-              - [256, 13]
-              - [448, 12]
-              - [704, 13]
-              - [1856, 11]
-              - [2368, 13]
-              - [3584, 11]
-              - [5056, 5]
-              - [-1, 11]
-          - - 2368
-            - - [4, 7]
-              - [64, 6]
-              - [704, 13]
-              - [1024, 11]
-              - [1856, 13]
-              - [2368, 11]
-              - [2944, 5]
-              - [3584, 12]
-              - [5056, 5]
-              - [5888, 11]
-              - [-1, 14]
-          - - 2944
-            - - [4, 7]
-              - [64, 2]
-              - [128, 13]
-              - [256, 10]
-              - [448, 13]
-              - [704, 12]
-              - [1024, 11]
-              - [1408, 14]
-              - [1856, 12]
-              - [2368, 14]
-              - [2944, 12]
-              - [3584, 11]
-              - [4288, 12]
-              - [5056, 5]
-              - [-1, 14]
-          - - 3584
-            - - [4, 7]
-              - [64, 2]
-              - [448, 13]
-              - [704, 12]
-              - [1024, 11]
-              - [1408, 14]
-              - [2944, 12]
-              - [3584, 14]
-              - [5056, 5]
-              - [-1, 14]
-          - - 4288
-            - - [4, 4]
-              - [256, 13]
+    - - - 1
+        - - - 32
+            - - [64, 14]
+              - [128, 12]
+              - [448, 14]
               - [1024, 12]
-              - [2368, 5]
-              - [2944, 11]
-              - [3584, 14]
-              - [5056, 5]
-              - [5888, 14]
-              - [-1, 5]
-          - - 5056
-            - - [4, 7]
-              - [448, 13]
+              - [1408, 13]
+              - [1856, 12]
+              - [2944, 14]
+              - [3584, 12]
+              - [4288, 13]
+              - [5056, 14]
+              - [5888, 13]
+              - [-1, 14]
+          - - 64
+            - - [32, 13]
+              - [64, 12]
+              - [448, 14]
               - [704, 12]
-              - [5056, 5]
-              - [5888, 14]
-              - [-1, 5]
-          - - 5888
-            - - [4, 7]
-              - [128, 13]
+              - [1408, 13]
+              - [2368, 14]
+              - [5056, 12]
+              - [-1, 14]
+          - - 128
+            - - [64, 12]
+              - [128, 14]
               - [256, 12]
-              - [448, 13]
-              - [1024, 5]
-              - [1408, 14]
+              - [704, 14]
               - [2368, 12]
               - [3584, 14]
-              - [5056, 5]
+              - [4288, 12]
               - [-1, 14]
-          - - -1
-            - - [4, 4]
-              - [256, 13]
+          - - 256
+            - - [32, 14]
+              - [64, 12]
+              - [256, 14]
+              - [448, 12]
+              - [1024, 13]
+              - [1856, 12]
+              - [2944, 14]
+              - [3584, 12]
+              - [4288, 14]
+              - [5056, 12]
+              - [-1, 14]
+          - - 448
+            - - [64, 14]
+              - [256, 12]
+              - [448, 14]
+              - [1024, 12]
+              - [1408, 13]
+              - [1856, 14]
+              - [4288, 12]
+              - [5056, 14]
+              - [-1, 12]
+          - - 704
+            - - [32, 12]
+              - [64, 14]
               - [448, 12]
               - [704, 13]
-              - [1024, 14]
-              - [1856, 12]
-              - [2368, 5]
-              - [3584, 14]
-              - [5056, 5]
-              - [-1, 14]
-      - - 1280
-        - - - 4
-            - - [-1, 4]
-          - - 64
-            - - [64, 4]
-              - [256, 6]
-              - [1408, 4]
-              - [1856, 3]
-              - [2368, 6]
-              - [2944, 2]
-              - [3584, 10]
-              - [-1, 13]
-          - - 128
-            - - [4, 4]
-              - [128, 6]
-              - [704, 4]
-              - [1024, 3]
-              - [1408, 13]
-              - [1856, 10]
-              - [5056, 13]
-              - [-1, 10]
-          - - 256
-            - - [4, 4]
-              - [64, 6]
-              - [128, 4]
-              - [256, 6]
-              - [448, 3]
-              - [2368, 13]
-              - [2944, 10]
-              - [5056, 13]
-              - [5888, 12]
-              - [-1, 13]
-          - - 448
-            - - [128, 4]
-              - [256, 3]
-              - [448, 13]
-              - [704, 10]
-              - [1024, 13]
-              - [1408, 10]
-              - [2368, 13]
-              - [2944, 11]
-              - [3584, 13]
-              - [4288, 11]
-              - [5888, 13]
-              - [-1, 11]
-          - - 704
-            - - [64, 4]
-              - [128, 6]
-              - [2368, 13]
-              - [5056, 11]
-              - [5888, 5]
-              - [-1, 14]
+              - [1024, 12]
+              - [2944, 14]
+              - [4288, 12]
+              - [5056, 14]
+              - [-1, 12]
           - - 1024
-            - - [64, 4]
-              - [128, 6]
-              - [704, 13]
-              - [1024, 10]
-              - [3584, 12]
-              - [4288, 13]
+            - - [64, 14]
+              - [128, 12]
+              - [256, 13]
+              - [448, 14]
+              - [1856, 12]
               - [-1, 14]
           - - 1408
-            - - [4, 4]
-              - [128, 6]
-              - [448, 13]
-              - [704, 12]
-              - [1024, 11]
-              - [1856, 12]
-              - [2368, 13]
-              - [5888, 14]
-              - [-1, 11]
-          - - 1856
-            - - [4, 4]
-              - [64, 3]
-              - [704, 13]
+            - - [32, 13]
+              - [128, 14]
+              - [448, 12]
+              - [704, 14]
               - [1024, 12]
-              - [1408, 11]
-              - [1856, 12]
-              - [2368, 13]
-              - [3584, 11]
+              - [1856, 14]
+              - [2944, 12]
               - [4288, 14]
-              - [5056, 5]
-              - [-1, 11]
-          - - 2368
-            - - [4, 4]
-              - [64, 6]
-              - [704, 13]
-              - [1024, 11]
-              - [1856, 13]
-              - [2368, 11]
-              - [2944, 14]
-              - [3584, 11]
-              - [4288, 5]
-              - [5056, 14]
-              - [-1, 11]
-          - - 2944
-            - - [4, 4]
-              - [64, 13]
-              - [128, 10]
-              - [256, 13]
+              - [5056, 12]
+              - [-1, 14]
+          - - 1856
+            - - [64, 14]
               - [704, 12]
-              - [1408, 14]
+              - [1024, 14]
+              - [1408, 12]
+              - [1856, 14]
+              - [2944, 12]
+              - [-1, 14]
+          - - 2368
+            - - [64, 14]
+              - [256, 12]
+              - [704, 14]
               - [1856, 12]
               - [2368, 14]
-              - [2944, 11]
+              - [2944, 12]
+              - [3584, 14]
               - [5056, 12]
               - [5888, 14]
               - [-1, 12]
-          - - 3584
-            - - [4, 4]
-              - [128, 13]
-              - [256, 10]
-              - [448, 13]
-              - [1024, 12]
-              - [1408, 14]
-              - [1856, 12]
-              - [2368, 11]
-              - [2944, 12]
-              - [3584, 11]
-              - [4288, 14]
-              - [5056, 12]
-              - [-1, 11]
-          - - 4288
-            - - [4, 4]
-              - [256, 13]
-              - [704, 12]
-              - [1024, 13]
+          - - 2944
+            - - [32, 14]
+              - [64, 13]
+              - [1024, 14]
+              - [1408, 12]
               - [1856, 14]
-              - [2368, 5]
-              - [2944, 11]
-              - [3584, 14]
-              - [5056, 5]
-              - [5888, 11]
-              - [-1, 5]
-          - - 5056
-            - - [4, 4]
-              - [448, 13]
-              - [704, 12]
-              - [1408, 14]
-              - [1856, 5]
-              - [2368, 14]
-              - [3584, 11]
-              - [4288, 5]
-              - [5888, 14]
-              - [-1, 5]
-          - - 5888
-            - - [4, 4]
-              - [448, 13]
-              - [704, 12]
-              - [1408, 14]
-              - [2368, 12]
-              - [2944, 14]
-              - [5056, 12]
-              - [-1, 14]
-          - - -1
-            - - [4, 4]
+              - [4288, 12]
+              - [5056, 14]
+              - [-1, 12]
+          - - 3584
+            - - [32, 12]
               - [64, 13]
               - [128, 12]
               - [256, 13]
-              - [448, 12]
-              - [1024, 14]
-              - [3584, 12]
-              - [5056, 5]
+              - [1024, 12]
+              - [1408, 14]
+              - [2368, 12]
+              - [2944, 14]
+              - [4288, 12]
+              - [5056, 14]
+              - [-1, 12]
+          - - 4288
+            - - [32, 14]
+              - [64, 12]
+              - [128, 13]
+              - [256, 12]
+              - [704, 14]
+              - [1856, 12]
+              - [4288, 14]
+              - [5888, 12]
               - [-1, 14]
-      - - -1
-        - - - 4
-            - - [-1, 4]
-          - - 64
-            - - [256, 4]
-              - [448, 6]
-              - [704, 4]
-              - [1408, 6]
-              - [1856, 3]
-              - [2368, 6]
-              - [4288, 10]
-              - [5056, 13]
-              - [-1, 10]
-          - - 128
-            - - [4, 4]
-              - [64, 6]
-              - [256, 4]
-              - [704, 6]
-              - [1024, 3]
-              - [1856, 10]
-              - [2368, 13]
-              - [2944, 10]
-              - [4288, 13]
+          - - 5056
+            - - [32, 12]
+              - [448, 14]
+              - [704, 12]
+              - [1024, 14]
+              - [1408, 12]
+              - [-1, 14]
+          - - 5888
+            - - [64, 14]
+              - [128, 12]
+              - [448, 14]
+              - [704, 12]
+              - [1024, 14]
+              - [1856, 12]
+              - [2944, 14]
+              - [3584, 12]
+              - [5056, 14]
+              - [5888, 12]
+              - [-1, 14]
+          - - -1
+            - - [64, 14]
+              - [256, 12]
+              - [704, 14]
+              - [2944, 12]
+              - [3584, 14]
+              - [5056, 12]
+              - [-1, 14]
+      - - 32
+        - - - 32
+            - - [32, 10]
+              - [128, 11]
+              - [256, 10]
+              - [704, 11]
+              - [1408, 10]
+              - [2368, 11]
+              - [2944, 8]
+              - [3584, 10]
+              - [5056, 11]
               - [5888, 10]
               - [-1, 11]
-          - - 256
-            - - [4, 4]
-              - [64, 6]
-              - [256, 4]
-              - [448, 3]
-              - [1024, 10]
-              - [1408, 13]
-              - [1856, 10]
-              - [2368, 13]
-              - [2944, 10]
-              - [3584, 12]
-              - [5056, 13]
-              - [5888, 11]
-              - [-1, 13]
-          - - 448
-            - - [128, 4]
-              - [256, 3]
-              - [448, 10]
-              - [1408, 13]
-              - [1856, 12]
-              - [2368, 13]
-              - [2944, 11]
-              - [3584, 13]
-              - [4288, 11]
-              - [5888, 13]
-              - [-1, 11]
-          - - 704
-            - - [4, 4]
-              - [128, 6]
-              - [256, 10]
-              - [1024, 13]
-              - [1408, 11]
-              - [2368, 13]
-              - [5888, 11]
-              - [-1, 14]
-          - - 1024
-            - - [64, 4]
-              - [128, 3]
-              - [448, 10]
-              - [704, 13]
-              - [1024, 11]
-              - [2368, 12]
-              - [2944, 14]
-              - [3584, 12]
-              - [4288, 13]
-              - [-1, 14]
-          - - 1408
-            - - [4, 4]
-              - [64, 6]
-              - [128, 10]
-              - [256, 13]
-              - [448, 10]
-              - [1856, 12]
-              - [2368, 13]
-              - [5888, 14]
-              - [-1, 11]
-          - - 1856
-            - - [4, 4]
-              - [64, 3]
-              - [128, 10]
-              - [256, 13]
-              - [448, 11]
-              - [704, 13]
-              - [1856, 11]
-              - [2368, 13]
-              - [3584, 11]
-              - [4288, 14]
-              - [5056, 5]
-              - [-1, 11]
-          - - 2368
-            - - [4, 4]
-              - [64, 6]
-              - [704, 13]
-              - [1024, 11]
-              - [1856, 13]
+          - - 64
+            - - [32, 11]
+              - [128, 8]
+              - [256, 11]
+              - [704, 8]
+              - [1408, 10]
+              - [1856, 8]
               - [2368, 11]
-              - [2944, 14]
-              - [3584, 11]
-              - [4288, 5]
-              - [5056, 14]
+              - [2944, 10]
+              - [3584, 8]
+              - [5056, 11]
+              - [-1, 10]
+          - - 128
+            - - [1024, 11]
+              - [1408, 8]
+              - [2368, 11]
+              - [2944, 10]
               - [-1, 11]
-          - - 2944
-            - - [4, 4]
-              - [128, 10]
-              - [256, 13]
+          - - 256
+            - - [64, 11]
+              - [128, 8]
+              - [256, 11]
+              - [448, 10]
+              - [704, 11]
+              - [1024, 10]
+              - [2368, 11]
+              - [2944, 10]
+              - [4288, 11]
+              - [-1, 10]
+          - - 448
+            - - [64, 11]
+              - [128, 8]
+              - [256, 10]
               - [448, 11]
-              - [704, 12]
-              - [1408, 14]
-              - [1856, 12]
-              - [2368, 14]
-              - [2944, 12]
-              - [3584, 11]
-              - [5056, 12]
-              - [5888, 14]
-              - [-1, 11]
+              - [704, 10]
+              - [1856, 11]
+              - [2368, 10]
+              - [2944, 9]
+              - [3584, 10]
+              - [4288, 9]
+              - [-1, 10]
+          - - 704
+            - - [64, 10]
+              - [128, 8]
+              - [256, 11]
+              - [448, 8]
+              - [704, 11]
+              - [2368, 10]
+              - [2944, 9]
+              - [3584, 10]
+              - [4288, 9]
+              - [5056, 10]
+              - [-1, 9]
+          - - 1024
+            - - [64, 10]
+              - [128, 8]
+              - [448, 10]
+              - [1024, 11]
+              - [1856, 9]
+              - [5888, 10]
+              - [-1, 9]
+          - - 1408
+            - - [32, 10]
+              - [64, 11]
+              - [256, 8]
+              - [448, 10]
+              - [704, 11]
+              - [1408, 9]
+              - [2368, 10]
+              - [2944, 9]
+              - [4288, 10]
+              - [5056, 9]
+              - [-1, 10]
+          - - 1856
+            - - [64, 10]
+              - [128, 11]
+              - [256, 10]
+              - [448, 11]
+              - [1024, 9]
+              - [2944, 10]
+              - [4288, 9]
+              - [5056, 10]
+              - [-1, 9]
+          - - 2368
+            - - [128, 10]
+              - [256, 11]
+              - [448, 10]
+              - [704, 9]
+              - [1408, 10]
+              - [1856, 9]
+              - [2944, 10]
+              - [3584, 9]
+              - [4288, 10]
+              - [-1, 9]
+          - - 2944
+            - - [32, 10]
+              - [64, 11]
+              - [128, 10]
+              - [256, 11]
+              - [448, 10]
+              - [704, 11]
+              - [1024, 10]
+              - [1408, 9]
+              - [2368, 10]
+              - [2944, 9]
+              - [3584, 10]
+              - [-1, 9]
           - - 3584
-            - - [4, 4]
-              - [128, 10]
-              - [256, 12]
-              - [448, 13]
-              - [1024, 12]
-              - [1408, 14]
-              - [2368, 12]
-              - [2944, 11]
-              - [3584, 12]
-              - [4288, 14]
-              - [5056, 12]
-              - [5888, 11]
-              - [-1, 12]
+            - - [32, 11]
+              - [1408, 10]
+              - [1856, 9]
+              - [2368, 10]
+              - [-1, 9]
           - - 4288
-            - - [4, 4]
-              - [128, 10]
-              - [256, 13]
-              - [704, 12]
-              - [1024, 13]
-              - [1856, 14]
-              - [2368, 5]
-              - [2944, 11]
-              - [3584, 14]
-              - [5056, 5]
-              - [5888, 11]
-              - [-1, 5]
+            - - [32, 8]
+              - [64, 10]
+              - [128, 11]
+              - [704, 10]
+              - [1408, 9]
+              - [1856, 10]
+              - [-1, 9]
           - - 5056
-            - - [4, 4]
-              - [128, 10]
-              - [448, 13]
-              - [704, 12]
-              - [1408, 14]
-              - [1856, 5]
-              - [2368, 14]
-              - [3584, 11]
-              - [4288, 5]
-              - [5056, 14]
-              - [5888, 11]
-              - [-1, 5]
+            - - [32, 8]
+              - [128, 11]
+              - [1024, 10]
+              - [1856, 9]
+              - [2368, 10]
+              - [3584, 9]
+              - [4288, 10]
+              - [-1, 9]
           - - 5888
-            - - [4, 4]
-              - [64, 10]
-              - [128, 13]
-              - [256, 12]
-              - [448, 13]
-              - [704, 12]
-              - [1408, 14]
-              - [2368, 12]
-              - [2944, 14]
-              - [3584, 11]
-              - [5056, 12]
-              - [-1, 14]
+            - - [64, 10]
+              - [128, 11]
+              - [256, 9]
+              - [1024, 10]
+              - [-1, 9]
           - - -1
-            - - [4, 4]
-              - [64, 10]
-              - [128, 12]
-              - [256, 13]
-              - [448, 12]
-              - [1024, 14]
-              - [1408, 11]
-              - [2368, 12]
+            - - [64, 10]
+              - [128, 11]
+              - [704, 10]
+              - [-1, 9]
+      - - 256
+        - - - 1
+            - - [-1, 13]
+          - - 32
+            - - [448, 11]
+              - [704, 8]
+              - [1024, 11]
+              - [1408, 8]
+              - [4288, 11]
+              - [5888, 8]
+              - [-1, 11]
+          - - 64
+            - - [1, 13]
+              - [32, 11]
+              - [128, 1]
+              - [256, 0]
+              - [2944, 1]
+              - [3584, 6]
+              - [4288, 1]
+              - [-1, 6]
+          - - 128
+            - - [1, 13]
+              - [32, 11]
+              - [1408, 1]
+              - [-1, 6]
+          - - 256
+            - - [1, 13]
+              - [32, 11]
+              - [448, 1]
+              - [5888, 6]
+              - [-1, 4]
+          - - 448
+            - - [1, 13]
+              - [32, 11]
+              - [448, 1]
+              - [3584, 6]
+              - [4288, 4]
+              - [5888, 6]
+              - [-1, 4]
+          - - 704
+            - - [1, 13]
+              - [32, 11]
+              - [64, 0]
+              - [128, 1]
+              - [2368, 6]
+              - [5056, 4]
+              - [-1, 3]
+          - - 1024
+            - - [1, 13]
+              - [32, 8]
+              - [64, 0]
+              - [128, 1]
+              - [1024, 6]
+              - [2368, 5]
+              - [2944, 7]
+              - [3584, 5]
+              - [4288, 6]
+              - [-1, 3]
+          - - 1408
+            - - [1, 13]
+              - [32, 11]
+              - [128, 1]
+              - [448, 6]
+              - [1856, 5]
+              - [2368, 6]
+              - [3584, 7]
+              - [5888, 3]
+              - [-1, 4]
+          - - 1856
+            - - [1, 13]
+              - [32, 11]
+              - [128, 1]
+              - [704, 6]
+              - [1408, 4]
+              - [1856, 5]
+              - [2944, 6]
+              - [3584, 4]
+              - [5056, 3]
+              - [5888, 4]
+              - [-1, 5]
+          - - 2368
+            - - [1, 13]
+              - [32, 11]
+              - [64, 1]
+              - [704, 6]
+              - [1024, 4]
+              - [1856, 6]
+              - [2368, 4]
+              - [2944, 3]
+              - [3584, 4]
+              - [-1, 3]
+          - - 2944
+            - - [1, 13]
+              - [32, 10]
+              - [64, 1]
+              - [448, 6]
+              - [704, 5]
+              - [1408, 3]
+              - [1856, 6]
+              - [2368, 3]
+              - [2944, 5]
+              - [3584, 4]
+              - [4288, 5]
+              - [5056, 3]
+              - [-1, 7]
+          - - 3584
+            - - [1, 13]
+              - [32, 11]
+              - [448, 6]
+              - [704, 5]
+              - [1024, 4]
+              - [1408, 7]
+              - [2368, 5]
+              - [2944, 4]
+              - [3584, 7]
+              - [5056, 3]
+              - [-1, 7]
+          - - 4288
+            - - [1, 13]
+              - [32, 11]
+              - [256, 6]
+              - [448, 5]
+              - [704, 6]
+              - [1024, 4]
+              - [5056, 3]
+              - [5888, 7]
+              - [-1, 3]
+          - - 5056
+            - - [1, 13]
+              - [32, 8]
+              - [448, 6]
+              - [704, 5]
+              - [2368, 3]
+              - [2944, 4]
+              - [3584, 7]
+              - [5056, 3]
+              - [5888, 7]
+              - [-1, 3]
+          - - 5888
+            - - [1, 13]
+              - [32, 8]
+              - [448, 6]
+              - [704, 3]
+              - [1408, 7]
+              - [2368, 5]
+              - [3584, 7]
+              - [5056, 3]
+              - [-1, 7]
+          - - -1
+            - - [1, 13]
+              - [32, 8]
+              - [256, 6]
+              - [448, 5]
+              - [704, 3]
+              - [1024, 7]
+              - [1408, 4]
+              - [1856, 5]
+              - [2368, 3]
+              - [3584, 7]
+              - [5056, 3]
+              - [-1, 7]
+      - - 1280
+        - - - 1
+            - - [-1, 13]
+          - - 32
+            - - [704, 8]
+              - [1856, 11]
+              - [2368, 8]
               - [3584, 11]
+              - [-1, 8]
+          - - 64
+            - - [1, 13]
+              - [32, 8]
+              - [64, 1]
+              - [704, 2]
+              - [1024, 1]
+              - [1856, 2]
+              - [2944, 1]
+              - [-1, 6]
+          - - 128
+            - - [1, 13]
+              - [32, 8]
+              - [64, 0]
+              - [256, 2]
+              - [448, 0]
+              - [704, 2]
+              - [1024, 0]
+              - [5888, 6]
+              - [-1, 4]
+          - - 256
+            - - [1, 13]
+              - [32, 8]
+              - [64, 2]
+              - [128, 0]
+              - [256, 1]
+              - [448, 2]
+              - [2944, 6]
+              - [3584, 4]
+              - [5056, 6]
+              - [5888, 4]
+              - [-1, 6]
+          - - 448
+            - - [1, 13]
+              - [32, 11]
+              - [128, 2]
+              - [256, 0]
+              - [2368, 6]
+              - [2944, 4]
+              - [3584, 6]
+              - [4288, 4]
+              - [5888, 6]
+              - [-1, 4]
+          - - 704
+            - - [1, 13]
+              - [32, 11]
+              - [64, 0]
+              - [128, 1]
+              - [2368, 6]
+              - [5056, 4]
+              - [5888, 3]
+              - [-1, 6]
+          - - 1024
+            - - [1, 13]
+              - [32, 11]
+              - [64, 1]
+              - [128, 0]
+              - [1024, 6]
+              - [3584, 5]
+              - [4288, 6]
+              - [-1, 7]
+          - - 1408
+            - - [1, 13]
+              - [32, 11]
+              - [64, 0]
+              - [448, 6]
+              - [704, 5]
+              - [1408, 4]
+              - [1856, 5]
+              - [2368, 6]
+              - [5888, 7]
+              - [-1, 4]
+          - - 1856
+            - - [1, 13]
+              - [32, 8]
+              - [64, 0]
+              - [704, 6]
+              - [1856, 4]
+              - [2944, 6]
+              - [3584, 4]
+              - [4288, 7]
+              - [5056, 3]
+              - [-1, 4]
+          - - 2368
+            - - [1, 13]
+              - [32, 8]
+              - [64, 1]
+              - [704, 6]
+              - [1024, 4]
+              - [1856, 6]
+              - [2368, 5]
+              - [2944, 7]
+              - [3584, 5]
+              - [4288, 3]
+              - [5056, 7]
+              - [-1, 4]
+          - - 2944
+            - - [1, 13]
+              - [32, 8]
+              - [256, 6]
+              - [704, 5]
+              - [1408, 7]
+              - [1856, 5]
+              - [2368, 7]
               - [5056, 5]
-              - [-1, 14]
+              - [5888, 7]
+              - [-1, 4]
+          - - 3584
+            - - [1, 13]
+              - [32, 11]
+              - [448, 6]
+              - [1024, 5]
+              - [1408, 7]
+              - [1856, 5]
+              - [2368, 4]
+              - [3584, 5]
+              - [4288, 7]
+              - [5888, 5]
+              - [-1, 4]
+          - - 4288
+            - - [1, 13]
+              - [32, 8]
+              - [256, 6]
+              - [704, 5]
+              - [1024, 4]
+              - [1856, 7]
+              - [2368, 3]
+              - [2944, 4]
+              - [3584, 7]
+              - [5056, 3]
+              - [5888, 4]
+              - [-1, 3]
+          - - 5056
+            - - [1, 13]
+              - [32, 8]
+              - [448, 6]
+              - [704, 5]
+              - [1408, 7]
+              - [1856, 3]
+              - [2368, 7]
+              - [3584, 4]
+              - [4288, 3]
+              - [5888, 7]
+              - [-1, 3]
+          - - 5888
+            - - [1, 13]
+              - [32, 8]
+              - [128, 6]
+              - [256, 5]
+              - [448, 6]
+              - [704, 3]
+              - [1408, 7]
+              - [2368, 5]
+              - [2944, 7]
+              - [3584, 4]
+              - [4288, 5]
+              - [-1, 7]
+          - - -1
+            - - [1, 13]
+              - [32, 8]
+              - [256, 6]
+              - [448, 5]
+              - [704, 3]
+              - [1024, 7]
+              - [2944, 5]
+              - [3584, 4]
+              - [5056, 3]
+              - [-1, 7]
+      - - -1
+        - - - 1
+            - - [-1, 13]
+          - - 32
+            - - [32, 8]
+              - [64, 11]
+              - [448, 8]
+              - [704, 11]
+              - [-1, 8]
+          - - 64
+            - - [1, 13]
+              - [32, 8]
+              - [64, 2]
+              - [128, 0]
+              - [256, 1]
+              - [1856, 2]
+              - [2368, 1]
+              - [-1, 6]
+          - - 128
+            - - [1, 13]
+              - [32, 8]
+              - [1024, 2]
+              - [5888, 6]
+              - [-1, 5]
+          - - 256
+            - - [1, 13]
+              - [32, 8]
+              - [64, 1]
+              - [256, 2]
+              - [448, 0]
+              - [2944, 6]
+              - [3584, 4]
+              - [5056, 6]
+              - [5888, 5]
+              - [-1, 6]
+          - - 448
+            - - [1, 13]
+              - [32, 8]
+              - [128, 0]
+              - [256, 2]
+              - [1408, 6]
+              - [1856, 4]
+              - [2368, 6]
+              - [2944, 4]
+              - [3584, 6]
+              - [4288, 4]
+              - [5888, 6]
+              - [-1, 4]
+          - - 704
+            - - [1, 13]
+              - [32, 8]
+              - [64, 2]
+              - [128, 0]
+              - [1024, 6]
+              - [1408, 4]
+              - [2368, 6]
+              - [5888, 4]
+              - [-1, 7]
+          - - 1024
+            - - [1, 13]
+              - [32, 8]
+              - [128, 0]
+              - [704, 6]
+              - [1024, 4]
+              - [2368, 5]
+              - [2944, 7]
+              - [3584, 5]
+              - [4288, 6]
+              - [-1, 7]
+          - - 1408
+            - - [1, 13]
+              - [32, 8]
+              - [64, 2]
+              - [448, 6]
+              - [1856, 5]
+              - [2368, 6]
+              - [5888, 7]
+              - [-1, 4]
+          - - 1856
+            - - [1, 13]
+              - [32, 8]
+              - [64, 2]
+              - [256, 6]
+              - [448, 5]
+              - [704, 6]
+              - [1408, 4]
+              - [1856, 5]
+              - [2368, 6]
+              - [3584, 4]
+              - [4288, 7]
+              - [5056, 3]
+              - [-1, 4]
+          - - 2368
+            - - [1, 13]
+              - [32, 8]
+              - [64, 1]
+              - [704, 6]
+              - [1024, 5]
+              - [1856, 6]
+              - [2368, 4]
+              - [2944, 7]
+              - [3584, 4]
+              - [4288, 3]
+              - [5056, 7]
+              - [-1, 4]
+          - - 2944
+            - - [1, 13]
+              - [32, 8]
+              - [256, 6]
+              - [704, 5]
+              - [1408, 7]
+              - [1856, 5]
+              - [2368, 7]
+              - [2944, 5]
+              - [3584, 4]
+              - [5056, 5]
+              - [5888, 7]
+              - [-1, 4]
+          - - 3584
+            - - [1, 13]
+              - [32, 8]
+              - [128, 6]
+              - [256, 4]
+              - [448, 6]
+              - [1024, 5]
+              - [1408, 7]
+              - [3584, 5]
+              - [4288, 7]
+              - [-1, 5]
+          - - 4288
+            - - [1, 13]
+              - [32, 8]
+              - [256, 6]
+              - [704, 5]
+              - [1024, 4]
+              - [1856, 7]
+              - [2368, 3]
+              - [2944, 5]
+              - [3584, 7]
+              - [5056, 3]
+              - [5888, 4]
+              - [-1, 3]
+          - - 5056
+            - - [1, 13]
+              - [32, 8]
+              - [448, 6]
+              - [704, 5]
+              - [1408, 7]
+              - [1856, 3]
+              - [2368, 7]
+              - [2944, 5]
+              - [3584, 4]
+              - [4288, 3]
+              - [5056, 7]
+              - [5888, 4]
+              - [-1, 3]
+          - - 5888
+            - - [1, 13]
+              - [32, 8]
+              - [128, 6]
+              - [256, 5]
+              - [448, 6]
+              - [704, 5]
+              - [1408, 7]
+              - [2368, 5]
+              - [2944, 7]
+              - [5056, 5]
+              - [-1, 7]
+          - - -1
+            - - [1, 13]
+              - [32, 8]
+              - [64, 6]
+              - [128, 5]
+              - [256, 6]
+              - [448, 5]
+              - [1024, 7]
+              - [1408, 4]
+              - [3584, 5]
+              - [5056, 3]
+              - [-1, 7]

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HB.yaml
@@ -44,145 +44,6 @@
     BufferLoad: true
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 16
-    LVCB: 4
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x032x16_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG16_08_01
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
     DepthU: 32
     DirectToLds: false
     DirectToLdsA: false
@@ -295,8 +156,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x32_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG32_08_01
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x32_PGR1_PLR1_TT02_02
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -434,8 +295,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -573,8 +434,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 3
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x16_GRVW08_LPB00_PBC0_PGR1_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x16_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -712,147 +573,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT016x016x08_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 16
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: true
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 5
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT016x016x16_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG08_08_01
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT016x016x08_PGR1_PLR1_TT02_02
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -990,8 +712,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 6
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x008x32_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG16_04_01
+    SolutionIndex: 4
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x008x32_PGR1_PLR1_TT02_02
     SubGroup0: 16
     SubGroup1: 4
     SubGroupA: 16
@@ -1129,8 +851,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT256x064x08_GRVW08_LPB00_PBC0_PGR1_TT08_08_USFGRO00_VW08_WG32_08_01
+    SolutionIndex: 5
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT256x064x08_PGR1_PLR1_TT08_08
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -1147,6 +869,145 @@
     VectorStore: true
     VectorWidth: 8
     WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 16
+    LSPA: 8
+    LSPB: 16
+    LVCA: 8
+    LVCB: 4
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 6
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x032x16_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -1268,8 +1129,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x016x16_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG16_08_01
+    SolutionIndex: 7
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x016x16_PGR1_PLR1_TT02_02
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
@@ -1407,8 +1268,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 9
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x16_GRVW02_LPB00_PBC1_PGR1_TT04_02_USFGRO01_VW02_WG16_08_01
+    SolutionIndex: 8
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x16_PGR1_PLR1_TT04_02
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
@@ -1546,8 +1407,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x008x32_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG32_04_01
+    SolutionIndex: 9
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x008x32_PGR1_PLR1_TT02_02
     SubGroup0: 32
     SubGroup1: 4
     SubGroupA: 32
@@ -1685,8 +1546,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT048x032x24_GRVW02_LPB00_PBC1_PGR1_TT06_04_USFGRO01_VW02_WG08_08_01
+    SolutionIndex: 10
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT048x032x24_PGR1_PLR1_TT06_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -1824,8 +1685,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 12
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x032x24_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG08_08_01
+    SolutionIndex: 11
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x032x24_PGR1_PLR1_TT04_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -1843,284 +1704,6 @@
     VectorWidth: 4
     WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 8
-    LSPA: 8
-    LSPB: 16
-    LVCA: 8
-    LVCB: 4
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 819
-    LdsNumElementsAlignedA: 128
-    LdsNumElementsAlignedB: 128
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 256
-    LdsOffsetB: 128
-    LdsOffsetB_Blk: 384
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 13
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT016x016x08_GRVW02_LPB00_PBC0_PGR1_TT02_02_USFGRO00_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 32
-    LSCB: 8
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 896
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 128
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 14
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x016x08_GRVW02_LPB00_PBC0_PGR1_TT02_02_USFGRO00_VW02_WG16_08_01
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 8, 1]
-    WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
     AssertSummationElementMultiple: 2
@@ -2241,8 +1824,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 15
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x016x16_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG16_08_01
+    SolutionIndex: 12
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x016x16_PGR1_PLR1_TT02_02
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
@@ -2259,145 +1842,6 @@
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 8, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 4
-    LSPB: 16
-    LVCA: 16
-    LVCB: 4
-    LVPA: 1
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 16
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x032x16_GRVW04_LPB00_PBC0_PGR1_TT08_04_USFGRO00_VW04_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -2519,8 +1963,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 17
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x008x32_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG16_04_01
+    SolutionIndex: 13
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x008x32_PGR1_PLR1_TT02_02
     SubGroup0: 16
     SubGroup1: 4
     SubGroupA: 16
@@ -2537,6 +1981,284 @@
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 4, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 24
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 8
+    LSPA: 4
+    LSPB: 16
+    LVCA: 16
+    LVCB: 4
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 3200
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 24
+    MacroTile0: 32
+    MacroTile1: 16
+    MacroTileA: 32
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 6
+    NumLoadsB: 3
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 3
+    NumLoadsPerpendicularA: 6
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: true
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 14
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT032x016x24_PGR1_PLR1_TT04_02
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    ThreadTile: [4, 2]
+    ThreadTile0: 4
+    ThreadTile1: 2
+    ThreadTileA: 4
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 6656
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 64
+    MacroTile1: 16
+    MacroTileA: 64
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 8
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: true
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 15
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x32_PGR1_PLR1_TT04_02
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    ThreadTile: [4, 2]
+    ThreadTile0: 4
+    ThreadTile1: 2
+    ThreadTileA: 4
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -2658,8 +2380,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 18
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x008x32_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG32_04_01
+    SolutionIndex: 16
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x008x32_PGR1_PLR1_TT02_02
     SubGroup0: 32
     SubGroup1: 4
     SubGroupA: 32
@@ -2676,6 +2398,145 @@
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [32, 4, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 32
+    LSPA: 8
+    LSPB: 32
+    LVCA: 32
+    LVCB: 8
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 13312
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 128
+    MacroTile1: 32
+    MacroTileA: 128
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 17
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 32
+    SubGroup1: 8
+    SubGroupA: 32
+    SubGroupB: 8
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -2797,8 +2658,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 19
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x16_GRVW02_LPB00_PBC1_PGR1_TT04_02_USFGRO01_VW02_WG16_08_01
+    SolutionIndex: 18
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x16_PGR1_PLR1_TT04_02
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
@@ -2824,7 +2685,7 @@
     BufferLoad: true
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 24
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -2847,20 +2708,20 @@
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 16
-    LSCB: 8
+    LSCB: 16
     LSPA: 8
-    LSPB: 16
+    LSPB: 8
     LVCA: 8
-    LVCB: 4
+    LVCB: 8
     LVPA: 4
-    LVPB: 8
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalRead2A: true
@@ -2872,7 +2733,7 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 24
+    LoopUnroll: 16
     MacroTile0: 16
     MacroTile1: 16
     MacroTileA: 16
@@ -2886,12 +2747,12 @@
     NonTemporalC: 0
     NumElementsPerThread: 4
     NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 3
-    NumLoadsB: 3
+    NumLoadsA: 2
+    NumLoadsB: 2
     NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 3
-    NumLoadsPerpendicularA: 3
-    NumLoadsPerpendicularB: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
     NumThreads: 64
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
@@ -2936,8 +2797,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 20
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT016x016x24_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG08_08_01
+    SolutionIndex: 19
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT016x016x16_PGR1_PLR1_TT02_02
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -2954,145 +2815,6 @@
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 16
-    LVCB: 4
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 21
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x032x16_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG16_08_01
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -3214,8 +2936,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 22
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x16_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG16_04_01
+    SolutionIndex: 20
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 4
     SubGroupA: 16
@@ -3353,8 +3075,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 23
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x32_GRVW02_LPB00_PBC1_PGR1_TT02_02_USFGRO01_VW02_WG32_08_01
+    SolutionIndex: 21
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x016x32_PGR1_PLR1_TT02_02
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -3492,8 +3214,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 24
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x032x16_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG32_08_01
+    SolutionIndex: 22
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x032x16_PGR1_PLR1_TT04_04
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -3510,280 +3232,6 @@
     VectorStore: true
     VectorWidth: 4
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 2
-    LVPB: 32
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 25
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x08_GRVW04_LPB00_PBC0_PGR0_TT08_04_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 26
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x08_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -3901,8 +3349,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 27
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x32_GRVW04_LPB00_PBC0_PGR0_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 23
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x32_PGR0_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -4040,8 +3488,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 28
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x16_GRVW04_LPB00_PBC0_PGR1_TT04_08_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 24
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x16_PGR1_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -4179,8 +3627,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 29
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_GRVW04_LPB00_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 25
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -4318,8 +3766,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 30
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_GRVW04_LPB00_PBC0_PGR1_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 26
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_PGR1_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -4453,8 +3901,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 31
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x32_GRVW08_LPB00_PBC0_PGR0_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 27
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x32_PGR0_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -4592,8 +4040,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 32
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x32_GRVW08_LPB00_PBC0_PGR1_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 28
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x32_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -4731,8 +4179,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 33
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x32_GRVW04_LPB00_PBC0_PGR1_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 29
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x32_PGR1_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -4866,8 +4314,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 34
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_GRVW08_LPB00_PBC0_PGR0_TT08_08_USFGRO00_VW08_WG08_08_01
+    SolutionIndex: 30
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_PGR0_PLR1_TT08_08
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -5005,8 +4453,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 35
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x08_GRVW04_LPB00_PBC0_PGR1_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 31
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x08_PGR1_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -5144,8 +4592,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 36
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x16_GRVW08_LPB00_PBC0_PGR1_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 32
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x128x16_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -5162,145 +4610,6 @@
     VectorStore: true
     VectorWidth: 8
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 7232
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1152
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 37
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_GRVW04_LPB04_PBC0_PGR1_TT04_08_USFGRO00_VW04_WG32_08_01
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -5422,8 +4731,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 38
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x16_GRVW04_LPB04_PBC0_PGR1_TT04_08_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 33
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x16_PGR1_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -5561,8 +4870,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 39
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x32_GRVW04_LPB04_PBC0_PGR1_TT04_04_USFGRO00_VW04_WG32_16_01
+    SolutionIndex: 34
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x32_PGR1_PLR1_TT04_04
     SubGroup0: 32
     SubGroup1: 16
     SubGroupA: 32
@@ -5700,8 +5009,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 40
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_GRVW04_LPB04_PBC0_PGR1_TT04_08_USFGRO00_VW04_WG32_08_01
+    SolutionIndex: 35
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_PGR1_PLR1_TT04_08
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -5839,8 +5148,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 41
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_GRVW04_LPB04_PBC0_PGR1_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 36
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_PGR1_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -5866,45 +5175,45 @@
     BufferLoad: true
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 32
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
+    GlobalReadVectorWidth: 4
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
+    GlobalWriteVectorWidth: 4
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 256
-    LSCB: 32
-    LSPA: 16
-    LSPB: 128
-    LVCA: 32
-    LVCB: 4
+    LSCB: 16
+    LSPA: 8
+    LSPB: 64
+    LVCA: 64
+    LVCB: 8
     LVPA: 2
-    LVPB: 16
-    LdsNumElements: 28672
-    LdsNumElementsAlignedA: 8192
-    LdsNumElementsAlignedB: 4096
+    LVPB: 32
+    LdsNumElements: 13376
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 1152
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 16384
-    LdsOffsetB: 8192
-    LdsOffsetB_Blk: 24576
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
     LdsPadA: 0
-    LdsPadB: 0
+    LdsPadB: 4
     LocalRead2A: true
     LocalRead2B: true
     LocalSplitU: 1
@@ -5914,11 +5223,11 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 32
+    LoopUnroll: 16
     MacroTile0: 256
-    MacroTile1: 128
+    MacroTile1: 64
     MacroTileA: 256
-    MacroTileB: 128
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -5926,7 +5235,7 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 64
+    NumElementsPerThread: 32
     NumGlobalWriteVectorsPerThread: 8
     NumLoadsA: 2
     NumLoadsB: 1
@@ -5978,24 +5287,163 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 42
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT256x128x32_GRVW08_LPB00_PBC0_PGR1_TT08_08_USFGRO00_VW08_WG32_16_01
+    SolutionIndex: 37
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT256x064x16_PGR1_PLR1_TT08_04
     SubGroup0: 32
     SubGroup1: 16
     SubGroupA: 32
     SubGroupB: 16
-    ThreadTile: [8, 8]
+    ThreadTile: [8, 4]
     ThreadTile0: 8
-    ThreadTile1: 8
+    ThreadTile1: 4
     ThreadTileA: 8
-    ThreadTileB: 8
+    ThreadTileB: 4
     UnrollMemFence: false
     UseSgprForGRO: 0
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
-    VectorWidth: 8
+    VectorWidth: 4
     WorkGroup: [32, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 8
+    LSPB: 64
+    LVCA: 32
+    LVCB: 4
+    LVPA: 2
+    LVPB: 16
+    LdsNumElements: 7232
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1152
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 38
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_PGR1_PLR1_TT08_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [8, 4]
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -6117,8 +5565,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 43
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_GRVW02_LPB04_PBC1_PGR1_TT04_04_USFGRO01_VW02_WG16_16_01
+    SolutionIndex: 39
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_PGR1_PLR0_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -6252,8 +5700,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 44
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT256x032x16_GRVW04_LPB04_PBC0_PGR0_TT08_04_USFGRO00_VW04_WG32_08_01
+    SolutionIndex: 40
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT256x032x16_PGR0_PLR0_TT08_04
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -6387,8 +5835,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 45
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x16_GRVW04_LPB04_PBC0_PGR0_TT04_08_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 41
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x16_PGR0_PLR0_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -6522,8 +5970,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 46
-    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_GRVW04_LPB04_PBC0_PGR0_TT04_08_USFGRO00_VW04_WG32_08_01
+    SolutionIndex: 42
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_PGR0_PLR0_TT04_08
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -6542,944 +5990,1933 @@
     WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 8
+    LSPB: 64
+    LVCA: 32
+    LVCB: 4
+    LVPA: 2
+    LVPB: 16
+    LdsNumElements: 3136
+    LdsOffsetA: 0
+    LdsOffsetB: 2048
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 43
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT128x064x16_PGR0_PLR0_TT08_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [8, 4]
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 8
+    LSPA: 8
+    LSPB: 64
+    LVCA: 32
+    LVCB: 4
+    LVPA: 4
+    LVPB: 32
+    LdsNumElements: 1536
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 44
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x08_PGR0_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 8
+    LSPA: 8
+    LSPB: 64
+    LVCA: 32
+    LVCB: 4
+    LVPA: 4
+    LVPB: 32
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 45
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x08_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 16
+    LSPA: 8
+    LSPB: 32
+    LVCA: 32
+    LVCB: 8
+    LVPA: 4
+    LVPB: 16
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 46
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 4
+    LSPA: 4
+    LSPB: 128
+    LVCA: 64
+    LVCB: 2
+    LVPA: 4
+    LVPB: 64
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 47
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x128x04_PGR0_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 16
+    LSPA: 8
+    LSPB: 32
+    LVCA: 32
+    LVCB: 8
+    LVPA: 4
+    LVPB: 16
+    LdsNumElements: 2048
+    LdsOffsetA: 0
+    LdsOffsetB: 1024
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 48
+    SolutionNameMin: Cijk_Ailk_Bljk_HB_MT064x064x16_PGR0_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
 - [2, 3, 0, 1]
 - - - [4096, 7000, 1, 4096]
-    - [36, 17704.7]
+    - [32, 17623.3]
   - - [5124, 9124, 1, 1760]
-    - [34, 18113.1]
+    - [30, 18128.4]
   - - [5124, 9124, 1, 2560]
-    - [36, 18110.8]
+    - [32, 18110.3]
   - - [1760, 32, 1, 1760]
-    - [6, 2424.71]
+    - [4, 2419.97]
   - - [1024, 1500, 1, 1536]
-    - [30, 14708.6]
+    - [26, 14708.6]
   - - [512, 24000, 1, 1536]
-    - [36, 18034.4]
+    - [32, 18042.7]
   - - [3072, 24000, 1, 1024]
-    - [36, 18519.3]
+    - [32, 18518.9]
   - - [1024, 3000, 1, 2560]
-    - [36, 16527.0]
+    - [32, 16568.8]
   - - [512, 3136, 1, 2048]
-    - [42, 12001.1]
+    - [37, 12269.7]
   - - [7680, 4, 1, 2560]
-    - [6, 1348.47]
+    - [4, 1333.82]
   - - [35, 1500, 1, 2048]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [8448, 1500, 1, 2816]
-    - [35, 17575.5]
+    - [31, 17589.3]
   - - [784, 512, 64, 128]
-    - [45, 15012.3]
+    - [41, 15017.8]
   - - [2560, 7000, 1, 2560]
-    - [36, 17865.6]
+    - [32, 17875.6]
   - - [3072, 16, 1, 1024]
-    - [6, 1941.81]
+    - [4, 1929.86]
   - - [512, 48000, 1, 2048]
-    - [31, 16900.0]
+    - [27, 16895.9]
   - - [1760, 64, 1, 1760]
-    - [1, 4243.24]
+    - [0, 4228.76]
   - - [1024, 16, 1, 512]
-    - [10, 620.459]
+    - [7, 624.129]
   - - [196, 256, 64, 1024]
-    - [44, 10734.8]
+    - [40, 10737.6]
   - - [512, 48000, 1, 1536]
-    - [36, 18433.2]
+    - [32, 18422.4]
   - - [2560, 32, 1, 2560]
-    - [18, 3301.51]
+    - [9, 3260.47]
   - - [4608, 1500, 1, 1536]
-    - [36, 16864.7]
+    - [32, 16854.0]
   - - [2048, 128, 1, 2048]
-    - [22, 7506.48]
+    - [22, 7131.56]
   - - [1024, 24000, 1, 2560]
-    - [36, 18485.3]
+    - [32, 18488.8]
   - - [4608, 3000, 1, 1536]
-    - [36, 17499.6]
+    - [32, 17523.9]
   - - [5124, 9124, 1, 2048]
-    - [30, 16983.4]
+    - [32, 17127.2]
   - - [1024, 700, 1, 512]
-    - [29, 9781.36]
+    - [25, 9823.25]
   - - [3072, 1, 1, 128]
-    - [4, 57.1535]
+    - [3, 57.1493]
   - - [5124, 700, 1, 2560]
-    - [36, 14956.5]
+    - [32, 14974.0]
   - - [8448, 16, 1, 2816]
-    - [10, 4349.05]
+    - [9, 4393.22]
   - - [6144, 6000, 1, 2560]
-    - [36, 18538.3]
+    - [32, 18532.8]
   - - [4608, 32, 1, 1536]
-    - [15, 4610.95]
+    - [12, 4595.98]
   - - [35, 8457, 1, 2560]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [3072, 64, 1, 1024]
-    - [19, 5579.93]
+    - [15, 5400.32]
   - - [512, 16, 1, 512]
-    - [10, 317.75]
+    - [16, 313.945]
   - - [7680, 2, 1, 2560]
-    - [6, 673.304]
+    - [9, 665.104]
   - - [4224, 1, 1, 128]
-    - [4, 77.6828]
+    - [3, 78.5803]
   - - [7680, 1, 1, 2560]
-    - [6, 336.194]
+    - [4, 335.277]
   - - [128, 1500, 1, 1280]
-    - [9, 5774.37]
+    - [6, 5525.06]
   - - [35, 8457, 1, 4096]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [1024, 1500, 1, 2816]
-    - [30, 15060.3]
+    - [26, 15031.0]
   - - [6144, 2, 1, 2560]
-    - [6, 542.362]
+    - [4, 547.65]
   - - [8448, 48000, 1, 2816]
-    - [36, 19228.9]
+    - [32, 19228.5]
   - - [512, 6000, 1, 1536]
-    - [36, 16226.0]
+    - [32, 16329.3]
   - - [4224, 1500, 1, 176]
-    - [35, 14504.7]
+    - [31, 14519.8]
   - - [1024, 6000, 1, 2816]
-    - [36, 17645.7]
+    - [32, 17652.9]
   - - [512, 6000, 1, 2560]
-    - [36, 16413.9]
+    - [32, 16549.3]
   - - [512, 32, 1, 512]
-    - [8, 613.202]
+    - [12, 613.202]
   - - [2560, 128, 1, 2560]
-    - [19, 7415.57]
+    - [18, 7420.82]
   - - [4608, 24000, 1, 1536]
-    - [36, 19024.9]
+    - [32, 19019.7]
   - - [512, 2, 1, 500000]
-    - [6, 51.4458]
+    - [4, 51.445]
   - - [7680, 48000, 1, 2560]
-    - [36, 19209.5]
+    - [32, 19209.0]
   - - [3072, 48000, 1, 1024]
-    - [36, 18877.9]
+    - [32, 18870.3]
   - - [1760, 16, 1, 1760]
-    - [6, 1254.07]
+    - [13, 1241.49]
   - - [512, 3000, 1, 2816]
-    - [30, 15001.8]
+    - [26, 15056.1]
   - - [1760, 7000, 1, 1760]
-    - [35, 17158.5]
+    - [31, 17135.7]
   - - [64, 193600, 1, 256]
-    - [38, 15493.8]
+    - [33, 15548.5]
   - - [1024, 3000, 1, 2048]
-    - [27, 12820.7]
+    - [23, 12835.3]
   - - [6144, 4, 1, 2560]
-    - [10, 1071.42]
+    - [13, 1075.82]
   - - [1024, 6000, 1, 2048]
-    - [31, 14774.0]
+    - [27, 14874.6]
   - - [512, 24000, 1, 2816]
-    - [36, 18218.0]
+    - [32, 18218.0]
   - - [6144, 48000, 1, 2560]
-    - [36, 19156.6]
+    - [32, 19150.9]
   - - [8448, 3000, 1, 2816]
-    - [36, 18324.2]
+    - [32, 18318.2]
   - - [35, 1500, 1, 2560]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [3072, 4, 1, 1024]
-    - [6, 502.512]
+    - [4, 499.312]
   - - [4608, 48000, 1, 1536]
-    - [36, 19154.3]
+    - [32, 19159.2]
   - - [2048, 32, 1, 2048]
-    - [17, 2819.64]
+    - [13, 2810.2]
   - - [7680, 1500, 1, 2560]
-    - [30, 17091.7]
+    - [26, 17086.2]
   - - [4096, 128, 1, 4096]
-    - [16, 10724.4]
+    - [17, 10925.2]
   - - [4608, 16, 1, 1536]
-    - [10, 2842.49]
+    - [9, 2848.21]
   - - [1024, 1500, 1, 2048]
-    - [27, 11051.4]
+    - [23, 11054.6]
   - - [3072, 3000, 1, 1024]
-    - [30, 16498.3]
+    - [26, 16388.3]
   - - [3072, 2, 1, 1024]
-    - [6, 248.086]
+    - [4, 248.866]
   - - [8448, 1, 1, 2816]
-    - [18, 343.378]
+    - [9, 338.3]
   - - [1024, 48000, 1, 2560]
-    - [36, 19020.0]
+    - [32, 19023.0]
   - - [1024, 3000, 1, 2816]
-    - [36, 16544.2]
+    - [32, 16559.4]
   - - [128, 1, 1, 1408]
-    - [6, 6.07213]
+    - [4, 5.88189]
   - - [35, 8457, 1, 1760]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [1024, 2, 1, 512]
-    - [10, 78.4862]
+    - [4, 78.4833]
   - - [1024, 4, 1, 500000]
-    - [6, 205.777]
+    - [4, 205.783]
   - - [6144, 1, 1, 2560]
-    - [6, 270.433]
+    - [13, 270.433]
   - - [1024, 48000, 1, 2816]
-    - [36, 19050.1]
+    - [32, 19048.4]
   - - [512, 48000, 1, 2816]
-    - [36, 18515.9]
+    - [32, 18519.5]
   - - [2048, 16, 1, 2048]
-    - [17, 1461.41]
+    - [4, 1463.96]
   - - [1024, 24000, 1, 1536]
-    - [36, 18409.4]
+    - [32, 18402.3]
   - - [64, 193600, 1, 64]
-    - [2, 12740.6]
+    - [1, 12707.9]
   - - [7680, 6000, 1, 2560]
-    - [36, 18634.6]
+    - [32, 18638.9]
   - - [1760, 128, 1, 1760]
-    - [12, 6428.17]
+    - [11, 6564.34]
   - - [35, 8457, 1, 2048]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [512, 1500, 1, 2816]
-    - [29, 12315.8]
+    - [25, 12310.2]
   - - [512, 1, 1, 512]
-    - [6, 20.1031]
+    - [4, 19.9797]
   - - [512, 16, 1, 500000]
-    - [6, 411.566]
+    - [4, 411.57]
   - - [512, 8, 1, 500000]
-    - [6, 205.782]
+    - [4, 205.788]
   - - [512, 24000, 1, 2560]
-    - [36, 18163.0]
+    - [32, 18188.2]
   - - [6144, 3000, 1, 2560]
-    - [36, 18217.7]
+    - [32, 18280.4]
   - - [1024, 24000, 1, 2816]
-    - [36, 18513.5]
+    - [32, 18513.1]
   - - [2048, 7000, 1, 2048]
-    - [31, 16428.5]
+    - [27, 16419.7]
   - - [7680, 3000, 1, 2560]
-    - [36, 18064.1]
+    - [32, 18061.9]
   - - [1024, 4, 1, 512]
-    - [6, 158.875]
+    - [16, 155.115]
   - - [5124, 700, 1, 2048]
-    - [32, 12887.1]
+    - [28, 13173.7]
   - - [5124, 9124, 1, 4096]
-    - [36, 17569.0]
+    - [32, 17588.2]
   - - [4096, 64, 1, 4096]
-    - [22, 8090.16]
+    - [20, 8099.92]
   - - [256, 193600, 1, 64]
-    - [7, 16229.5]
+    - [5, 16117.4]
   - - [512, 6000, 1, 2048]
-    - [27, 12708.8]
+    - [23, 12706.7]
   - - [7680, 32, 1, 2560]
-    - [12, 7315.56]
+    - [20, 7248.1]
   - - [2560, 64, 1, 2560]
-    - [15, 5344.36]
+    - [12, 5360.75]
   - - [3136, 2048, 1, 512]
-    - [46, 15291.5]
+    - [43, 15274.4]
   - - [3072, 128, 1, 1024]
-    - [21, 8131.04]
+    - [20, 8131.04]
   - - [8448, 6000, 1, 2816]
-    - [36, 18850.2]
+    - [32, 18841.1]
   - - [7680, 64, 1, 2560]
-    - [24, 10354.5]
+    - [22, 10361.3]
   - - [5124, 1500, 1, 2560]
-    - [36, 16711.9]
+    - [32, 16686.9]
   - - [1024, 1500, 1, 2560]
-    - [30, 14971.5]
+    - [26, 14948.7]
   - - [3025, 64, 64, 64]
-    - [43, 0.0]
+    - [39, 0.0]
   - - [512, 4, 1, 512]
-    - [6, 79.4376]
+    - [13, 78.9561]
   - - [1024, 6000, 1, 2560]
-    - [36, 17539.9]
+    - [32, 17536.8]
   - - [3072, 32, 1, 1024]
-    - [15, 3466.31]
+    - [13, 3495.19]
   - - [35, 700, 1, 2560]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [3136, 512, 1, 2048]
-    - [44, 9610.38]
+    - [40, 9592.45]
   - - [196, 1024, 64, 256]
-    - [46, 12733.4]
+    - [42, 12721.6]
   - - [512, 50176, 1, 128]
-    - [3, 17069.6]
+    - [2, 17069.6]
   - - [4608, 1, 1, 1536]
-    - [6, 194.873]
+    - [4, 193.171]
   - - [49, 512, 64, 2048]
-    - [43, 0.0]
+    - [39, 0.0]
   - - [4096, 32, 1, 4096]
-    - [23, 5107.15]
+    - [21, 5154.22]
   - - [7680, 24000, 1, 2560]
-    - [36, 19082.7]
+    - [32, 19082.1]
   - - [8448, 4, 1, 2816]
-    - [10, 1396.08]
+    - [9, 1379.89]
   - - [64, 1, 1, 1216]
-    - [6, 2.65064]
+    - [4, 2.65788]
   - - [512, 1, 1, 500000]
-    - [6, 25.7227]
+    - [4, 25.7202]
   - - [176, 1500, 1, 1408]
-    - [9, 5837.14]
+    - [8, 5866.57]
   - - [512, 3000, 1, 1536]
-    - [30, 14664.8]
+    - [26, 14701.3]
   - - [8448, 24000, 1, 2816]
-    - [36, 19156.1]
+    - [32, 19154.9]
   - - [4608, 2, 1, 1536]
-    - [6, 390.607]
+    - [4, 389.746]
   - - [1024, 48000, 1, 1536]
-    - [36, 18950.7]
+    - [32, 18945.3]
   - - [7680, 128, 1, 2560]
-    - [30, 13541.5]
+    - [26, 13448.9]
   - - [3072, 6000, 1, 1024]
-    - [30, 17130.9]
+    - [26, 17087.4]
   - - [3072, 1500, 1, 128]
-    - [30, 13236.5]
+    - [31, 13527.9]
   - - [2048, 3136, 1, 512]
-    - [37, 15999.8]
+    - [38, 16006.1]
   - - [3025, 256, 64, 64]
-    - [43, 0.0]
+    - [39, 0.0]
   - - [1024, 3000, 1, 1536]
-    - [36, 16324.8]
+    - [32, 16257.3]
   - - [512, 4, 1, 500000]
-    - [6, 102.89]
+    - [4, 102.892]
   - - [35, 700, 1, 2048]
-    - [11, 0.0]
+    - [10, 0.0]
   - - [1024, 16, 1, 500000]
-    - [6, 823.08]
+    - [4, 823.086]
   - - [512, 24000, 1, 2048]
-    - [31, 16010.2]
+    - [27, 15984.2]
   - - [128, 50176, 1, 512]
-    - [40, 15944.0]
+    - [36, 15925.4]
   - - [1024, 32, 1, 512]
-    - [6, 1198.37]
+    - [4, 1198.33]
   - - [256, 12544, 1, 1024]
-    - [39, 13733.2]
+    - [34, 13788.5]
   - - [1024, 12544, 1, 256]
-    - [41, 16790.7]
+    - [35, 16797.5]
   - - [512, 48000, 1, 2560]
-    - [36, 18500.5]
+    - [32, 18499.2]
   - - [2560, 16, 1, 2560]
-    - [6, 1815.39]
+    - [4, 1846.07]
   - - [2048, 64, 1, 2048]
-    - [23, 4848.86]
+    - [16, 4814.08]
   - - [512, 2, 1, 512]
-    - [6, 40.2061]
+    - [4, 39.9595]
   - - [1024, 1, 1, 512]
-    - [8, 36.4076]
+    - [7, 36.611]
   - - [512, 1500, 1, 2560]
-    - [29, 11283.6]
+    - [25, 11367.1]
   - - [6144, 32, 1, 2560]
-    - [12, 6014.7]
+    - [14, 6131.95]
   - - [1024, 1, 1, 500000]
-    - [6, 51.445]
+    - [4, 51.4462]
   - - [6144, 16, 1, 2560]
-    - [18, 3941.98]
+    - [16, 3941.98]
   - - [1024, 24000, 1, 2048]
-    - [31, 17005.1]
+    - [27, 16993.1]
   - - [4096, 16, 1, 4096]
-    - [17, 2969.39]
+    - [4, 2956.31]
   - - [5124, 1500, 1, 2048]
-    - [31, 14669.3]
+    - [27, 14583.4]
   - - [3072, 1500, 1, 1024]
-    - [30, 15127.4]
+    - [26, 15166.2]
   - - [1024, 2, 1, 500000]
-    - [6, 102.89]
+    - [4, 102.893]
   - - [1024, 8, 1, 500000]
-    - [6, 411.553]
+    - [4, 411.53]
   - - [7680, 16, 1, 2560]
-    - [1, 4760.41]
+    - [0, 4771.97]
   - - [6144, 1500, 1, 2560]
-    - [36, 17746.3]
+    - [32, 17728.2]
   - - [3072, 1, 1, 1024]
-    - [6, 124.04]
+    - [4, 124.435]
   - - [512, 6000, 1, 2816]
-    - [36, 16546.7]
+    - [32, 16574.6]
   - - [8448, 2, 1, 2816]
-    - [10, 687.55]
+    - [9, 687.55]
   - - [4608, 4, 1, 1536]
-    - [6, 779.492]
+    - [4, 774.375]
   - - [1024, 6000, 1, 1536]
-    - [36, 17258.7]
+    - [32, 17311.9]
   - - [8448, 32, 1, 2816]
-    - [0, 6219.42]
+    - [18, 6147.1]
   - - [512, 3000, 1, 2048]
-    - [27, 11045.2]
+    - [28, 10946.8]
   - - [6144, 24000, 1, 2560]
-    - [36, 19040.4]
+    - [32, 19086.7]
   - - [512, 3000, 1, 2560]
-    - [30, 14976.0]
+    - [26, 15008.0]
   - - [4608, 6000, 1, 1536]
-    - [36, 18435.6]
+    - [32, 18438.8]
   - - [1024, 1024, 1, 1024]
-    - [33, 12246.0]
+    - [29, 12201.5]
   - - [512, 1500, 1, 2048]
-    - [33, 9300.17]
+    - [29, 9295.75]
   - - [512, 1500, 1, 1536]
-    - [29, 10700.6]
+    - [25, 10963.1]
   - - [128, 1, 1, 1024]
-    - [5, 5.35425]
+    - [19, 5.35414]
   - - [49, 2048, 64, 512]
-    - [43, 0.0]
+    - [39, 0.0]
   - - [1024, 48000, 1, 2048]
-    - [31, 17690.3]
+    - [27, 17677.3]
 - - - -1
-    - - - 128
-        - - - 4
-            - - [-1, 13]
+    - - - 1
+        - - - 32
+            - - [64, 48]
+              - [128, 47]
+              - [704, 48]
+              - [1024, 46]
+              - [1408, 48]
+              - [2368, 46]
+              - [3584, 48]
+              - [4288, 46]
+              - [5888, 48]
+              - [-1, 46]
           - - 64
-            - - [64, 13]
-              - [448, 14]
-              - [704, 13]
-              - [5888, 14]
-              - [-1, 26]
+            - - [64, 48]
+              - [128, 46]
+              - [256, 48]
+              - [448, 46]
+              - [704, 48]
+              - [1024, 46]
+              - [2368, 48]
+              - [2944, 46]
+              - [3584, 48]
+              - [4288, 47]
+              - [-1, 48]
           - - 128
-            - - [64, 13]
-              - [2368, 14]
+            - - [64, 46]
+              - [448, 48]
+              - [704, 46]
+              - [1024, 48]
+              - [1408, 47]
+              - [2944, 46]
+              - [4288, 48]
+              - [5056, 46]
+              - [5888, 48]
+              - [-1, 46]
+          - - 256
+            - - [32, 46]
+              - [128, 48]
+              - [256, 46]
+              - [1024, 48]
+              - [1408, 46]
+              - [2368, 48]
+              - [2944, 46]
+              - [4288, 47]
+              - [5888, 48]
+              - [-1, 47]
+          - - 448
+            - - [1024, 48]
+              - [1856, 46]
+              - [2368, 47]
+              - [2944, 48]
+              - [5056, 47]
+              - [-1, 48]
+          - - 704
+            - - [32, 46]
+              - [64, 48]
+              - [128, 46]
+              - [448, 48]
+              - [704, 46]
+              - [2944, 47]
+              - [3584, 48]
+              - [-1, 47]
+          - - 1024
+            - - [64, 46]
+              - [128, 48]
+              - [256, 47]
+              - [704, 48]
+              - [1024, 47]
+              - [1408, 48]
+              - [1856, 47]
+              - [3584, 48]
+              - [-1, 47]
+          - - 1408
+            - - [448, 48]
+              - [704, 46]
+              - [1408, 47]
+              - [2368, 48]
+              - [-1, 47]
+          - - 1856
+            - - [64, 48]
+              - [128, 47]
+              - [448, 48]
+              - [3584, 47]
+              - [-1, 48]
+          - - 2368
+            - - [256, 48]
+              - [448, 46]
+              - [704, 47]
+              - [1408, 48]
+              - [1856, 47]
+              - [2368, 48]
+              - [2944, 47]
+              - [-1, 48]
+          - - 2944
+            - - [32, 48]
+              - [64, 46]
+              - [128, 48]
+              - [256, 46]
+              - [1024, 48]
+              - [-1, 47]
+          - - 3584
+            - - [64, 48]
+              - [256, 46]
+              - [448, 47]
+              - [1024, 48]
+              - [-1, 47]
+          - - 4288
+            - - [32, 46]
+              - [448, 48]
+              - [1408, 47]
+              - [-1, 48]
+          - - 5056
+            - - [64, 46]
+              - [128, 48]
+              - [256, 47]
+              - [448, 48]
+              - [1408, 47]
+              - [-1, 48]
+          - - 5888
+            - - [64, 46]
+              - [128, 48]
+              - [256, 47]
+              - [448, 48]
+              - [-1, 47]
+          - - -1
+            - - [64, 46]
+              - [256, 48]
+              - [448, 47]
+              - [704, 48]
+              - [-1, 47]
+      - - 32
+        - - - 128
+            - - [-1, 45]
+          - - 256
+            - - [3584, 45]
+              - [-1, 44]
+          - - 448
+            - - [1408, 45]
+              - [1856, 44]
+              - [2368, 45]
+              - [2944, 44]
+              - [3584, 45]
+              - [4288, 44]
+              - [5888, 45]
+              - [-1, 44]
+          - - 704
+            - - [1408, 45]
+              - [2944, 44]
+              - [4288, 45]
+              - [-1, 44]
+          - - 1024
+            - - [1024, 45]
+              - [1856, 44]
+              - [2944, 45]
+              - [3584, 44]
+              - [4288, 45]
+              - [-1, 44]
+          - - 1408
+            - - [704, 45]
+              - [1408, 44]
+              - [2368, 45]
+              - [-1, 44]
+          - - 1856
+            - - [704, 45]
+              - [1024, 44]
+              - [1856, 45]
+              - [-1, 44]
+          - - 2368
+            - - [448, 45]
+              - [-1, 44]
+          - - 2944
+            - - [256, 45]
+              - [448, 44]
+              - [1024, 45]
+              - [-1, 44]
+          - - 3584
+            - - [256, 45]
+              - [448, 44]
+              - [704, 45]
+              - [-1, 44]
+          - - 4288
+            - - [704, 45]
+              - [-1, 44]
+          - - 5056
+            - - [128, 45]
+              - [256, 44]
+              - [448, 45]
+              - [-1, 44]
+          - - -1
+            - - [128, 45]
+              - [256, 44]
+              - [704, 45]
+              - [-1, 44]
+      - - 256
+        - - - 1
+            - - [-1, 46]
+          - - 32
+            - - [-1, 45]
+          - - 64
+            - - [1, 46]
+              - [32, 45]
+              - [64, 19]
+              - [128, 12]
+              - [256, 7]
+              - [1024, 3]
+              - [1856, 12]
+              - [2368, 7]
+              - [2944, 0]
+              - [4288, 8]
+              - [5056, 18]
+              - [5888, 20]
+              - [-1, 1]
+          - - 128
+            - - [1, 46]
+              - [32, 45]
+              - [128, 7]
+              - [256, 21]
+              - [448, 7]
+              - [704, 12]
+              - [1024, 7]
+              - [1408, 8]
+              - [1856, 6]
+              - [2368, 8]
+              - [2944, 25]
+              - [4288, 20]
+              - [-1, 25]
+          - - 256
+            - - [1, 46]
+              - [32, 45]
+              - [256, 7]
+              - [448, 0]
+              - [2944, 25]
+              - [3584, 26]
+              - [5056, 25]
+              - [5888, 31]
+              - [-1, 26]
+          - - 448
+            - - [1, 46]
+              - [32, 45]
+              - [64, 3]
+              - [256, 7]
+              - [448, 8]
+              - [1408, 25]
+              - [1856, 26]
+              - [2368, 25]
+              - [2944, 31]
+              - [3584, 25]
+              - [4288, 24]
+              - [5056, 31]
+              - [5888, 26]
+              - [-1, 24]
+          - - 704
+            - - [1, 46]
+              - [32, 45]
+              - [64, 21]
+              - [128, 7]
+              - [1856, 25]
+              - [2368, 26]
+              - [5888, 24]
+              - [-1, 32]
+          - - 1024
+            - - [1, 46]
+              - [32, 45]
+              - [64, 7]
+              - [128, 12]
+              - [704, 25]
+              - [1024, 31]
+              - [4288, 26]
+              - [-1, 32]
+          - - 1408
+            - - [1, 46]
+              - [32, 45]
+              - [64, 7]
+              - [128, 18]
+              - [704, 25]
+              - [1024, 31]
+              - [1408, 26]
+              - [1856, 31]
+              - [2368, 26]
+              - [5888, 32]
+              - [-1, 31]
+          - - 1856
+            - - [1, 46]
+              - [32, 45]
+              - [64, 0]
+              - [128, 8]
+              - [256, 25]
+              - [448, 31]
+              - [704, 25]
+              - [1024, 26]
+              - [1408, 24]
+              - [1856, 26]
+              - [2944, 31]
+              - [4288, 32]
+              - [5056, 30]
+              - [5888, 32]
+              - [-1, 31]
+          - - 2368
+            - - [1, 46]
+              - [32, 45]
+              - [64, 9]
+              - [128, 8]
+              - [704, 25]
+              - [1024, 26]
+              - [1408, 31]
+              - [1856, 26]
+              - [2368, 31]
+              - [2944, 32]
+              - [4288, 31]
+              - [-1, 32]
+          - - 2944
+            - - [1, 46]
+              - [32, 45]
+              - [64, 0]
+              - [128, 6]
+              - [256, 25]
+              - [448, 31]
+              - [704, 26]
+              - [1408, 32]
+              - [1856, 31]
+              - [2368, 32]
+              - [5056, 31]
+              - [-1, 32]
+          - - 3584
+            - - [1, 46]
+              - [32, 45]
+              - [64, 6]
+              - [256, 25]
+              - [448, 26]
+              - [704, 31]
+              - [1024, 26]
+              - [1408, 32]
+              - [2944, 31]
+              - [4288, 32]
+              - [5056, 31]
+              - [-1, 32]
+          - - 4288
+            - - [1, 46]
+              - [32, 45]
+              - [64, 18]
+              - [128, 22]
+              - [256, 25]
+              - [704, 26]
+              - [1024, 31]
+              - [1856, 32]
+              - [2944, 31]
+              - [3584, 32]
+              - [5056, 31]
+              - [5888, 32]
+              - [-1, 30]
+          - - 5056
+            - - [1, 46]
+              - [32, 45]
+              - [64, 1]
+              - [256, 25]
+              - [448, 26]
+              - [704, 31]
+              - [1408, 32]
+              - [1856, 31]
+              - [2368, 32]
+              - [2944, 31]
+              - [3584, 32]
+              - [4288, 31]
+              - [5888, 32]
+              - [-1, 30]
+          - - 5888
+            - - [1, 46]
+              - [32, 45]
+              - [64, 22]
+              - [128, 25]
+              - [704, 26]
+              - [1408, 32]
+              - [2368, 31]
+              - [3584, 32]
+              - [4288, 30]
+              - [-1, 32]
+          - - -1
+            - - [1, 46]
+              - [32, 45]
+              - [64, 1]
+              - [448, 26]
+              - [704, 31]
+              - [1024, 32]
+              - [2368, 31]
+              - [3584, 32]
+              - [5056, 30]
+              - [-1, 32]
+      - - 1280
+        - - - 1
+            - - [-1, 46]
+          - - 32
+            - - [-1, 45]
+          - - 64
+            - - [1, 46]
+              - [32, 45]
+              - [64, 13]
+              - [128, 4]
+              - [256, 7]
+              - [1024, 4]
+              - [1408, 9]
+              - [1856, 0]
+              - [2368, 7]
+              - [2944, 18]
+              - [3584, 6]
+              - [5056, 8]
+              - [5888, 20]
+              - [-1, 1]
+          - - 128
+            - - [1, 46]
+              - [32, 45]
+              - [64, 4]
+              - [128, 9]
+              - [256, 4]
+              - [448, 21]
+              - [704, 12]
+              - [1024, 21]
+              - [1408, 20]
+              - [1856, 6]
+              - [2368, 8]
+              - [2944, 20]
+              - [3584, 25]
+              - [4288, 20]
+              - [5888, 25]
               - [-1, 26]
           - - 256
-            - - [4, 13]
-              - [448, 14]
-              - [5888, 26]
-              - [-1, 25]
-          - - 448
-            - - [4, 13]
-              - [64, 14]
+            - - [1, 46]
+              - [32, 45]
+              - [64, 4]
               - [128, 13]
-              - [448, 14]
-              - [2368, 26]
+              - [256, 4]
+              - [448, 0]
               - [2944, 25]
+              - [3584, 26]
+              - [5056, 25]
               - [-1, 26]
-          - - 704
-            - - [64, 13]
-              - [128, 14]
-              - [448, 26]
-              - [704, 25]
+          - - 448
+            - - [1, 46]
+              - [32, 45]
+              - [128, 4]
+              - [256, 0]
+              - [448, 6]
+              - [1408, 25]
+              - [1856, 26]
+              - [2368, 25]
+              - [3584, 26]
+              - [4288, 24]
               - [5888, 26]
-              - [-1, 25]
-          - - 1024
-            - - [64, 13]
-              - [128, 14]
-              - [704, 26]
-              - [-1, 25]
-          - - 1408
-            - - [4, 13]
-              - [128, 14]
-              - [704, 26]
-              - [-1, 25]
-          - - 1856
-            - - [4, 13]
-              - [128, 14]
-              - [704, 26]
+              - [-1, 24]
+          - - 704
+            - - [1, 46]
+              - [32, 45]
+              - [64, 4]
+              - [128, 7]
               - [1024, 25]
-              - [1408, 26]
-              - [-1, 25]
-          - - 2368
-            - - [4, 13]
-              - [128, 14]
+              - [1408, 24]
+              - [1856, 25]
+              - [2368, 26]
+              - [5056, 24]
+              - [5888, 30]
+              - [-1, 32]
+          - - 1024
+            - - [1, 46]
+              - [32, 45]
+              - [64, 4]
+              - [128, 21]
+              - [704, 25]
+              - [2368, 26]
+              - [2944, 32]
+              - [3584, 26]
+              - [4288, 31]
+              - [-1, 32]
+          - - 1408
+            - - [1, 46]
+              - [32, 45]
+              - [64, 7]
+              - [128, 20]
+              - [448, 25]
+              - [2368, 26]
+              - [5888, 32]
+              - [-1, 31]
+          - - 1856
+            - - [1, 46]
+              - [32, 45]
+              - [64, 21]
+              - [128, 20]
+              - [256, 25]
               - [448, 26]
               - [704, 25]
               - [1024, 26]
+              - [1408, 24]
+              - [2368, 26]
+              - [2944, 31]
+              - [4288, 32]
+              - [5056, 30]
+              - [5888, 32]
+              - [-1, 31]
+          - - 2368
+            - - [1, 46]
+              - [32, 45]
+              - [64, 12]
+              - [128, 8]
+              - [448, 25]
+              - [1856, 26]
+              - [2368, 31]
+              - [2944, 32]
+              - [4288, 31]
+              - [-1, 32]
+          - - 2944
+            - - [1, 46]
+              - [32, 45]
+              - [64, 14]
+              - [128, 20]
+              - [256, 25]
+              - [704, 26]
+              - [1408, 32]
+              - [1856, 26]
+              - [2368, 32]
+              - [5056, 31]
+              - [-1, 32]
+          - - 3584
+            - - [1, 46]
+              - [32, 45]
+              - [64, 6]
+              - [128, 20]
+              - [1024, 26]
+              - [1408, 32]
+              - [1856, 26]
+              - [3584, 31]
+              - [-1, 32]
+          - - 4288
+            - - [1, 46]
+              - [32, 45]
+              - [64, 8]
+              - [128, 20]
+              - [256, 25]
+              - [704, 26]
+              - [1024, 31]
+              - [1856, 32]
+              - [2944, 31]
+              - [3584, 32]
+              - [5056, 31]
+              - [-1, 32]
+          - - 5056
+            - - [1, 46]
+              - [32, 45]
+              - [64, 8]
+              - [256, 25]
+              - [704, 26]
+              - [1408, 32]
+              - [1856, 31]
+              - [3584, 32]
+              - [4288, 31]
+              - [-1, 32]
+          - - 5888
+            - - [1, 46]
+              - [32, 45]
+              - [64, 20]
+              - [128, 25]
+              - [704, 26]
+              - [1408, 32]
+              - [2368, 31]
+              - [-1, 32]
+          - - -1
+            - - [1, 46]
+              - [32, 45]
+              - [64, 20]
+              - [448, 26]
+              - [1024, 32]
+              - [1856, 31]
+              - [3584, 32]
+              - [5056, 30]
+              - [-1, 32]
+      - - -1
+        - - - 1
+            - - [-1, 46]
+          - - 32
+            - - [-1, 45]
+          - - 64
+            - - [1, 46]
+              - [32, 45]
+              - [256, 4]
+              - [704, 13]
+              - [1024, 4]
+              - [1408, 16]
+              - [1856, 0]
+              - [2368, 12]
+              - [2944, 18]
+              - [3584, 6]
+              - [5056, 8]
+              - [5888, 25]
+              - [-1, 1]
+          - - 128
+            - - [1, 46]
+              - [32, 45]
+              - [64, 13]
+              - [128, 7]
+              - [448, 4]
+              - [704, 16]
+              - [1024, 21]
+              - [1408, 14]
+              - [1856, 11]
+              - [2368, 8]
+              - [2944, 11]
+              - [4288, 20]
+              - [5888, 25]
+              - [-1, 26]
+          - - 256
+            - - [1, 46]
+              - [32, 45]
+              - [256, 4]
+              - [448, 0]
+              - [2944, 25]
+              - [3584, 26]
+              - [5056, 25]
+              - [-1, 26]
+          - - 448
+            - - [1, 46]
+              - [32, 45]
+              - [64, 4]
+              - [128, 13]
+              - [256, 0]
+              - [448, 20]
               - [1408, 25]
               - [1856, 26]
-              - [-1, 25]
-          - - 3584
-            - - [4, 13]
-              - [64, 14]
-              - [448, 26]
-              - [-1, 25]
-          - - 4288
-            - - [4, 13]
-              - [128, 14]
-              - [256, 26]
-              - [-1, 25]
-          - - 5056
-            - - [4, 13]
-              - [64, 14]
-              - [128, 26]
+              - [2368, 25]
+              - [3584, 26]
+              - [4288, 24]
+              - [5056, 26]
+              - [5888, 32]
+              - [-1, 24]
+          - - 704
+            - - [1, 46]
+              - [32, 45]
+              - [64, 4]
+              - [128, 9]
+              - [1024, 25]
+              - [1408, 24]
+              - [1856, 25]
+              - [2368, 26]
+              - [5888, 24]
+              - [-1, 32]
+          - - 1024
+            - - [1, 46]
+              - [32, 45]
+              - [64, 13]
+              - [128, 21]
+              - [704, 25]
+              - [2368, 26]
+              - [2944, 32]
+              - [4288, 26]
+              - [-1, 32]
+          - - 1408
+            - - [1, 46]
+              - [32, 45]
+              - [64, 9]
+              - [128, 20]
+              - [448, 25]
+              - [2368, 26]
+              - [5888, 32]
+              - [-1, 31]
+          - - 1856
+            - - [1, 46]
+              - [32, 45]
+              - [64, 0]
+              - [128, 20]
               - [256, 25]
               - [448, 26]
-              - [-1, 25]
+              - [704, 25]
+              - [1024, 26]
+              - [1408, 24]
+              - [2944, 26]
+              - [4288, 32]
+              - [5056, 31]
+              - [5888, 32]
+              - [-1, 31]
+          - - 2368
+            - - [1, 46]
+              - [32, 45]
+              - [64, 7]
+              - [128, 18]
+              - [448, 25]
+              - [2368, 26]
+              - [2944, 32]
+              - [4288, 31]
+              - [-1, 32]
+          - - 2944
+            - - [1, 46]
+              - [32, 45]
+              - [64, 6]
+              - [128, 20]
+              - [256, 25]
+              - [704, 26]
+              - [1408, 32]
+              - [1856, 26]
+              - [2368, 32]
+              - [5056, 31]
+              - [-1, 32]
+          - - 3584
+            - - [1, 46]
+              - [32, 45]
+              - [64, 20]
+              - [128, 25]
+              - [1024, 26]
+              - [1408, 32]
+              - [3584, 31]
+              - [4288, 32]
+              - [5056, 31]
+              - [-1, 32]
+          - - 4288
+            - - [1, 46]
+              - [32, 45]
+              - [64, 18]
+              - [128, 20]
+              - [256, 25]
+              - [1024, 26]
+              - [1856, 32]
+              - [2944, 31]
+              - [3584, 32]
+              - [5056, 31]
+              - [-1, 32]
+          - - 5056
+            - - [1, 46]
+              - [32, 45]
+              - [64, 18]
+              - [256, 25]
+              - [704, 26]
+              - [1408, 32]
+              - [1856, 31]
+              - [2368, 32]
+              - [4288, 31]
+              - [-1, 32]
           - - 5888
-            - - [4, 13]
-              - [64, 14]
-              - [128, 26]
-              - [-1, 25]
-          - - -1
-            - - [4, 13]
+            - - [1, 46]
+              - [32, 45]
+              - [64, 20]
+              - [128, 25]
               - [256, 26]
-              - [-1, 25]
-      - - 256
-        - - - 4
-            - - [704, 5]
-              - [2368, 4]
-              - [2944, 5]
-              - [3584, 4]
-              - [-1, 5]
-          - - 64
-            - - [64, 5]
-              - [128, 10]
-              - [256, 8]
-              - [704, 5]
-              - [1024, 8]
-              - [1408, 15]
-              - [1856, 6]
-              - [2368, 8]
-              - [2944, 1]
-              - [3584, 9]
-              - [4288, 0]
-              - [5056, 9]
-              - [5888, 21]
-              - [-1, 29]
-          - - 128
-            - - [4, 5]
-              - [64, 6]
-              - [128, 8]
-              - [256, 23]
-              - [1024, 8]
-              - [1856, 9]
-              - [2944, 0]
-              - [3584, 29]
-              - [5056, 0]
-              - [5888, 29]
-              - [-1, 35]
-          - - 256
-            - - [128, 5]
-              - [256, 6]
-              - [448, 8]
-              - [2944, 29]
-              - [3584, 30]
-              - [5056, 29]
-              - [-1, 30]
-          - - 448
-            - - [128, 5]
-              - [256, 8]
-              - [448, 19]
-              - [1408, 29]
-              - [1856, 30]
-              - [2368, 29]
-              - [2944, 35]
-              - [3584, 29]
-              - [4288, 28]
-              - [5056, 35]
-              - [5888, 30]
-              - [-1, 28]
-          - - 704
-            - - [4, 5]
-              - [64, 23]
-              - [128, 10]
-              - [1856, 29]
-              - [2368, 30]
-              - [5888, 28]
-              - [-1, 36]
-          - - 1024
-            - - [4, 5]
-              - [64, 6]
-              - [128, 15]
-              - [704, 29]
-              - [1024, 35]
-              - [3584, 30]
-              - [4288, 35]
-              - [-1, 36]
-          - - 1408
-            - - [64, 5]
-              - [128, 1]
-              - [448, 29]
-              - [1408, 30]
-              - [1856, 35]
-              - [2368, 30]
-              - [5888, 36]
-              - [-1, 35]
-          - - 1856
-            - - [4, 4]
-              - [64, 15]
-              - [128, 9]
-              - [256, 29]
-              - [448, 30]
-              - [704, 29]
-              - [1024, 30]
-              - [1408, 28]
-              - [2368, 30]
-              - [2944, 35]
-              - [4288, 36]
-              - [5056, 35]
-              - [5888, 36]
-              - [-1, 35]
-          - - 2368
-            - - [4, 5]
-              - [64, 15]
-              - [128, 19]
-              - [448, 29]
-              - [1024, 35]
-              - [1408, 30]
-              - [2368, 35]
-              - [2944, 36]
-              - [4288, 35]
-              - [-1, 36]
-          - - 2944
-            - - [4, 4]
-              - [64, 1]
-              - [128, 22]
-              - [256, 29]
-              - [704, 30]
-              - [1408, 36]
-              - [1856, 35]
-              - [2368, 36]
-              - [5056, 35]
-              - [-1, 36]
-          - - 3584
-            - - [4, 5]
-              - [64, 9]
-              - [128, 22]
-              - [1024, 30]
-              - [1408, 36]
-              - [2944, 35]
-              - [4288, 36]
-              - [5056, 35]
-              - [-1, 36]
-          - - 4288
-            - - [4, 5]
-              - [64, 9]
-              - [128, 0]
-              - [256, 29]
-              - [448, 30]
-              - [1024, 35]
-              - [1856, 36]
-              - [2944, 35]
-              - [3584, 36]
-              - [5056, 35]
-              - [5888, 36]
-              - [-1, 34]
-          - - 5056
-            - - [4, 5]
-              - [128, 0]
-              - [256, 29]
-              - [704, 30]
-              - [1408, 36]
-              - [1856, 35]
-              - [3584, 36]
-              - [4288, 34]
-              - [5888, 36]
-              - [-1, 34]
-          - - 5888
-            - - [4, 5]
-              - [64, 22]
-              - [128, 29]
-              - [256, 35]
-              - [704, 30]
-              - [1408, 36]
-              - [2368, 35]
-              - [-1, 36]
+              - [448, 32]
+              - [704, 26]
+              - [1408, 32]
+              - [2368, 31]
+              - [-1, 32]
           - - -1
-            - - [4, 5]
-              - [64, 24]
-              - [448, 30]
-              - [704, 35]
-              - [1024, 36]
-              - [2368, 35]
-              - [3584, 36]
-              - [5056, 34]
-              - [-1, 36]
-      - - 1280
-        - - - 4
-            - - [4, 5]
-              - [-1, 20]
-          - - 64
-            - - [4, 20]
-              - [128, 6]
-              - [256, 18]
-              - [704, 6]
-              - [1024, 17]
-              - [1408, 10]
-              - [1856, 1]
-              - [2368, 10]
-              - [2944, 19]
-              - [3584, 22]
-              - [5056, 9]
-              - [-1, 22]
-          - - 128
-            - - [4, 20]
-              - [64, 6]
-              - [128, 8]
-              - [448, 6]
-              - [704, 15]
-              - [1024, 1]
-              - [1408, 9]
-              - [1856, 22]
-              - [2368, 9]
-              - [2944, 22]
-              - [3584, 29]
-              - [5056, 0]
-              - [5888, 29]
-              - [-1, 30]
-          - - 256
-            - - [4, 20]
-              - [64, 15]
-              - [256, 6]
-              - [448, 1]
-              - [2944, 29]
-              - [3584, 30]
-              - [5056, 29]
-              - [-1, 30]
-          - - 448
-            - - [4, 20]
-              - [128, 6]
-              - [256, 1]
-              - [448, 22]
-              - [1408, 29]
-              - [1856, 30]
-              - [2368, 29]
-              - [3584, 30]
-              - [4288, 28]
-              - [5056, 30]
-              - [5888, 36]
-              - [-1, 28]
-          - - 704
-            - - [4, 20]
-              - [64, 6]
-              - [128, 8]
-              - [1024, 29]
-              - [1408, 16]
-              - [1856, 29]
-              - [2368, 30]
-              - [5056, 28]
-              - [5888, 34]
-              - [-1, 36]
-          - - 1024
-            - - [4, 20]
-              - [64, 6]
-              - [128, 10]
-              - [704, 29]
-              - [2368, 30]
-              - [2944, 36]
-              - [3584, 30]
-              - [4288, 35]
-              - [-1, 36]
-          - - 1408
-            - - [4, 20]
-              - [64, 8]
-              - [128, 9]
-              - [448, 29]
-              - [2368, 30]
-              - [5888, 36]
-              - [-1, 35]
-          - - 1856
-            - - [4, 20]
+            - - [1, 46]
+              - [32, 45]
               - [64, 1]
-              - [128, 22]
-              - [256, 29]
-              - [448, 30]
-              - [704, 29]
-              - [1024, 30]
-              - [1408, 28]
-              - [2944, 30]
-              - [4288, 36]
-              - [5056, 34]
-              - [5888, 36]
-              - [-1, 35]
-          - - 2368
-            - - [4, 20]
-              - [64, 15]
-              - [128, 9]
-              - [448, 29]
-              - [2368, 30]
-              - [2944, 36]
-              - [4288, 35]
-              - [-1, 36]
-          - - 2944
-            - - [4, 20]
-              - [64, 19]
-              - [128, 0]
-              - [256, 29]
-              - [704, 30]
-              - [1408, 36]
-              - [1856, 30]
-              - [2368, 36]
-              - [5056, 35]
-              - [-1, 36]
-          - - 3584
-            - - [4, 20]
-              - [64, 22]
-              - [128, 0]
-              - [1024, 30]
-              - [1408, 36]
-              - [1856, 30]
-              - [3584, 35]
-              - [-1, 36]
-          - - 4288
-            - - [4, 20]
-              - [64, 19]
-              - [128, 0]
-              - [256, 29]
-              - [1024, 30]
-              - [1856, 36]
-              - [2944, 35]
-              - [3584, 36]
-              - [5056, 35]
-              - [-1, 36]
-          - - 5056
-            - - [4, 20]
-              - [64, 19]
-              - [128, 21]
-              - [256, 29]
-              - [704, 30]
-              - [1408, 36]
-              - [1856, 35]
-              - [2368, 36]
-              - [2944, 35]
-              - [3584, 36]
-              - [4288, 35]
-              - [-1, 36]
-          - - 5888
-            - - [4, 20]
-              - [64, 22]
-              - [128, 29]
-              - [704, 30]
-              - [1408, 36]
-              - [2368, 35]
-              - [-1, 36]
-          - - -1
-            - - [4, 20]
-              - [64, 22]
-              - [448, 30]
-              - [1024, 36]
-              - [2368, 35]
-              - [3584, 36]
-              - [5056, 34]
-              - [-1, 36]
-      - - -1
-        - - - 4
-            - - [5056, 20]
-              - [-1, 12]
-          - - 64
-            - - [4, 20]
-              - [448, 6]
-              - [1024, 17]
-              - [1408, 10]
-              - [1856, 1]
-              - [2368, 8]
-              - [2944, 19]
-              - [3584, 12]
-              - [5056, 21]
-              - [-1, 29]
-          - - 128
-            - - [4, 20]
-              - [448, 6]
-              - [704, 10]
-              - [1024, 1]
-              - [1408, 22]
-              - [1856, 12]
-              - [2368, 21]
-              - [3584, 22]
-              - [4288, 21]
-              - [5056, 0]
-              - [5888, 29]
-              - [-1, 30]
-          - - 256
-            - - [4, 20]
-              - [256, 6]
-              - [448, 23]
-              - [2944, 29]
-              - [3584, 30]
-              - [5056, 29]
-              - [-1, 30]
-          - - 448
-            - - [4, 20]
-              - [128, 6]
-              - [256, 1]
-              - [448, 12]
-              - [1408, 29]
-              - [1856, 30]
-              - [2368, 29]
-              - [3584, 30]
-              - [4288, 28]
-              - [5056, 30]
-              - [5888, 36]
-              - [-1, 28]
-          - - 704
-            - - [4, 20]
-              - [64, 17]
-              - [128, 10]
-              - [1024, 29]
-              - [1408, 16]
-              - [1856, 29]
-              - [2368, 30]
-              - [5888, 28]
-              - [-1, 36]
-          - - 1024
-            - - [4, 20]
-              - [64, 6]
-              - [128, 1]
-              - [704, 29]
-              - [2368, 30]
-              - [2944, 36]
-              - [4288, 30]
-              - [-1, 36]
-          - - 1408
-            - - [4, 20]
-              - [64, 10]
-              - [128, 19]
-              - [448, 29]
-              - [2368, 30]
-              - [5888, 36]
-              - [-1, 35]
-          - - 1856
-            - - [4, 20]
-              - [64, 1]
-              - [128, 12]
-              - [256, 29]
-              - [448, 30]
-              - [704, 29]
-              - [1024, 30]
-              - [1408, 28]
-              - [2944, 30]
-              - [4288, 36]
-              - [5056, 35]
-              - [5888, 36]
-              - [-1, 35]
-          - - 2368
-            - - [4, 20]
-              - [64, 8]
-              - [128, 19]
-              - [448, 29]
-              - [2368, 30]
-              - [2944, 36]
-              - [4288, 35]
-              - [-1, 36]
-          - - 2944
-            - - [4, 20]
-              - [128, 22]
-              - [256, 29]
-              - [704, 30]
-              - [1408, 36]
-              - [1856, 35]
-              - [2368, 36]
-              - [5056, 35]
-              - [-1, 36]
-          - - 3584
-            - - [4, 20]
-              - [64, 12]
-              - [128, 29]
-              - [1024, 30]
-              - [1408, 36]
-              - [3584, 35]
-              - [-1, 36]
-          - - 4288
-            - - [4, 20]
-              - [64, 19]
-              - [128, 0]
-              - [256, 29]
-              - [1024, 30]
-              - [1856, 36]
-              - [2944, 35]
-              - [3584, 36]
-              - [5056, 35]
-              - [-1, 36]
-          - - 5056
-            - - [4, 20]
-              - [64, 19]
-              - [128, 0]
-              - [256, 29]
-              - [704, 30]
-              - [1408, 36]
-              - [1856, 35]
-              - [2368, 36]
-              - [4288, 35]
-              - [-1, 36]
-          - - 5888
-            - - [4, 20]
-              - [64, 21]
-              - [128, 29]
-              - [256, 30]
-              - [448, 36]
-              - [704, 30]
-              - [1408, 36]
-              - [2368, 35]
-              - [-1, 36]
-          - - -1
-            - - [4, 20]
-              - [64, 22]
-              - [448, 30]
-              - [1024, 36]
-              - [2368, 35]
-              - [3584, 36]
-              - [5056, 35]
-              - [-1, 36]
+              - [448, 26]
+              - [1024, 32]
+              - [2368, 31]
+              - [3584, 32]
+              - [5056, 31]
+              - [-1, 32]

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HB.yaml
@@ -37,702 +37,7 @@
   TransposeB: true
   UseBeta: true
   UseInitialStrides: false
-- - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 64
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 0
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x064x08_GRVW04_NLCA01_PBC0_TT04_04_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 16
-    LSPA: 16
-    LSPB: 8
-    LVCA: 4
-    LVCB: 8
-    LVPA: 8
-    LVPB: 4
-    LdsNumElements: 819
-    LdsNumElementsAlignedA: 128
-    LdsNumElementsAlignedB: 128
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 256
-    LdsOffsetB: 128
-    LdsOffsetB_Blk: 384
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT016x016x08_GRVW02_NLCA01_PBC0_TT02_02_USFGRO00_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 32
-    LSPA: 32
-    LSPB: 8
-    LVCA: 8
-    LVCB: 32
-    LVPA: 32
-    LVPB: 8
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT032x032x08_GRVW02_NLCA01_PBC0_TT02_02_USFGRO00_VW02_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 3
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x08_GRVW04_NLCA01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x08_GRVW04_NLCA01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
+- - AssertFree0ElementMultiple: 2
     AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -851,8 +156,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 5
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x32_GRVW04_NLCA01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x32_PGR1_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -990,8 +295,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 6
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x16_GRVW04_NLCA01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x16_PGR1_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -1009,284 +314,6 @@
     VectorWidth: 4
     WorkGroup: [16, 16, 1]
     WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x16_GRVW04_NLCA01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x08_GRVW04_NLCA01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
     AssertSummationElementMultiple: 2
@@ -1407,8 +434,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 9
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x064x16_GRVW04_NLCA01_PBC0_TT04_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -1546,8 +573,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT128x128x16_GRVW08_NLCA01_PBC0_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT128x128x16_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -1564,423 +591,6 @@
     VectorStore: true
     VectorWidth: 8
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 128
-    LSPA: 128
-    LSPB: 16
-    LVCA: 2
-    LVCB: 16
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT128x128x16_GRVW08_NLCA01_PBC0_TT08_08_USFGRO00_VW08_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 16
-    LSPA: 16
-    LSPB: 8
-    LVCA: 4
-    LVCB: 8
-    LVPA: 8
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 3
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 3
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: true
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 12
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT016x016x24_GRVW02_NLCA03_PBC1_TT02_02_USFGRO01_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 32
-    LSPA: 16
-    LSPB: 8
-    LVCA: 4
-    LVCB: 8
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 13
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT032x032x16_GRVW04_NLCA01_PBC0_TT04_04_USFGRO00_VW04_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [8, 8, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -2102,8 +712,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 14
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT016x064x32_GRVW02_NLCA01_PBC1_TT02_02_USFGRO01_VW02_WG08_32_01
+    SolutionIndex: 4
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT016x064x32_PGR1_PLR1_TT02_02
     SubGroup0: 8
     SubGroup1: 32
     SubGroupA: 8
@@ -2122,145 +732,6 @@
     WorkGroup: [8, 32, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 32
-    LSPB: 8
-    LVCA: 4
-    LVCB: 16
-    LVPA: 8
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 64
-    MacroTileA: 32
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 15
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT032x064x16_GRVW04_NLCA01_PBC0_TT04_04_USFGRO00_VW04_WG08_16_01
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [8, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 1
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
@@ -2276,26 +747,26 @@
     EdgeType: ShiftPtr
     FractionalLoad: false
     GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
+    GlobalReadVectorWidth: 2
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
+    GlobalWriteVectorWidth: 2
     InnerUnroll: 1
     KernelLanguage: Source
     LSCA: 8
     LSCB: 128
     LSPA: 64
-    LSPB: 8
+    LSPB: 4
     LVCA: 4
-    LVCB: 32
+    LVCB: 64
     LVPA: 32
     LVPB: 2
     LdsNumElements: 1536
@@ -2325,13 +796,13 @@
     NonTemporalB: 0
     NonTemporalC: 0
     NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsA: 1
-    NumLoadsB: 1
+    NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
+    NumLoadsPerpendicularB: 2
     NumThreads: 256
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
@@ -2339,7 +810,7 @@
     PersistentKernel: 0
     PreciseBoundsCheck: false
     PrefetchGlobalRead: false
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -2376,8 +847,8 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 16
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x08_GRVW04_NLCA01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 5
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x08_PGR0_PLR0_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -2392,54 +863,54 @@
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
-    VectorWidth: 4
+    VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -1
+    WorkGroupMapping: -8
     WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
+    BufferLoad: false
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 16
+    DepthU: 8
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
+    GlobalReadVectorWidth: 2
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
+    GlobalWriteVectorWidth: 2
     InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
+    KernelLanguage: Source
+    LSCA: 8
     LSCB: 64
     LSPA: 64
-    LSPB: 16
+    LSPB: 8
     LVCA: 4
-    LVCB: 16
-    LVPA: 16
+    LVCB: 32
+    LVPA: 32
     LVPB: 4
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalRead2A: true
@@ -2451,10 +922,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
+    LoopUnroll: 8
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 128
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -2463,13 +934,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
+    NumElementsPerThread: 16
     NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
+    NumLoadsA: 1
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PerformanceSyncLocation: -1
@@ -2515,669 +986,835 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 17
-    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT128x064x16_GRVW04_NLCA01_PBC0_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 6
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x064x08_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 8
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
     UseSgprForGRO: 0
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
-    VectorWidth: 4
+    VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: -1
+    WorkGroupMapping: -8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 8
+    LSCB: 64
+    LSPA: 64
+    LSPB: 8
+    LVCA: 4
+    LVCB: 32
+    LVPA: 32
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 7
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x064x08_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: -8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 4
+    LSCB: 128
+    LSPA: 64
+    LSPB: 4
+    LVCA: 4
+    LVCB: 64
+    LVPA: 64
+    LVPB: 2
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 8
+    SolutionNameMin: Cijk_Alik_Bjlk_HB_MT064x128x04_PGR0_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: -8
     WorkGroupMappingType: B
 - [2, 3, 0, 1]
 - - - [1024, 1024, 1, 1024]
-    - [5, 12234.8]
+    - [0, 12113.3]
 - - - -1
-    - - - 128
-        - - - 4
-            - - [-1, 1]
+    - - - 1
+        - - - 32
+            - - [-1, 7]
           - - 64
-            - - [4, 1]
-              - [2368, 2]
-              - [2944, 0]
-              - [5888, 2]
-              - [-1, 0]
+            - - [256, 7]
+              - [448, 8]
+              - [2368, 7]
+              - [2944, 8]
+              - [5056, 7]
+              - [5888, 8]
+              - [-1, 7]
           - - 128
-            - - [4, 1]
-              - [2944, 2]
-              - [5888, 0]
-              - [-1, 4]
+            - - [1408, 7]
+              - [1856, 8]
+              - [2944, 7]
+              - [3584, 8]
+              - [5888, 7]
+              - [-1, 8]
           - - 256
-            - - [4, 1]
+            - - [704, 7]
+              - [1024, 8]
+              - [1408, 7]
+              - [2368, 8]
+              - [2944, 7]
+              - [3584, 8]
+              - [4288, 7]
+              - [5056, 8]
+              - [5888, 7]
+              - [-1, 8]
+          - - 448
+            - - [448, 7]
+              - [704, 8]
+              - [1856, 7]
+              - [-1, 8]
+          - - 704
+            - - [1408, 7]
+              - [-1, 8]
+          - - 1024
+            - - [1024, 7]
+              - [2368, 8]
+              - [2944, 7]
+              - [-1, 8]
+          - - 1408
+            - - [256, 7]
+              - [704, 8]
+              - [1024, 7]
+              - [-1, 8]
+          - - 1856
+            - - [448, 7]
+              - [-1, 8]
+          - - 2368
+            - - [64, 7]
+              - [128, 8]
+              - [448, 7]
+              - [-1, 8]
+          - - 2944
+            - - [64, 7]
+              - [256, 8]
+              - [448, 7]
+              - [-1, 8]
+          - - 3584
+            - - [256, 7]
+              - [-1, 8]
+          - - 4288
+            - - [128, 7]
+              - [-1, 8]
+          - - 5056
+            - - [32, 8]
+              - [64, 7]
+              - [256, 8]
+              - [448, 7]
+              - [5888, 8]
+              - [-1, 7]
+          - - 5888
+            - - [32, 7]
+              - [256, 8]
+              - [448, 7]
+              - [-1, 8]
+          - - -1
+            - - [64, 7]
+              - [-1, 8]
+      - - 32
+        - - - 64
+            - - [-1, 6]
+          - - 128
+            - - [1856, 6]
+              - [2368, 5]
+              - [-1, 6]
+          - - 256
+            - - [3584, 6]
+              - [-1, 5]
+          - - 448
+            - - [2368, 6]
+              - [-1, 5]
+          - - 704
+            - - [1408, 6]
+              - [1856, 5]
+              - [2368, 6]
+              - [-1, 5]
+          - - 1024
+            - - [1024, 6]
+              - [-1, 5]
+          - - 1408
+            - - [704, 6]
+              - [1408, 5]
+              - [1856, 6]
+              - [-1, 5]
+          - - 1856
+            - - [448, 6]
+              - [1024, 5]
+              - [1856, 6]
+              - [-1, 5]
+          - - 2368
+            - - [448, 6]
+              - [704, 5]
+              - [1024, 6]
+              - [-1, 5]
+          - - 3584
+            - - [256, 6]
+              - [448, 5]
+              - [704, 6]
+              - [-1, 5]
+          - - 5888
+            - - [128, 6]
+              - [256, 5]
+              - [448, 6]
+              - [-1, 5]
+          - - -1
+            - - [128, 6]
+              - [-1, 5]
+      - - 256
+        - - - 1
+            - - [-1, 7]
+          - - 32
+            - - [-1, 6]
+          - - 64
+            - - [1, 7]
+              - [32, 6]
+              - [2944, 4]
+              - [-1, 2]
+          - - 128
+            - - [1, 7]
+              - [32, 6]
+              - [1408, 4]
+              - [5888, 2]
+              - [-1, 1]
+          - - 256
+            - - [1, 7]
+              - [32, 6]
+              - [448, 4]
+              - [2944, 2]
+              - [4288, 1]
+              - [5056, 2]
+              - [5888, 1]
+              - [-1, 2]
+          - - 448
+            - - [1, 7]
+              - [32, 6]
+              - [256, 4]
+              - [1408, 2]
+              - [1856, 1]
+              - [2368, 2]
+              - [-1, 1]
+          - - 704
+            - - [1, 7]
+              - [32, 6]
+              - [128, 4]
+              - [1024, 2]
+              - [1408, 1]
+              - [1856, 2]
+              - [5888, 1]
+              - [-1, 3]
+          - - 1024
+            - - [1, 7]
+              - [32, 6]
+              - [128, 4]
+              - [704, 2]
+              - [-1, 1]
+          - - 1408
+            - - [1, 7]
+              - [32, 6]
+              - [128, 4]
+              - [704, 2]
+              - [1408, 1]
+              - [1856, 2]
+              - [2368, 1]
+              - [-1, 3]
+          - - 1856
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [256, 2]
+              - [448, 1]
+              - [704, 2]
+              - [3584, 1]
+              - [4288, 3]
+              - [5056, 1]
+              - [-1, 3]
+          - - 2368
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [704, 2]
+              - [2368, 1]
+              - [2944, 3]
+              - [4288, 1]
+              - [-1, 3]
+          - - 2944
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [256, 2]
+              - [448, 1]
+              - [704, 2]
+              - [1408, 3]
+              - [1856, 1]
+              - [2368, 3]
+              - [2944, 1]
+              - [-1, 3]
+          - - 3584
+            - - [1, 7]
+              - [32, 6]
+              - [128, 2]
+              - [256, 1]
+              - [704, 2]
+              - [1024, 1]
+              - [1856, 3]
+              - [2368, 1]
+              - [-1, 3]
+          - - 4288
+            - - [1, 7]
+              - [32, 6]
+              - [448, 2]
+              - [1024, 1]
+              - [1856, 3]
+              - [2368, 1]
+              - [-1, 3]
+          - - 5056
+            - - [1, 7]
+              - [32, 6]
+              - [256, 2]
+              - [448, 1]
+              - [1408, 3]
+              - [1856, 1]
+              - [-1, 3]
+          - - 5888
+            - - [1, 7]
+              - [32, 6]
+              - [128, 2]
+              - [704, 1]
+              - [-1, 3]
+          - - -1
+            - - [1, 7]
+              - [32, 6]
               - [128, 2]
               - [256, 1]
               - [448, 2]
-              - [1408, 0]
-              - [1856, 4]
-              - [2944, 0]
-              - [3584, 3]
-              - [4288, 0]
-              - [5888, 3]
-              - [-1, 0]
-          - - 448
-            - - [4, 1]
-              - [448, 2]
-              - [1408, 0]
-              - [1856, 4]
-              - [2368, 0]
-              - [2944, 3]
-              - [3584, 0]
-              - [4288, 16]
-              - [5056, 4]
-              - [5888, 3]
-              - [-1, 4]
-          - - 704
-            - - [4, 1]
-              - [64, 2]
-              - [128, 1]
-              - [1024, 0]
-              - [1408, 4]
-              - [1856, 3]
-              - [2944, 16]
-              - [5888, 4]
               - [-1, 3]
-          - - 1024
-            - - [4, 1]
-              - [128, 2]
-              - [704, 0]
-              - [1856, 3]
-              - [2368, 0]
-              - [-1, 3]
-          - - 1408
-            - - [4, 1]
-              - [128, 2]
-              - [448, 0]
-              - [704, 4]
-              - [1024, 3]
-              - [2368, 16]
-              - [2944, 3]
-              - [4288, 4]
-              - [5056, 16]
-              - [-1, 4]
-          - - 1856
-            - - [4, 1]
-              - [128, 2]
-              - [256, 0]
-              - [704, 3]
-              - [1024, 16]
-              - [3584, 4]
-              - [5056, 16]
-              - [-1, 4]
-          - - 2368
-            - - [4, 1]
-              - [128, 2]
-              - [448, 0]
-              - [704, 16]
-              - [1024, 3]
-              - [1408, 16]
-              - [2368, 4]
-              - [2944, 16]
-              - [3584, 4]
-              - [5888, 16]
-              - [-1, 4]
-          - - 2944
-            - - [4, 1]
-              - [128, 2]
-              - [256, 4]
-              - [448, 3]
-              - [704, 0]
-              - [1408, 16]
-              - [3584, 4]
-              - [5888, 16]
-              - [-1, 4]
-          - - 3584
-            - - [4, 1]
-              - [64, 2]
-              - [128, 0]
-              - [256, 3]
-              - [448, 16]
-              - [1024, 4]
-              - [-1, 3]
-          - - 4288
-            - - [4, 1]
-              - [64, 2]
-              - [704, 0]
-              - [1408, 4]
-              - [1856, 16]
-              - [2368, 4]
-              - [3584, 16]
-              - [4288, 4]
-              - [5888, 16]
-              - [-1, 4]
-          - - 5056
-            - - [4, 1]
-              - [64, 2]
-              - [128, 0]
-              - [1024, 4]
-              - [1408, 16]
-              - [1856, 4]
-              - [3584, 16]
-              - [4288, 4]
-              - [5888, 16]
-              - [-1, 4]
-          - - 5888
-            - - [4, 1]
-              - [64, 2]
-              - [128, 0]
-              - [2368, 4]
-              - [2944, 16]
-              - [3584, 4]
-              - [5888, 16]
-              - [-1, 4]
-          - - -1
-            - - [4, 1]
-              - [64, 2]
-              - [128, 4]
-              - [256, 0]
-              - [448, 16]
-              - [1408, 4]
-              - [5888, 16]
-              - [-1, 4]
-      - - 256
-        - - - 4
-            - - [-1, 12]
-          - - 64
-            - - [4, 12]
-              - [64, 14]
-              - [128, 12]
-              - [704, 14]
-              - [1024, 12]
-              - [2944, 14]
-              - [3584, 13]
-              - [-1, 15]
-          - - 128
-            - - [4, 12]
-              - [256, 14]
-              - [448, 12]
-              - [1408, 14]
-              - [1856, 9]
-              - [5056, 15]
-              - [5888, 9]
-              - [-1, 8]
-          - - 256
-            - - [4, 12]
-              - [128, 14]
-              - [256, 12]
-              - [448, 14]
-              - [704, 9]
-              - [1024, 13]
-              - [2944, 9]
-              - [3584, 8]
-              - [5056, 9]
-              - [5888, 8]
-              - [-1, 6]
-          - - 448
-            - - [4, 12]
-              - [64, 14]
-              - [128, 12]
-              - [256, 14]
-              - [1408, 9]
-              - [1856, 8]
-              - [2368, 9]
-              - [2944, 6]
-              - [3584, 7]
-              - [4288, 6]
-              - [-1, 7]
-          - - 704
-            - - [4, 12]
-              - [128, 14]
-              - [448, 13]
-              - [1024, 9]
-              - [1408, 8]
-              - [1856, 9]
-              - [2368, 6]
-              - [5888, 7]
-              - [-1, 10]
-          - - 1024
-            - - [64, 12]
-              - [128, 14]
-              - [256, 13]
-              - [704, 9]
-              - [1024, 7]
-              - [4288, 6]
-              - [5888, 11]
-              - [-1, 6]
-          - - 1408
-            - - [64, 12]
-              - [704, 9]
-              - [1408, 7]
-              - [1856, 17]
-              - [2368, 7]
-              - [2944, 11]
-              - [3584, 10]
-              - [4288, 11]
-              - [5888, 10]
-              - [-1, 7]
-          - - 1856
-            - - [4, 12]
-              - [64, 14]
-              - [128, 15]
-              - [256, 9]
-              - [448, 8]
-              - [704, 9]
-              - [1408, 6]
-              - [2368, 7]
-              - [2944, 6]
-              - [3584, 7]
-              - [4288, 10]
-              - [5056, 8]
-              - [5888, 10]
-              - [-1, 7]
-          - - 2368
-            - - [4, 12]
-              - [64, 14]
-              - [128, 15]
-              - [448, 9]
-              - [1024, 7]
-              - [1408, 6]
-              - [2368, 7]
-              - [2944, 10]
-              - [4288, 7]
-              - [5056, 11]
-              - [-1, 10]
-          - - 2944
-            - - [4, 12]
-              - [64, 14]
-              - [128, 15]
-              - [256, 9]
-              - [448, 7]
-              - [704, 17]
-              - [1024, 10]
-              - [1408, 11]
-              - [1856, 7]
-              - [2368, 10]
-              - [2944, 7]
-              - [-1, 10]
-          - - 3584
-            - - [4, 12]
-              - [64, 13]
-              - [128, 9]
-              - [448, 6]
-              - [704, 17]
-              - [1024, 6]
-              - [1856, 10]
-              - [2368, 7]
-              - [2944, 10]
-              - [3584, 11]
-              - [4288, 10]
-              - [5056, 11]
-              - [-1, 10]
-          - - 4288
-            - - [4, 12]
-              - [128, 15]
-              - [256, 9]
-              - [704, 17]
-              - [1024, 7]
-              - [1856, 10]
-              - [2368, 7]
-              - [3584, 10]
-              - [4288, 8]
-              - [-1, 10]
-          - - 5056
-            - - [4, 12]
-              - [128, 15]
-              - [256, 9]
-              - [448, 7]
-              - [704, 17]
-              - [1024, 10]
-              - [1408, 11]
-              - [1856, 7]
-              - [3584, 10]
-              - [4288, 8]
-              - [-1, 10]
-          - - 5888
-            - - [4, 12]
-              - [64, 15]
-              - [128, 9]
-              - [256, 7]
-              - [448, 8]
-              - [704, 17]
-              - [1024, 11]
-              - [1856, 10]
-              - [2944, 11]
-              - [-1, 10]
-          - - -1
-            - - [4, 12]
-              - [128, 15]
-              - [256, 7]
-              - [448, 17]
-              - [704, 7]
-              - [1408, 10]
-              - [1856, 11]
-              - [-1, 10]
       - - 1280
-        - - - 4
-            - - [-1, 12]
+        - - - 1
+            - - [-1, 7]
+          - - 32
+            - - [-1, 6]
           - - 64
-            - - [256, 12]
-              - [448, 14]
-              - [1024, 12]
-              - [1856, 14]
-              - [3584, 13]
-              - [-1, 15]
+            - - [1, 7]
+              - [32, 6]
+              - [2368, 4]
+              - [-1, 2]
           - - 128
-            - - [128, 12]
-              - [448, 14]
-              - [704, 12]
-              - [1024, 14]
-              - [1856, 13]
-              - [5056, 15]
-              - [5888, 9]
-              - [-1, 7]
+            - - [1, 7]
+              - [32, 6]
+              - [1408, 4]
+              - [5888, 2]
+              - [-1, 1]
           - - 256
-            - - [64, 12]
-              - [128, 14]
-              - [256, 12]
-              - [448, 14]
-              - [704, 13]
-              - [2944, 9]
-              - [3584, 7]
-              - [5056, 9]
-              - [5888, 7]
-              - [-1, 6]
+            - - [1, 7]
+              - [32, 6]
+              - [448, 4]
+              - [2944, 2]
+              - [3584, 1]
+              - [5056, 2]
+              - [-1, 1]
           - - 448
-            - - [4, 12]
-              - [256, 14]
-              - [704, 13]
-              - [1408, 9]
-              - [1856, 7]
-              - [2368, 9]
-              - [5056, 7]
-              - [5888, 10]
-              - [-1, 6]
+            - - [1, 7]
+              - [32, 6]
+              - [256, 4]
+              - [1408, 2]
+              - [1856, 1]
+              - [2368, 2]
+              - [5056, 1]
+              - [5888, 3]
+              - [-1, 1]
           - - 704
-            - - [128, 12]
-              - [448, 13]
-              - [1024, 9]
-              - [1408, 7]
-              - [1856, 9]
-              - [2368, 7]
-              - [2944, 6]
-              - [3584, 7]
-              - [5056, 6]
-              - [5888, 7]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 4]
+              - [1024, 2]
+              - [1408, 1]
+              - [1856, 2]
+              - [5888, 1]
+              - [-1, 3]
           - - 1024
-            - - [64, 12]
-              - [128, 14]
-              - [256, 13]
-              - [704, 9]
-              - [1024, 7]
-              - [2368, 6]
-              - [2944, 11]
-              - [4288, 6]
-              - [-1, 11]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 4]
+              - [704, 2]
+              - [4288, 1]
+              - [-1, 3]
           - - 1408
-            - - [64, 12]
-              - [256, 13]
-              - [448, 9]
-              - [704, 17]
-              - [1024, 7]
-              - [1408, 6]
-              - [1856, 17]
-              - [2368, 7]
-              - [3584, 10]
-              - [4288, 11]
-              - [5888, 10]
-              - [-1, 7]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [704, 2]
+              - [1408, 1]
+              - [1856, 3]
+              - [2368, 1]
+              - [5888, 3]
+              - [-1, 1]
           - - 1856
-            - - [4, 12]
-              - [64, 14]
-              - [128, 13]
-              - [256, 9]
-              - [448, 6]
-              - [704, 9]
-              - [1024, 6]
-              - [3584, 7]
-              - [4288, 10]
-              - [5056, 8]
-              - [5888, 7]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [256, 2]
+              - [448, 1]
+              - [704, 2]
+              - [3584, 1]
+              - [4288, 3]
+              - [5888, 1]
+              - [-1, 3]
           - - 2368
-            - - [4, 12]
-              - [64, 13]
-              - [128, 15]
-              - [448, 9]
-              - [1024, 6]
-              - [2368, 7]
-              - [2944, 10]
-              - [4288, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [448, 2]
+              - [2368, 1]
+              - [2944, 3]
+              - [4288, 1]
+              - [-1, 3]
           - - 2944
-            - - [4, 12]
-              - [64, 13]
-              - [128, 15]
-              - [256, 9]
-              - [448, 7]
-              - [704, 17]
-              - [1408, 10]
-              - [1856, 7]
-              - [2368, 11]
-              - [4288, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [256, 2]
+              - [448, 1]
+              - [704, 2]
+              - [1408, 3]
+              - [1856, 1]
+              - [2368, 3]
+              - [2944, 1]
+              - [-1, 3]
           - - 3584
-            - - [4, 12]
-              - [64, 13]
-              - [128, 15]
-              - [256, 6]
-              - [448, 7]
-              - [704, 17]
-              - [1024, 6]
-              - [1856, 10]
-              - [3584, 8]
-              - [4288, 10]
-              - [5888, 11]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 2]
+              - [448, 1]
+              - [704, 2]
+              - [1024, 1]
+              - [1856, 3]
+              - [2368, 1]
+              - [-1, 3]
           - - 4288
-            - - [4, 12]
-              - [128, 15]
-              - [256, 9]
-              - [704, 17]
-              - [1024, 7]
-              - [1856, 10]
-              - [2944, 8]
-              - [3584, 10]
-              - [4288, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [448, 2]
+              - [1024, 1]
+              - [1856, 3]
+              - [2368, 1]
+              - [3584, 3]
+              - [4288, 1]
+              - [-1, 3]
           - - 5056
-            - - [4, 12]
-              - [128, 15]
-              - [256, 9]
-              - [448, 7]
-              - [704, 17]
-              - [1024, 11]
-              - [1408, 10]
-              - [1856, 8]
-              - [3584, 10]
-              - [4288, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [256, 2]
+              - [448, 1]
+              - [1408, 3]
+              - [1856, 1]
+              - [-1, 3]
           - - 5888
-            - - [4, 12]
-              - [64, 15]
-              - [128, 9]
-              - [256, 7]
-              - [448, 6]
-              - [704, 17]
-              - [1024, 11]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 2]
+              - [256, 1]
+              - [448, 3]
+              - [704, 1]
+              - [-1, 3]
           - - -1
-            - - [4, 12]
-              - [64, 15]
-              - [128, 7]
-              - [256, 6]
-              - [448, 17]
-              - [1024, 10]
-              - [1856, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 2]
+              - [448, 1]
+              - [1024, 3]
+              - [1408, 1]
+              - [-1, 3]
       - - -1
-        - - - 4
-            - - [-1, 12]
+        - - - 1
+            - - [-1, 7]
+          - - 32
+            - - [-1, 6]
           - - 64
-            - - [256, 12]
-              - [1856, 14]
-              - [3584, 13]
-              - [-1, 15]
+            - - [1, 7]
+              - [32, 6]
+              - [1856, 4]
+              - [-1, 2]
           - - 128
-            - - [128, 12]
-              - [1024, 14]
-              - [1856, 13]
-              - [2944, 15]
-              - [3584, 9]
-              - [5056, 15]
-              - [5888, 9]
-              - [-1, 6]
+            - - [1, 7]
+              - [32, 6]
+              - [1024, 4]
+              - [5888, 2]
+              - [-1, 1]
           - - 256
-            - - [128, 12]
-              - [448, 14]
-              - [1024, 13]
-              - [2944, 9]
-              - [3584, 7]
-              - [5056, 9]
-              - [5888, 7]
-              - [-1, 6]
+            - - [1, 7]
+              - [32, 6]
+              - [448, 4]
+              - [2944, 2]
+              - [3584, 1]
+              - [5056, 2]
+              - [-1, 1]
           - - 448
-            - - [4, 12]
-              - [256, 14]
-              - [704, 13]
-              - [1408, 9]
-              - [1856, 6]
-              - [2368, 9]
-              - [3584, 7]
-              - [5056, 6]
-              - [5888, 10]
-              - [-1, 7]
+            - - [1, 7]
+              - [32, 6]
+              - [256, 4]
+              - [1408, 2]
+              - [1856, 1]
+              - [2368, 2]
+              - [5056, 1]
+              - [5888, 3]
+              - [-1, 1]
           - - 704
-            - - [128, 12]
-              - [448, 13]
-              - [1024, 9]
-              - [1408, 7]
-              - [1856, 9]
-              - [2368, 7]
-              - [3584, 6]
-              - [5888, 7]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 4]
+              - [1024, 2]
+              - [1408, 1]
+              - [1856, 2]
+              - [5888, 1]
+              - [-1, 3]
           - - 1024
-            - - [64, 12]
-              - [128, 14]
-              - [704, 9]
-              - [1024, 7]
-              - [1408, 6]
-              - [1856, 10]
-              - [2368, 6]
-              - [2944, 11]
-              - [4288, 6]
-              - [-1, 11]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 4]
+              - [704, 2]
+              - [2368, 1]
+              - [2944, 3]
+              - [4288, 1]
+              - [-1, 3]
           - - 1408
-            - - [64, 12]
-              - [128, 13]
-              - [448, 9]
-              - [704, 17]
-              - [1024, 7]
-              - [1408, 6]
-              - [1856, 17]
-              - [2368, 7]
-              - [4288, 10]
-              - [5056, 11]
-              - [5888, 10]
-              - [-1, 7]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [704, 2]
+              - [1024, 1]
+              - [1856, 3]
+              - [2368, 1]
+              - [5888, 3]
+              - [-1, 1]
           - - 1856
-            - - [4, 12]
-              - [64, 14]
-              - [256, 9]
-              - [448, 6]
-              - [704, 9]
-              - [1024, 7]
-              - [1408, 6]
-              - [2368, 7]
-              - [2944, 6]
-              - [3584, 8]
-              - [4288, 10]
-              - [5056, 7]
-              - [5888, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [256, 2]
+              - [448, 1]
+              - [704, 2]
+              - [1024, 3]
+              - [3584, 1]
+              - [4288, 3]
+              - [5888, 1]
+              - [-1, 3]
           - - 2368
-            - - [4, 12]
-              - [64, 13]
-              - [128, 15]
-              - [448, 9]
-              - [704, 6]
-              - [1408, 7]
-              - [1856, 6]
-              - [2368, 7]
-              - [2944, 10]
-              - [3584, 8]
-              - [4288, 7]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [448, 2]
+              - [704, 3]
+              - [2368, 1]
+              - [2944, 3]
+              - [4288, 1]
+              - [-1, 3]
           - - 2944
-            - - [4, 12]
-              - [64, 13]
-              - [128, 15]
-              - [256, 9]
-              - [448, 6]
-              - [704, 17]
-              - [1408, 10]
-              - [1856, 7]
-              - [2368, 10]
-              - [3584, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 4]
+              - [256, 2]
+              - [448, 1]
+              - [704, 2]
+              - [1408, 3]
+              - [1856, 1]
+              - [2368, 3]
+              - [3584, 1]
+              - [-1, 3]
           - - 3584
-            - - [4, 12]
-              - [64, 9]
-              - [128, 15]
-              - [256, 7]
-              - [448, 6]
-              - [704, 17]
-              - [1024, 6]
-              - [1856, 10]
-              - [3584, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 2]
+              - [448, 1]
+              - [704, 3]
+              - [1024, 1]
+              - [1856, 3]
+              - [2944, 1]
+              - [-1, 3]
           - - 4288
-            - - [4, 12]
-              - [128, 15]
-              - [256, 9]
-              - [704, 17]
-              - [1024, 6]
-              - [1856, 10]
-              - [2944, 8]
-              - [3584, 10]
-              - [4288, 7]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [448, 2]
+              - [1024, 1]
+              - [1856, 3]
+              - [2368, 1]
+              - [3584, 3]
+              - [4288, 1]
+              - [-1, 3]
           - - 5056
-            - - [4, 12]
-              - [64, 15]
-              - [256, 9]
-              - [448, 6]
-              - [704, 17]
-              - [1408, 10]
-              - [1856, 8]
-              - [2368, 10]
-              - [3584, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [256, 2]
+              - [448, 1]
+              - [1408, 3]
+              - [1856, 1]
+              - [-1, 3]
           - - 5888
-            - - [4, 13]
-              - [64, 15]
-              - [128, 9]
-              - [256, 7]
-              - [448, 10]
-              - [704, 17]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [128, 2]
+              - [256, 1]
+              - [448, 3]
+              - [704, 1]
+              - [-1, 3]
           - - -1
-            - - [4, 13]
-              - [64, 15]
-              - [128, 7]
-              - [256, 10]
-              - [448, 17]
-              - [1024, 10]
-              - [1856, 8]
-              - [-1, 10]
+            - - [1, 7]
+              - [32, 6]
+              - [64, 2]
+              - [448, 1]
+              - [1024, 3]
+              - [1408, 1]
+              - [-1, 3]

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HB.yaml
@@ -51,145 +51,6 @@
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 64
-    LSPB: 64
-    LVCA: 4
-    LVCB: 4
-    LVPA: 8
-    LVPB: 8
-    LdsNumElements: 26624
-    LdsNumElementsAlignedA: 8192
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 16384
-    LdsOffsetB: 8192
-    LdsOffsetB_Blk: 24576
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 256
-    MacroTile1: 64
-    MacroTileA: 256
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 0
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT256x064x32_GRVW08_NLCA01_NLCB01_PBC0_TT08_08_USFGRO00_VW08_WG32_08_01
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    ThreadTile: [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
     GlobalLoadVectorWidthA: 4
     GlobalLoadVectorWidthB: 4
     GlobalRead2A: true
@@ -295,8 +156,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x032x32_GRVW04_NLCA01_NLCB01_PBC0_TT04_04_USFGRO00_VW04_WG32_08_01
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x032x32_PGR1_PLR1_TT04_04
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
@@ -313,6 +174,145 @@
     VectorStore: true
     VectorWidth: 4
     WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 16
+    LSPB: 16
+    LVCA: 8
+    LVCB: 8
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -435,7 +435,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 2
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT016x016x32_GRVW02_NLCA01_NLCB01_PBC1_TT02_02_USFGRO01_VW02_WG08_08_01
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT016x016x32_PGR1_PLR1_TT02_02
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -574,7 +574,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 3
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x064x32_GRVW08_NLCA01_NLCB01_PBC0_TT08_08_USFGRO00_VW08_WG16_08_01
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x064x32_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
@@ -713,7 +713,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 4
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x32_GRVW04_NLCA01_NLCB01_PBC0_TT04_04_USFGRO00_VW04_WG08_08_01
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x32_PGR1_PLR1_TT04_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -730,145 +730,6 @@
     VectorStore: true
     VectorWidth: 4
     WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: true
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 5
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x016x32_GRVW02_NLCA01_NLCB01_PBC1_TT02_02_USFGRO01_VW02_WG16_08_01
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -990,8 +851,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 6
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x16_GRVW04_NLCA01_NLCB01_PBC0_TT04_04_USFGRO00_VW04_WG08_08_01
+    SolutionIndex: 5
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x16_PGR1_PLR1_TT04_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -1129,8 +990,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT048x032x24_GRVW02_NLCA03_NLCB03_PBC1_TT06_04_USFGRO01_VW02_WG08_08_01
+    SolutionIndex: 6
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT048x032x24_PGR1_PLR1_TT06_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -1268,8 +1129,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x24_GRVW04_NLCA03_NLCB03_PBC0_TT04_04_USFGRO00_VW04_WG08_08_01
+    SolutionIndex: 7
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x24_PGR1_PLR1_TT04_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -1288,20 +1149,20 @@
     WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
+    BufferLoad: true
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 16
+    DepthU: 24
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
-    FractionalLoad: false
+    FractionalLoad: 0
     GlobalLoadVectorWidthA: 2
     GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
@@ -1316,22 +1177,22 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
     InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 16
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
+    KernelLanguage: Assembly
+    LSCA: 8
+    LSCB: 8
+    LSPA: 16
+    LSPB: 16
+    LVCA: 4
+    LVCB: 4
+    LVPA: 8
+    LVPB: 8
+    LdsNumElements: 3200
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 384
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
     LdsPadA: 0
     LdsPadB: 0
     LocalRead2A: true
@@ -1343,10 +1204,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
+    LoopUnroll: 24
+    MacroTile0: 32
     MacroTile1: 16
-    MacroTileA: 16
+    MacroTileA: 32
     MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -1355,14 +1216,153 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
+    NumElementsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 6
+    NumLoadsB: 3
+    NumLoadsCoalescedA: 3
+    NumLoadsCoalescedB: 3
     NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: true
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 8
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x016x24_PGR1_PLR1_TT04_02
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    ThreadTile: [4, 2]
+    ThreadTile0: 4
+    ThreadTile1: 2
+    ThreadTileA: 4
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 24
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 8
+    LSCB: 8
+    LSPA: 32
+    LSPB: 32
+    LVCA: 2
+    LVCB: 2
+    LVPA: 8
+    LVPB: 8
+    LdsNumElements: 3584
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 768
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 24
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 3
+    NumLoadsB: 3
+    NumLoadsCoalescedA: 3
+    NumLoadsCoalescedB: 3
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
     NumThreads: 64
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
@@ -1408,24 +1408,24 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 9
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT016x016x16_GRVW02_NLCA01_NLCB01_PBC0_TT02_02_USFGRO00_VW02_WG08_08_01
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x24_PGR1_PLR1_TT04_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    ThreadTile: [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
     UnrollMemFence: false
     UseSgprForGRO: 0
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
-    VectorWidth: 2
+    VectorWidth: 4
     WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
     AssertSummationElementMultiple: 2
@@ -1547,146 +1547,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 10
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x016x24_GRVW02_NLCA03_NLCB03_PBC1_TT04_02_USFGRO01_VW02_WG08_08_01
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    ThreadTile: [4, 2]
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 8
-    LSPA: 16
-    LSPB: 16
-    LVCA: 4
-    LVCB: 4
-    LVPA: 8
-    LVPB: 8
-    LdsNumElements: 3200
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 6
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 3
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: true
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x016x24_GRVW02_NLCA03_NLCB03_PBC1_TT04_02_USFGRO01_VW02_WG08_08_01
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x016x24_PGR1_PLR1_TT04_02
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -1824,8 +1685,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 12
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x032x32_GRVW04_NLCA01_NLCB01_PBC0_TT08_04_USFGRO00_VW04_WG08_08_01
+    SolutionIndex: 11
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x032x32_PGR1_PLR1_TT08_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -1858,32 +1719,32 @@
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
+    GlobalReadVectorWidth: 8
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
+    GlobalWriteVectorWidth: 8
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 32
     LSCB: 32
     LSPA: 16
     LSPB: 16
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 7168
+    LVCA: 4
+    LVCB: 4
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 8192
     LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedB: 2048
     LdsOffsetA: 0
     LdsOffsetA_Blk: 4096
     LdsOffsetB: 2048
@@ -1901,9 +1762,9 @@
     LoopTail: true
     LoopUnroll: 32
     MacroTile0: 64
-    MacroTile1: 32
+    MacroTile1: 64
     MacroTileA: 64
-    MacroTileB: 32
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -1911,15 +1772,15 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsA: 4
-    NumLoadsB: 2
+    NumLoadsB: 4
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1963,25 +1824,164 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 13
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x032x32_GRVW04_NLCA01_NLCB01_PBC0_TT04_04_USFGRO00_VW04_WG16_08_01
-    SubGroup0: 16
+    SolutionIndex: 12
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x32_PGR1_PLR1_TT08_08
+    SubGroup0: 8
     SubGroup1: 8
-    SubGroupA: 16
+    SubGroupA: 8
     SubGroupB: 8
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
+    ThreadTile: [8, 8]
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
     UnrollMemFence: false
     UseSgprForGRO: 0
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 8, 1]
+    VectorWidth: 8
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 24
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 8
+    LSCB: 8
+    LSPA: 16
+    LSPB: 16
+    LVCA: 4
+    LVCB: 4
+    LVPA: 8
+    LVPB: 8
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 24
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 3
+    NumLoadsB: 3
+    NumLoadsCoalescedA: 3
+    NumLoadsCoalescedB: 3
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: true
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 13
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT016x016x24_PGR1_PLR1_TT02_02
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
     AssertSummationElementMultiple: 2
@@ -2103,7 +2103,7 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 14
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT016x016x24_GRVW02_NLCA03_NLCB03_PBC1_TT02_02_USFGRO01_VW02_WG08_08_01
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT016x016x24_PGR1_PLR1_TT02_02
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -2120,7 +2120,7 @@
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 1
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
     AssertSummationElementMultiple: 2
@@ -2129,7 +2129,146 @@
     BufferLoad: true
     BufferStore: true
     CheckTensorDimAsserts: false
-    DepthU: 24
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 15
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 2
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 32
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -2151,21 +2290,21 @@
     GlobalWriteVectorWidth: 2
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 8
+    LSCA: 32
+    LSCB: 32
     LSPA: 16
     LSPB: 16
-    LVCA: 4
-    LVCB: 4
+    LVCA: 16
+    LVCB: 16
     LVPA: 8
     LVPB: 8
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
+    LdsNumElements: 6656
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
     LdsPadA: 0
     LdsPadB: 0
     LocalRead2A: true
@@ -2177,10 +2316,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 16
+    LoopUnroll: 32
+    MacroTile0: 64
     MacroTile1: 16
-    MacroTileA: 16
+    MacroTileA: 64
     MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -2191,13 +2330,13 @@
     NonTemporalC: 0
     NumElementsPerThread: 4
     NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 3
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 3
-    NumLoadsPerpendicularA: 1
+    NumLoadsA: 4
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
-    NumThreads: 64
+    NumThreads: 256
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2241,11 +2380,11 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 15
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT016x016x24_GRVW02_NLCA03_NLCB03_PBC1_TT02_02_USFGRO01_VW02_WG08_08_01
-    SubGroup0: 8
+    SolutionIndex: 16
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x016x32_PGR1_PLR1_TT02_02
+    SubGroup0: 32
     SubGroup1: 8
-    SubGroupA: 8
+    SubGroupA: 32
     SubGroupB: 8
     ThreadTile: [2, 2]
     ThreadTile0: 2
@@ -2258,7 +2397,7 @@
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [8, 8, 1]
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -2380,8 +2519,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 16
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x16_GRVW04_NLCA01_NLCB01_PBC0_TT04_04_USFGRO00_VW04_WG08_08_01
+    SolutionIndex: 17
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT032x032x16_PGR1_PLR1_TT04_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
@@ -2398,284 +2537,6 @@
     VectorStore: true
     VectorWidth: 4
     WorkGroup: [8, 8, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 8
-    LSPA: 64
-    LSPB: 128
-    LVCA: 4
-    LVCB: 2
-    LVPA: 32
-    LVPB: 32
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 17
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x128x08_GRVW04_NLCA01_NLCB01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 32
-    LSPB: 32
-    LVCA: 8
-    LVCB: 8
-    LVPA: 8
-    LVPB: 8
-    LdsNumElements: 14336
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 10240
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 18
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x128x32_GRVW04_NLCA01_NLCB01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AssertFree0ElementMultiple: 2
@@ -2797,8 +2658,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 19
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x32_GRVW04_NLCA01_NLCB01_PBC0_TT04_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 18
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x32_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -2936,286 +2797,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 20
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x128x32_GRVW08_NLCA01_NLCB01_PBC0_TT08_08_USFGRO00_VW08_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 16
-    LSPA: 64
-    LSPB: 64
-    LVCA: 4
-    LVCB: 4
-    LVPA: 16
-    LVPB: 16
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 21
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x128x16_GRVW04_NLCA01_NLCB01_PBC0_TT04_08_USFGRO00_VW04_WG16_16_01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    ThreadTile: [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AssertFree0ElementMultiple: 2
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 32
-    LSPB: 32
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 32768
-    LdsNumElementsAlignedA: 8192
-    LdsNumElementsAlignedB: 8192
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 16384
-    LdsOffsetB: 8192
-    LdsOffsetB_Blk: 24576
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PreciseBoundsCheck: false
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 22
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x128x64_GRVW08_NLCA01_NLCB01_PBC0_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 19
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x128x32_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -3353,8 +2936,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 23
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x064x16_GRVW04_NLCA01_NLCB01_PBC0_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 20
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x064x16_PGR1_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -3492,8 +3075,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 24
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x064x08_GRVW04_NLCA01_NLCB01_PBC0_TT08_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 21
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x064x08_PGR1_PLR1_TT08_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -3631,8 +3214,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 25
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x16_GRVW04_NLCA01_NLCB01_PBC0_TT04_04_USFGRO00_VW04_WG16_16_01
+    SolutionIndex: 22
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -3770,8 +3353,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 26
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x128x08_GRVW08_NLCA01_NLCB01_PBC0_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 23
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x128x08_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -3909,8 +3492,8 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 27
-    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x128x16_GRVW08_NLCA01_NLCB01_PBC0_TT08_08_USFGRO00_VW08_WG16_16_01
+    SolutionIndex: 24
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT128x128x16_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
@@ -3929,642 +3512,1354 @@
     WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 8
+    LSCB: 8
+    LSPA: 64
+    LSPB: 64
+    LVCA: 4
+    LVCB: 4
+    LVPA: 32
+    LVPB: 32
+    LdsNumElements: 1536
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 25
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x128x08_PGR0_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 8
+    LSCB: 8
+    LSPA: 64
+    LSPB: 64
+    LVCA: 4
+    LVCB: 4
+    LVPA: 32
+    LVPB: 32
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 26
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x08_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 4
+    LSCB: 4
+    LSPA: 64
+    LSPB: 64
+    LVCA: 4
+    LVCB: 4
+    LVPA: 64
+    LVPB: 64
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 27
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x04_PGR0_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AssertFree0ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 8
+    LSCB: 8
+    LSPA: 64
+    LSPB: 64
+    LVCA: 4
+    LVCB: 4
+    LVPA: 32
+    LVPB: 32
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PreciseBoundsCheck: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 28
+    SolutionNameMin: Cijk_Alik_Bljk_HB_MT064x064x08_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
 - [2, 3, 0, 1]
 - - - [4096, 7000, 1, 4096]
-    - [20, 14692.5]
+    - [19, 14394.8]
   - - [7680, 12000, 1, 2560]
-    - [27, 18507.2]
+    - [24, 18518.1]
   - - [5124, 9124, 1, 1760]
-    - [26, 17892.2]
+    - [23, 17867.3]
   - - [1760, 32, 1, 1760]
-    - [15, 2320.27]
+    - [14, 2337.76]
   - - [512, 24000, 1, 1536]
-    - [27, 15959.3]
+    - [24, 16050.5]
   - - [3072, 24000, 1, 1024]
-    - [27, 16714.6]
+    - [24, 16684.7]
   - - [2048, 400, 1, 512]
-    - [27, 7426.11]
+    - [24, 7500.48]
   - - [2560, 7000, 1, 2560]
-    - [27, 17016.8]
+    - [24, 17011.2]
   - - [3072, 16, 1, 1024]
-    - [2, 1490.84]
+    - [14, 1483.81]
   - - [512, 48000, 1, 2816]
-    - [27, 18174.7]
+    - [24, 18175.5]
   - - [512, 48000, 1, 2048]
-    - [20, 13403.0]
+    - [19, 13370.2]
   - - [1760, 64, 1, 1760]
-    - [15, 3896.31]
+    - [14, 3794.88]
   - - [35, 8457, 1, 4096]
-    - [7, 0.0]
+    - [6, 0.0]
   - - [2048, 1600, 1, 2048]
-    - [19, 7893.56]
+    - [18, 8041.88]
   - - [512, 48000, 1, 1536]
-    - [27, 17265.6]
+    - [24, 17215.9]
   - - [2560, 32, 1, 2560]
-    - [15, 2739.19]
+    - [14, 2713.67]
   - - [8448, 5984, 1, 2816]
-    - [27, 18464.8]
+    - [24, 18470.5]
   - - [4096, 3200, 1, 1024]
-    - [20, 13714.5]
+    - [19, 13813.9]
   - - [1024, 24000, 1, 2560]
-    - [27, 17614.2]
+    - [24, 17676.0]
   - - [1760, 6400, 1, 1760]
-    - [26, 17849.5]
+    - [23, 17826.4]
   - - [1024, 700, 1, 512]
-    - [19, 7112.37]
+    - [24, 7014.49]
   - - [4608, 32, 1, 1536]
-    - [8, 3739.91]
+    - [9, 3730.05]
   - - [3072, 64, 1, 1024]
-    - [1, 3400.73]
+    - [15, 3442.6]
   - - [16384, 3200, 1, 4096]
-    - [20, 15087.6]
+    - [19, 15111.8]
   - - [2560, 16, 1, 2560]
-    - [14, 1742.96]
+    - [14, 1726.89]
   - - [1024, 48000, 1, 2560]
-    - [27, 18268.3]
+    - [24, 18226.5]
   - - [35, 8457, 1, 2560]
-    - [7, 0.0]
+    - [6, 0.0]
   - - [8448, 48000, 1, 2816]
-    - [27, 18909.2]
+    - [24, 18909.6]
   - - [2048, 32, 1, 2048]
-    - [14, 1939.53]
+    - [13, 1917.37]
   - - [2560, 3200, 1, 2560]
-    - [27, 16374.6]
+    - [24, 15901.7]
   - - [16384, 800, 1, 4096]
-    - [20, 12513.8]
+    - [19, 12750.9]
   - - [4608, 24000, 1, 1536]
-    - [27, 18396.8]
+    - [24, 18433.7]
   - - [7680, 48000, 1, 2560]
-    - [27, 18845.7]
+    - [24, 18850.7]
   - - [3072, 48000, 1, 1024]
-    - [27, 17843.6]
+    - [24, 17815.8]
   - - [1760, 16, 1, 1760]
-    - [15, 1207.63]
+    - [14, 1207.61]
   - - [8192, 3200, 1, 2048]
-    - [20, 13854.1]
+    - [19, 13772.2]
   - - [512, 24000, 1, 2816]
-    - [27, 17854.0]
+    - [24, 17851.1]
   - - [4096, 400, 1, 1024]
-    - [20, 9416.81]
+    - [19, 9341.3]
   - - [6144, 48000, 1, 2560]
-    - [27, 18710.2]
+    - [24, 18718.2]
   - - [4608, 48000, 1, 1536]
-    - [27, 18690.2]
+    - [24, 18699.9]
   - - [35, 8457, 1, 2048]
-    - [7, 0.0]
+    - [6, 0.0]
   - - [4096, 128, 1, 4096]
-    - [3, 4181.83]
+    - [3, 4598.01]
   - - [2048, 800, 1, 512]
-    - [20, 9763.16]
+    - [19, 9808.77]
   - - [4608, 5984, 1, 1536]
-    - [27, 17182.8]
+    - [24, 17340.9]
   - - [2560, 128, 1, 2560]
-    - [16, 5631.37]
+    - [17, 5568.55]
   - - [6144, 5984, 1, 2048]
-    - [20, 14195.5]
+    - [19, 14116.3]
   - - [35, 8457, 1, 1760]
-    - [7, 0.0]
+    - [6, 0.0]
   - - [7680, 24000, 1, 2560]
-    - [27, 18711.5]
+    - [24, 18692.6]
   - - [6144, 48000, 1, 2048]
-    - [27, 16388.2]
+    - [24, 16283.3]
   - - [5124, 9124, 1, 2560]
-    - [27, 17565.1]
+    - [24, 17589.9]
   - - [2048, 3200, 1, 2048]
-    - [18, 9013.1]
+    - [19, 9367.9]
   - - [2048, 16, 1, 2048]
-    - [14, 1034.34]
+    - [14, 957.59]
   - - [1024, 24000, 1, 1536]
-    - [27, 17230.3]
+    - [24, 17263.1]
   - - [7680, 16, 1, 2560]
-    - [10, 3024.69]
+    - [10, 3041.07]
   - - [2560, 6400, 1, 2560]
-    - [27, 17293.3]
+    - [24, 17257.4]
   - - [2048, 128, 1, 2048]
-    - [1, 3068.5]
+    - [0, 3159.5]
   - - [512, 16, 1, 500000]
-    - [2, 376.144]
+    - [2, 376.142]
   - - [1024, 8, 1, 500000]
-    - [2, 376.122]
+    - [2, 376.131]
   - - [512, 24000, 1, 2560]
-    - [27, 16855.7]
+    - [24, 16881.8]
   - - [1024, 24000, 1, 2816]
-    - [27, 18159.1]
+    - [24, 18162.1]
   - - [7680, 5984, 1, 2560]
-    - [27, 18071.5]
+    - [24, 18039.2]
   - - [2048, 1600, 1, 512]
-    - [20, 10623.7]
+    - [19, 10480.4]
   - - [2048, 7000, 1, 2048]
-    - [20, 12236.1]
+    - [19, 11912.0]
   - - [1760, 800, 1, 1760]
-    - [24, 12062.2]
+    - [21, 12020.0]
   - - [5124, 9124, 1, 4096]
-    - [20, 14653.2]
+    - [19, 14662.2]
   - - [4096, 64, 1, 4096]
-    - [4, 3436.15]
+    - [0, 3431.75]
   - - [7680, 32, 1, 2560]
-    - [1, 5153.47]
+    - [0, 5160.25]
   - - [2560, 64, 1, 2560]
-    - [16, 4365.36]
+    - [17, 4405.74]
   - - [3072, 128, 1, 1024]
-    - [1, 4734.81]
+    - [0, 4699.42]
   - - [7680, 64, 1, 2560]
-    - [12, 6658.95]
+    - [11, 6537.16]
   - - [1760, 128, 1, 1760]
-    - [8, 6103.55]
+    - [7, 6149.03]
   - - [2560, 1600, 1, 2560]
-    - [27, 12851.3]
+    - [24, 12667.4]
   - - [2048, 3200, 1, 512]
-    - [20, 12760.1]
+    - [19, 12846.1]
   - - [2560, 800, 1, 2560]
-    - [27, 10502.4]
+    - [24, 10485.6]
   - - [3072, 32, 1, 1024]
-    - [2, 2238.93]
+    - [2, 2254.98]
   - - [6144, 32, 1, 2560]
-    - [6, 4568.9]
+    - [5, 4516.42]
   - - [4608, 12000, 1, 1536]
-    - [27, 18234.5]
+    - [24, 18180.8]
   - - [4096, 32, 1, 4096]
-    - [13, 2290.37]
+    - [1, 2318.07]
   - - [6144, 24000, 1, 2048]
-    - [27, 15633.1]
+    - [24, 15721.9]
   - - [8192, 800, 1, 2048]
-    - [20, 10749.7]
+    - [19, 10347.2]
   - - [4096, 1600, 1, 1024]
-    - [20, 11653.9]
+    - [19, 11332.7]
   - - [5124, 9124, 1, 2048]
-    - [20, 14084.4]
+    - [19, 14165.0]
   - - [8448, 24000, 1, 2816]
-    - [27, 18834.1]
+    - [24, 18834.9]
   - - [1024, 48000, 1, 1536]
-    - [27, 18067.9]
+    - [24, 18029.6]
   - - [7680, 128, 1, 2560]
-    - [0, 10747.1]
+    - [12, 11418.1]
   - - [8192, 1600, 1, 2048]
-    - [20, 11701.1]
+    - [19, 11510.8]
   - - [4096, 800, 1, 1024]
-    - [20, 10104.2]
+    - [19, 10158.0]
   - - [1024, 16, 1, 500000]
-    - [2, 752.261]
+    - [2, 752.245]
   - - [2048, 800, 1, 2048]
-    - [19, 6743.16]
+    - [19, 6668.11]
   - - [1760, 3200, 1, 1760]
-    - [26, 15820.0]
+    - [23, 15856.4]
   - - [512, 48000, 1, 2560]
-    - [27, 17649.0]
+    - [24, 17663.6]
   - - [8448, 16, 1, 2816]
-    - [10, 3315.58]
+    - [8, 3304.06]
   - - [2048, 64, 1, 2048]
-    - [4, 2388.18]
+    - [4, 2295.08]
   - - [512, 24000, 1, 2048]
-    - [20, 11910.1]
+    - [19, 11121.4]
   - - [16384, 1600, 1, 4096]
-    - [20, 13919.2]
+    - [19, 13838.4]
   - - [4608, 16, 1, 1536]
-    - [14, 2479.09]
+    - [13, 2470.44]
   - - [1024, 24000, 1, 2048]
-    - [20, 13316.2]
+    - [19, 13444.2]
   - - [8192, 400, 1, 2048]
-    - [22, 7457.1]
+    - [18, 7305.13]
   - - [2048, 6400, 1, 2048]
-    - [20, 11717.8]
+    - [19, 11971.2]
   - - [6144, 12000, 1, 2048]
-    - [20, 14989.9]
+    - [19, 15028.5]
   - - [512, 8, 1, 500000]
-    - [2, 188.054]
+    - [2, 188.058]
   - - [1760, 7000, 1, 1760]
-    - [26, 16637.2]
+    - [23, 16640.2]
   - - [1024, 48000, 1, 2816]
-    - [27, 18689.1]
+    - [24, 18693.4]
   - - [6144, 16, 1, 2560]
-    - [11, 2803.65]
+    - [8, 2723.54]
   - - [8448, 32, 1, 2816]
-    - [6, 5202.68]
+    - [17, 5135.29]
   - - [4096, 16, 1, 4096]
-    - [5, 1301.55]
+    - [16, 1309.68]
   - - [6144, 24000, 1, 2560]
-    - [27, 18539.7]
+    - [24, 18517.6]
   - - [1024, 1024, 1, 1024]
-    - [20, 8755.13]
+    - [19, 8812.58]
   - - [8448, 12000, 1, 2816]
-    - [27, 18787.3]
+    - [24, 18785.4]
   - - [16384, 400, 1, 4096]
-    - [20, 9682.84]
+    - [19, 9716.49]
   - - [1760, 1600, 1, 1760]
-    - [26, 14669.9]
+    - [23, 14743.2]
   - - [1024, 48000, 1, 2048]
-    - [20, 14609.5]
+    - [19, 14700.7]
 - - - -1
-    - - - 128
-        - - - 4
-            - - [-1, 9]
+    - - - 1
+        - - - 32
+            - - [32, 27]
+              - [64, 28]
+              - [448, 27]
+              - [704, 28]
+              - [2368, 27]
+              - [2944, 28]
+              - [4288, 27]
+              - [-1, 28]
           - - 64
-            - - [5888, 9]
-              - [-1, 17]
+            - - [448, 27]
+              - [704, 28]
+              - [1024, 27]
+              - [1408, 28]
+              - [2944, 27]
+              - [3584, 28]
+              - [4288, 27]
+              - [5888, 28]
+              - [-1, 27]
           - - 128
-            - - [2368, 9]
-              - [-1, 17]
-          - - 448
-            - - [448, 9]
-              - [-1, 17]
-          - - 2368
-            - - [128, 9]
-              - [-1, 17]
-          - - 5888
-            - - [64, 9]
-              - [-1, 17]
-          - - -1
-            - - [4, 9]
-              - [-1, 17]
-      - - 256
-        - - - 4
-            - - [4, 14]
-              - [64, 2]
-              - [128, 14]
-              - [704, 2]
-              - [1024, 14]
-              - [1408, 2]
-              - [-1, 14]
-          - - 64
-            - - [128, 14]
-              - [256, 2]
-              - [1856, 14]
-              - [2368, 6]
-              - [2944, 16]
-              - [4288, 6]
-              - [5056, 25]
-              - [5888, 6]
-              - [-1, 25]
-          - - 128
-            - - [4, 2]
-              - [64, 14]
-              - [128, 2]
-              - [1024, 14]
-              - [1408, 11]
-              - [2368, 6]
-              - [5888, 25]
-              - [-1, 23]
+            - - [128, 27]
+              - [256, 28]
+              - [448, 27]
+              - [704, 28]
+              - [1408, 27]
+              - [1856, 28]
+              - [2368, 27]
+              - [2944, 28]
+              - [3584, 27]
+              - [4288, 28]
+              - [-1, 27]
           - - 256
-            - - [4, 14]
-              - [128, 2]
-              - [448, 14]
-              - [1024, 16]
-              - [2944, 25]
-              - [3584, 23]
+            - - [64, 28]
+              - [448, 27]
+              - [1408, 28]
+              - [1856, 27]
+              - [2368, 28]
+              - [4288, 27]
+              - [5056, 28]
+              - [-1, 27]
+          - - 448
+            - - [32, 28]
+              - [448, 27]
+              - [1024, 28]
+              - [1408, 27]
+              - [1856, 28]
+              - [2368, 27]
+              - [2944, 28]
+              - [-1, 27]
+          - - 704
+            - - [448, 27]
+              - [1024, 28]
+              - [-1, 27]
+          - - 1024
+            - - [64, 27]
+              - [128, 28]
+              - [1408, 27]
+              - [2368, 28]
+              - [-1, 27]
+          - - 1408
+            - - [64, 28]
+              - [256, 27]
+              - [704, 28]
+              - [-1, 27]
+          - - 1856
+            - - [32, 27]
+              - [64, 28]
+              - [128, 27]
+              - [256, 28]
+              - [-1, 27]
+          - - 2368
+            - - [32, 27]
+              - [64, 28]
+              - [1856, 27]
+              - [2368, 28]
+              - [-1, 27]
+          - - 2944
+            - - [128, 27]
+              - [256, 28]
+              - [-1, 27]
+          - - 3584
+            - - [64, 28]
+              - [448, 27]
+              - [704, 28]
+              - [-1, 27]
+          - - 4288
+            - - [-1, 27]
+          - - 5056
+            - - [32, 27]
+              - [64, 28]
+              - [-1, 27]
+          - - 5888
+            - - [-1, 27]
+          - - -1
+            - - [32, 28]
+              - [128, 27]
+              - [256, 28]
+              - [-1, 27]
+      - - 32
+        - - - 32
+            - - [5056, 26]
+              - [5888, 25]
+              - [-1, 26]
+          - - 128
+            - - [-1, 26]
+          - - 256
+            - - [3584, 26]
+              - [-1, 25]
+          - - 448
+            - - [1856, 26]
               - [4288, 25]
-              - [5888, 21]
-              - [-1, 27]
-          - - 448
-            - - [4, 14]
-              - [64, 15]
-              - [128, 14]
-              - [256, 15]
-              - [1408, 25]
-              - [1856, 21]
-              - [2368, 23]
-              - [2944, 21]
-              - [3584, 27]
-              - [5056, 21]
-              - [5888, 27]
-              - [-1, 21]
-          - - 704
-            - - [4, 2]
-              - [128, 15]
-              - [256, 16]
-              - [1024, 25]
-              - [1856, 21]
-              - [2368, 27]
-              - [2944, 21]
-              - [3584, 27]
-              - [4288, 21]
-              - [5056, 27]
-              - [5888, 21]
-              - [-1, 27]
-          - - 1024
-            - - [64, 14]
-              - [128, 15]
-              - [256, 16]
-              - [704, 25]
-              - [1408, 23]
-              - [1856, 27]
-              - [2368, 23]
-              - [-1, 27]
-          - - 1408
-            - - [4, 14]
-              - [128, 15]
-              - [448, 25]
-              - [704, 23]
-              - [1024, 21]
-              - [-1, 27]
-          - - 1856
-            - - [4, 2]
-              - [64, 15]
-              - [128, 16]
-              - [256, 25]
-              - [704, 21]
-              - [-1, 27]
-          - - 2368
-            - - [4, 14]
-              - [64, 16]
-              - [256, 25]
-              - [448, 23]
-              - [704, 27]
-              - [1024, 21]
-              - [-1, 27]
-          - - 2944
-            - - [4, 2]
-              - [64, 6]
-              - [256, 25]
-              - [704, 23]
-              - [-1, 27]
-          - - 3584
-            - - [4, 2]
-              - [64, 16]
-              - [128, 25]
-              - [256, 21]
-              - [448, 27]
-              - [704, 23]
-              - [-1, 27]
-          - - 4288
-            - - [4, 14]
-              - [128, 25]
-              - [256, 21]
-              - [704, 23]
-              - [-1, 27]
-          - - 5056
-            - - [4, 14]
-              - [128, 25]
-              - [448, 21]
-              - [-1, 27]
-          - - 5888
-            - - [4, 14]
-              - [128, 25]
-              - [256, 23]
-              - [448, 27]
-              - [704, 23]
-              - [-1, 27]
-          - - -1
-            - - [4, 14]
-              - [64, 25]
-              - [128, 23]
-              - [256, 27]
-              - [448, 23]
-              - [-1, 27]
-      - - 1280
-        - - - 4
-            - - [-1, 14]
-          - - 64
-            - - [256, 14]
-              - [704, 15]
-              - [1408, 14]
-              - [1856, 15]
-              - [2944, 16]
-              - [5056, 6]
-              - [5888, 16]
+              - [5056, 26]
               - [-1, 25]
+          - - 704
+            - - [1408, 26]
+              - [-1, 25]
+          - - 1024
+            - - [1024, 26]
+              - [1856, 25]
+              - [2368, 26]
+              - [-1, 25]
+          - - 1408
+            - - [704, 26]
+              - [-1, 25]
+          - - 1856
+            - - [256, 26]
+              - [-1, 25]
+          - - 2368
+            - - [448, 26]
+              - [704, 25]
+              - [1024, 26]
+              - [-1, 25]
+          - - 2944
+            - - [704, 26]
+              - [-1, 25]
+          - - 3584
+            - - [32, 26]
+              - [64, 25]
+              - [256, 26]
+              - [-1, 25]
+          - - 4288
+            - - [128, 26]
+              - [256, 25]
+              - [448, 26]
+              - [-1, 25]
+          - - -1
+            - - [128, 26]
+              - [-1, 25]
+      - - 256
+        - - - 1
+            - - [-1, 28]
+          - - 32
+            - - [-1, 26]
+          - - 64
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [256, 2]
+              - [1408, 13]
+              - [1856, 14]
+              - [2368, 13]
+              - [3584, 5]
+              - [4288, 17]
+              - [5888, 5]
+              - [-1, 22]
           - - 128
-            - - [128, 14]
-              - [256, 15]
-              - [448, 14]
-              - [704, 15]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 2]
+              - [704, 13]
               - [1024, 14]
-              - [1856, 6]
-              - [2368, 8]
-              - [5888, 25]
-              - [-1, 23]
+              - [1408, 5]
+              - [2368, 17]
+              - [2944, 5]
+              - [5888, 22]
+              - [-1, 20]
           - - 256
-            - - [448, 14]
-              - [1024, 16]
-              - [2944, 25]
-              - [3584, 23]
-              - [5056, 25]
-              - [5888, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [128, 2]
+              - [448, 13]
+              - [2944, 22]
+              - [5888, 20]
+              - [-1, 24]
           - - 448
-            - - [4, 14]
-              - [256, 15]
-              - [1408, 25]
-              - [1856, 21]
-              - [2368, 25]
-              - [2944, 23]
-              - [3584, 27]
-              - [4288, 21]
-              - [5056, 23]
-              - [5888, 27]
-              - [-1, 21]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 2]
+              - [128, 13]
+              - [256, 14]
+              - [1408, 22]
+              - [2944, 20]
+              - [3584, 24]
+              - [5056, 20]
+              - [-1, 24]
           - - 704
-            - - [64, 14]
-              - [128, 15]
-              - [448, 16]
-              - [1024, 25]
-              - [1408, 21]
-              - [1856, 25]
-              - [2368, 27]
-              - [4288, 21]
-              - [5056, 27]
-              - [5888, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 14]
+              - [256, 17]
+              - [1408, 22]
+              - [1856, 20]
+              - [2368, 24]
+              - [2944, 22]
+              - [-1, 24]
           - - 1024
-            - - [64, 14]
-              - [128, 15]
-              - [256, 16]
-              - [704, 25]
-              - [1024, 21]
-              - [1408, 23]
-              - [1856, 27]
-              - [2368, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [128, 13]
+              - [256, 17]
+              - [704, 22]
+              - [1408, 20]
+              - [1856, 24]
+              - [2368, 20]
+              - [-1, 24]
           - - 1408
-            - - [4, 14]
-              - [64, 15]
-              - [128, 16]
-              - [448, 25]
-              - [704, 23]
-              - [1024, 21]
-              - [1408, 27]
-              - [1856, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 5]
+              - [448, 22]
+              - [1024, 20]
+              - [-1, 24]
           - - 1856
-            - - [4, 14]
-              - [64, 15]
-              - [128, 16]
-              - [256, 25]
-              - [448, 27]
-              - [704, 25]
-              - [1024, 27]
-              - [1408, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 14]
+              - [128, 17]
+              - [256, 22]
+              - [448, 20]
+              - [704, 22]
+              - [-1, 24]
           - - 2368
-            - - [4, 14]
-              - [64, 6]
-              - [448, 25]
-              - [704, 27]
-              - [1024, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 14]
+              - [256, 22]
+              - [448, 20]
+              - [-1, 24]
           - - 2944
-            - - [4, 14]
-              - [64, 6]
-              - [256, 25]
-              - [448, 21]
-              - [704, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 5]
+              - [128, 17]
+              - [256, 22]
+              - [704, 20]
+              - [-1, 24]
           - - 3584
-            - - [4, 14]
-              - [64, 16]
-              - [128, 25]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [128, 22]
+              - [256, 20]
+              - [-1, 24]
           - - 4288
-            - - [4, 14]
-              - [64, 6]
-              - [256, 25]
-              - [704, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [256, 22]
+              - [704, 20]
+              - [-1, 24]
           - - 5056
-            - - [4, 14]
-              - [64, 16]
-              - [256, 25]
-              - [448, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 17]
+              - [256, 22]
+              - [448, 20]
+              - [-1, 24]
           - - 5888
-            - - [4, 14]
-              - [128, 25]
-              - [256, 21]
-              - [448, 27]
-              - [704, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [128, 22]
+              - [256, 20]
+              - [448, 24]
+              - [704, 20]
+              - [-1, 24]
           - - -1
-            - - [4, 14]
-              - [64, 25]
-              - [128, 21]
-              - [256, 27]
-              - [448, 23]
-              - [-1, 27]
-      - - -1
-        - - - 4
-            - - [5056, 14]
-              - [-1, 8]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 22]
+              - [128, 20]
+              - [256, 24]
+              - [448, 20]
+              - [-1, 24]
+      - - 1280
+        - - - 1
+            - - [-1, 28]
+          - - 32
+            - - [-1, 26]
           - - 64
-            - - [256, 14]
-              - [448, 15]
-              - [1408, 14]
-              - [1856, 15]
-              - [4288, 6]
-              - [-1, 25]
+            - - [1, 28]
+              - [32, 26]
+              - [1408, 13]
+              - [1856, 14]
+              - [2944, 5]
+              - [3584, 17]
+              - [4288, 5]
+              - [5056, 17]
+              - [-1, 22]
           - - 128
-            - - [448, 14]
-              - [1024, 15]
-              - [1408, 16]
-              - [1856, 6]
-              - [2368, 8]
-              - [5888, 25]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 14]
+              - [256, 13]
+              - [704, 14]
+              - [1024, 13]
+              - [1408, 5]
+              - [2944, 7]
+              - [5888, 22]
+              - [-1, 20]
           - - 256
-            - - [256, 14]
-              - [448, 15]
-              - [1024, 16]
-              - [2944, 25]
-              - [3584, 27]
-              - [5056, 25]
-              - [5888, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 14]
+              - [128, 13]
+              - [256, 14]
+              - [448, 13]
+              - [704, 9]
+              - [1024, 17]
+              - [2944, 22]
+              - [3584, 20]
+              - [5056, 22]
+              - [5888, 20]
+              - [-1, 24]
           - - 448
-            - - [4, 14]
-              - [256, 15]
-              - [448, 16]
-              - [1408, 25]
-              - [1856, 27]
-              - [2368, 25]
-              - [2944, 23]
-              - [3584, 27]
-              - [4288, 21]
-              - [5056, 23]
-              - [5888, 27]
-              - [-1, 21]
+            - - [1, 28]
+              - [32, 26]
+              - [256, 14]
+              - [1408, 22]
+              - [1856, 24]
+              - [2368, 22]
+              - [2944, 20]
+              - [3584, 24]
+              - [4288, 22]
+              - [5056, 20]
+              - [-1, 24]
           - - 704
-            - - [64, 14]
-              - [128, 15]
-              - [256, 16]
-              - [1024, 25]
-              - [1408, 21]
-              - [1856, 25]
-              - [2368, 27]
-              - [4288, 21]
-              - [5056, 27]
-              - [5888, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 14]
+              - [448, 17]
+              - [1856, 22]
+              - [2368, 24]
+              - [2944, 22]
+              - [-1, 24]
           - - 1024
-            - - [4, 14]
-              - [128, 15]
-              - [256, 16]
-              - [704, 25]
-              - [1024, 27]
-              - [1408, 21]
-              - [1856, 27]
-              - [2368, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 14]
+              - [256, 9]
+              - [704, 22]
+              - [1408, 20]
+              - [1856, 24]
+              - [2368, 20]
+              - [-1, 24]
           - - 1408
-            - - [4, 14]
-              - [64, 15]
-              - [128, 8]
-              - [448, 25]
-              - [704, 23]
-              - [1024, 21]
-              - [1408, 27]
-              - [1856, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 14]
+              - [128, 17]
+              - [256, 9]
+              - [448, 22]
+              - [1024, 20]
+              - [1408, 24]
+              - [1856, 20]
+              - [-1, 24]
           - - 1856
-            - - [4, 14]
-              - [64, 15]
-              - [128, 16]
-              - [256, 25]
-              - [448, 27]
-              - [704, 25]
-              - [1024, 27]
-              - [1408, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 14]
+              - [128, 17]
+              - [256, 22]
+              - [448, 24]
+              - [704, 22]
+              - [-1, 24]
           - - 2368
-            - - [4, 14]
-              - [64, 8]
-              - [128, 6]
-              - [448, 25]
-              - [704, 27]
-              - [1024, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 5]
+              - [128, 9]
+              - [448, 22]
+              - [704, 24]
+              - [1024, 20]
+              - [-1, 24]
           - - 2944
-            - - [4, 14]
-              - [64, 16]
-              - [256, 25]
-              - [704, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 5]
+              - [256, 22]
+              - [704, 20]
+              - [-1, 24]
           - - 3584
-            - - [4, 14]
-              - [64, 6]
-              - [128, 25]
-              - [448, 27]
-              - [704, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 17]
+              - [128, 22]
+              - [448, 24]
+              - [704, 20]
+              - [-1, 24]
           - - 4288
-            - - [4, 14]
-              - [64, 6]
-              - [256, 25]
-              - [704, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 5]
+              - [256, 22]
+              - [704, 20]
+              - [-1, 24]
           - - 5056
-            - - [4, 14]
-              - [64, 6]
-              - [256, 25]
-              - [448, 21]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 17]
+              - [256, 22]
+              - [448, 20]
+              - [-1, 24]
           - - 5888
-            - - [4, 8]
-              - [128, 25]
-              - [256, 21]
-              - [448, 27]
-              - [704, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [128, 22]
+              - [256, 20]
+              - [448, 24]
+              - [704, 20]
+              - [-1, 24]
           - - -1
-            - - [4, 8]
-              - [64, 25]
-              - [256, 27]
-              - [448, 23]
-              - [-1, 27]
+            - - [1, 28]
+              - [32, 26]
+              - [64, 22]
+              - [256, 24]
+              - [448, 20]
+              - [-1, 24]
+      - - -1
+        - - - 1
+            - - [-1, 28]
+          - - 32
+            - - [-1, 26]
+          - - 64
+            - - [1, 28]
+              - [32, 26]
+              - [448, 13]
+              - [704, 14]
+              - [1408, 13]
+              - [1856, 14]
+              - [2944, 5]
+              - [5056, 9]
+              - [-1, 22]
+          - - 128
+            - - [1, 28]
+              - [32, 26]
+              - [1024, 13]
+              - [1408, 17]
+              - [1856, 9]
+              - [2944, 7]
+              - [5888, 22]
+              - [-1, 24]
+          - - 256
+            - - [1, 28]
+              - [32, 26]
+              - [256, 13]
+              - [448, 14]
+              - [1408, 9]
+              - [2944, 22]
+              - [3584, 24]
+              - [5056, 22]
+              - [5888, 20]
+              - [-1, 24]
+          - - 448
+            - - [1, 28]
+              - [32, 26]
+              - [128, 13]
+              - [256, 14]
+              - [448, 9]
+              - [1408, 22]
+              - [1856, 24]
+              - [2368, 22]
+              - [2944, 20]
+              - [3584, 24]
+              - [4288, 22]
+              - [5056, 20]
+              - [-1, 24]
+          - - 704
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 14]
+              - [256, 9]
+              - [448, 17]
+              - [1856, 22]
+              - [2368, 24]
+              - [2944, 22]
+              - [-1, 24]
+          - - 1024
+            - - [1, 28]
+              - [32, 26]
+              - [64, 13]
+              - [128, 14]
+              - [256, 9]
+              - [704, 22]
+              - [1024, 24]
+              - [1408, 20]
+              - [1856, 24]
+              - [2368, 20]
+              - [-1, 24]
+          - - 1408
+            - - [1, 28]
+              - [32, 26]
+              - [64, 14]
+              - [128, 7]
+              - [256, 9]
+              - [448, 22]
+              - [1024, 20]
+              - [1408, 24]
+              - [1856, 20]
+              - [-1, 24]
+          - - 1856
+            - - [1, 28]
+              - [32, 26]
+              - [64, 14]
+              - [128, 17]
+              - [256, 22]
+              - [448, 24]
+              - [704, 22]
+              - [-1, 24]
+          - - 2368
+            - - [1, 28]
+              - [32, 26]
+              - [64, 7]
+              - [128, 9]
+              - [448, 22]
+              - [704, 24]
+              - [1024, 20]
+              - [-1, 24]
+          - - 2944
+            - - [1, 28]
+              - [32, 26]
+              - [64, 17]
+              - [256, 22]
+              - [704, 20]
+              - [-1, 24]
+          - - 3584
+            - - [1, 28]
+              - [32, 26]
+              - [64, 17]
+              - [128, 22]
+              - [448, 24]
+              - [704, 20]
+              - [-1, 24]
+          - - 4288
+            - - [1, 28]
+              - [32, 26]
+              - [64, 5]
+              - [256, 22]
+              - [704, 20]
+              - [-1, 24]
+          - - 5056
+            - - [1, 28]
+              - [32, 26]
+              - [64, 5]
+              - [256, 22]
+              - [448, 20]
+              - [-1, 24]
+          - - 5888
+            - - [1, 28]
+              - [32, 26]
+              - [128, 22]
+              - [256, 20]
+              - [448, 24]
+              - [704, 20]
+              - [-1, 24]
+          - - -1
+            - - [1, 28]
+              - [32, 26]
+              - [64, 22]
+              - [256, 24]
+              - [448, 20]
+              - [-1, 24]


### PR DESCRIPTION
-  partial backport of Correct gemm test matrix initialization
-  logic using hgemm hip yaml update for VW=2 and VW=1 on Vega 20
-  logic using changes from Tensile PR#297 for Vega 20