### PR TITLE
correct column names in gemm-bench output

### DIFF
--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -456,7 +456,7 @@ rocblas_status testing_gemm(Arguments argus)
         cout << "transA,transB,M,N,K,alpha,lda,ldb,beta,ldc,rocblas-Gflops,us";
 
         if(argus.unit_check || argus.norm_check)
-            cout << ",CPU-Gflops(us),norm-error";
+            cout << ",CPU-Gflops,us,norm-error";
 
         cout << endl;
 
@@ -559,10 +559,10 @@ rocblas_status range_testing_gemm(Arguments argus)
     myfile.open(filename);
     if(myfile.is_open())
     {
-        myfile << "M, N, K, lda, ldb, ldc, rocblas-Gflops (us) ";
+        myfile << "M,N,K,lda,ldb,ldc,rocblas-Gflops,us";
         if(argus.norm_check)
         {
-            myfile << "CPU-Gflops(us), norm-error";
+            myfile << ",CPU-Gflops,us,norm-error";
         }
         myfile << endl;
     }


### PR DESCRIPTION
Correct output from gemm-bench to give correct csv column names. Previous output had Gflops(us) and it should be Gflops,us
