### PR TITLE
initial gemm_ex

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -36,6 +36,7 @@ if( BUILD_WITH_TENSILE )
   set(Tensile_TEST_SRC
       gemm_gtest.cpp
       gemm_strided_batched_gtest.cpp
+      gemm_ex_gtest.cpp
       trsm_gtest.cpp
       )
 endif( )

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -25,7 +25,8 @@ README: This file contains testers to verify the correctness of
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
-typedef std::tuple<vector<int>, vector<double>, vector<char>, vector<rocblas_precision>> gemm_ex_tuple;
+typedef std::tuple<vector<int>, vector<double>, vector<char>, vector<rocblas_precision>>
+    gemm_ex_tuple;
 
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc, ldd};
 // add/delete as a group
@@ -34,46 +35,46 @@ const vector<vector<int>> tiny_matrix_size_range = {
 };
 
 const vector<vector<int>> small_matrix_size_range = {
-//    {-1, -1, -1, -1, 1, 1, 1},
-      {1, 1, 1, 1, 1, 1, 1},
-      {2, 2, 2, 2, 2, 2, 2},
-      {3, 3, 3, 3, 3, 3, 3},
-      {4, 4, 4, 4, 4, 4, 4},
-      {4, 4, 4, 4, 4, 6, 5},
-      {5, 5, 5, 5, 5, 5, 5},
-      {6, 6, 6, 6, 6, 6, 6},
-      {7, 7, 7, 7, 7, 7, 7},
-      {8, 8, 8, 8, 8, 8, 8},
-      {9, 9, 9, 9, 9, 9, 9},
-      {10, 10, 10, 10, 10, 10, 10},
-//    {11, 11, 11, 11, 11, 11, 11},
-//    {12, 12, 12, 12, 12, 12, 12},
-//    {13, 13, 13, 13, 13, 13, 13},
-//    {14, 14, 14, 14, 14, 14, 14},
-//    {15, 15, 15, 15, 15, 15, 15},
-//    {16, 16, 16, 16, 16, 16, 16},
-//    {17, 17, 17, 17, 17, 17, 17},
-//    {18, 18, 18, 18, 18, 18, 18},
-//    {19, 19, 19, 19, 19, 19, 19},
-//    {20, 20, 20, 20, 20, 20, 20},
-      {2, 3, 4, 5, 6, 7, 8},
-//    {3, 4, 5, 6, 7, 8, 8},
-//    {4, 5, 6, 6, 6, 6, 6},
-//    {5, 6, 7, 7, 8, 9, 9},
-//    {6, 7, 8, 10, 9, 8, 8},
-//    {7, 8, 9, 11, 9, 10, 10},
-//    {8, 9, 10, 10, 11, 12, 12},
-//    {9, 10, 11, 12, 11, 13, 13},
-//    {13, 12, 11, 15, 14, 13, 13},
-//    {13, 14, 12, 12, 13, 14, 14},
-//    {15, 16, 17, 17, 18, 19, 19},
-//    {18, 17, 16, 18, 18, 18, 18},
-//    {16, 17, 18, 20, 19, 18, 18},
-//    {3, 33, 3, 33, 35, 35, 35},
-//    {5, 6, 7, 9, 11, 13, 13},
-//    {10, 10, 20, 100, 21, 22, 22},
-      {500, 501, 502, 503, 604, 505, 505},
-      {500, 501, 502, 203, 204, 205, 505},
+    {-1, -1, -1, -1, 1, 1, 1},
+    {1, 1, 1, 1, 1, 1, 1},
+    {2, 2, 2, 2, 2, 2, 2},
+    {3, 3, 3, 3, 3, 3, 3},
+    {4, 4, 4, 4, 4, 4, 4},
+    {4, 4, 4, 4, 4, 6, 5},
+    {5, 5, 5, 5, 5, 5, 5},
+    {6, 6, 6, 6, 6, 6, 6},
+    {7, 7, 7, 7, 7, 7, 7},
+    {8, 8, 8, 8, 8, 8, 8},
+    {9, 9, 9, 9, 9, 9, 9},
+    {10, 10, 10, 10, 10, 10, 10},
+    {11, 11, 11, 11, 11, 11, 11},
+    {12, 12, 12, 12, 12, 12, 12},
+    {13, 13, 13, 13, 13, 13, 13},
+    {14, 14, 14, 14, 14, 14, 14},
+    {15, 15, 15, 15, 15, 15, 15},
+    {16, 16, 16, 16, 16, 16, 16},
+    {17, 17, 17, 17, 17, 17, 17},
+    {18, 18, 18, 18, 18, 18, 18},
+    {19, 19, 19, 19, 19, 19, 19},
+    {20, 20, 20, 20, 20, 20, 20},
+    {2, 3, 4, 5, 6, 7, 8},
+    {3, 4, 5, 6, 7, 8, 9},
+    //    {4, 5, 6, 6, 6, 6, 6},
+    //    {5, 6, 7, 7, 8, 9, 9},
+    //    {6, 7, 8, 10, 9, 8, 8},
+    //    {7, 8, 9, 11, 9, 10, 10},
+    //    {8, 9, 10, 10, 11, 12, 12},
+    //    {9, 10, 11, 12, 11, 13, 13},
+    //    {13, 12, 11, 15, 14, 13, 13},
+    //    {13, 14, 12, 12, 13, 14, 14},
+    //    {15, 16, 17, 17, 18, 19, 19},
+    //    {18, 17, 16, 18, 18, 18, 18},
+    //    {16, 17, 18, 20, 19, 18, 18},
+    //    {3, 33, 3, 33, 35, 35, 35},
+    //    {5, 6, 7, 9, 11, 13, 13},
+    //    {10, 10, 20, 100, 21, 22, 22},
+    {500, 501, 502, 503, 604, 505, 505},
+    {500, 501, 502, 203, 204, 205, 505},
 };
 
 const vector<vector<int>> large_matrix_size_range = {
@@ -110,7 +111,8 @@ const vector<vector<double>> alpha_beta_range = {
 };
 
 const vector<vector<double>> small_alpha_beta_range = {
-    {1.0, 1.0}, };
+    {1.0, 2.0},
+};
 
 const vector<vector<double>> full_alpha_beta_range = {
     {1.0, 0.0}, {-1.0, -1.0}, {2.0, 1.0}, {0.0, 1.0}};
@@ -122,11 +124,21 @@ const vector<vector<double>> full_alpha_beta_range = {
 const vector<vector<char>> small_transA_transB_range = {{'N', 'N'}};
 const vector<vector<char>> transA_transB_range = {{'N', 'N'}, {'N', 'T'}, {'C', 'N'}, {'T', 'C'}};
 
-const vector<vector<rocblas_precision>> precision_type_range = {
-{rocblas_precision_half,rocblas_precision_half,rocblas_precision_half,rocblas_precision_half,rocblas_precision_half},
-{rocblas_precision_single,rocblas_precision_single,rocblas_precision_single,rocblas_precision_single,rocblas_precision_single},
-{rocblas_precision_double,rocblas_precision_double,rocblas_precision_double,rocblas_precision_double,rocblas_precision_double}
-};
+const vector<vector<rocblas_precision>> precision_type_range = {{rocblas_precision_half,
+                                                                 rocblas_precision_half,
+                                                                 rocblas_precision_half,
+                                                                 rocblas_precision_half,
+                                                                 rocblas_precision_half},
+                                                                {rocblas_precision_single,
+                                                                 rocblas_precision_single,
+                                                                 rocblas_precision_single,
+                                                                 rocblas_precision_single,
+                                                                 rocblas_precision_single},
+                                                                {rocblas_precision_double,
+                                                                 rocblas_precision_double,
+                                                                 rocblas_precision_double,
+                                                                 rocblas_precision_double,
+                                                                 rocblas_precision_double}};
 
 /* ===============Google Unit Test==================================================== */
 
@@ -145,9 +157,9 @@ const vector<vector<rocblas_precision>> precision_type_range = {
 
 Arguments setup_gemm_ex_arguments(gemm_ex_tuple tup)
 {
-    vector<int> matrix_size    = std::get<0>(tup);
-    vector<double> alpha_beta  = std::get<1>(tup);
-    vector<char> transA_transB = std::get<2>(tup);
+    vector<int> matrix_size                   = std::get<0>(tup);
+    vector<double> alpha_beta                 = std::get<1>(tup);
+    vector<char> transA_transB                = std::get<2>(tup);
     vector<rocblas_precision> precision_types = std::get<3>(tup);
 
     Arguments arg;
@@ -170,16 +182,16 @@ Arguments setup_gemm_ex_arguments(gemm_ex_tuple tup)
 
     arg.timing = 0;
 
-    arg.a_type = precision_types[0];
-    arg.b_type = precision_types[1];
-    arg.c_type = precision_types[2];
-    arg.d_type = precision_types[3];
+    arg.a_type       = precision_types[0];
+    arg.b_type       = precision_types[1];
+    arg.c_type       = precision_types[2];
+    arg.d_type       = precision_types[3];
     arg.compute_type = precision_types[4];
 
     return arg;
 }
 
-//class parameterized_gemm_ex_NaN : public ::TestWithParam<gemm_ex_tuple>
+// class parameterized_gemm_ex_NaN : public ::TestWithParam<gemm_ex_tuple>
 //{
 //    protected:
 //    parameterized_gemm_ex_NaN() {}
@@ -188,21 +200,21 @@ Arguments setup_gemm_ex_arguments(gemm_ex_tuple tup)
 //    virtual void TearDown() {}
 //};
 //
-//TEST_P(parameterized_gemm_ex_NaN, rocblas_half)
+// TEST_P(parameterized_gemm_ex_NaN, rocblas_half)
 //{
 //    Arguments arg = setup_gemm_ex_arguments(GetParam());
 //
 //    testing_gemm_ex_NaN<rocblas_half>(arg);
 //}
 //
-//TEST_P(parameterized_gemm_ex_NaN, float)
+// TEST_P(parameterized_gemm_ex_NaN, float)
 //{
 //    Arguments arg = setup_gemm_ex_arguments(GetParam());
 //
 //    testing_gemm_ex_NaN<float>(arg);
 //}
 //
-//TEST_P(parameterized_gemm_ex_NaN, double)
+// TEST_P(parameterized_gemm_ex_NaN, double)
 //{
 //    Arguments arg = setup_gemm_ex_arguments(GetParam());
 //
@@ -227,7 +239,7 @@ TEST_P(parameterized_gemm_ex, standard)
 
     Arguments arg = setup_gemm_ex_arguments(GetParam());
 
-//  rocblas_status status = testing_gemm_ex<float>(arg);
+    //  rocblas_status status = testing_gemm_ex<float>(arg);
     rocblas_status status = testing_gemm_ex(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
@@ -303,12 +315,11 @@ class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
     virtual void TearDown() {}
 };
 
+// TEST(checkin_blas3_bad_arg, gemm_ex_half) { testing_gemm_ex_bad_arg<rocblas_half>(); }
 
-//TEST(checkin_blas3_bad_arg, gemm_ex_half) { testing_gemm_ex_bad_arg<rocblas_half>(); }
+// TEST(checkin_blas3_bad_arg, gemm_ex_float) { testing_gemm_ex_bad_arg<float>(); }
 
-//TEST(checkin_blas3_bad_arg, gemm_ex_float) { testing_gemm_ex_bad_arg<float>(); }
-
-//TEST(checkin_blas3_bad_arg, gemm_ex_double) { testing_gemm_ex_bad_arg<double>(); }
+// TEST(checkin_blas3_bad_arg, gemm_ex_double) { testing_gemm_ex_bad_arg<double>(); }
 
 // notice we are using vector of vector
 // so each elment in xxx_range is a avector,
@@ -316,7 +327,7 @@ class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
 // The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB} }
 
 // INSTANTIATE_TEST_CASE_P(rocblas_gemm_ex_beta_eq_0, parameterized_gemm_ex_NaN,
-//INSTANTIATE_TEST_CASE_P(checkin_blas3_NaN,
+// INSTANTIATE_TEST_CASE_P(checkin_blas3_NaN,
 //                        parameterized_gemm_ex_NaN,
 //                        Combine(ValuesIn(NaN_matrix_size_range),
 //                                ValuesIn(NaN_alpha_beta_range),
@@ -324,7 +335,7 @@ class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
 
 // THis function mainly test the scope of matrix_size. the scope of alpha_beta, transA_transB is
 // small
-//INSTANTIATE_TEST_CASE_P(daily_blas3_large,
+// INSTANTIATE_TEST_CASE_P(daily_blas3_large,
 //                        parameterized_gemm_ex,
 //                        Combine(ValuesIn(large_matrix_size_range),
 //                                ValuesIn(alpha_beta_range),
@@ -336,35 +347,35 @@ class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
 INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
                         parameterized_gemm_ex,
                         Combine(ValuesIn(small_matrix_size_range),
-                                ValuesIn(small_alpha_beta_range),
-                                ValuesIn(small_transA_transB_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
                                 ValuesIn(precision_type_range)));
 
-//INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
+// INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
 //                        parameterized_gemm_ex,
 //                        Combine(ValuesIn(tiny_matrix_size_range),
 //                                ValuesIn(full_alpha_beta_range),
 //                                ValuesIn(transA_transB_range)));
 //
-//INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
+// INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
 //                        parameterized_half_gemm_ex,
 //                        Combine(ValuesIn(small_matrix_size_range),
 //                                ValuesIn(full_alpha_beta_range),
 //                                ValuesIn(transA_transB_range)));
 //
-//INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
+// INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
 //                        parameterized_half_gemm_ex,
 //                        Combine(ValuesIn(tiny_matrix_size_range),
 //                                ValuesIn(full_alpha_beta_range),
 //                                ValuesIn(transA_transB_range)));
 //
-//INSTANTIATE_TEST_CASE_P(daily_blas3_large,
+// INSTANTIATE_TEST_CASE_P(daily_blas3_large,
 //                        parameterized_half_gemm_ex,
 //                        Combine(ValuesIn(large_matrix_size_range),
 //                                ValuesIn(alpha_beta_range),
 //                                ValuesIn(transA_transB_range)));
 //
-//INSTANTIATE_TEST_CASE_P(daily_blas3_chunk,
+// INSTANTIATE_TEST_CASE_P(daily_blas3_chunk,
 //                        parameterized_chunk_gemm_ex,
 //                        Combine(ValuesIn(chunk_matrix_size_range),
 //                                ValuesIn(alpha_beta_2_3_range),

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -1,0 +1,371 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include <gtest/gtest.h>
+#include <math.h>
+#include <stdexcept>
+#include <vector>
+#include "testing_gemm_ex.hpp"
+#include "utility.h"
+
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using ::testing::Combine;
+using namespace std;
+
+/* =====================================================================
+README: This file contains testers to verify the correctness of
+        BLAS routines with google test
+
+        It is supposed to be played/used by advance / expert users
+        Normal users only need to get the library routines without testers
+     =================================================================== */
+
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+
+typedef std::tuple<vector<int>, vector<double>, vector<char>, vector<rocblas_precision>> gemm_ex_tuple;
+
+// vector of vector, each vector is a {M, N, K, lda, ldb, ldc, ldd};
+// add/delete as a group
+const vector<vector<int>> tiny_matrix_size_range = {
+    {1, 1, 1, 1, 1, 1, 1}, {1, 2, 3, 4, 5, 6, 6}, {7, 9, 15, 17, 18, 19, 19},
+};
+
+const vector<vector<int>> small_matrix_size_range = {
+//    {-1, -1, -1, -1, 1, 1, 1},
+      {1, 1, 1, 1, 1, 1, 1},
+      {2, 2, 2, 2, 2, 2, 2},
+      {3, 3, 3, 3, 3, 3, 3},
+      {4, 4, 4, 4, 4, 4, 4},
+      {4, 4, 4, 4, 4, 6, 5},
+      {5, 5, 5, 5, 5, 5, 5},
+      {6, 6, 6, 6, 6, 6, 6},
+      {7, 7, 7, 7, 7, 7, 7},
+      {8, 8, 8, 8, 8, 8, 8},
+      {9, 9, 9, 9, 9, 9, 9},
+      {10, 10, 10, 10, 10, 10, 10},
+//    {11, 11, 11, 11, 11, 11, 11},
+//    {12, 12, 12, 12, 12, 12, 12},
+//    {13, 13, 13, 13, 13, 13, 13},
+//    {14, 14, 14, 14, 14, 14, 14},
+//    {15, 15, 15, 15, 15, 15, 15},
+//    {16, 16, 16, 16, 16, 16, 16},
+//    {17, 17, 17, 17, 17, 17, 17},
+//    {18, 18, 18, 18, 18, 18, 18},
+//    {19, 19, 19, 19, 19, 19, 19},
+//    {20, 20, 20, 20, 20, 20, 20},
+      {2, 3, 4, 5, 6, 7, 8},
+//    {3, 4, 5, 6, 7, 8, 8},
+//    {4, 5, 6, 6, 6, 6, 6},
+//    {5, 6, 7, 7, 8, 9, 9},
+//    {6, 7, 8, 10, 9, 8, 8},
+//    {7, 8, 9, 11, 9, 10, 10},
+//    {8, 9, 10, 10, 11, 12, 12},
+//    {9, 10, 11, 12, 11, 13, 13},
+//    {13, 12, 11, 15, 14, 13, 13},
+//    {13, 14, 12, 12, 13, 14, 14},
+//    {15, 16, 17, 17, 18, 19, 19},
+//    {18, 17, 16, 18, 18, 18, 18},
+//    {16, 17, 18, 20, 19, 18, 18},
+//    {3, 33, 3, 33, 35, 35, 35},
+//    {5, 6, 7, 9, 11, 13, 13},
+//    {10, 10, 20, 100, 21, 22, 22},
+      {500, 501, 502, 503, 604, 505, 505},
+      {500, 501, 502, 203, 204, 205, 505},
+};
+
+const vector<vector<int>> large_matrix_size_range = {
+    {191, 193, 194, 195, 196, 197, 197},
+    {639, 640, 347, 960, 961, 1062, 1062},
+    {1000, 1001, 101, 2002, 1003, 1004, 1004},
+    {925, 1026, 1027, 1028, 2029, 1031, 1031},
+    {4011, 4012, 103, 4014, 4015, 4016, 4016},
+};
+
+const vector<vector<int>> chunk_matrix_size_range = {
+    {24000, 256, 256, 24010, 256, 24000, 24000},
+    {24000, 256, 256, 24000, 256, 24020, 24020},
+    {256, 24001, 256, 256, 24030, 24000, 24000},
+    {256, 24001, 256, 256, 24000, 24040, 24040},
+};
+
+const vector<vector<int>> NaN_matrix_size_range = {
+    {5, 6, 7, 8, 9, 10, 10}, {4011, 4012, 111, 4013, 4014, 4015, 4015},
+};
+
+// vector of vector, each pair is a {alpha, beta};
+// add/delete this list in pairs, like {2.0, 4.0}
+const vector<vector<double>> alpha_beta_2_3_range = {
+    {2.0, 3.0},
+};
+
+const vector<vector<double>> NaN_alpha_beta_range = {
+    {1.0, 0.0},
+};
+
+const vector<vector<double>> alpha_beta_range = {
+    {5.0, 0.0}, {0.0, 3.0}, {1.0, 3.0},
+};
+
+const vector<vector<double>> small_alpha_beta_range = {
+    {1.0, 1.0}, };
+
+const vector<vector<double>> full_alpha_beta_range = {
+    {1.0, 0.0}, {-1.0, -1.0}, {2.0, 1.0}, {0.0, 1.0}};
+
+// vector of vector, each pair is a {transA, transB};
+// add/delete this list in pairs, like {'N', 'T'}
+// for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
+// sgemm/dgemm,
+const vector<vector<char>> small_transA_transB_range = {{'N', 'N'}};
+const vector<vector<char>> transA_transB_range = {{'N', 'N'}, {'N', 'T'}, {'C', 'N'}, {'T', 'C'}};
+
+const vector<vector<rocblas_precision>> precision_type_range = {
+{rocblas_precision_half,rocblas_precision_half,rocblas_precision_half,rocblas_precision_half,rocblas_precision_half},
+{rocblas_precision_single,rocblas_precision_single,rocblas_precision_single,rocblas_precision_single,rocblas_precision_single},
+{rocblas_precision_double,rocblas_precision_double,rocblas_precision_double,rocblas_precision_double,rocblas_precision_double}
+};
+
+/* ===============Google Unit Test==================================================== */
+
+/* =====================================================================
+     BLAS-3 GEMM:
+=================================================================== */
+/* ============================Setup Arguments======================================= */
+
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
+
+Arguments setup_gemm_ex_arguments(gemm_ex_tuple tup)
+{
+    vector<int> matrix_size    = std::get<0>(tup);
+    vector<double> alpha_beta  = std::get<1>(tup);
+    vector<char> transA_transB = std::get<2>(tup);
+    vector<rocblas_precision> precision_types = std::get<3>(tup);
+
+    Arguments arg;
+
+    // see the comments about matrix_size_range above
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
+    arg.K   = matrix_size[2];
+    arg.lda = matrix_size[3];
+    arg.ldb = matrix_size[4];
+    arg.ldc = matrix_size[5];
+    arg.ldd = matrix_size[6];
+
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
+    arg.alpha = alpha_beta[0];
+    arg.beta  = alpha_beta[1];
+
+    arg.transA_option = transA_transB[0];
+    arg.transB_option = transA_transB[1];
+
+    arg.timing = 0;
+
+    arg.a_type = precision_types[0];
+    arg.b_type = precision_types[1];
+    arg.c_type = precision_types[2];
+    arg.d_type = precision_types[3];
+    arg.compute_type = precision_types[4];
+
+    return arg;
+}
+
+//class parameterized_gemm_ex_NaN : public ::TestWithParam<gemm_ex_tuple>
+//{
+//    protected:
+//    parameterized_gemm_ex_NaN() {}
+//    virtual ~parameterized_gemm_ex_NaN() {}
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+//};
+//
+//TEST_P(parameterized_gemm_ex_NaN, rocblas_half)
+//{
+//    Arguments arg = setup_gemm_ex_arguments(GetParam());
+//
+//    testing_gemm_ex_NaN<rocblas_half>(arg);
+//}
+//
+//TEST_P(parameterized_gemm_ex_NaN, float)
+//{
+//    Arguments arg = setup_gemm_ex_arguments(GetParam());
+//
+//    testing_gemm_ex_NaN<float>(arg);
+//}
+//
+//TEST_P(parameterized_gemm_ex_NaN, double)
+//{
+//    Arguments arg = setup_gemm_ex_arguments(GetParam());
+//
+//    testing_gemm_ex_NaN<double>(arg);
+//}
+//
+class parameterized_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
+{
+    protected:
+    parameterized_gemm_ex() {}
+    virtual ~parameterized_gemm_ex() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_P(parameterized_gemm_ex, standard)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_gemm_ex_arguments(GetParam());
+
+//  rocblas_status status = testing_gemm_ex<float>(arg);
+    rocblas_status status = testing_gemm_ex(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != rocblas_status_success)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transA_option == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transB_option == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.ldc < arg.M || arg.ldd < arg.M)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+    }
+}
+
+class parameterized_chunk_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
+{
+    protected:
+    parameterized_chunk_gemm_ex() {}
+    virtual ~parameterized_chunk_gemm_ex() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_P(parameterized_chunk_gemm_ex, float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_gemm_ex_arguments(GetParam());
+
+    rocblas_status status = testing_gemm_ex(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != rocblas_status_success)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transA_option == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transB_option == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.ldc < arg.M || arg.ldd < arg.M)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+    }
+}
+
+class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
+{
+    protected:
+    parameterized_half_gemm_ex() {}
+    virtual ~parameterized_half_gemm_ex() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+
+//TEST(checkin_blas3_bad_arg, gemm_ex_half) { testing_gemm_ex_bad_arg<rocblas_half>(); }
+
+//TEST(checkin_blas3_bad_arg, gemm_ex_float) { testing_gemm_ex_bad_arg<float>(); }
+
+//TEST(checkin_blas3_bad_arg, gemm_ex_double) { testing_gemm_ex_bad_arg<double>(); }
+
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
+// The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB} }
+
+// INSTANTIATE_TEST_CASE_P(rocblas_gemm_ex_beta_eq_0, parameterized_gemm_ex_NaN,
+//INSTANTIATE_TEST_CASE_P(checkin_blas3_NaN,
+//                        parameterized_gemm_ex_NaN,
+//                        Combine(ValuesIn(NaN_matrix_size_range),
+//                                ValuesIn(NaN_alpha_beta_range),
+//                                ValuesIn(transA_transB_range)));
+
+// THis function mainly test the scope of matrix_size. the scope of alpha_beta, transA_transB is
+// small
+//INSTANTIATE_TEST_CASE_P(daily_blas3_large,
+//                        parameterized_gemm_ex,
+//                        Combine(ValuesIn(large_matrix_size_range),
+//                                ValuesIn(alpha_beta_range),
+//                                ValuesIn(transA_transB_range)));
+
+// THis function mainly test the scope of alpha_beta, transA_transB,.the scope of matrix_size_range
+// is small
+
+INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
+                        parameterized_gemm_ex,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(small_alpha_beta_range),
+                                ValuesIn(small_transA_transB_range),
+                                ValuesIn(precision_type_range)));
+
+//INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
+//                        parameterized_gemm_ex,
+//                        Combine(ValuesIn(tiny_matrix_size_range),
+//                                ValuesIn(full_alpha_beta_range),
+//                                ValuesIn(transA_transB_range)));
+//
+//INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
+//                        parameterized_half_gemm_ex,
+//                        Combine(ValuesIn(small_matrix_size_range),
+//                                ValuesIn(full_alpha_beta_range),
+//                                ValuesIn(transA_transB_range)));
+//
+//INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
+//                        parameterized_half_gemm_ex,
+//                        Combine(ValuesIn(tiny_matrix_size_range),
+//                                ValuesIn(full_alpha_beta_range),
+//                                ValuesIn(transA_transB_range)));
+//
+//INSTANTIATE_TEST_CASE_P(daily_blas3_large,
+//                        parameterized_half_gemm_ex,
+//                        Combine(ValuesIn(large_matrix_size_range),
+//                                ValuesIn(alpha_beta_range),
+//                                ValuesIn(transA_transB_range)));
+//
+//INSTANTIATE_TEST_CASE_P(daily_blas3_chunk,
+//                        parameterized_chunk_gemm_ex,
+//                        Combine(ValuesIn(chunk_matrix_size_range),
+//                                ValuesIn(alpha_beta_2_3_range),
+//                                ValuesIn(transA_transB_range)));

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -24,26 +24,25 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename T>
-rocblas_status testing_gemm_ex_template(
-                  rocblas_operation transA, 
-                  rocblas_operation transB, 
-                  rocblas_int M, 
-                  rocblas_int N, 
-                  rocblas_int K, 
-                  float alpha_float,
-                  rocblas_int lda,
-                  rocblas_int ldb, 
-                  float beta_float,
-                  rocblas_int ldc,
-                  rocblas_int ldd,
-                  rocblas_int norm_check,
-                  rocblas_int unit_check,
-                  rocblas_int timing,
-                  int number_hot_calls)
+rocblas_status testing_gemm_ex_template(rocblas_operation transA,
+                                        rocblas_operation transB,
+                                        rocblas_int M,
+                                        rocblas_int N,
+                                        rocblas_int K,
+                                        float alpha_float,
+                                        rocblas_int lda,
+                                        rocblas_int ldb,
+                                        float beta_float,
+                                        rocblas_int ldc,
+                                        rocblas_int ldd,
+                                        rocblas_int norm_check,
+                                        rocblas_int unit_check,
+                                        rocblas_int timing,
+                                        int number_hot_calls)
 {
     rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
-    uint32_t kernel_index = 0;
-    uint32_t flags = 0;
+    uint32_t kernel_index  = 0;
+    uint32_t flags         = 0;
 
     T h_alpha;
     T h_beta;
@@ -55,37 +54,37 @@ rocblas_status testing_gemm_ex_template(
 
     if(is_same<T, rocblas_half>::value)
     {
-        h_alpha = float_to_half(alpha_float);
-        h_beta  = float_to_half(beta_float);
-        a_type = rocblas_precision_half;
-        b_type = rocblas_precision_half;
-        c_type = rocblas_precision_half;
-        d_type = rocblas_precision_half;
+        h_alpha      = float_to_half(alpha_float);
+        h_beta       = float_to_half(beta_float);
+        a_type       = rocblas_precision_half;
+        b_type       = rocblas_precision_half;
+        c_type       = rocblas_precision_half;
+        d_type       = rocblas_precision_half;
         compute_type = rocblas_precision_half;
     }
     else if(is_same<T, float>::value)
     {
-        h_alpha = static_cast<T>(alpha_float);
-        h_beta  = static_cast<T>(beta_float);
-        a_type = rocblas_precision_single;
-        b_type = rocblas_precision_single;
-        c_type = rocblas_precision_single;
-        d_type = rocblas_precision_single;
+        h_alpha      = static_cast<T>(alpha_float);
+        h_beta       = static_cast<T>(beta_float);
+        a_type       = rocblas_precision_single;
+        b_type       = rocblas_precision_single;
+        c_type       = rocblas_precision_single;
+        d_type       = rocblas_precision_single;
         compute_type = rocblas_precision_single;
     }
     else if(is_same<T, double>::value)
     {
-        h_alpha = static_cast<T>(alpha_float);
-        h_beta  = static_cast<T>(beta_float);
-        a_type = rocblas_precision_double;
-        b_type = rocblas_precision_double;
-        c_type = rocblas_precision_double;
-        d_type = rocblas_precision_double;
+        h_alpha      = static_cast<T>(alpha_float);
+        h_beta       = static_cast<T>(beta_float);
+        a_type       = rocblas_precision_double;
+        b_type       = rocblas_precision_double;
+        c_type       = rocblas_precision_double;
+        d_type       = rocblas_precision_double;
         compute_type = rocblas_precision_double;
     }
     else
     {
-       return rocblas_status_not_implemented;
+        return rocblas_status_not_implemented;
     }
 
     const size_t safe_size = 100;
@@ -127,13 +126,29 @@ rocblas_status testing_gemm_ex_template(
         }
 
         status = rocblas_gemm_ex(handle,
-                  transA, transB, M, N, K, &alpha_float,
-                  dA, a_type, lda,
-                  dB, b_type, ldb, &beta_float,
-                  dC, c_type, ldc,
-                  dD, d_type, ldd,
-                  compute_type, algo, kernel_index, flags);
-
+                                 transA,
+                                 transB,
+                                 M,
+                                 N,
+                                 K,
+                                 &alpha_float,
+                                 dA,
+                                 a_type,
+                                 lda,
+                                 dB,
+                                 b_type,
+                                 ldb,
+                                 &beta_float,
+                                 dC,
+                                 c_type,
+                                 ldc,
+                                 dD,
+                                 d_type,
+                                 ldd,
+                                 compute_type,
+                                 algo,
+                                 kernel_index,
+                                 flags);
 
         gemm_arg_check(status, M, N, K, lda, ldb, ldc);
 
@@ -154,17 +169,17 @@ rocblas_status testing_gemm_ex_template(
                                          rocblas_test::device_free};
     auto dD_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_D),
                                          rocblas_test::device_free};
-    auto d_alpha_managed =
-        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
-    auto d_beta_managed =
-        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
-    T* dA      = (T*)dA_managed.get();
-    T* dB      = (T*)dB_managed.get();
-    T* dC      = (T*)dC_managed.get();
-    T* dD      = (T*)dD_managed.get();
-    T* d_alpha = (T*)d_alpha_managed.get();
-    T* d_beta  = (T*)d_beta_managed.get();
-    if(!dA || !dB || !dC || !dD || !d_alpha || !d_beta)
+    auto d_alpha_float_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(float)), rocblas_test::device_free};
+    auto d_beta_float_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(float)), rocblas_test::device_free};
+    T* dA                = (T*)dA_managed.get();
+    T* dB                = (T*)dB_managed.get();
+    T* dC                = (T*)dC_managed.get();
+    T* dD                = (T*)dD_managed.get();
+    float* d_alpha_float = (float*)d_alpha_float_managed.get();
+    float* d_beta_float  = (float*)d_beta_float_managed.get();
+    if(!dA || !dB || !dC || !dD || !d_alpha_float || !d_beta_float)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return rocblas_status_memory_error;
@@ -185,34 +200,28 @@ rocblas_status testing_gemm_ex_template(
     rocblas_init<T>(hC, M, N, ldc);
     rocblas_init<T>(hD_1, M, N, ldd);
 
-//TODO change back to random initialization
-//  rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
-//  rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);
-//  rocblas_init<T>(hC, M, N, ldc, 1.0);
-//  rocblas_init<T>(hD_1, M, N, ldd, 1.0);
-
-/*
-    std::cout << "----A-------------------------------------------" << std::endl;
-    for(int i = 0; i < size_A; i++){ cout << half_to_float(hA[i]) << "  "; }
-    std::cout << std::endl << "-----B------------------------------------------" << std::endl;
-    for(int i = 0; i < size_B; i++){ cout << half_to_float(hB[i]) << "  "; }
-    std::cout << std::endl << "-----C------------------------------------------" << std::endl;
-    for(int i = 0; i < size_C; i++){ cout << half_to_float(hC[i]) << "  "; }
-    std::cout << std::endl << "-----D------------------------------------------" << std::endl;
-    for(int i = 0; i < size_C; i++){ cout << half_to_float(hD_1[i]) << "  "; }
-    std::cout << std::endl << "------------------------------------------------" << std::endl;
-*/
-/*
-    std::cout << "----A-------------------------------------------" << std::endl;
-    for(int i = 0; i < size_A; i++){ cout << hA[i] << "  "; }
-    std::cout << std::endl << "-----B------------------------------------------" << std::endl;
-    for(int i = 0; i < size_B; i++){ cout << hB[i] << "  "; }
-    std::cout << std::endl << "-----C------------------------------------------" << std::endl;
-    for(int i = 0; i < size_C; i++){ cout << hC[i] << "  "; }
-    std::cout << std::endl << "-----D------------------------------------------" << std::endl;
-    for(int i = 0; i < size_D; i++){ cout << hD_1[i] << "  "; }
-    std::cout << std::endl << "------------------------------------------------" << std::endl;
-*/
+    /*
+        std::cout << "----A-------------------------------------------" << std::endl;
+        for(int i = 0; i < size_A; i++){ cout << half_to_float(hA[i]) << "  "; }
+        std::cout << std::endl << "-----B------------------------------------------" << std::endl;
+        for(int i = 0; i < size_B; i++){ cout << half_to_float(hB[i]) << "  "; }
+        std::cout << std::endl << "-----C------------------------------------------" << std::endl;
+        for(int i = 0; i < size_C; i++){ cout << half_to_float(hC[i]) << "  "; }
+        std::cout << std::endl << "-----D------------------------------------------" << std::endl;
+        for(int i = 0; i < size_C; i++){ cout << half_to_float(hD_1[i]) << "  "; }
+        std::cout << std::endl << "------------------------------------------------" << std::endl;
+    */
+    /*
+        std::cout << "----A-------------------------------------------" << std::endl;
+        for(int i = 0; i < size_A; i++){ cout << hA[i] << "  "; }
+        std::cout << std::endl << "-----B------------------------------------------" << std::endl;
+        for(int i = 0; i < size_B; i++){ cout << hB[i] << "  "; }
+        std::cout << std::endl << "-----C------------------------------------------" << std::endl;
+        for(int i = 0; i < size_C; i++){ cout << hC[i] << "  "; }
+        std::cout << std::endl << "-----D------------------------------------------" << std::endl;
+        for(int i = 0; i < size_D; i++){ cout << hD_1[i] << "  "; }
+        std::cout << std::endl << "------------------------------------------------" << std::endl;
+    */
     hD_2    = hD_1;
     hD_gold = hD_1;
 
@@ -228,51 +237,82 @@ rocblas_status testing_gemm_ex_template(
 
         CHECK_HIP_ERROR(hipMemcpy(dD, hD_1.data(), sizeof(T) * size_D, hipMemcpyHostToDevice));
 
-        //      std::cout << std::endl << "------------------------------------------------" <<
-        //      std::endl;
-        //      std::cout << "alpha, beta = " << half_to_float(h_alpha) << ", " <<
-        //      half_to_float(h_beta);
-        //      std::cout << std::endl << "------------------------------------------------" <<
-        //      std::endl;
-//      CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
-//          handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
-
-
         CHECK_ROCBLAS_ERROR(rocblas_gemm_ex(handle,
-                  transA, transB, M, N, K, &alpha_float,
-                  dA, a_type, lda,
-                  dB, b_type, ldb, &beta_float,
-                  dC, c_type, ldc,
-                  dD, d_type, ldd,
-                  compute_type, algo, kernel_index, flags));
-
+                                            transA,
+                                            transB,
+                                            M,
+                                            N,
+                                            K,
+                                            &alpha_float,
+                                            dA,
+                                            a_type,
+                                            lda,
+                                            dB,
+                                            b_type,
+                                            ldb,
+                                            &beta_float,
+                                            dC,
+                                            c_type,
+                                            ldc,
+                                            dD,
+                                            d_type,
+                                            ldd,
+                                            compute_type,
+                                            algo,
+                                            kernel_index,
+                                            flags));
 
         CHECK_HIP_ERROR(hipMemcpy(hD_1.data(), dD, sizeof(T) * size_D, hipMemcpyDeviceToHost));
-//      std::cout << std::endl << "-----hD_1---------------------------------------" << std::endl;
-//      for(int i = 0; i < size_D; i++){ cout << hD_1[i] << "  "; }
-//      for(int i = 0; i < size_C; i++){ cout << half_to_float(hD_1[i]) << "  "; }
-//      for(int i = 0; i < size_C; i++){ cout << std::hex << hD_1[i] << "  "; }
-//      std::cout << std::endl << "------------------------------------------------" << std::endl;
+        //      std::cout << std::endl << "-----hD_1---------------------------------------" <<
+        //      std::endl;
+        //      for(int i = 0; i < size_D; i++){ cout << hD_1[i] << "  "; }
+        //      for(int i = 0; i < size_C; i++){ cout << half_to_float(hD_1[i]) << "  "; }
+        //      for(int i = 0; i < size_C; i++){ cout << std::hex << hD_1[i] << "  "; }
+        //      std::cout << std::endl << "------------------------------------------------" <<
+        //      std::endl;
 
         // ROCBLAS rocblas_pointer_mode_device
-//      CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
-//      CHECK_HIP_ERROR(hipMemcpy(dD, hD_2.data(), sizeof(T) * size_D, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dD, hD_2.data(), sizeof(T) * size_D, hipMemcpyHostToDevice));
 
-//      CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(d_alpha_float, &alpha_float, sizeof(float), hipMemcpyHostToDevice));
 
-//      CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(d_beta_float, &beta_float, sizeof(float), hipMemcpyHostToDevice));
 
-//      CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
-//          handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+        CHECK_ROCBLAS_ERROR(rocblas_gemm_ex(handle,
+                                            transA,
+                                            transB,
+                                            M,
+                                            N,
+                                            K,
+                                            d_alpha_float,
+                                            dA,
+                                            a_type,
+                                            lda,
+                                            dB,
+                                            b_type,
+                                            ldb,
+                                            d_beta_float,
+                                            dC,
+                                            c_type,
+                                            ldc,
+                                            dD,
+                                            d_type,
+                                            ldd,
+                                            compute_type,
+                                            algo,
+                                            kernel_index,
+                                            flags));
 
-//      CHECK_HIP_ERROR(hipMemcpy(hD_2.data(), dD, sizeof(T) * size_D, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hD_2.data(), dD, sizeof(T) * size_D, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         // copy C matrix into D matrix
-        for (int i2 = 0; i2 < N; i2++)
+        for(int i2 = 0; i2 < N; i2++)
         {
-            for (int i1 = 0; i1 < M; i1++)
+            for(int i1 = 0; i1 < M; i1++)
             {
                 hD_gold[i1 + i2 * ldd] = hC[i1 + i2 * ldc];
             }
@@ -296,11 +336,11 @@ rocblas_status testing_gemm_ex_template(
         cpu_time_used = get_time_us() - cpu_time_used;
         cblas_gflops  = gemm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
 
-//std::cout << std::endl << "---gold---gold---gold---------------------------" << std::endl;
-//for(int i = 0; i < size_D; i++){ std::cout << hD_gold[i] << "  "; }
-//for(int i = 0; i < size_D; i++){ std::cout << half_to_float(hD_gold[i]) << "  "; }
-//for(int i = 0; i < size_D; i++){ std::cout << std::hex << hD_gold[i] << "  "; }
-//std::cout << std::endl << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
+// std::cout << std::endl << "---gold---gold---gold---------------------------" << std::endl;
+// for(int i = 0; i < size_D; i++){ std::cout << hD_gold[i] << "  "; }
+// for(int i = 0; i < size_D; i++){ std::cout << half_to_float(hD_gold[i]) << "  "; }
+// for(int i = 0; i < size_D; i++){ std::cout << std::hex << hD_gold[i] << "  "; }
+// std::cout << std::endl << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
 #ifndef NDEBUG
 // print_matrix(hC_gold, hC, min(M, 3), min(N, 3), ldc);
 #endif
@@ -310,7 +350,7 @@ rocblas_status testing_gemm_ex_template(
         if(unit_check)
         {
             unit_check_general<T>(M, N, ldd, hD_gold.data(), hD_1.data());
-//          unit_check_general<T>(M, N, ldd, hD_gold.data(), hD_2.data());
+            unit_check_general<T>(M, N, ldd, hD_gold.data(), hD_2.data());
         }
 
         // if enable norm check, norm check is invasive
@@ -319,7 +359,7 @@ rocblas_status testing_gemm_ex_template(
         if(norm_check)
         {
             rocblas_error = norm_check_general<T>('F', M, N, ldd, hD_gold.data(), hD_1.data());
-//          rocblas_error = norm_check_general<T>('F', M, N, ldd, hD_gold.data(), hD_2.data());
+            rocblas_error = norm_check_general<T>('F', M, N, ldd, hD_gold.data(), hD_2.data());
         }
     }
 
@@ -351,9 +391,9 @@ rocblas_status testing_gemm_ex_template(
 
         cout << endl;
 
-        cout << transA << "," << transB << "," << M << "," << N << ","
-             << K << "," << h_alpha << "," << lda << "," << ldb << "," << h_beta << "," << ldc
-             << "," << rocblas_gflops << "," << gpu_time_used / number_hot_calls;
+        cout << transA << "," << transB << "," << M << "," << N << "," << K << "," << h_alpha << ","
+             << lda << "," << ldb << "," << h_beta << "," << ldc << "," << rocblas_gflops << ","
+             << gpu_time_used / number_hot_calls;
 
         if(unit_check || norm_check)
         {
@@ -364,7 +404,6 @@ rocblas_status testing_gemm_ex_template(
     }
     return status;
 }
-
 
 // template <typename T>
 rocblas_status testing_gemm_ex(Arguments argus)
@@ -381,10 +420,10 @@ rocblas_status testing_gemm_ex(Arguments argus)
     rocblas_int ldc = argus.ldc;
     rocblas_int ldd = argus.ldd;
 
-    rocblas_precision a_type = argus.a_type;
-    rocblas_precision b_type = argus.b_type;
-    rocblas_precision c_type = argus.c_type;
-    rocblas_precision d_type = argus.d_type;
+    rocblas_precision a_type       = argus.a_type;
+    rocblas_precision b_type       = argus.b_type;
+    rocblas_precision c_type       = argus.c_type;
+    rocblas_precision d_type       = argus.d_type;
     rocblas_precision compute_type = argus.compute_type;
 
     float alpha = argus.alpha;
@@ -392,38 +431,68 @@ rocblas_status testing_gemm_ex(Arguments argus)
 
     rocblas_int norm_check = argus.norm_check;
     rocblas_int unit_check = argus.unit_check;
-    rocblas_int timing = argus.timing;
-    int number_hot_calls = argus.iters;
+    rocblas_int timing     = argus.timing;
+    int number_hot_calls   = argus.iters;
 
-    if( a_type == rocblas_precision_half && b_type == rocblas_precision_half && 
-        c_type == rocblas_precision_half && d_type == rocblas_precision_half && 
-        compute_type == rocblas_precision_half)
+    if(a_type == rocblas_precision_half && b_type == rocblas_precision_half &&
+       c_type == rocblas_precision_half && d_type == rocblas_precision_half &&
+       compute_type == rocblas_precision_half)
     {
-        return testing_gemm_ex_template<rocblas_half>(
-                  transA, transB, 
-                  M, N, K, 
-                  alpha, lda, ldb, beta, ldc, ldd,
-                  norm_check, unit_check, timing, number_hot_calls);
+        return testing_gemm_ex_template<rocblas_half>(transA,
+                                                      transB,
+                                                      M,
+                                                      N,
+                                                      K,
+                                                      alpha,
+                                                      lda,
+                                                      ldb,
+                                                      beta,
+                                                      ldc,
+                                                      ldd,
+                                                      norm_check,
+                                                      unit_check,
+                                                      timing,
+                                                      number_hot_calls);
     }
-    else if( a_type == rocblas_precision_single && b_type == rocblas_precision_single && 
-             c_type == rocblas_precision_single && d_type == rocblas_precision_single && 
-             compute_type == rocblas_precision_single)
+    else if(a_type == rocblas_precision_single && b_type == rocblas_precision_single &&
+            c_type == rocblas_precision_single && d_type == rocblas_precision_single &&
+            compute_type == rocblas_precision_single)
     {
-        return testing_gemm_ex_template<float>(
-                  transA, transB, 
-                  M, N, K, 
-                  alpha, lda, ldb, beta, ldc, ldd,
-                  norm_check, unit_check, timing, number_hot_calls);
+        return testing_gemm_ex_template<float>(transA,
+                                               transB,
+                                               M,
+                                               N,
+                                               K,
+                                               alpha,
+                                               lda,
+                                               ldb,
+                                               beta,
+                                               ldc,
+                                               ldd,
+                                               norm_check,
+                                               unit_check,
+                                               timing,
+                                               number_hot_calls);
     }
-    else if( a_type == rocblas_precision_double && b_type == rocblas_precision_double && 
-             c_type == rocblas_precision_double && d_type == rocblas_precision_double && 
-             compute_type == rocblas_precision_double)
+    else if(a_type == rocblas_precision_double && b_type == rocblas_precision_double &&
+            c_type == rocblas_precision_double && d_type == rocblas_precision_double &&
+            compute_type == rocblas_precision_double)
     {
-        return testing_gemm_ex_template<double>(
-                  transA, transB, 
-                  M, N, K, 
-                  alpha, lda, ldb, beta, ldc, ldd,
-                  norm_check, unit_check, timing, number_hot_calls);
+        return testing_gemm_ex_template<double>(transA,
+                                                transB,
+                                                M,
+                                                N,
+                                                K,
+                                                alpha,
+                                                lda,
+                                                ldb,
+                                                beta,
+                                                ldc,
+                                                ldd,
+                                                norm_check,
+                                                unit_check,
+                                                timing,
+                                                number_hot_calls);
     }
     else
     {

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -1,0 +1,432 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include <sys/time.h>
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <limits>
+
+#include "rocblas.hpp"
+#include "arg_check.h"
+#include "rocblas_test_unique_ptr.hpp"
+#include "utility.h"
+#include "cblas_interface.h"
+#include "norm.h"
+#include "unit.h"
+#include "flops.h"
+#include <typeinfo>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+rocblas_status testing_gemm_ex_template(
+                  rocblas_operation transA, 
+                  rocblas_operation transB, 
+                  rocblas_int M, 
+                  rocblas_int N, 
+                  rocblas_int K, 
+                  float alpha_float,
+                  rocblas_int lda,
+                  rocblas_int ldb, 
+                  float beta_float,
+                  rocblas_int ldc,
+                  rocblas_int ldd,
+                  rocblas_int norm_check,
+                  rocblas_int unit_check,
+                  rocblas_int timing,
+                  int number_hot_calls)
+{
+    rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
+    uint32_t kernel_index = 0;
+    uint32_t flags = 0;
+
+    T h_alpha;
+    T h_beta;
+    rocblas_precision a_type;
+    rocblas_precision b_type;
+    rocblas_precision c_type;
+    rocblas_precision d_type;
+    rocblas_precision compute_type;
+
+    if(is_same<T, rocblas_half>::value)
+    {
+        h_alpha = float_to_half(alpha_float);
+        h_beta  = float_to_half(beta_float);
+        a_type = rocblas_precision_half;
+        b_type = rocblas_precision_half;
+        c_type = rocblas_precision_half;
+        d_type = rocblas_precision_half;
+        compute_type = rocblas_precision_half;
+    }
+    else if(is_same<T, float>::value)
+    {
+        h_alpha = static_cast<T>(alpha_float);
+        h_beta  = static_cast<T>(beta_float);
+        a_type = rocblas_precision_single;
+        b_type = rocblas_precision_single;
+        c_type = rocblas_precision_single;
+        d_type = rocblas_precision_single;
+        compute_type = rocblas_precision_single;
+    }
+    else if(is_same<T, double>::value)
+    {
+        h_alpha = static_cast<T>(alpha_float);
+        h_beta  = static_cast<T>(beta_float);
+        a_type = rocblas_precision_double;
+        b_type = rocblas_precision_double;
+        c_type = rocblas_precision_double;
+        d_type = rocblas_precision_double;
+        compute_type = rocblas_precision_double;
+    }
+    else
+    {
+       return rocblas_status_not_implemented;
+    }
+
+    const size_t safe_size = 100;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_gflops, cblas_gflops;
+
+    T rocblas_error = 0.0;
+
+    rocblas_status status;
+
+    std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
+    rocblas_handle handle = unique_ptr_handle->handle;
+
+    rocblas_int A_row = transA == rocblas_operation_none ? M : K;
+    rocblas_int A_col = transA == rocblas_operation_none ? K : M;
+    rocblas_int B_row = transB == rocblas_operation_none ? K : N;
+    rocblas_int B_col = transB == rocblas_operation_none ? N : K;
+
+    // check here to prevent undefined memory allocation error
+    if(M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M || ldd < M)
+    {
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dD_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dA = (T*)dA_managed.get();
+        T* dB = (T*)dB_managed.get();
+        T* dC = (T*)dC_managed.get();
+        T* dD = (T*)dD_managed.get();
+        if(!dA || !dB || !dC || !dD)
+        {
+            PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
+            return rocblas_status_memory_error;
+        }
+
+        status = rocblas_gemm_ex(handle,
+                  transA, transB, M, N, K, &alpha_float,
+                  dA, a_type, lda,
+                  dB, b_type, ldb, &beta_float,
+                  dC, c_type, ldc,
+                  dD, d_type, ldd,
+                  compute_type, algo, kernel_index, flags);
+
+
+        gemm_arg_check(status, M, N, K, lda, ldb, ldc);
+
+        return status;
+    }
+
+    const size_t size_A = static_cast<size_t>(lda) * static_cast<size_t>(A_col);
+    const size_t size_B = static_cast<size_t>(ldb) * static_cast<size_t>(B_col);
+    const size_t size_C = static_cast<size_t>(ldc) * static_cast<size_t>(N);
+    const size_t size_D = static_cast<size_t>(ldd) * static_cast<size_t>(N);
+
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    auto dD_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_D),
+                                         rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    auto d_beta_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA      = (T*)dA_managed.get();
+    T* dB      = (T*)dB_managed.get();
+    T* dC      = (T*)dC_managed.get();
+    T* dD      = (T*)dD_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    T* d_beta  = (T*)d_beta_managed.get();
+    if(!dA || !dB || !dC || !dD || !d_alpha || !d_beta)
+    {
+        PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
+        return rocblas_status_memory_error;
+    }
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
+    vector<T> hA(size_A);
+    vector<T> hB(size_B);
+    vector<T> hC(size_C);
+    vector<T> hD_1(size_D);
+    vector<T> hD_2(size_D);
+    vector<T> hD_gold(size_D);
+
+    // Initial Data on CPU
+    srand(1);
+    rocblas_init<T>(hA, A_row, A_col, lda);
+    rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
+    rocblas_init<T>(hC, M, N, ldc);
+    rocblas_init<T>(hD_1, M, N, ldd);
+
+//TODO change back to random initialization
+//  rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
+//  rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);
+//  rocblas_init<T>(hC, M, N, ldc, 1.0);
+//  rocblas_init<T>(hD_1, M, N, ldd, 1.0);
+
+/*
+    std::cout << "----A-------------------------------------------" << std::endl;
+    for(int i = 0; i < size_A; i++){ cout << half_to_float(hA[i]) << "  "; }
+    std::cout << std::endl << "-----B------------------------------------------" << std::endl;
+    for(int i = 0; i < size_B; i++){ cout << half_to_float(hB[i]) << "  "; }
+    std::cout << std::endl << "-----C------------------------------------------" << std::endl;
+    for(int i = 0; i < size_C; i++){ cout << half_to_float(hC[i]) << "  "; }
+    std::cout << std::endl << "-----D------------------------------------------" << std::endl;
+    for(int i = 0; i < size_C; i++){ cout << half_to_float(hD_1[i]) << "  "; }
+    std::cout << std::endl << "------------------------------------------------" << std::endl;
+*/
+/*
+    std::cout << "----A-------------------------------------------" << std::endl;
+    for(int i = 0; i < size_A; i++){ cout << hA[i] << "  "; }
+    std::cout << std::endl << "-----B------------------------------------------" << std::endl;
+    for(int i = 0; i < size_B; i++){ cout << hB[i] << "  "; }
+    std::cout << std::endl << "-----C------------------------------------------" << std::endl;
+    for(int i = 0; i < size_C; i++){ cout << hC[i] << "  "; }
+    std::cout << std::endl << "-----D------------------------------------------" << std::endl;
+    for(int i = 0; i < size_D; i++){ cout << hD_1[i] << "  "; }
+    std::cout << std::endl << "------------------------------------------------" << std::endl;
+*/
+    hD_2    = hD_1;
+    hD_gold = hD_1;
+
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
+
+    if(unit_check || norm_check)
+    {
+        // ROCBLAS rocblas_pointer_mode_host
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        CHECK_HIP_ERROR(hipMemcpy(dD, hD_1.data(), sizeof(T) * size_D, hipMemcpyHostToDevice));
+
+        //      std::cout << std::endl << "------------------------------------------------" <<
+        //      std::endl;
+        //      std::cout << "alpha, beta = " << half_to_float(h_alpha) << ", " <<
+        //      half_to_float(h_beta);
+        //      std::cout << std::endl << "------------------------------------------------" <<
+        //      std::endl;
+//      CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
+//          handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+
+        CHECK_ROCBLAS_ERROR(rocblas_gemm_ex(handle,
+                  transA, transB, M, N, K, &alpha_float,
+                  dA, a_type, lda,
+                  dB, b_type, ldb, &beta_float,
+                  dC, c_type, ldc,
+                  dD, d_type, ldd,
+                  compute_type, algo, kernel_index, flags));
+
+
+        CHECK_HIP_ERROR(hipMemcpy(hD_1.data(), dD, sizeof(T) * size_D, hipMemcpyDeviceToHost));
+//      std::cout << std::endl << "-----hD_1---------------------------------------" << std::endl;
+//      for(int i = 0; i < size_D; i++){ cout << hD_1[i] << "  "; }
+//      for(int i = 0; i < size_C; i++){ cout << half_to_float(hD_1[i]) << "  "; }
+//      for(int i = 0; i < size_C; i++){ cout << std::hex << hD_1[i] << "  "; }
+//      std::cout << std::endl << "------------------------------------------------" << std::endl;
+
+        // ROCBLAS rocblas_pointer_mode_device
+//      CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+
+//      CHECK_HIP_ERROR(hipMemcpy(dD, hD_2.data(), sizeof(T) * size_D, hipMemcpyHostToDevice));
+
+//      CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+
+//      CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
+
+//      CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
+//          handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+//      CHECK_HIP_ERROR(hipMemcpy(hD_2.data(), dD, sizeof(T) * size_D, hipMemcpyDeviceToHost));
+
+        // CPU BLAS
+        // copy C matrix into D matrix
+        for (int i2 = 0; i2 < N; i2++)
+        {
+            for (int i1 = 0; i1 < M; i1++)
+            {
+                hD_gold[i1 + i2 * ldd] = hC[i1 + i2 * ldc];
+            }
+        }
+        cpu_time_used = get_time_us();
+
+        cblas_gemm<T>(transA,
+                      transB,
+                      M,
+                      N,
+                      K,
+                      h_alpha,
+                      hA.data(),
+                      lda,
+                      hB.data(),
+                      ldb,
+                      h_beta,
+                      hD_gold.data(),
+                      ldd);
+
+        cpu_time_used = get_time_us() - cpu_time_used;
+        cblas_gflops  = gemm_gflop_count<T>(M, N, K) / cpu_time_used * 1e6;
+
+//std::cout << std::endl << "---gold---gold---gold---------------------------" << std::endl;
+//for(int i = 0; i < size_D; i++){ std::cout << hD_gold[i] << "  "; }
+//for(int i = 0; i < size_D; i++){ std::cout << half_to_float(hD_gold[i]) << "  "; }
+//for(int i = 0; i < size_D; i++){ std::cout << std::hex << hD_gold[i] << "  "; }
+//std::cout << std::endl << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
+#ifndef NDEBUG
+// print_matrix(hC_gold, hC, min(M, 3), min(N, 3), ldc);
+#endif
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(unit_check)
+        {
+            unit_check_general<T>(M, N, ldd, hD_gold.data(), hD_1.data());
+//          unit_check_general<T>(M, N, ldd, hD_gold.data(), hD_2.data());
+        }
+
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched
+        // in compilation time
+        if(norm_check)
+        {
+            rocblas_error = norm_check_general<T>('F', M, N, ldd, hD_gold.data(), hD_1.data());
+//          rocblas_error = norm_check_general<T>('F', M, N, ldd, hD_gold.data(), hD_2.data());
+        }
+    }
+
+    if(timing)
+    {
+        int number_cold_calls = 2;
+
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        for(int i = 0; i < number_cold_calls; i++)
+        {
+            rocblas_gemm<T>(
+                handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
+        }
+
+        gpu_time_used = get_time_us(); // in microseconds
+        for(int i = 0; i < number_hot_calls; i++)
+        {
+            rocblas_gemm<T>(
+                handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
+        }
+        gpu_time_used  = get_time_us() - gpu_time_used;
+        rocblas_gflops = gemm_gflop_count<T>(M, N, K) * number_hot_calls / gpu_time_used * 1e6;
+
+        cout << "transA,transB,M,N,K,alpha,lda,ldb,beta,ldc,rocblas-Gflops,us";
+
+        if(unit_check || norm_check)
+            cout << ",CPU-Gflops(us),norm-error";
+
+        cout << endl;
+
+        cout << transA << "," << transB << "," << M << "," << N << ","
+             << K << "," << h_alpha << "," << lda << "," << ldb << "," << h_beta << "," << ldc
+             << "," << rocblas_gflops << "," << gpu_time_used / number_hot_calls;
+
+        if(unit_check || norm_check)
+        {
+            cout << "," << cblas_gflops << "," << cpu_time_used << "," << rocblas_error;
+        }
+
+        cout << endl;
+    }
+    return status;
+}
+
+
+// template <typename T>
+rocblas_status testing_gemm_ex(Arguments argus)
+{
+    rocblas_operation transA = char2rocblas_operation(argus.transA_option);
+    rocblas_operation transB = char2rocblas_operation(argus.transB_option);
+
+    rocblas_int M = argus.M;
+    rocblas_int N = argus.N;
+    rocblas_int K = argus.K;
+
+    rocblas_int lda = argus.lda;
+    rocblas_int ldb = argus.ldb;
+    rocblas_int ldc = argus.ldc;
+    rocblas_int ldd = argus.ldd;
+
+    rocblas_precision a_type = argus.a_type;
+    rocblas_precision b_type = argus.b_type;
+    rocblas_precision c_type = argus.c_type;
+    rocblas_precision d_type = argus.d_type;
+    rocblas_precision compute_type = argus.compute_type;
+
+    float alpha = argus.alpha;
+    float beta  = argus.beta;
+
+    rocblas_int norm_check = argus.norm_check;
+    rocblas_int unit_check = argus.unit_check;
+    rocblas_int timing = argus.timing;
+    int number_hot_calls = argus.iters;
+
+    if( a_type == rocblas_precision_half && b_type == rocblas_precision_half && 
+        c_type == rocblas_precision_half && d_type == rocblas_precision_half && 
+        compute_type == rocblas_precision_half)
+    {
+        return testing_gemm_ex_template<rocblas_half>(
+                  transA, transB, 
+                  M, N, K, 
+                  alpha, lda, ldb, beta, ldc, ldd,
+                  norm_check, unit_check, timing, number_hot_calls);
+    }
+    else if( a_type == rocblas_precision_single && b_type == rocblas_precision_single && 
+             c_type == rocblas_precision_single && d_type == rocblas_precision_single && 
+             compute_type == rocblas_precision_single)
+    {
+        return testing_gemm_ex_template<float>(
+                  transA, transB, 
+                  M, N, K, 
+                  alpha, lda, ldb, beta, ldc, ldd,
+                  norm_check, unit_check, timing, number_hot_calls);
+    }
+    else if( a_type == rocblas_precision_double && b_type == rocblas_precision_double && 
+             c_type == rocblas_precision_double && d_type == rocblas_precision_double && 
+             compute_type == rocblas_precision_double)
+    {
+        return testing_gemm_ex_template<double>(
+                  transA, transB, 
+                  M, N, K, 
+                  alpha, lda, ldb, beta, ldc, ldd,
+                  norm_check, unit_check, timing, number_hot_calls);
+    }
+    else
+    {
+        return rocblas_status_not_implemented;
+    }
+}

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -693,8 +693,8 @@ void testing_logging()
             trace_ofs2 << "\n"
                        << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
                        << "," << n << "," << k << "," << alpha << "," << (void*)da << "," << lda
-                       << "," << (void*)db << "," << ldb << "," << beta << "," << (void*)dc << ","
-                       << ldc;
+                       << "," << (void*)db << "," << ldb << "," << beta << "," << (void*)dd << ","
+                       << ldd;
 
             bench_ofs2 << "\n"
                        << "./rocblas-bench -f gemm_ex"
@@ -710,7 +710,7 @@ void testing_logging()
                        << "./rocblas-bench -f gemm -r " << replaceX<T>("X") << " --transposeA "
                        << transA_letter << " --transposeB " << transB_letter << " -m " << m
                        << " -n " << n << " -k " << k << " --alpha " << alpha << " --lda " << lda
-                       << " --ldb " << ldb << " --beta " << beta << " --ldc " << ldc;
+                       << " --ldb " << ldb << " --beta " << beta << " --ldc " << ldd;
         }
         else
         {

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -248,47 +248,81 @@ void testing_logging()
         // BLAS_EX
         if(BUILD_WITH_TENSILE)
         {
-           float alpha_float = 1.0;
-           float beta_float = 1.0;
+            float alpha_float = 1.0;
+            float beta_float  = 1.0;
 
-           if(std::is_same<T, float>::value)
-           {
-              rocblas_precision a_type = rocblas_precision_single;
-              rocblas_precision b_type = rocblas_precision_single;
-              rocblas_precision c_type = rocblas_precision_single;
-              rocblas_precision d_type = rocblas_precision_single;
-              rocblas_precision compute_type = rocblas_precision_single;
-              rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
-              uint32_t kernel_index = 0;
-              uint32_t flags = 0;
-   
-              status = rocblas_gemm_ex(handle,
-                  transA, transB, m, n, k, &alpha_float, 
-                  da, a_type, lda, 
-                  db, b_type, ldb, &beta_float, 
-                  dc, c_type, ldc, 
-                  dd, d_type, ldd, 
-                  compute_type, algo, kernel_index, flags);
-           }
-           if(std::is_same<T, double>::value)
-           {
-              rocblas_precision a_type = rocblas_precision_double;
-              rocblas_precision b_type = rocblas_precision_double;
-              rocblas_precision c_type = rocblas_precision_double;
-              rocblas_precision d_type = rocblas_precision_double;
-              rocblas_precision compute_type = rocblas_precision_double;
-              rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
-              uint32_t kernel_index = 0;
-              uint32_t flags = 0;
-   
-              status = rocblas_gemm_ex(handle,
-                  transA, transB, m, n, k, &alpha_float, 
-                  da, a_type, lda, 
-                  db, b_type, ldb, &beta_float, 
-                  dc, c_type, ldc, 
-                  dd, d_type, ldd, 
-                  compute_type, algo, kernel_index, flags);
-           }
+            if(std::is_same<T, float>::value)
+            {
+                rocblas_precision a_type       = rocblas_precision_single;
+                rocblas_precision b_type       = rocblas_precision_single;
+                rocblas_precision c_type       = rocblas_precision_single;
+                rocblas_precision d_type       = rocblas_precision_single;
+                rocblas_precision compute_type = rocblas_precision_single;
+                rocblas_gemm_algo algo         = rocblas_gemm_algo_standard;
+                uint32_t kernel_index          = 0;
+                uint32_t flags                 = 0;
+
+                status = rocblas_gemm_ex(handle,
+                                         transA,
+                                         transB,
+                                         m,
+                                         n,
+                                         k,
+                                         &alpha_float,
+                                         da,
+                                         a_type,
+                                         lda,
+                                         db,
+                                         b_type,
+                                         ldb,
+                                         &beta_float,
+                                         dc,
+                                         c_type,
+                                         ldc,
+                                         dd,
+                                         d_type,
+                                         ldd,
+                                         compute_type,
+                                         algo,
+                                         kernel_index,
+                                         flags);
+            }
+            if(std::is_same<T, double>::value)
+            {
+                rocblas_precision a_type       = rocblas_precision_double;
+                rocblas_precision b_type       = rocblas_precision_double;
+                rocblas_precision c_type       = rocblas_precision_double;
+                rocblas_precision d_type       = rocblas_precision_double;
+                rocblas_precision compute_type = rocblas_precision_double;
+                rocblas_gemm_algo algo         = rocblas_gemm_algo_standard;
+                uint32_t kernel_index          = 0;
+                uint32_t flags                 = 0;
+
+                status = rocblas_gemm_ex(handle,
+                                         transA,
+                                         transB,
+                                         m,
+                                         n,
+                                         k,
+                                         &alpha_float,
+                                         da,
+                                         a_type,
+                                         lda,
+                                         db,
+                                         b_type,
+                                         ldb,
+                                         &beta_float,
+                                         dc,
+                                         c_type,
+                                         ldc,
+                                         dd,
+                                         d_type,
+                                         ldd,
+                                         compute_type,
+                                         algo,
+                                         kernel_index,
+                                         flags);
+            }
         }
     }
 
@@ -622,47 +656,39 @@ void testing_logging()
                        << ldc << "," << stride_c << "," << batch_count;
         }
 
-
-
         if(test_pointer_mode == rocblas_pointer_mode_host)
         {
             rocblas_precision a_type, b_type, c_type, d_type, compute_type;
- 
+
             if(std::is_same<T, float>::value)
             {
-               a_type = rocblas_precision_single;
-               b_type = rocblas_precision_single;
-               c_type = rocblas_precision_single;
-               d_type = rocblas_precision_single;
-               compute_type = rocblas_precision_single;
+                a_type       = rocblas_precision_single;
+                b_type       = rocblas_precision_single;
+                c_type       = rocblas_precision_single;
+                d_type       = rocblas_precision_single;
+                compute_type = rocblas_precision_single;
             }
             if(std::is_same<T, double>::value)
             {
-               a_type = rocblas_precision_double;
-               b_type = rocblas_precision_double;
-               c_type = rocblas_precision_double;
-               d_type = rocblas_precision_double;
-               compute_type = rocblas_precision_double;
+                a_type       = rocblas_precision_double;
+                b_type       = rocblas_precision_double;
+                c_type       = rocblas_precision_double;
+                d_type       = rocblas_precision_double;
+                compute_type = rocblas_precision_double;
             }
 
-            rocblas_gemm_algo     algo = rocblas_gemm_algo_standard;
-            uint32_t              kernel_index = 0;
-            uint32_t              flags = 0;
+            rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
+            uint32_t kernel_index  = 0;
+            uint32_t flags         = 0;
 
             trace_ofs2 << "\n"
-                       << "rocblas_gemm_ex" << "," << transA << "," << transB << "," << m
-                       << "," << n << "," << k << "," << alpha << "," << (void*)da 
-                       << "," << a_type
-                       << "," << lda
-                       << "," << (void*)db 
-                       << "," << b_type
-                       << "," << ldb << "," << beta 
-                       << "," << (void*)dc << "," << c_type << "," << ldc
-                       << "," << (void*)dd << "," << d_type << "," << ldd
-                       << "," << compute_type
-                       << "," << algo
-                       << "," << kernel_index
-                       << "," << flags;
+                       << "rocblas_gemm_ex"
+                       << "," << transA << "," << transB << "," << m << "," << n << "," << k << ","
+                       << alpha << "," << (void*)da << "," << a_type << "," << lda << ","
+                       << (void*)db << "," << b_type << "," << ldb << "," << beta << ","
+                       << (void*)dc << "," << c_type << "," << ldc << "," << (void*)dd << ","
+                       << d_type << "," << ldd << "," << compute_type << "," << algo << ","
+                       << kernel_index << "," << flags;
 
             trace_ofs2 << "\n"
                        << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
@@ -672,28 +698,19 @@ void testing_logging()
 
             bench_ofs2 << "\n"
                        << "./rocblas-bench -f gemm_ex"
-                       << " --transposeA " << transA_letter 
-                       << " --transposeB " << transB_letter 
-                       << " -m " << m << " -n " << n << " -k " << k 
-                       << " --alpha " << alpha 
-                       << " --a_type " << a_type << " --lda " << lda
-                       << " --b_type " << b_type << " --ldb " << ldb << " --beta " << beta 
-                       << " --c_type " << c_type << " --ldc " << ldc
-                       << " --d_type " << d_type << " --ldd " << ldd
-                       << " --compute_type " << compute_type
-                       << " --algo " << algo
-                       << " --kernel_index " << kernel_index
-                       << " --flags " << flags;
+                       << " --transposeA " << transA_letter << " --transposeB " << transB_letter
+                       << " -m " << m << " -n " << n << " -k " << k << " --alpha " << alpha
+                       << " --a_type " << a_type << " --lda " << lda << " --b_type " << b_type
+                       << " --ldb " << ldb << " --beta " << beta << " --c_type " << c_type
+                       << " --ldc " << ldc << " --d_type " << d_type << " --ldd " << ldd
+                       << " --compute_type " << compute_type << " --algo " << algo
+                       << " --kernel_index " << kernel_index << " --flags " << flags;
 
             bench_ofs2 << "\n"
-                       << "./rocblas-bench -f gemm -r " << replaceX<T>("X") 
-                       << " --transposeA " << transA_letter 
-                       << " --transposeB " << transB_letter 
-                       << " -m " << m << " -n " << n << " -k " << k 
-                       << " --alpha " << alpha 
-                       << " --lda " << lda
-                       << " --ldb " << ldb << " --beta " << beta 
-                       << " --ldc " << ldc;
+                       << "./rocblas-bench -f gemm -r " << replaceX<T>("X") << " --transposeA "
+                       << transA_letter << " --transposeB " << transB_letter << " -m " << m
+                       << " -n " << n << " -k " << k << " --alpha " << alpha << " --lda " << lda
+                       << " --ldb " << ldb << " --beta " << beta << " --ldc " << ldc;
         }
         else
         {

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <iterator>
 #include <sys/param.h>
+#include <type_traits>
 
 using namespace std;
 
@@ -119,6 +120,8 @@ void testing_logging()
     rocblas_int stride_b     = 1;
     rocblas_int ldc          = 1;
     rocblas_int stride_c     = 1;
+    rocblas_int ldd          = 1;
+    rocblas_int stride_d     = 1;
     rocblas_int batch_count  = 1;
     T alpha                  = 1.0;
     T beta                   = 1.0;
@@ -134,6 +137,7 @@ void testing_logging()
     rocblas_int size_a   = (lda > stride_a ? lda : stride_a) * safe_dim * batch_count;
     rocblas_int size_b   = (ldb > stride_b ? ldb : stride_b) * safe_dim * batch_count;
     rocblas_int size_c   = (ldc > stride_c ? ldc : stride_c) * safe_dim * batch_count;
+    rocblas_int size_d   = (ldd > stride_d ? ldd : stride_d) * safe_dim * batch_count;
 
     // allocate memory on device
     auto dx_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_x),
@@ -146,12 +150,15 @@ void testing_logging()
                                          rocblas_test::device_free};
     auto dc_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_c),
                                          rocblas_test::device_free};
+    auto dd_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_d),
+                                         rocblas_test::device_free};
     T* dx = (T*)dx_managed.get();
     T* dy = (T*)dy_managed.get();
     T* da = (T*)da_managed.get();
     T* db = (T*)db_managed.get();
     T* dc = (T*)dc_managed.get();
-    if(!dx || !dy || !da || !db || !dc)
+    T* dd = (T*)dd_managed.get();
+    if(!dx || !dy || !da || !db || !dc || !dd)
     {
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return;
@@ -237,6 +244,52 @@ void testing_logging()
 
         // trmm
         // tritri
+
+        // BLAS_EX
+        if(BUILD_WITH_TENSILE)
+        {
+           float alpha_float = 1.0;
+           float beta_float = 1.0;
+
+           if(std::is_same<T, float>::value)
+           {
+              rocblas_precision a_type = rocblas_precision_single;
+              rocblas_precision b_type = rocblas_precision_single;
+              rocblas_precision c_type = rocblas_precision_single;
+              rocblas_precision d_type = rocblas_precision_single;
+              rocblas_precision compute_type = rocblas_precision_single;
+              rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
+              uint32_t kernel_index = 0;
+              uint32_t flags = 0;
+   
+              status = rocblas_gemm_ex(handle,
+                  transA, transB, m, n, k, &alpha_float, 
+                  da, a_type, lda, 
+                  db, b_type, ldb, &beta_float, 
+                  dc, c_type, ldc, 
+                  dd, d_type, ldd, 
+                  compute_type, algo, kernel_index, flags);
+           }
+           if(std::is_same<T, double>::value)
+           {
+              rocblas_precision a_type = rocblas_precision_double;
+              rocblas_precision b_type = rocblas_precision_double;
+              rocblas_precision c_type = rocblas_precision_double;
+              rocblas_precision d_type = rocblas_precision_double;
+              rocblas_precision compute_type = rocblas_precision_double;
+              rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
+              uint32_t kernel_index = 0;
+              uint32_t flags = 0;
+   
+              status = rocblas_gemm_ex(handle,
+                  transA, transB, m, n, k, &alpha_float, 
+                  da, a_type, lda, 
+                  db, b_type, ldb, &beta_float, 
+                  dc, c_type, ldc, 
+                  dd, d_type, ldd, 
+                  compute_type, algo, kernel_index, flags);
+           }
+        }
     }
 
     //
@@ -567,6 +620,88 @@ void testing_logging()
                        << (void*)da << "," << lda << "," << stride_a << "," << (void*)db << ","
                        << ldb << "," << stride_b << "," << (void*)&beta << "," << (void*)dc << ","
                        << ldc << "," << stride_c << "," << batch_count;
+        }
+
+
+
+        if(test_pointer_mode == rocblas_pointer_mode_host)
+        {
+            rocblas_precision a_type, b_type, c_type, d_type, compute_type;
+ 
+            if(std::is_same<T, float>::value)
+            {
+               a_type = rocblas_precision_single;
+               b_type = rocblas_precision_single;
+               c_type = rocblas_precision_single;
+               d_type = rocblas_precision_single;
+               compute_type = rocblas_precision_single;
+            }
+            if(std::is_same<T, double>::value)
+            {
+               a_type = rocblas_precision_double;
+               b_type = rocblas_precision_double;
+               c_type = rocblas_precision_double;
+               d_type = rocblas_precision_double;
+               compute_type = rocblas_precision_double;
+            }
+
+            rocblas_gemm_algo     algo = rocblas_gemm_algo_standard;
+            uint32_t              kernel_index = 0;
+            uint32_t              flags = 0;
+
+            trace_ofs2 << "\n"
+                       << "rocblas_gemm_ex" << "," << transA << "," << transB << "," << m
+                       << "," << n << "," << k << "," << alpha << "," << (void*)da 
+                       << "," << a_type
+                       << "," << lda
+                       << "," << (void*)db 
+                       << "," << b_type
+                       << "," << ldb << "," << beta 
+                       << "," << (void*)dc << "," << c_type << "," << ldc
+                       << "," << (void*)dd << "," << d_type << "," << ldd
+                       << "," << compute_type
+                       << "," << algo
+                       << "," << kernel_index
+                       << "," << flags;
+
+            trace_ofs2 << "\n"
+                       << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
+                       << "," << n << "," << k << "," << alpha << "," << (void*)da << "," << lda
+                       << "," << (void*)db << "," << ldb << "," << beta << "," << (void*)dc << ","
+                       << ldc;
+
+            bench_ofs2 << "\n"
+                       << "./rocblas-bench -f gemm_ex"
+                       << " --transposeA " << transA_letter 
+                       << " --transposeB " << transB_letter 
+                       << " -m " << m << " -n " << n << " -k " << k 
+                       << " --alpha " << alpha 
+                       << " --a_type " << a_type << " --lda " << lda
+                       << " --b_type " << b_type << " --ldb " << ldb << " --beta " << beta 
+                       << " --c_type " << c_type << " --ldc " << ldc
+                       << " --d_type " << d_type << " --ldd " << ldd
+                       << " --compute_type " << compute_type
+                       << " --algo " << algo
+                       << " --kernel_index " << kernel_index
+                       << " --flags " << flags;
+
+            bench_ofs2 << "\n"
+                       << "./rocblas-bench -f gemm -r " << replaceX<T>("X") 
+                       << " --transposeA " << transA_letter 
+                       << " --transposeB " << transB_letter 
+                       << " -m " << m << " -n " << n << " -k " << k 
+                       << " --alpha " << alpha 
+                       << " --lda " << lda
+                       << " --ldb " << ldb << " --beta " << beta 
+                       << " --ldc " << ldc;
+        }
+        else
+        {
+            trace_ofs2 << "\n"
+                       << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
+                       << "," << n << "," << k << "," << (void*)&alpha << "," << (void*)da << ","
+                       << lda << "," << (void*)db << "," << ldb << "," << (void*)&beta << ","
+                       << (void*)dc << "," << ldc;
         }
     }
     // exclude trtri as it is an internal function

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -408,6 +408,13 @@ class Arguments
     rocblas_int lda = 128;
     rocblas_int ldb = 128;
     rocblas_int ldc = 128;
+    rocblas_int ldd = 128;
+
+    rocblas_precision a_type = rocblas_precision_single;
+    rocblas_precision b_type = rocblas_precision_single;
+    rocblas_precision c_type = rocblas_precision_single;
+    rocblas_precision d_type = rocblas_precision_single;
+    rocblas_precision compute_type = rocblas_precision_single;
 
     rocblas_int incx = 1;
     rocblas_int incy = 1;
@@ -449,6 +456,13 @@ class Arguments
         lda = rhs.lda;
         ldb = rhs.ldb;
         ldc = rhs.ldc;
+        ldd = rhs.ldd;
+
+        a_type = rhs.a_type;
+        b_type = rhs.b_type;
+        c_type = rhs.c_type;
+        d_type = rhs.d_type;
+        compute_type = rhs.compute_type;
 
         incx = rhs.incx;
         incy = rhs.incy;

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -410,10 +410,10 @@ class Arguments
     rocblas_int ldc = 128;
     rocblas_int ldd = 128;
 
-    rocblas_precision a_type = rocblas_precision_single;
-    rocblas_precision b_type = rocblas_precision_single;
-    rocblas_precision c_type = rocblas_precision_single;
-    rocblas_precision d_type = rocblas_precision_single;
+    rocblas_precision a_type       = rocblas_precision_single;
+    rocblas_precision b_type       = rocblas_precision_single;
+    rocblas_precision c_type       = rocblas_precision_single;
+    rocblas_precision d_type       = rocblas_precision_single;
     rocblas_precision compute_type = rocblas_precision_single;
 
     rocblas_int incx = 1;
@@ -458,10 +458,10 @@ class Arguments
         ldc = rhs.ldc;
         ldd = rhs.ldd;
 
-        a_type = rhs.a_type;
-        b_type = rhs.b_type;
-        c_type = rhs.c_type;
-        d_type = rhs.d_type;
+        a_type       = rhs.a_type;
+        b_type       = rhs.b_type;
+        c_type       = rhs.c_type;
+        d_type       = rhs.d_type;
         compute_type = rhs.compute_type;
 
         incx = rhs.incx;

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1397,34 +1397,30 @@ ROCBLAS_EXPORT rocblas_status rocblas_dgeam(rocblas_handle handle,
  *    extensions BLAS
  * ===========================================================================
  */
-ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(
-                           rocblas_handle        handle,
-                           rocblas_operation     trans_a,
-                           rocblas_operation     trans_b,
-                           int                   m,
-                           int                   n,
-                           int                   k,
-                           const float           *alpha,
-                           const void            *a,
-                           rocblas_precision     a_type,
-                           int                   lda,
-                           const void            *b,
-                           rocblas_precision     b_type,
-                           int                   ldb,
-                           const float           *beta,
-                           void                  *c,
-                           rocblas_precision     c_type,
-                           int                   ldc,
-                           void                  *d,
-                           rocblas_precision     d_type,
-                           int                   ldd,
-                           rocblas_precision     compute_type,
-                           rocblas_gemm_algo     algo,
-                           uint32_t              kernel_index,
-                           uint32_t              flags);
-
-
-
+ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(rocblas_handle handle,
+                                              rocblas_operation trans_a,
+                                              rocblas_operation trans_b,
+                                              int m,
+                                              int n,
+                                              int k,
+                                              const float* alpha,
+                                              const void* a,
+                                              rocblas_precision a_type,
+                                              int lda,
+                                              const void* b,
+                                              rocblas_precision b_type,
+                                              int ldb,
+                                              const float* beta,
+                                              void* c,
+                                              rocblas_precision c_type,
+                                              int ldc,
+                                              void* d,
+                                              rocblas_precision d_type,
+                                              int ldd,
+                                              rocblas_precision compute_type,
+                                              rocblas_gemm_algo algo,
+                                              uint32_t kernel_index,
+                                              uint32_t flags);
 
 #ifdef __cplusplus
 }

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1,6 +1,5 @@
 /* ************************************************************************
  * Copyright 2016 Advanced Micro Devices, Inc.
- *
  * ************************************************************************ */
 
 #pragma once
@@ -1392,6 +1391,40 @@ ROCBLAS_EXPORT rocblas_status rocblas_dgeam(rocblas_handle handle,
                                             rocblas_int ldb,
                                             double* C,
                                             rocblas_int ldc);
+
+/*
+ * ===========================================================================
+ *    extensions BLAS
+ * ===========================================================================
+ */
+ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(
+                           rocblas_handle        handle,
+                           rocblas_operation     trans_a,
+                           rocblas_operation     trans_b,
+                           int                   m,
+                           int                   n,
+                           int                   k,
+                           const float           *alpha,
+                           const void            *a,
+                           rocblas_precision     a_type,
+                           int                   lda,
+                           const void            *b,
+                           rocblas_precision     b_type,
+                           int                   ldb,
+                           const float           *beta,
+                           void                  *c,
+                           rocblas_precision     c_type,
+                           int                   ldc,
+                           void                  *d,
+                           rocblas_precision     d_type,
+                           int                   ldd,
+                           rocblas_precision     compute_type,
+                           rocblas_gemm_algo     algo,
+                           uint32_t              kernel_index,
+                           uint32_t              flags);
+
+
+
 
 #ifdef __cplusplus
 }

--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -117,8 +117,6 @@ typedef enum rocblas_gemm_algo_ {
     rocblas_gemm_algo_standard = 0b0000000000,
 } rocblas_gemm_algo;
 
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -114,7 +114,7 @@ typedef enum rocblas_layer_mode_ {
 
 /*! \brief Indicates if layer is active with bitmask*/
 typedef enum rocblas_gemm_algo_ {
-    rocblas_layer_mode_general = 0b0000000000,
+    rocblas_gemm_algo_standard = 0b0000000000,
 } rocblas_gemm_algo;
 
 

--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -106,11 +106,18 @@ typedef enum rocblas_pointer_mode_ {
 } rocblas_pointer_mode;
 
 /*! \brief Indicates if layer is active with bitmask*/
-typedef enum rocblas_layer_mode {
+typedef enum rocblas_layer_mode_ {
     rocblas_layer_mode_none      = 0b0000000000,
     rocblas_layer_mode_log_trace = 0b0000000001,
     rocblas_layer_mode_log_bench = 0b0000000010,
 } rocblas_layer_mode;
+
+/*! \brief Indicates if layer is active with bitmask*/
+typedef enum rocblas_gemm_algo_ {
+    rocblas_layer_mode_general = 0b0000000000,
+} rocblas_gemm_algo;
+
+
 
 #ifdef __cplusplus
 }

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -90,6 +90,10 @@ set( rocblas_auxiliary_source
   status.cpp
 )
 
+set( rocblas_ex_source
+  blas_ex/rocblas_gemm_ex.cpp
+)
+
 set( rocblas_blas3_source
   blas3/rocblas_trtri.cpp
   blas3/rocblas_trtri_batched.cpp
@@ -119,6 +123,7 @@ set( rocblas_blas1_source
 prepend_path( ".." rocblas_headers_public relative_rocblas_headers_public )
 
 add_library( rocblas
+  ${rocblas_ex_source}
   ${rocblas_blas3_source}
   ${rocblas_blas2_source}
   ${rocblas_blas1_source}

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -1,0 +1,345 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#include <hip/hip_runtime.h>
+
+#include "rocblas.h"
+#include "status.h"
+#include "definitions.h"
+#include "handle.h"
+#include "logging.h"
+#include "utility.h"
+
+/*! \brief BLAS EX API
+
+    \details
+    GEMM_EX performs one of the matrix-matrix operations
+
+        D = alpha*op( A )*op( B ) + beta*C,
+
+    where op( X ) is one of
+
+        op( X ) = X      or
+        op( X ) = X**T   or
+        op( X ) = X**H,
+
+    alpha and beta are scalars, and A, B, C, and D are matrices, with
+    op( A ) an m by k matrix, op( B ) a k by n matrix and C and D m by n matrices.
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    transA    rocblas_operation
+              specifies the form of op( A )
+    @param[in]
+    transB    rocblas_operation
+              specifies the form of op( B )
+    @param[in]
+    m         rocblas_int.
+    @param[in]
+    n         rocblas_int.
+    @param[in]
+    k         rocblas_int.
+    @param[in]
+    alpha     specifies the scalar alpha.
+    @param[in]
+    A         pointer storing matrix A on the GPU.
+    @param[in]
+    lda       rocblas_int
+              specifies the leading dimension of A.
+    @param[in]
+    Atype     rocblas_precision
+              specifies the datatype of matrix A
+    @param[in]
+    B         pointer storing matrix B on the GPU.
+    @param[in]
+    ldb       rocblas_int
+              specifies the leading dimension of B.
+    @param[in]
+    Btype     rocblas_precision
+              specifies the datatype of matrix B
+    @param[in]
+    beta      specifies the scalar beta.
+    @param[in]
+    C         pointer storing matrix C on the GPU.
+    @param[in]
+    ldc       rocblas_int
+              specifies the leading dimension of C.
+    @param[in]
+    Ctype     rocblas_precision
+              specifies the datatype of matrix C
+    @param[out]
+    D         pointer storing matrix D on the GPU.
+    @param[in]
+    ldd       rocblas_int
+              specifies the leading dimension of D.
+    @param[in]
+    Dtype     rocblas_precision
+              specifies the datatype of matrix D
+
+    @param[in]
+    computeType
+              specifies the datatype of computation
+
+    @param[in]
+    algo      rocblas_gemm_algo
+              enumerant specifying the algorithm type.
+    @param[in]
+    kernel_index
+              reserved for future use
+
+    @param[in]
+    flags     uint32_t
+              reserved for future use
+
+
+    ********************************************************************/
+
+extern "C" rocblas_status rocblas_gemm_ex_template(
+                           rocblas_handle        handle,
+                           rocblas_operation     trans_a,
+                           rocblas_operation     trans_b,
+                           int                   m,
+                           int                   n,
+                           int                   k,
+                           const float           *alpha,
+                           const void            *a,
+                           rocblas_precision     a_type,
+                           int                   lda,
+                           const void            *b,
+                           rocblas_precision     b_type,
+                           int                   ldb,
+                           const float           *beta,
+                           void                  *c,
+                           rocblas_precision     c_type,
+                           int                   ldc,
+                           void                  *d,
+                           rocblas_precision     d_type,
+                           int                   ldd,
+                           rocblas_precision     compute_type,
+                           rocblas_gemm_algo     algo,
+                           uint32_t              kernel_index,
+                           uint32_t              flags)
+{
+    if(nullptr == handle)
+        return rocblas_status_invalid_handle;
+
+    if(handle->pointer_mode == rocblas_pointer_mode_host)
+    {
+        log_trace(handle,
+                  "rocblas_gemm_ex",
+                  trans_a, trans_b,
+                  m, n, k, *alpha,
+                  (const void*&)a, a_type, lda,
+                  (const void*&)b, b_type, ldb, *beta,
+                  (const void*&)c, c_type, ldc,
+                  (const void*&)d, d_type, ldd,
+                  compute_type,
+                  algo,
+                  kernel_index,
+                  flags);        
+
+        log_bench(handle,
+                  "./rocblas-bench -f gemm-ex",
+                  "-m", m,
+                  "-n", n,
+                  "-k", k,
+                  "--alpha", *alpha,
+                  "--beta", *beta,
+                  "--lda", lda,
+                  "--ldb", ldb,
+                  "--ldc", ldc,
+                  "--ldd", ldd,
+                  "--a_type", a_type,
+                  "--b_type", b_type,
+                  "--c_type", c_type,
+                  "--d_type", d_type,
+                  "--compute_type", compute_type,
+                  "--algo", algo,
+                  "kernel_index", kernel_index,
+                  "flags", flags);
+    }
+    else
+    {
+        log_trace(handle,
+                  "rocblas_gemm_ex",
+                  trans_a, trans_b,
+                  m, n, k,
+                  (const void*&)alpha,
+                  (const void*&)a, a_type, lda, 
+                  (const void*&)b, b_type, ldb, (const void*&)beta,
+                  (const void*&)c, c_type, ldc,
+                  (const void*&)d, d_type, ldd,
+                  compute_type,
+                  algo,
+                  kernel_index,
+                  flags);        
+    }
+
+   // quick return m,n,k equal to 0 is valid in BLAS
+    if(m == 0 || n == 0 || k == 0)
+    {
+        return rocblas_status_success;
+    }
+
+    // sizes must not be negative
+    if(m < 0 || n < 0 || k < 0)
+    {
+        return rocblas_status_invalid_size;
+    }
+
+    // pointers must be valid
+    if(a == nullptr || b == nullptr || c == nullptr || d == nullptr || alpha == nullptr || beta == nullptr)
+    {
+        return rocblas_status_invalid_pointer;
+    }
+
+    rocblas_int num_rows_a = (trans_a == rocblas_operation_none) ? m : k;
+    rocblas_int num_rows_b = (trans_b == rocblas_operation_none) ? k : n;
+    rocblas_int num_rows_c = m;
+    rocblas_int num_rows_d = m;
+
+    // leading dimensions must be valid
+    if(num_rows_a > lda || num_rows_b > ldb || num_rows_c > ldc || num_rows_d > ldd) 
+    {
+        return rocblas_status_invalid_size;
+    }
+
+    rocblas_status status;
+    size_t c_byte_size;
+    size_t d_byte_size;
+
+
+//TODO: templated function needs to replace non-templated code below
+//template <typename T>
+//rocblas_matrix_copy_device_to_device(rocblas_int m, rocblas_int n, T *dest, rocblas_int ld_dest, T *orig, rocblas_int ld_orig)
+//{
+//    size_t byte_size = sizeof(T);
+//    size_t column_byte_size = byte_size * m;
+//    size_t dest_byte_stride = byte_size * ld_dest;
+//    size_t orig_byte_stride = byte_size * ld_orig;
+//
+//    if((dest != orig) || (ld_dest != ld_orig))
+//    {
+//        for (int i = 0; i < n; i++)
+//        {
+//            void *c_void = static_cast<void*>(&(c_double[i*c_byte_stride]));
+//            void *d_void = static_cast<void*>(&(d_double[i*d_byte_stride]));
+//            PRINT_IF_HIP_ERROR(hipMemcpy(d_void, c_void, column_byte_size, hipMemcpyDeviceToDevice))
+//        }
+//    }
+//} 
+
+
+
+
+    if(a_type == rocblas_precision_double && b_type == rocblas_precision_double && 
+       c_type == rocblas_precision_double && d_type == rocblas_precision_double && compute_type == rocblas_precision_double)
+    {
+        const double alpha_double = static_cast<double>(*alpha);
+        const double beta_double = static_cast<double>(*beta);
+
+        status = rocblas_dgemm(handle,
+                               trans_a, trans_b,
+                               m, n, k, static_cast<const double*>(&alpha_double),
+                               static_cast<const double*>(a), lda,
+                               static_cast<const double*>(b), ldb, static_cast<const double*>(&beta_double),
+                               static_cast<      double*>(c), ldc);
+
+        if(status != rocblas_status_success) return status;
+
+        if(c != d || ldc != ldd)  // no copy if c matrix == d matrix
+        {
+            c_byte_size = sizeof(double);
+            d_byte_size = sizeof(double);
+
+            size_t column_size = m * c_byte_size;
+
+            size_t c_byte_stride = ldc * c_byte_size;
+            size_t d_byte_stride = ldd * d_byte_size;
+
+            double *c_double = static_cast<double*>(c);
+            double *d_double = static_cast<double*>(d);
+
+            for (int i = 0; i < n; i++)
+            {
+                void *c_void = static_cast<void*>(&(c_double[i*c_byte_stride]));
+                void *d_void = static_cast<void*>(&(d_double[i*d_byte_stride]));
+                PRINT_IF_HIP_ERROR(hipMemcpy(d_void, c_void, column_size, hipMemcpyDeviceToDevice))
+            }
+        }
+
+    }
+    else if(a_type == rocblas_precision_single && b_type == rocblas_precision_single && 
+            c_type == rocblas_precision_single && d_type == rocblas_precision_single && compute_type == rocblas_precision_single)
+    {
+        const float alpha_float = static_cast<float>(*alpha);
+        const float beta_float = static_cast<float>(*beta);
+
+        status = rocblas_sgemm(handle,
+                               trans_a, trans_b,
+                               m, n, k, static_cast<const float*>(&alpha_float),
+                               static_cast<const float*>(a), lda,
+                               static_cast<const float*>(b), ldb, static_cast<const float*>(&beta_float),
+                               static_cast<      float*>(c), ldc);
+
+        if(status != rocblas_status_success) return status;
+
+        if(c != d || ldc != ldd)  // no copy if c matrix == d matrix
+        {
+            c_byte_size = sizeof(float);
+            d_byte_size = sizeof(float);
+
+            size_t column_size = m * c_byte_size;
+
+            size_t c_byte_stride = ldc * c_byte_size;
+            size_t d_byte_stride = ldd * d_byte_size;
+
+            float *c_float = static_cast<float*>(c);
+            float *d_float = static_cast<float*>(d);
+
+            for (int i = 0; i < n; i++)
+            {
+                void *c_void = static_cast<void*>(&(c_float[i*c_byte_stride]));
+                void *d_void = static_cast<void*>(&(d_float[i*d_byte_stride]));
+                PRINT_IF_HIP_ERROR(hipMemcpy(d_void, c_void, column_size, hipMemcpyDeviceToDevice))
+            }
+        }
+    }
+//  else if(a_type == rocblas_precision_half && b_type == rocblas_precision_half && 
+//          c_type == rocblas_precision_half && d_type == rocblas_precision_half && compute_type == rocblas_precision_half)
+//  {
+//      status = rocblas_hgemm(handle,
+//                             trans_a, trans_b,
+//                             m, n, k, alpha,
+//                             a, lda,
+//                             b, ldb, beta,
+//                             c, ldc);
+//      c_byte_size = 2;
+//      d_byte_size = 2;
+//  }
+    else
+    {
+        return rocblas_status_not_implemented;
+    }
+
+/*
+    //copy matrix c into matrix d
+    if(status == rocblas_success)
+    {
+        size_t column_size = m * c_byte_size;
+        size_t c_byte_stride = ldc * c_byte_size;
+        size_t d_byte_stride = ldd * d_byte_size;
+        if(c != d || ldc != ldd)  // no copy if c matrix == d matrix
+        {
+            for (int i = 0; i < n; i++)
+            {
+                PRINT_IF_HIP_ERROR(hipMemcpy(d + i*d_byte_stride, c + i*c_byte_stride, column_size, hipMemcpyDeviceToDevice))
+            }
+        }
+    }
+*/
+
+    return status;
+}

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -96,7 +96,7 @@
 
     ********************************************************************/
 
-extern "C" rocblas_status rocblas_gemm_ex_template(
+extern "C" rocblas_status rocblas_gemm_ex(
                            rocblas_handle        handle,
                            rocblas_operation     trans_a,
                            rocblas_operation     trans_b,
@@ -140,25 +140,29 @@ extern "C" rocblas_status rocblas_gemm_ex_template(
                   kernel_index,
                   flags);        
 
+        std::string trans_a_letter = rocblas_transpose_letter(trans_a);
+        std::string trans_b_letter = rocblas_transpose_letter(trans_b);
         log_bench(handle,
-                  "./rocblas-bench -f gemm-ex",
+                  "./rocblas-bench -f gemm_ex",
+                  "--transposeA", trans_a_letter,
+                  "--transposeB", trans_b_letter,
                   "-m", m,
                   "-n", n,
                   "-k", k,
                   "--alpha", *alpha,
-                  "--beta", *beta,
-                  "--lda", lda,
-                  "--ldb", ldb,
-                  "--ldc", ldc,
-                  "--ldd", ldd,
                   "--a_type", a_type,
+                  "--lda", lda,
                   "--b_type", b_type,
+                  "--ldb", ldb,
+                  "--beta", *beta,
                   "--c_type", c_type,
+                  "--ldc", ldc,
                   "--d_type", d_type,
+                  "--ldd", ldd,
                   "--compute_type", compute_type,
                   "--algo", algo,
-                  "kernel_index", kernel_index,
-                  "flags", flags);
+                  "--kernel_index", kernel_index,
+                  "--flags", flags);
     }
     else
     {

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -10,10 +10,15 @@
 #include "logging.h"
 #include "utility.h"
 
-void device_matrix_copy(void *src, rocblas_int ld_src, void *dst, rocblas_int ld_dst, 
-                                   rocblas_int n1, rocblas_int n2, size_t elem_size)
+void device_matrix_copy(void* src,
+                        rocblas_int ld_src,
+                        void* dst,
+                        rocblas_int ld_dst,
+                        rocblas_int n1,
+                        rocblas_int n2,
+                        size_t elem_size)
 {
-    if((src != dst) || (ld_src != ld_dst))  // no copy if src matrix == dst matrix
+    if((src != dst) || (ld_src != ld_dst)) // no copy if src matrix == dst matrix
     {
         if((n1 == ld_src) && (n1 == ld_dst))
         {
@@ -25,12 +30,15 @@ void device_matrix_copy(void *src, rocblas_int ld_src, void *dst, rocblas_int ld
         {
             size_t column_size = n1 * elem_size;
 
-            for (int i2 = 0; i2 < n2; i2++)
+            for(int i2 = 0; i2 < n2; i2++)
             {
-                void *src_void = static_cast<void*>(static_cast<uint8_t*>(src) + (i2 * ld_src * elem_size));
-                void *dst_void = static_cast<void*>(static_cast<uint8_t*>(dst) + (i2 * ld_dst * elem_size));
+                void* src_void =
+                    static_cast<void*>(static_cast<uint8_t*>(src) + (i2 * ld_src * elem_size));
+                void* dst_void =
+                    static_cast<void*>(static_cast<uint8_t*>(dst) + (i2 * ld_dst * elem_size));
 
-                PRINT_IF_HIP_ERROR(hipMemcpy(dst_void, src_void, column_size, hipMemcpyDeviceToDevice))
+                PRINT_IF_HIP_ERROR(
+                    hipMemcpy(dst_void, src_void, column_size, hipMemcpyDeviceToDevice))
             }
         }
     }
@@ -50,7 +58,7 @@ void device_matrix_copy(void *src, rocblas_int ld_src, void *dst, rocblas_int ld
         op( X ) = X**H,
 
     alpha and beta are scalars, and A, B, C, and D are matrices, with
-    op( A ) an m by k matrix, op( B ) a k by n matrix and C and D m by n matrices.
+    op( A ) an m by k matrix, op( B ) a k by n matrix and C and D are m by n matrices.
 
     @param[in]
     handle    rocblas_handle.
@@ -72,49 +80,46 @@ void device_matrix_copy(void *src, rocblas_int ld_src, void *dst, rocblas_int ld
     @param[in]
     A         pointer storing matrix A on the GPU.
     @param[in]
-    lda       rocblas_int
-              specifies the leading dimension of A.
-    @param[in]
     Atype     rocblas_precision
               specifies the datatype of matrix A
     @param[in]
-    B         pointer storing matrix B on the GPU.
+    lda       rocblas_int
+              specifies the leading dimension of A.
     @param[in]
-    ldb       rocblas_int
-              specifies the leading dimension of B.
+    B         pointer storing matrix B on the GPU.
     @param[in]
     Btype     rocblas_precision
               specifies the datatype of matrix B
+    @param[in]
+    ldb       rocblas_int
+              specifies the leading dimension of B.
     @param[in]
     beta      specifies the scalar beta.
     @param[in]
     C         pointer storing matrix C on the GPU.
     @param[in]
-    ldc       rocblas_int
-              specifies the leading dimension of C.
-    @param[in]
     Ctype     rocblas_precision
               specifies the datatype of matrix C
+    @param[in]
+    ldc       rocblas_int
+              specifies the leading dimension of C.
     @param[out]
     D         pointer storing matrix D on the GPU.
     @param[in]
-    ldd       rocblas_int
-              specifies the leading dimension of D.
     @param[in]
     Dtype     rocblas_precision
               specifies the datatype of matrix D
-
+    ldd       rocblas_int
+              specifies the leading dimension of D.
     @param[in]
     computeType
               specifies the datatype of computation
-
     @param[in]
     algo      rocblas_gemm_algo
               enumerant specifying the algorithm type.
     @param[in]
     kernel_index
               reserved for future use
-
     @param[in]
     flags     uint32_t
               reserved for future use
@@ -122,31 +127,30 @@ void device_matrix_copy(void *src, rocblas_int ld_src, void *dst, rocblas_int ld
 
     ********************************************************************/
 
-extern "C" rocblas_status rocblas_gemm_ex(
-                           rocblas_handle        handle,
-                           rocblas_operation     trans_a,
-                           rocblas_operation     trans_b,
-                           int                   m,
-                           int                   n,
-                           int                   k,
-                           const float           *alpha,
-                           const void            *a,
-                           rocblas_precision     a_type,
-                           int                   lda,
-                           const void            *b,
-                           rocblas_precision     b_type,
-                           int                   ldb,
-                           const float           *beta,
-                           void                  *c,
-                           rocblas_precision     c_type,
-                           int                   ldc,
-                           void                  *d,
-                           rocblas_precision     d_type,
-                           int                   ldd,
-                           rocblas_precision     compute_type,
-                           rocblas_gemm_algo     algo,
-                           uint32_t              kernel_index,
-                           uint32_t              flags)
+extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle handle,
+                                          rocblas_operation trans_a,
+                                          rocblas_operation trans_b,
+                                          int m,
+                                          int n,
+                                          int k,
+                                          const float* alpha,
+                                          const void* a,
+                                          rocblas_precision a_type,
+                                          int lda,
+                                          const void* b,
+                                          rocblas_precision b_type,
+                                          int ldb,
+                                          const float* beta,
+                                          void* c,
+                                          rocblas_precision c_type,
+                                          int ldc,
+                                          void* d,
+                                          rocblas_precision d_type,
+                                          int ldd,
+                                          rocblas_precision compute_type,
+                                          rocblas_gemm_algo algo,
+                                          uint32_t kernel_index,
+                                          uint32_t flags)
 {
     if(nullptr == handle)
         return rocblas_status_invalid_handle;
@@ -155,59 +159,103 @@ extern "C" rocblas_status rocblas_gemm_ex(
     {
         log_trace(handle,
                   "rocblas_gemm_ex",
-                  trans_a, trans_b,
-                  m, n, k, *alpha,
-                  (const void*&)a, a_type, lda,
-                  (const void*&)b, b_type, ldb, *beta,
-                  (const void*&)c, c_type, ldc,
-                  (const void*&)d, d_type, ldd,
+                  trans_a,
+                  trans_b,
+                  m,
+                  n,
+                  k,
+                  *alpha,
+                  (const void*&)a,
+                  a_type,
+                  lda,
+                  (const void*&)b,
+                  b_type,
+                  ldb,
+                  *beta,
+                  (const void*&)c,
+                  c_type,
+                  ldc,
+                  (const void*&)d,
+                  d_type,
+                  ldd,
                   compute_type,
                   algo,
                   kernel_index,
-                  flags);        
+                  flags);
 
         std::string trans_a_letter = rocblas_transpose_letter(trans_a);
         std::string trans_b_letter = rocblas_transpose_letter(trans_b);
         log_bench(handle,
                   "./rocblas-bench -f gemm_ex",
-                  "--transposeA", trans_a_letter,
-                  "--transposeB", trans_b_letter,
-                  "-m", m,
-                  "-n", n,
-                  "-k", k,
-                  "--alpha", *alpha,
-                  "--a_type", a_type,
-                  "--lda", lda,
-                  "--b_type", b_type,
-                  "--ldb", ldb,
-                  "--beta", *beta,
-                  "--c_type", c_type,
-                  "--ldc", ldc,
-                  "--d_type", d_type,
-                  "--ldd", ldd,
-                  "--compute_type", compute_type,
-                  "--algo", algo,
-                  "--kernel_index", kernel_index,
-                  "--flags", flags);
+                  "--transposeA",
+                  trans_a_letter,
+                  "--transposeB",
+                  trans_b_letter,
+                  "-m",
+                  m,
+                  "-n",
+                  n,
+                  "-k",
+                  k,
+                  "--alpha",
+                  *alpha,
+                  "--a_type",
+                  a_type,
+                  "--lda",
+                  lda,
+                  "--b_type",
+                  b_type,
+                  "--ldb",
+                  ldb,
+                  "--beta",
+                  *beta,
+                  "--c_type",
+                  c_type,
+                  "--ldc",
+                  ldc,
+                  "--d_type",
+                  d_type,
+                  "--ldd",
+                  ldd,
+                  "--compute_type",
+                  compute_type,
+                  "--algo",
+                  algo,
+                  "--kernel_index",
+                  kernel_index,
+                  "--flags",
+                  flags);
     }
     else
     {
         log_trace(handle,
                   "rocblas_gemm_ex",
-                  trans_a, trans_b,
-                  m, n, k,
+                  trans_a,
+                  trans_b,
+                  m,
+                  n,
+                  k,
                   (const void*&)alpha,
-                  (const void*&)a, a_type, lda, 
-                  (const void*&)b, b_type, ldb, (const void*&)beta,
-                  (const void*&)c, c_type, ldc,
-                  (const void*&)d, d_type, ldd,
+                  (const void*&)a,
+                  a_type,
+                  lda,
+                  (const void*&)b,
+                  b_type,
+                  ldb,
+                  (const void*&)beta,
+                  (const void*&)c,
+                  c_type,
+                  ldc,
+                  (const void*&)d,
+                  d_type,
+                  ldd,
                   compute_type,
                   algo,
                   kernel_index,
-                  flags);        
+                  flags);
     }
 
-   // quick return m,n,k equal to 0 is valid in BLAS
+    // quick return m,n,k equal to 0 is valid in BLAS
     if(m == 0 || n == 0 || k == 0)
     {
         return rocblas_status_success;
@@ -220,7 +268,8 @@ extern "C" rocblas_status rocblas_gemm_ex(
     }
 
     // pointers must be valid
-    if(a == nullptr || b == nullptr || c == nullptr || d == nullptr || alpha == nullptr || beta == nullptr)
+    if(a == nullptr || b == nullptr || c == nullptr || d == nullptr || alpha == nullptr ||
+       beta == nullptr)
     {
         return rocblas_status_invalid_pointer;
     }
@@ -231,7 +280,7 @@ extern "C" rocblas_status rocblas_gemm_ex(
     rocblas_int num_rows_d = m;
 
     // leading dimensions must be valid
-    if(num_rows_a > lda || num_rows_b > ldb || num_rows_c > ldc || num_rows_d > ldd) 
+    if(num_rows_a > lda || num_rows_b > ldb || num_rows_c > ldc || num_rows_d > ldd)
     {
         return rocblas_status_invalid_size;
     }
@@ -240,57 +289,206 @@ extern "C" rocblas_status rocblas_gemm_ex(
     size_t c_byte_size;
     size_t d_byte_size;
 
-    if(a_type == rocblas_precision_double && b_type == rocblas_precision_double && 
-       c_type == rocblas_precision_double && d_type == rocblas_precision_double && compute_type == rocblas_precision_double)
+    if(a_type == rocblas_precision_double && b_type == rocblas_precision_double &&
+       c_type == rocblas_precision_double && d_type == rocblas_precision_double &&
+       compute_type == rocblas_precision_double)
     {
-        const double alpha_double = static_cast<double>(*alpha);
-        const double beta_double = static_cast<double>(*beta);
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
+        {
+            // copy alpha and beta from device to host to convert type, then copy back to device
+            float h_alpha_float;
+            float h_beta_float;
+            hipMemcpy(&h_alpha_float, alpha, sizeof(float), hipMemcpyDeviceToHost);
+            hipMemcpy(&h_beta_float, beta, sizeof(float), hipMemcpyDeviceToHost);
 
-        status = rocblas_dgemm(handle,
-                               trans_a, trans_b,
-                               m, n, k, static_cast<const double*>(&alpha_double),
-                               static_cast<const double*>(a), lda,
-                               static_cast<const double*>(b), ldb, static_cast<const double*>(&beta_double),
-                               static_cast<      double*>(c), ldc);
+            const double h_alpha_double = static_cast<double>(h_alpha_float);
+            const double h_beta_double  = static_cast<double>(h_beta_float);
 
-        if(status != rocblas_status_success) return status;
+            double* d_alpha_double;
+            double* d_beta_double;
 
-        device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(double));
+            hipMalloc(&d_alpha_double, sizeof(double));
+            hipMalloc(&d_beta_double, sizeof(double));
+
+            hipMemcpy(d_alpha_double, &h_alpha_double, sizeof(double), hipMemcpyHostToDevice);
+            hipMemcpy(d_beta_double, &h_beta_double, sizeof(double), hipMemcpyHostToDevice);
+
+            // copy matrix C to matrix D
+            device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(double));
+
+            // call rocblas_dgemm
+            status = rocblas_dgemm(handle,
+                                   trans_a,
+                                   trans_b,
+                                   m,
+                                   n,
+                                   k,
+                                   d_alpha_double,
+                                   static_cast<const double*>(a),
+                                   lda,
+                                   static_cast<const double*>(b),
+                                   ldb,
+                                   d_beta_double,
+                                   static_cast<double*>(d),
+                                   ldd);
+        }
+        else
+        {
+            // convert type of alpha and beta
+            const double alpha_double = static_cast<double>(*alpha);
+            const double beta_double  = static_cast<double>(*beta);
+
+            // copy matrix C to matrix D
+            device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(double));
+
+            // call rocblas_dgemm
+            status = rocblas_dgemm(handle,
+                                   trans_a,
+                                   trans_b,
+                                   m,
+                                   n,
+                                   k,
+                                   static_cast<const double*>(&alpha_double),
+                                   static_cast<const double*>(a),
+                                   lda,
+                                   static_cast<const double*>(b),
+                                   ldb,
+                                   static_cast<const double*>(&beta_double),
+                                   static_cast<double*>(d),
+                                   ldd);
+        }
+
+        if(status != rocblas_status_success)
+            return status;
     }
-    else if(a_type == rocblas_precision_single && b_type == rocblas_precision_single && 
-            c_type == rocblas_precision_single && d_type == rocblas_precision_single && compute_type == rocblas_precision_single)
+    else if(a_type == rocblas_precision_single && b_type == rocblas_precision_single &&
+            c_type == rocblas_precision_single && d_type == rocblas_precision_single &&
+            compute_type == rocblas_precision_single)
     {
-        const float alpha_float = static_cast<float>(*alpha);
-        const float beta_float = static_cast<float>(*beta);
 
-        status = rocblas_sgemm(handle,
-                               trans_a, trans_b,
-                               m, n, k, static_cast<const float*>(&alpha_float),
-                               static_cast<const float*>(a), lda,
-                               static_cast<const float*>(b), ldb, static_cast<const float*>(&beta_float),
-                               static_cast<      float*>(c), ldc);
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
+        {
+            // no need for type conversion for alpha and beta
 
-        if(status != rocblas_status_success) return status;
+            // copy matrix C to matrix D
+            device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(float));
 
-        device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(float));
+            // call rocblas_sgemm
+            status = rocblas_sgemm(handle,
+                                   trans_a,
+                                   trans_b,
+                                   m,
+                                   n,
+                                   k,
+                                   alpha,
+                                   static_cast<const float*>(a),
+                                   lda,
+                                   static_cast<const float*>(b),
+                                   ldb,
+                                   beta,
+                                   static_cast<float*>(d),
+                                   ldd);
+        }
+        else
+        {
+            // no need for type conversion for alpha and beta
+
+            // copy matrix C to matrix D
+            device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(float));
+
+            // call rocblas_sgemm
+            status = rocblas_sgemm(handle,
+                                   trans_a,
+                                   trans_b,
+                                   m,
+                                   n,
+                                   k,
+                                   alpha,
+                                   static_cast<const float*>(a),
+                                   lda,
+                                   static_cast<const float*>(b),
+                                   ldb,
+                                   beta,
+                                   static_cast<float*>(d),
+                                   ldd);
+        }
+
+        if(status != rocblas_status_success)
+            return status;
     }
-    else if(a_type == rocblas_precision_half && b_type == rocblas_precision_half && 
-            c_type == rocblas_precision_half && d_type == rocblas_precision_half && compute_type == rocblas_precision_half)
+    else if(a_type == rocblas_precision_half && b_type == rocblas_precision_half &&
+            c_type == rocblas_precision_half && d_type == rocblas_precision_half &&
+            compute_type == rocblas_precision_half)
     {
-        const _Float16 alpha_half= static_cast<_Float16>(*alpha);
-        const _Float16 beta_half= static_cast<_Float16>(*beta);
+        if(rocblas_pointer_mode_device == handle->pointer_mode)
+        {
+            // copy alpha and beta from device to host to convert type, then copy back to device
+            float h_alpha_float;
+            float h_beta_float;
+            hipMemcpy(&h_alpha_float, alpha, sizeof(float), hipMemcpyDeviceToHost);
+            hipMemcpy(&h_beta_float, beta, sizeof(float), hipMemcpyDeviceToHost);
 
-        status = rocblas_hgemm(handle,
-                               trans_a, trans_b,
-                               m, n, k, reinterpret_cast<const rocblas_half*>(&alpha_half),
-                               static_cast<const rocblas_half*>(a), lda,
-                               static_cast<const rocblas_half*>(b), ldb, reinterpret_cast<const rocblas_half*>(&beta_half),
-                               static_cast<      rocblas_half*>(c), ldc);
+            const _Float16 h_alpha_half = static_cast<_Float16>(h_alpha_float);
+            const _Float16 h_beta_half  = static_cast<_Float16>(h_beta_float);
 
-        if(status != rocblas_status_success) std::cout << "ERROR: status = " << status << std::endl;
-        if(status != rocblas_status_success) return status;
+            rocblas_half* d_alpha_half;
+            rocblas_half* d_beta_half;
 
-        device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(rocblas_half));
+            hipMalloc(&d_alpha_half, sizeof(rocblas_half));
+            hipMalloc(&d_beta_half, sizeof(rocblas_half));
+
+            hipMemcpy(d_alpha_half, &h_alpha_half, sizeof(rocblas_half), hipMemcpyHostToDevice);
+            hipMemcpy(d_beta_half, &h_beta_half, sizeof(rocblas_half), hipMemcpyHostToDevice);
+
+            // copy matrix C to matrix D
+            device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(rocblas_half));
+
+            // call rocblas_hgemm
+            status = rocblas_hgemm(handle,
+                                   trans_a,
+                                   trans_b,
+                                   m,
+                                   n,
+                                   k,
+                                   d_alpha_half,
+                                   static_cast<const rocblas_half*>(a),
+                                   lda,
+                                   static_cast<const rocblas_half*>(b),
+                                   ldb,
+                                   d_beta_half,
+                                   static_cast<rocblas_half*>(d),
+                                   ldd);
+        }
+        else
+        {
+            // convert type of alpha and beta
+            const _Float16 alpha_half = static_cast<_Float16>(*alpha);
+            const _Float16 beta_half  = static_cast<_Float16>(*beta);
+
+            // copy matrix C to matrix D
+            device_matrix_copy(c, ldc, d, ldd, m, n, sizeof(rocblas_half));
+
+            // call rocblas_hgemm
+            status = rocblas_hgemm(handle,
+                                   trans_a,
+                                   trans_b,
+                                   m,
+                                   n,
+                                   k,
+                                   reinterpret_cast<const rocblas_half*>(&alpha_half),
+                                   static_cast<const rocblas_half*>(a),
+                                   lda,
+                                   static_cast<const rocblas_half*>(b),
+                                   ldb,
+                                   reinterpret_cast<const rocblas_half*>(&beta_half),
+                                   static_cast<rocblas_half*>(d),
+                                   ldd);
+        }
+
+        if(status != rocblas_status_success)
+            std::cout << "ERROR: status = " << status << std::endl;
+        if(status != rocblas_status_success)
+            return status;
     }
     else
     {


### PR DESCRIPTION
Initial code for mixed precision gemm_ex

This code only supports the cases where all precision is half, float, or double. These fall back to calling the rocblas functions rocblas_hgemm, rocblas_sgemm, and rocblas_dgemm. It will be extended to support mixed precision gemm.

The pull request includes test code with limited testing. 