### PR TITLE
Add __device__ to llvm_fma_v2f16

### DIFF
--- a/library/src/include/definitions.h
+++ b/library/src/include/definitions.h
@@ -17,7 +17,7 @@
 // half vectors
 typedef _Float16 half8 __attribute__((ext_vector_type(8)));
 typedef _Float16 half2 __attribute__((ext_vector_type(2)));
-extern "C" half2 llvm_fma_v2f16(half2, half2, half2) __asm("llvm.fma.v2f16");
+extern "C" __device__ half2 llvm_fma_v2f16(half2, half2, half2) __asm("llvm.fma.v2f16");
 
 __device__ inline half2 rocblas_fmadd_half2(half2 multiplier, half2 multiplicand, half2 addend)
 {


### PR DESCRIPTION
resolves build failure for hip-clang.

Summary of proposed changes:
-  llvm_fma_v2f16 is a device function, therefore should be qualified with __device__

