### PR TITLE
Change client cmake files to support hip-clang

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -83,8 +83,8 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( rocblas-bench PRIVATE -Wno-unused-command-line-argument -mf16c )
 
-elseif( CMAKE_COMPILER_IS_GNUCXX )
-  # GCC needs specific flags to turn on f16c intrinsics
+elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
+  # GCC or hip-clang needs specific flags to turn on f16c intrinsics
   target_compile_options( rocblas-bench PRIVATE -mf16c )
 endif( )
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -112,9 +112,13 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( rocblas-test PRIVATE -Wno-unused-command-line-argument -mf16c )
 
-elseif( CMAKE_COMPILER_IS_GNUCXX )
-  # GCC needs specific flag to turn on f16c intrinsics
+elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
+  # GCC or hip-clang needs specific flag to turn on f16c intrinsics
   target_compile_options( rocblas-test PRIVATE -mf16c )
+endif( )
+
+if( CXX_VERSION_STRING MATCHES "clang" )
+  target_link_libraries( rocblas-test PRIVATE -lpthread -lm )
 endif( )
 
 set_target_properties( rocblas-test PROPERTIES CXX_EXTENSIONS NO )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -46,8 +46,8 @@ foreach( exe ${sample_list} )
     # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
     target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument )
-  elseif( CMAKE_COMPILER_IS_GNUCXX )
-    # GCC needs specific flags to turn on f16c intrinsics
+  elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
+    # GCC or hip-clang needs specific flags to turn on f16c intrinsics
     target_compile_options( ${exe} PRIVATE -mf16c )
   endif( )
 endforeach( )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -131,7 +131,7 @@ endif( )
 set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib" )
 
 # Give rocblas compiled for CUDA backend a different name
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CXX_VERSION_STRING MATCHES "clang" )
     set( package_name rocblas )
 else( )
     set( package_name rocblas-alt )


### PR DESCRIPTION
resolves build failure of clients for hip-clang

Summary of proposed changes:
-  need -mf16c for f16c intrinsic
-  need -lpthread -lm for rocblas_test
