### PR TITLE
move newline from front to end of logging trace line

### DIFF
--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -350,87 +350,71 @@ void testing_logging()
     bench_ofs2.open(bench_path2);
 
     // Auxiliary function
-    trace_ofs2 << "rocblas_create_handle";
-    trace_ofs2 << "\nrocblas_set_pointer_mode,0";
-    trace_ofs2 << "\nrocblas_get_pointer_mode,0";
+    trace_ofs2 << "rocblas_create_handle\n";
+    trace_ofs2 << "rocblas_set_pointer_mode,0\n";
+    trace_ofs2 << "rocblas_get_pointer_mode,0\n";
 
     // BLAS1
-    trace_ofs2 << "\n"
-               << replaceX<T>("rocblas_iXamax") << "," << n << "," << (void*)dx << "," << incx;
-    bench_ofs2 << "\n"
-               << "./rocblas-bench -f iamax -r " << replaceX<T>("X") << " -n " << n << " --incx "
-               << incx;
+    trace_ofs2 << replaceX<T>("rocblas_iXamax") << "," << n << "," << (void*)dx << "," << incx
+               << '\n';
+    bench_ofs2 << "./rocblas-bench -f iamax -r " << replaceX<T>("X") << " -n " << n << " --incx "
+               << incx << '\n';
 
-    trace_ofs2 << "\n"
-               << replaceX<T>("rocblas_iXamin") << "," << n << "," << (void*)dx << "," << incx;
-    bench_ofs2 << "\n"
-               << "./rocblas-bench -f iamin -r " << replaceX<T>("X") << " -n " << n << " --incx "
-               << incx;
+    trace_ofs2 << replaceX<T>("rocblas_iXamin") << "," << n << "," << (void*)dx << "," << incx
+               << '\n';
+    bench_ofs2 << "./rocblas-bench -f iamin -r " << replaceX<T>("X") << " -n " << n << " --incx "
+               << incx << '\n';
 
-    trace_ofs2 << "\n"
-               << replaceX<T>("rocblas_Xasum") << "," << n << "," << (void*)dx << "," << incx;
-    bench_ofs2 << "\n"
-               << "./rocblas-bench -f asum -r " << replaceX<T>("X") << " -n " << n << " --incx "
-               << incx;
+    trace_ofs2 << replaceX<T>("rocblas_Xasum") << "," << n << "," << (void*)dx << "," << incx
+               << '\n';
+    bench_ofs2 << "./rocblas-bench -f asum -r " << replaceX<T>("X") << " -n " << n << " --incx "
+               << incx << '\n';
 
     if(test_pointer_mode == rocblas_pointer_mode_host)
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xaxpy") << "," << n << "," << alpha << "," << (void*)dx
-                   << "," << incx << "," << (void*)dy << "," << incy;
-        bench_ofs2 << "\n"
-                   << "./rocblas-bench -f axpy -r " << replaceX<T>("X") << " -n " << n
-                   << " --alpha " << alpha << " --incx " << incx << " --incy " << incy;
+        trace_ofs2 << replaceX<T>("rocblas_Xaxpy") << "," << n << "," << alpha << "," << (void*)dx
+                   << "," << incx << "," << (void*)dy << "," << incy << '\n';
+        bench_ofs2 << "./rocblas-bench -f axpy -r " << replaceX<T>("X") << " -n " << n
+                   << " --alpha " << alpha << " --incx " << incx << " --incy " << incy << '\n';
     }
     else
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xaxpy") << "," << n << "," << (void*)&alpha << ","
-                   << (void*)dx << "," << incx << "," << (void*)dy << "," << incy;
+        trace_ofs2 << replaceX<T>("rocblas_Xaxpy") << "," << n << "," << (void*)&alpha << ","
+                   << (void*)dx << "," << incx << "," << (void*)dy << "," << incy << '\n';
     }
 
-    trace_ofs2 << "\n"
-               << replaceX<T>("rocblas_Xcopy") << "," << n << "," << (void*)dx << "," << incx << ","
-               << (void*)dy << "," << incy;
-    bench_ofs2 << "\n"
-               << "./rocblas-bench -f copy -r " << replaceX<T>("X") << " -n " << n << " --incx "
-               << incx << " --incy " << incy;
+    trace_ofs2 << replaceX<T>("rocblas_Xcopy") << "," << n << "," << (void*)dx << "," << incx << ","
+               << (void*)dy << "," << incy << '\n';
+    bench_ofs2 << "./rocblas-bench -f copy -r " << replaceX<T>("X") << " -n " << n << " --incx "
+               << incx << " --incy " << incy << '\n';
 
-    trace_ofs2 << "\n"
-               << replaceX<T>("rocblas_Xdot") << "," << n << "," << (void*)dx << "," << incx << ","
-               << (void*)dy << "," << incy;
-    bench_ofs2 << "\n"
-               << "./rocblas-bench -f dot -r " << replaceX<T>("X") << " -n " << n << " --incx "
-               << incx << " --incy " << incy;
+    trace_ofs2 << replaceX<T>("rocblas_Xdot") << "," << n << "," << (void*)dx << "," << incx << ","
+               << (void*)dy << "," << incy << '\n';
+    bench_ofs2 << "./rocblas-bench -f dot -r " << replaceX<T>("X") << " -n " << n << " --incx "
+               << incx << " --incy " << incy << '\n';
 
-    trace_ofs2 << "\n"
-               << replaceX<T>("rocblas_Xnrm2") << "," << n << "," << (void*)dx << "," << incx;
-    bench_ofs2 << "\n"
-               << "./rocblas-bench -f nrm2 -r " << replaceX<T>("X") << " -n " << n << " --incx "
-               << incx;
+    trace_ofs2 << replaceX<T>("rocblas_Xnrm2") << "," << n << "," << (void*)dx << "," << incx
+               << '\n';
+    bench_ofs2 << "./rocblas-bench -f nrm2 -r " << replaceX<T>("X") << " -n " << n << " --incx "
+               << incx << '\n';
 
     if(test_pointer_mode == rocblas_pointer_mode_host)
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xscal") << "," << n << "," << alpha << "," << (void*)dx
-                   << "," << incx;
-        bench_ofs2 << "\n"
-                   << "./rocblas-bench -f scal -r " << replaceX<T>("X") << " -n " << n << " --incx "
-                   << incx << " --alpha " << alpha;
+        trace_ofs2 << replaceX<T>("rocblas_Xscal") << "," << n << "," << alpha << "," << (void*)dx
+                   << "," << incx << '\n';
+        bench_ofs2 << "./rocblas-bench -f scal -r " << replaceX<T>("X") << " -n " << n << " --incx "
+                   << incx << " --alpha " << alpha << '\n';
     }
     else
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xscal") << "," << n << "," << (void*)&alpha << ","
-                   << (void*)dx << "," << incx;
+        trace_ofs2 << replaceX<T>("rocblas_Xscal") << "," << n << "," << (void*)&alpha << ","
+                   << (void*)dx << "," << incx << '\n';
     }
-    trace_ofs2 << "\n"
-               << replaceX<T>("rocblas_Xswap") << "," << n << "," << (void*)dx << "," << incx << ","
-               << (void*)dy << "," << incy;
+    trace_ofs2 << replaceX<T>("rocblas_Xswap") << "," << n << "," << (void*)dx << "," << incx << ","
+               << (void*)dy << "," << incy << '\n';
 
-    bench_ofs2 << "\n"
-               << "./rocblas-bench -f swap -r " << replaceX<T>("X") << " -n " << n << " --incx "
-               << incx << " --incy " << incy;
+    bench_ofs2 << "./rocblas-bench -f swap -r " << replaceX<T>("X") << " -n " << n << " --incx "
+               << incx << " --incy " << incy << '\n';
 
     // BLAS2
     std::string transA_letter;
@@ -501,82 +485,71 @@ void testing_logging()
 
     if(test_pointer_mode == rocblas_pointer_mode_host)
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xger") << "," << m << "," << n << "," << alpha << ","
+        trace_ofs2 << replaceX<T>("rocblas_Xger") << "," << m << "," << n << "," << alpha << ","
                    << (void*)dx << "," << incx << "," << (void*)dy << "," << incy << ","
-                   << (void*)da << "," << lda;
-        bench_ofs2 << "\n"
-                   << "./rocblas-bench -f ger -r " << replaceX<T>("X") << " -m " << m << " -n " << n
+                   << (void*)da << "," << lda << '\n';
+        bench_ofs2 << "./rocblas-bench -f ger -r " << replaceX<T>("X") << " -m " << m << " -n " << n
                    << " --alpha " << alpha << " --incx " << incx << " --incy " << incy << " --lda "
-                   << lda;
+                   << lda << '\n';
     }
     else
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xger") << "," << m << "," << n << "," << (void*)&alpha
+        trace_ofs2 << replaceX<T>("rocblas_Xger") << "," << m << "," << n << "," << (void*)&alpha
                    << "," << (void*)dx << "," << incx << "," << (void*)dy << "," << incy << ","
-                   << (void*)da << "," << lda;
+                   << (void*)da << "," << lda << '\n';
     }
 
     if(test_pointer_mode == rocblas_pointer_mode_host)
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xsyr") << "," << uplo << "," << n << "," << alpha << ","
-                   << (void*)dx << "," << incx << "," << (void*)da << "," << lda;
-        bench_ofs2 << "\n"
-                   << "./rocblas-bench -f syr -r " << replaceX<T>("X") << " --uplo " << uplo_letter
-                   << " -n " << n << " --alpha " << alpha << " --incx " << incx << " --lda " << lda;
+        trace_ofs2 << replaceX<T>("rocblas_Xsyr") << "," << uplo << "," << n << "," << alpha << ","
+                   << (void*)dx << "," << incx << "," << (void*)da << "," << lda << '\n';
+        bench_ofs2 << "./rocblas-bench -f syr -r " << replaceX<T>("X") << " --uplo " << uplo_letter
+                   << " -n " << n << " --alpha " << alpha << " --incx " << incx << " --lda " << lda
+                   << '\n';
     }
     else
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xsyr") << "," << uplo << "," << n << "," << (void*)&alpha
-                   << "," << (void*)dx << "," << incx << "," << (void*)da << "," << lda;
+        trace_ofs2 << replaceX<T>("rocblas_Xsyr") << "," << uplo << "," << n << "," << (void*)&alpha
+                   << "," << (void*)dx << "," << incx << "," << (void*)da << "," << lda << '\n';
     }
 
     if(test_pointer_mode == rocblas_pointer_mode_host)
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xgemv") << "," << transA << "," << m << "," << n << ","
+        trace_ofs2 << replaceX<T>("rocblas_Xgemv") << "," << transA << "," << m << "," << n << ","
                    << alpha << "," << (void*)da << "," << lda << "," << (void*)dx << "," << incx
-                   << "," << beta << "," << (void*)dy << "," << incy;
+                   << "," << beta << "," << (void*)dy << "," << incy << '\n';
 
-        bench_ofs2 << "\n"
-                   << "./rocblas-bench -f gemv -r " << replaceX<T>("X") << " --transposeA "
+        bench_ofs2 << "./rocblas-bench -f gemv -r " << replaceX<T>("X") << " --transposeA "
                    << transA_letter << " -m " << m << " -n " << n << " --alpha " << alpha
                    << " --lda " << lda << " --incx " << incx << " --beta " << beta << " --incy "
-                   << incy;
+                   << incy << '\n';
     }
     else
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xgemv") << "," << transA << "," << m << "," << n << ","
+        trace_ofs2 << replaceX<T>("rocblas_Xgemv") << "," << transA << "," << m << "," << n << ","
                    << (void*)&alpha << "," << (void*)da << "," << lda << "," << (void*)dx << ","
-                   << incx << "," << (void*)&beta << "," << (void*)dy << "," << incy;
+                   << incx << "," << (void*)&beta << "," << (void*)dy << "," << incy << '\n';
     }
 
     // BLAS3
 
     if(test_pointer_mode == rocblas_pointer_mode_host)
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xgeam") << "," << transA << "," << transB << "," << m
+        trace_ofs2 << replaceX<T>("rocblas_Xgeam") << "," << transA << "," << transB << "," << m
                    << "," << n << "," << alpha << "," << (void*)da << "," << lda << "," << beta
-                   << "," << (void*)db << "," << ldb << "," << (void*)dc << "," << ldc;
+                   << "," << (void*)db << "," << ldb << "," << (void*)dc << "," << ldc << '\n';
 
-        bench_ofs2 << "\n"
-                   << "./rocblas-bench -f geam -r " << replaceX<T>("X") << " --transposeA "
+        bench_ofs2 << "./rocblas-bench -f geam -r " << replaceX<T>("X") << " --transposeA "
                    << transA_letter << " --transposeB " << transB_letter << " -m " << m << " -n "
                    << n << " --alpha " << alpha << " --lda " << lda << " --beta " << beta
-                   << " --ldb " << ldb << " --ldc " << ldc;
+                   << " --ldb " << ldb << " --ldc " << ldc << '\n';
     }
     else
     {
-        trace_ofs2 << "\n"
-                   << replaceX<T>("rocblas_Xgeam") << "," << transA << "," << transB << "," << m
+        trace_ofs2 << replaceX<T>("rocblas_Xgeam") << "," << transA << "," << transB << "," << m
                    << "," << n << "," << (void*)&alpha << "," << (void*)da << "," << lda << ","
                    << (void*)&beta << "," << (void*)db << "," << ldb << "," << (void*)dc << ","
-                   << ldc;
+                   << ldc << '\n';
     }
 
     if(BUILD_WITH_TENSILE)
@@ -608,52 +581,46 @@ void testing_logging()
         */
         if(test_pointer_mode == rocblas_pointer_mode_host)
         {
-            trace_ofs2 << "\n"
-                       << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
+            trace_ofs2 << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
                        << "," << n << "," << k << "," << alpha << "," << (void*)da << "," << lda
                        << "," << (void*)db << "," << ldb << "," << beta << "," << (void*)dc << ","
-                       << ldc;
+                       << ldc << '\n';
 
-            bench_ofs2 << "\n"
-                       << "./rocblas-bench -f gemm -r " << replaceX<T>("X") << " --transposeA "
+            bench_ofs2 << "./rocblas-bench -f gemm -r " << replaceX<T>("X") << " --transposeA "
                        << transA_letter << " --transposeB " << transB_letter << " -m " << m
                        << " -n " << n << " -k " << k << " --alpha " << alpha << " --lda " << lda
-                       << " --ldb " << ldb << " --beta " << beta << " --ldc " << ldc;
+                       << " --ldb " << ldb << " --beta " << beta << " --ldc " << ldc << '\n';
         }
         else
         {
-            trace_ofs2 << "\n"
-                       << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
+            trace_ofs2 << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
                        << "," << n << "," << k << "," << (void*)&alpha << "," << (void*)da << ","
                        << lda << "," << (void*)db << "," << ldb << "," << (void*)&beta << ","
-                       << (void*)dc << "," << ldc;
+                       << (void*)dc << "," << ldc << '\n';
         }
 
         if(test_pointer_mode == rocblas_pointer_mode_host)
         {
-            trace_ofs2 << "\n"
-                       << replaceX<T>("rocblas_Xgemm_strided_batched") << "," << transA << ","
+            trace_ofs2 << replaceX<T>("rocblas_Xgemm_strided_batched") << "," << transA << ","
                        << transB << "," << m << "," << n << "," << k << "," << alpha << ","
                        << (void*)da << "," << lda << "," << stride_a << "," << (void*)db << ","
                        << ldb << "," << stride_b << "," << beta << "," << (void*)dc << "," << ldc
-                       << "," << stride_c << "," << batch_count;
+                       << "," << stride_c << "," << batch_count << '\n';
 
-            bench_ofs2 << "\n"
-                       << "./rocblas-bench -f gemm_strided_batched -r " << replaceX<T>("X")
+            bench_ofs2 << "./rocblas-bench -f gemm_strided_batched -r " << replaceX<T>("X")
                        << " --transposeA " << transA_letter << " --transposeB " << transB_letter
                        << " -m " << m << " -n " << n << " -k " << k << " --alpha " << alpha
                        << " --lda " << lda << " --stride_a " << stride_a << " --ldb " << ldb
                        << " --stride_b " << stride_b << " --beta " << beta << " --ldc " << ldc
-                       << " --stride_c " << stride_c << " --batch " << batch_count;
+                       << " --stride_c " << stride_c << " --batch " << batch_count << '\n';
         }
         else
         {
-            trace_ofs2 << "\n"
-                       << replaceX<T>("rocblas_Xgemm_strided_batched") << "," << transA << ","
+            trace_ofs2 << replaceX<T>("rocblas_Xgemm_strided_batched") << "," << transA << ","
                        << transB << "," << m << "," << n << "," << k << "," << (void*)&alpha << ","
                        << (void*)da << "," << lda << "," << stride_a << "," << (void*)db << ","
                        << ldb << "," << stride_b << "," << (void*)&beta << "," << (void*)dc << ","
-                       << ldc << "," << stride_c << "," << batch_count;
+                       << ldc << "," << stride_c << "," << batch_count << '\n';
         }
 
         if(test_pointer_mode == rocblas_pointer_mode_host)
@@ -681,44 +648,39 @@ void testing_logging()
             uint32_t kernel_index  = 0;
             uint32_t flags         = 0;
 
-            trace_ofs2 << "\n"
-                       << "rocblas_gemm_ex"
+            trace_ofs2 << "rocblas_gemm_ex"
                        << "," << transA << "," << transB << "," << m << "," << n << "," << k << ","
                        << alpha << "," << (void*)da << "," << a_type << "," << lda << ","
                        << (void*)db << "," << b_type << "," << ldb << "," << beta << ","
                        << (void*)dc << "," << c_type << "," << ldc << "," << (void*)dd << ","
                        << d_type << "," << ldd << "," << compute_type << "," << algo << ","
-                       << kernel_index << "," << flags;
+                       << kernel_index << "," << flags << '\n';
 
-            trace_ofs2 << "\n"
-                       << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
+            trace_ofs2 << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
                        << "," << n << "," << k << "," << alpha << "," << (void*)da << "," << lda
                        << "," << (void*)db << "," << ldb << "," << beta << "," << (void*)dd << ","
-                       << ldd;
+                       << ldd << '\n';
 
-            bench_ofs2 << "\n"
-                       << "./rocblas-bench -f gemm_ex"
+            bench_ofs2 << "./rocblas-bench -f gemm_ex"
                        << " --transposeA " << transA_letter << " --transposeB " << transB_letter
                        << " -m " << m << " -n " << n << " -k " << k << " --alpha " << alpha
                        << " --a_type " << a_type << " --lda " << lda << " --b_type " << b_type
                        << " --ldb " << ldb << " --beta " << beta << " --c_type " << c_type
                        << " --ldc " << ldc << " --d_type " << d_type << " --ldd " << ldd
                        << " --compute_type " << compute_type << " --algo " << algo
-                       << " --kernel_index " << kernel_index << " --flags " << flags;
+                       << " --kernel_index " << kernel_index << " --flags " << flags << '\n';
 
-            bench_ofs2 << "\n"
-                       << "./rocblas-bench -f gemm -r " << replaceX<T>("X") << " --transposeA "
+            bench_ofs2 << "./rocblas-bench -f gemm -r " << replaceX<T>("X") << " --transposeA "
                        << transA_letter << " --transposeB " << transB_letter << " -m " << m
                        << " -n " << n << " -k " << k << " --alpha " << alpha << " --lda " << lda
-                       << " --ldb " << ldb << " --beta " << beta << " --ldc " << ldd;
+                       << " --ldb " << ldb << " --beta " << beta << " --ldc " << ldd << '\n';
         }
         else
         {
-            trace_ofs2 << "\n"
-                       << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
+            trace_ofs2 << replaceX<T>("rocblas_Xgemm") << "," << transA << "," << transB << "," << m
                        << "," << n << "," << k << "," << (void*)&alpha << "," << (void*)da << ","
                        << lda << "," << (void*)db << "," << ldb << "," << (void*)&beta << ","
-                       << (void*)dc << "," << ldc;
+                       << (void*)dc << "," << ldc << '\n';
         }
     }
     // exclude trtri as it is an internal function
@@ -727,7 +689,7 @@ void testing_logging()
     //  << "," << (void*)da << "," << lda << "," << (void*)db << "," << ldb;
 
     // Auxiliary function
-    trace_ofs2 << "\nrocblas_destroy_handle";
+    trace_ofs2 << "rocblas_destroy_handle\n";
 
     trace_ofs2.close();
     bench_ofs2.close();

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -40,7 +40,7 @@ _rocblas_handle::_rocblas_handle()
     {
         open_log_stream(&log_trace_os, &log_trace_ofs, "ROCBLAS_LOG_TRACE_PATH");
 
-        *log_trace_os << "rocblas_create_handle";
+        *log_trace_os << "rocblas_create_handle\n";
     }
 
     // open log_bench file

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -160,8 +160,9 @@ struct log_arg
 template <typename H, typename... Ts>
 void log_arguments(std::ostream& os, std::string& separator, H head, Ts&... xs)
 {
-    os << "\n" << head;
+    os << head;
     each_args(log_arg{os, separator}, xs...);
+    os << "\n";
 }
 
 /**
@@ -186,7 +187,7 @@ void log_arguments(std::ostream& os, std::string& separator, H head, Ts&... xs)
 template <typename H>
 void log_argument(std::ostream& os, std::string& separator, H head)
 {
-    os << "\n" << head;
+    os << head << "\n";
 }
 
 /**
@@ -207,7 +208,7 @@ void log_argument(std::ostream& os, std::string& separator, H head)
 template <typename H>
 void log_argument(std::ostream& os, H head)
 {
-    os << "\n" << head;
+    os << head << "\n";
 }
 
 #endif


### PR DESCRIPTION
Logging had a newline at the beginning of a line, not at the end of a line. This results in incorrect newline when rocBLAS logging is streamed to std::err and mixed with other logging.

The main change in this pull request is in the file library/src/include/logging.h. Many lines in the file clients/include/testing_logging.hpp are to change the reference output.




