### PR TITLE
rename tests quick, pre_checkin, nightly, add sweep tests for gemm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,7 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
           sh """#!/usr/bin/env bash
                 set -x
                 cd ${paths.project_build_prefix}/build/release/clients/staging
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes --gtest_filter=-*known_bug* #--gtest_filter=*nightly*
+                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
             """
           junit "${paths.project_build_prefix}/build/release/clients/staging/*.xml"
         }
@@ -234,7 +234,7 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
                 set -x
                 cd ${paths.project_build_prefix}/build/release/clients/staging
                 LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./example-sscal${build_type_postfix}
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes  --gtest_filter=-*known_bug* #--gtest_filter=*checkin* 
+                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin* 
             """
           junit "${paths.project_build_prefix}/build/release/clients/staging/*.xml"
         }

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -53,8 +53,8 @@ Advance users only: BrainStorm the parameters
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
-int N_range[] = {
-    -1, 0, 5, 10, 500, 1000, 1024, 1025, 7111, 10000, 33792, 1048576, 1049600, 4000000, 8000000};
+int N_range[]       = {-1, 0, 5, 10, 500, 1000, 1024, 1025, 7111, 10000, 33792};
+int N_range_large[] = {1048576, 1049600, 4000000, 8000000};
 
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
@@ -276,8 +276,13 @@ TEST_P(parameterized, swap_float)
 // so each elment in xxx_range is a avector,
 // ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { N, {alpha, beta}, {incx, incy} }
-INSTANTIATE_TEST_CASE_P(checkin_blas1,
+INSTANTIATE_TEST_CASE_P(quick_blas1,
                         parameterized,
                         Combine(ValuesIn(N_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(incx_incy_range)));
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas1,
+                        parameterized,
+                        Combine(ValuesIn(N_range_large),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(incx_incy_range)));

--- a/clients/gtest/geam_gtest.cpp
+++ b/clients/gtest/geam_gtest.cpp
@@ -202,19 +202,19 @@ TEST_P(parameterized_geam, double)
 
 TEST(checkin_blas3_bad_arg, geam_float) { testing_geam_bad_arg<float>(); }
 
-INSTANTIATE_TEST_CASE_P(checkin_blas3,
+INSTANTIATE_TEST_CASE_P(quick_blas3,
                         parameterized_geam,
                         Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(small_alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_1,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3,
                         parameterized_geam,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(large_alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_2,
+INSTANTIATE_TEST_CASE_P(nightly_blas3,
                         parameterized_geam,
                         Combine(ValuesIn(huge_matrix_size_range),
                                 ValuesIn(huge_alpha_beta_range),

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -31,15 +31,11 @@ typedef std::tuple<vector<int>, vector<double>, vector<char>, vector<rocblas_pre
 // clang-format off
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc, ldd};
 // add/delete as a group
-const vector<vector<int>> tiny_matrix_size_range = {
+const vector<vector<int>> small_matrix_size_range = {
     {1, 1,  1,  1,  1,  1,  1}, 
     {1, 2,  3,  4,  5,  6,  6}, 
     {7, 9, 15, 17, 18, 19, 19}, 
     {8, 1,  1,  8,  8,  8,  8},
-};
-
-// vector of vector, each vector is a {M, N, K, lda, ldb, ldc, ldd};
-const vector<vector<int>> small_matrix_size_range = {
     { 2,  2,  2,  2,  2,  2,  2},
     { 3,  3,  3,  3,  3,  3,  3},
     { 4,  4,  4,  4,  4,  4,  4},
@@ -95,6 +91,8 @@ const vector<vector<int>> small_matrix_size_range = {
     {56, 56, 56, 56, 56, 56, 56},
     {64, 64, 64, 64, 64, 64, 64},
     {72, 72, 72, 72, 72, 72, 72},
+};
+const vector<vector<int>> medium_matrix_size_range = {
     {127, 127,  63, 127, 127, 127, 127},
     {128, 127,  63, 128, 128, 128, 128},
     {129, 127,  63, 129, 129, 129, 129},
@@ -122,13 +120,13 @@ const vector<vector<int>> small_matrix_size_range = {
     {127, 129,  65, 129, 129, 129, 129},
     {128, 129,  65, 129, 129, 129, 129},
     {129, 129,  65, 129, 129, 129, 129},
+    {191, 193, 194, 195, 196, 197, 197},
+    {500, 501, 502, 503, 604, 505, 505},
+    {639, 640, 347, 960, 961,1062,1062},
 };
 
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc, ldd};
 const vector<vector<int>> large_matrix_size_range = {
-    { 191,  193,  194,  195,  196,  197,  197},
-    { 500,  501,  502,  503,  604,  505,  505},
-    { 639,  640,  347,  960,  961, 1062, 1062},
     {1000, 1001,  101, 2002, 1003, 1004, 1004},
     { 925, 1026, 1027, 1028, 2029, 1031, 1031},
     {4011, 4012,  103, 4014, 4015, 4016, 4016},
@@ -368,94 +366,94 @@ class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
     virtual void TearDown() {}
 };
 
-TEST(checkin_blas_ex_bad_arg, float) { testing_gemm_ex_bad_arg(); }
+TEST(pre_checkin_blas_ex_bad_arg, float) { testing_gemm_ex_bad_arg(); }
 
-//----tiny
-INSTANTIATE_TEST_CASE_P(known_bug_blas_ex_tiny_hpa_half,
+//----small
+INSTANTIATE_TEST_CASE_P(known_bug_blas_ex_small_hpa_half,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(tiny_matrix_size_range),
+                        Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_hpa_half)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas_ex_tiny_half,
+INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_half,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(tiny_matrix_size_range),
+                        Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_half)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas_ex_tiny_single,
+INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_single,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(tiny_matrix_size_range),
+                        Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_single)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas_ex_tiny_double,
+INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_double,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(tiny_matrix_size_range),
+                        Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_double)));
-//----small
-INSTANTIATE_TEST_CASE_P(checkin_blas_ex_small_hpa_half,
+//----medium
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas_ex_medium_hpa_half,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(small_matrix_size_range),
+                        Combine(ValuesIn(medium_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_hpa_half)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas_ex_small_half,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas_ex_medium_half,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(small_matrix_size_range),
+                        Combine(ValuesIn(medium_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_half)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas_ex_small_float,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas_ex_medium_float,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(small_matrix_size_range),
+                        Combine(ValuesIn(medium_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_single)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas_ex_small_double,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas_ex_medium_double,
                         parameterized_gemm_ex,
-                        Combine(ValuesIn(small_matrix_size_range),
+                        Combine(ValuesIn(medium_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_double)));
 //----large
-INSTANTIATE_TEST_CASE_P(daily_blas_ex_large_hpa_half,
+INSTANTIATE_TEST_CASE_P(nightly_blas_ex_large_hpa_half,
                         parameterized_gemm_ex,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_hpa_half)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas_ex_large_half,
+INSTANTIATE_TEST_CASE_P(nightly_blas_ex_large_half,
                         parameterized_gemm_ex,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_half)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas_ex_large_float,
+INSTANTIATE_TEST_CASE_P(nightly_blas_ex_large_float,
                         parameterized_gemm_ex,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_single)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas_ex_large_double,
+INSTANTIATE_TEST_CASE_P(nightly_blas_ex_large_double,
                         parameterized_gemm_ex,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_double)));
 //----chunk
-INSTANTIATE_TEST_CASE_P(daily_blas_ex_chunk,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas_ex_chunk,
                         parameterized_chunk_gemm_ex,
                         Combine(ValuesIn(chunk_matrix_size_range),
                                 ValuesIn(alpha_beta_2_3_range),

--- a/clients/gtest/gemm_gtest.cpp
+++ b/clients/gtest/gemm_gtest.cpp
@@ -42,6 +42,7 @@ const vector<int> size_range_32    = {  31,   32,   33};
 const vector<int> size_range_48    = {  47,   48,   49};
 const vector<int> size_range_64    = {  63,   64,   65};
 const vector<int> size_range_96    = {  95,   96,   97};
+const vector<int> size_range_128   = { 127,  128,  129};
 const vector<int> size_range_256   = { 255,  256,  257};
 const vector<int> size_range_512   = { 511,  512,  513};
 const vector<int> size_range_1024  = {1023, 1024, 1025};
@@ -61,11 +62,11 @@ const vector<int> size_range_9_129 = {9, 10,  11,  12,  13,  14,  15,  16,  17, 
 
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
 // add/delete as a group
-const vector<vector<int>> tiny_matrix_size_range = {
+const vector<vector<int>> small_matrix_size_range = {
     {1, 1, 1, 1, 1, 1}, {1, 2, 3, 4, 5, 6}, {7, 9, 15, 17, 18, 19},
 };
 
-const vector<vector<int>> small_matrix_size_range = {
+const vector<vector<int>> medium_matrix_size_range = {
     {-1, -1, -1, -1, 1, 1},
     {1, 1, 1, 1, 1, 1},
     {2, 2, 2, 2, 2, 2},
@@ -103,13 +104,13 @@ const vector<vector<int>> small_matrix_size_range = {
     {3, 33, 3, 33, 35, 35},
     {5, 6, 7, 9, 11, 13},
     {10, 10, 20, 100, 21, 22},
+    {191, 193, 194, 195, 196, 197},
     {500, 501, 502, 503, 604, 505},
     {500, 501, 502, 203, 204, 205},
+    {639, 640, 347, 960, 961, 1062},
 };
 
 const vector<vector<int>> large_matrix_size_range = {
-    {191, 193, 194, 195, 196, 197},
-    {639, 640, 347, 960, 961, 1062},
     {1000, 1001, 101, 2002, 1003, 1004},
     {925, 1026, 1027, 1028, 2029, 1031},
     {4011, 4012, 103, 4014, 4015, 4016},
@@ -669,11 +670,11 @@ TEST_P(parameterized_half_gemm, half)
     }
 }
 
-TEST(checkin_blas3_bad_arg, gemm_half) { testing_gemm_bad_arg<rocblas_half>(); }
+TEST(pre_checkin_blas3_bad_arg, gemm_half) { testing_gemm_bad_arg<rocblas_half>(); }
 
-TEST(checkin_blas3_bad_arg, gemm_float) { testing_gemm_bad_arg<float>(); }
+TEST(pre_checkin_blas3_bad_arg, gemm_float) { testing_gemm_bad_arg<float>(); }
 
-TEST(checkin_blas3_bad_arg, gemm_double) { testing_gemm_bad_arg<double>(); }
+TEST(pre_checkin_blas3_bad_arg, gemm_double) { testing_gemm_bad_arg<double>(); }
 
 // notice we are using vector of vector
 // so each elment in xxx_range is a avector,
@@ -681,62 +682,57 @@ TEST(checkin_blas3_bad_arg, gemm_double) { testing_gemm_bad_arg<double>(); }
 // The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB} }
 
 // INSTANTIATE_TEST_CASE_P(rocblas_gemm_beta_eq_0, parameterized_gemm_NaN,
-INSTANTIATE_TEST_CASE_P(checkin_blas3_NaN,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_NaN,
                         parameterized_gemm_NaN,
                         Combine(ValuesIn(NaN_matrix_size_range),
                                 ValuesIn(NaN_alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-// THis function mainly test the scope of matrix_size. the scope of alpha_beta, transA_transB is
-// small
-INSTANTIATE_TEST_CASE_P(daily_blas3_large,
-                        parameterized_gemm,
-                        Combine(ValuesIn(large_matrix_size_range),
-                                ValuesIn(alpha_beta_range),
-                                ValuesIn(transA_transB_range)));
-
-// THis function mainly test the scope of alpha_beta, transA_transB,.the scope of matrix_size_range
-// is small
-
-INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
+INSTANTIATE_TEST_CASE_P(quick_blas3_small,
                         parameterized_gemm,
                         Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(full_alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
-                        parameterized_gemm,
-                        Combine(ValuesIn(tiny_matrix_size_range),
-                                ValuesIn(full_alpha_beta_range),
-                                ValuesIn(transA_transB_range)));
-
-INSTANTIATE_TEST_CASE_P(checkin_blas3_small,
+INSTANTIATE_TEST_CASE_P(quick_blas3_small,
                         parameterized_half_gemm,
                         Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(full_alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas3_tiny,
-                        parameterized_half_gemm,
-                        Combine(ValuesIn(tiny_matrix_size_range),
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_medium,
+                        parameterized_gemm,
+                        Combine(ValuesIn(medium_matrix_size_range),
                                 ValuesIn(full_alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_large,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_medium,
+                        parameterized_half_gemm,
+                        Combine(ValuesIn(medium_matrix_size_range),
+                                ValuesIn(full_alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(nightly_blas3_large,
+                        parameterized_gemm,
+                        Combine(ValuesIn(large_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(nightly_blas3_large,
                         parameterized_half_gemm,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_chunk,
+INSTANTIATE_TEST_CASE_P(nightly_blas3_chunk,
                         parameterized_chunk_gemm,
                         Combine(ValuesIn(chunk_matrix_size_range),
                                 ValuesIn(alpha_beta_2_3_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_deepbench_sizes, parameterized_gemm, ValuesIn(deepbench_vec));
+INSTANTIATE_TEST_CASE_P(nightly_blas3_deepbench_sizes, parameterized_gemm, ValuesIn(deepbench_vec));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_deepbench_sizes,
+INSTANTIATE_TEST_CASE_P(nightly_blas3_deepbench_sizes,
                         parameterized_half_gemm,
                         ValuesIn(deepbench_vec));
 
@@ -749,7 +745,7 @@ INSTANTIATE_TEST_CASE_P(known_bug_blas3_sweep_1_4,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_5_8,
+INSTANTIATE_TEST_CASE_P(quick_blas3_sweep_5_8,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_5_8),
                                 ValuesIn(size_range_5_8),
@@ -757,7 +753,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_5_8,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_9_12,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_9_12,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_9_12),
                                 ValuesIn(size_range_9_12),
@@ -765,7 +761,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_9_12,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_13_16,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_13_16,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_13_16),
                                 ValuesIn(size_range_13_16),
@@ -773,7 +769,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_13_16,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_17_20,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_17_20,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_17_20),
                                 ValuesIn(size_range_17_20),
@@ -781,7 +777,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_17_20,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_20_23,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_20_23,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_20_23),
                                 ValuesIn(size_range_20_23),
@@ -789,7 +785,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_20_23,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_24_27,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_24_27,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_24_27),
                                 ValuesIn(size_range_24_27),
@@ -797,7 +793,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_24_27,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_28_31,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_28_31,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_28_31),
                                 ValuesIn(size_range_28_31),
@@ -805,7 +801,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_28_31,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 //---32
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_32,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_32,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_32),
                                 ValuesIn(size_range_32),
@@ -813,7 +809,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_32,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_32_9_129,
+INSTANTIATE_TEST_CASE_P(nightly_blas3_sweep_32_9_129,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_9_129),
                                 ValuesIn(size_range_32),
@@ -822,7 +818,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_32_9_129,
                                 ValuesIn(transA_transB_range)));
 
 //---48
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_48,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_48,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_48),
                                 ValuesIn(size_range_48),
@@ -830,7 +826,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_48,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_48_9_129,
+INSTANTIATE_TEST_CASE_P(nightly_blas3_sweep_48_9_129,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_48),
                                 ValuesIn(size_range_9_129),
@@ -839,7 +835,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_48_9_129,
                                 ValuesIn(transA_transB_range)));
 
 //---64
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_64,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_64),
                                 ValuesIn(size_range_64),
@@ -847,7 +843,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64_9_129,
+INSTANTIATE_TEST_CASE_P(nightly_blas3_sweep_64_9_129,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_64),
                                 ValuesIn(size_range_64),
@@ -880,7 +876,7 @@ INSTANTIATE_TEST_CASE_P(known_bug_blas3_sweep_1_4_5_8_64,
                                 ValuesIn(transA_transB_range)));
 
 //--- 96
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_96,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_96,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_96),
                                 ValuesIn(size_range_96),
@@ -888,8 +884,17 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_96,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
+//--- 128
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_128,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_128),
+                                ValuesIn(size_range_128),
+                                ValuesIn(size_range_128),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
 //--- 256
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_256,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_256,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_256),
                                 ValuesIn(size_range_256),
@@ -897,7 +902,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_256,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64_9_12_13_16,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_256_9_12_13_16,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_256),
                                 ValuesIn(size_range_9_12),
@@ -905,7 +910,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64_9_12_13_16,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_13_16_256_9_12,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_13_16_256_9_12,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_13_16),
                                 ValuesIn(size_range_256),
@@ -913,7 +918,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_13_16_256_9_12,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_9_12_13_16_256,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_9_12_13_16_256,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_9_12),
                                 ValuesIn(size_range_13_16),
@@ -922,7 +927,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_9_12_13_16_256,
                                 ValuesIn(transA_transB_range)));
 
 //--- 512
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_512,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_sweep_512,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_512),
                                 ValuesIn(size_range_512),
@@ -931,7 +936,7 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_512,
                                 ValuesIn(transA_transB_range)));
 
 //--- 1024
-INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_1024,
+INSTANTIATE_TEST_CASE_P(nightly_blas3_sweep_1024,
                         parameterized_gemm_sweep,
                         Combine(ValuesIn(size_range_1024),
                                 ValuesIn(size_range_1024),

--- a/clients/gtest/gemm_gtest.cpp
+++ b/clients/gtest/gemm_gtest.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <vector>
 #include "testing_gemm.hpp"
+#include "testing_gemm_sweep.hpp"
 #include "utility.h"
 
 using ::testing::TestWithParam;
@@ -25,7 +26,38 @@ README: This file contains testers to verify the correctness of
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
+typedef std::tuple<int, int, int, vector<double>, vector<char>> gemm_sweep_tuple;
 typedef std::tuple<vector<int>, vector<double>, vector<char>> gemm_tuple;
+
+// clang-format off
+const vector<int> size_range_1_4   = {   1,    2,    3,   4};
+const vector<int> size_range_5_8   = {   5,    6,    7,   8};
+const vector<int> size_range_9_12  = {   9,   10,   11,  12};
+const vector<int> size_range_13_16 = {  13,   14,   15,  16};
+const vector<int> size_range_17_20 = {  17,   18,   19,  20};
+const vector<int> size_range_20_23 = {  20,   21,   22,  23};
+const vector<int> size_range_24_27 = {  24,   25,   26,  27};
+const vector<int> size_range_28_31 = {  28,   29,   30,  31};
+const vector<int> size_range_32    = {  31,   32,   33};
+const vector<int> size_range_48    = {  47,   48,   49};
+const vector<int> size_range_64    = {  63,   64,   65};
+const vector<int> size_range_96    = {  95,   96,   97};
+const vector<int> size_range_256   = { 255,  256,  257};
+const vector<int> size_range_512   = { 511,  512,  513};
+const vector<int> size_range_1024  = {1023, 1024, 1025};
+const vector<int> size_range_9_129 = {9, 10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
+                                         20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+                                         30,  31,  32,  33,  34,  35,  36,  37,  38,  39,
+                                         40,  41,  42,  43,  44,  45,  46,  47,  48,  49,
+                                         50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+                                         60,  61,  62,  63,  64,  65,  66,  67,  68,  69,
+                                         70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
+                                         80,  81,  82,  83,  84,  85,  86,  87,  88,  89,
+                                         90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
+                                        100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+                                        110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+                                        120, 121, 122, 123, 124, 125, 126, 127, 128, 129};
+// clang-format on
 
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
 // add/delete as a group
@@ -116,6 +148,7 @@ const vector<vector<double>> full_alpha_beta_range = {
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
 // sgemm/dgemm,
 const vector<vector<char>> transA_transB_range = {{'N', 'N'}, {'N', 'T'}, {'C', 'N'}, {'T', 'C'}};
+const vector<vector<char>> transA_transB_N_N_range = {{'N', 'N'}};
 
 // clang-format off
 gemm_tuple deepbench0{{192, 64, 784, 784, 784, 192}, {1, 1}, {'T', 'N'}};
@@ -289,6 +322,28 @@ const vector<gemm_tuple> deepbench_vec = {
 // by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
 // not intuitive and error-prone
 
+Arguments setup_gemm_sweep_arguments(gemm_sweep_tuple tup)
+{
+    Arguments arg;
+
+    arg.M                      = std::get<0>(tup);
+    arg.N                      = std::get<1>(tup);
+    arg.K                      = std::get<2>(tup);
+    vector<double> alpha_beta  = std::get<3>(tup);
+    vector<char> transA_transB = std::get<4>(tup);
+
+    // the first element of alpha_beta_range is always alpha, and the second is always beta
+    arg.alpha = alpha_beta[0];
+    arg.beta  = alpha_beta[1];
+
+    arg.transA_option = transA_transB[0];
+    arg.transB_option = transA_transB[1];
+
+    arg.timing = 0;
+
+    return arg;
+}
+
 Arguments setup_gemm_arguments(gemm_tuple tup)
 {
     vector<int> matrix_size    = std::get<0>(tup);
@@ -347,6 +402,15 @@ TEST_P(parameterized_gemm_NaN, double)
     testing_gemm_NaN<double>(arg);
 }
 
+class parameterized_gemm_sweep : public ::TestWithParam<gemm_sweep_tuple>
+{
+    protected:
+    parameterized_gemm_sweep() {}
+    virtual ~parameterized_gemm_sweep() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class parameterized_gemm : public ::TestWithParam<gemm_tuple>
 {
     protected:
@@ -355,6 +419,105 @@ class parameterized_gemm : public ::TestWithParam<gemm_tuple>
     virtual void SetUp() {}
     virtual void TearDown() {}
 };
+
+TEST_P(parameterized_gemm_sweep, half)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_gemm_sweep_arguments(GetParam());
+
+    rocblas_status status = testing_gemm_sweep<rocblas_half>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != rocblas_status_success)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transA_option == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transB_option == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.ldc < arg.M)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+    }
+}
+
+TEST_P(parameterized_gemm_sweep, float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_gemm_sweep_arguments(GetParam());
+
+    rocblas_status status = testing_gemm_sweep<float>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != rocblas_status_success)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transA_option == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transB_option == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.ldc < arg.M)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+    }
+}
+
+TEST_P(parameterized_gemm_sweep, double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_gemm_sweep_arguments(GetParam());
+
+    rocblas_status status = testing_gemm_sweep<double>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != rocblas_status_success)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transA_option == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.transB_option == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if(arg.ldc < arg.M)
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+    }
+}
 
 TEST_P(parameterized_gemm, float)
 {
@@ -576,3 +739,202 @@ INSTANTIATE_TEST_CASE_P(daily_blas3_deepbench_sizes, parameterized_gemm, ValuesI
 INSTANTIATE_TEST_CASE_P(daily_blas3_deepbench_sizes,
                         parameterized_half_gemm,
                         ValuesIn(deepbench_vec));
+
+//--- sweep tests
+INSTANTIATE_TEST_CASE_P(known_bug_blas3_sweep_1_4,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_1_4),
+                                ValuesIn(size_range_1_4),
+                                ValuesIn(size_range_1_4),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_5_8,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_5_8),
+                                ValuesIn(size_range_5_8),
+                                ValuesIn(size_range_5_8),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_9_12,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_9_12),
+                                ValuesIn(size_range_9_12),
+                                ValuesIn(size_range_9_12),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_13_16,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_13_16),
+                                ValuesIn(size_range_13_16),
+                                ValuesIn(size_range_13_16),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_17_20,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_17_20),
+                                ValuesIn(size_range_17_20),
+                                ValuesIn(size_range_17_20),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_20_23,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_20_23),
+                                ValuesIn(size_range_20_23),
+                                ValuesIn(size_range_20_23),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_24_27,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_24_27),
+                                ValuesIn(size_range_24_27),
+                                ValuesIn(size_range_24_27),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_28_31,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_28_31),
+                                ValuesIn(size_range_28_31),
+                                ValuesIn(size_range_28_31),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+//---32
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_32,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_32),
+                                ValuesIn(size_range_32),
+                                ValuesIn(size_range_32),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_32_9_129,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_9_129),
+                                ValuesIn(size_range_32),
+                                ValuesIn(size_range_32),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+//---48
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_48,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_48),
+                                ValuesIn(size_range_48),
+                                ValuesIn(size_range_48),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_48_9_129,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_48),
+                                ValuesIn(size_range_9_129),
+                                ValuesIn(size_range_48),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+//---64
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_64),
+                                ValuesIn(size_range_64),
+                                ValuesIn(size_range_64),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64_9_129,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_64),
+                                ValuesIn(size_range_64),
+                                ValuesIn(size_range_9_129),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(known_bug_blas3_sweep_64_1_4_5_8,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_64),
+                                ValuesIn(size_range_1_4),
+                                ValuesIn(size_range_5_8),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(known_bug_blas3_sweep_5_8_64_1_4,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_5_8),
+                                ValuesIn(size_range_64),
+                                ValuesIn(size_range_1_4),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(known_bug_blas3_sweep_1_4_5_8_64,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_1_4),
+                                ValuesIn(size_range_5_8),
+                                ValuesIn(size_range_64),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+//--- 96
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_96,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_96),
+                                ValuesIn(size_range_96),
+                                ValuesIn(size_range_96),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+//--- 256
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_256,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_256),
+                                ValuesIn(size_range_256),
+                                ValuesIn(size_range_256),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_64_9_12_13_16,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_256),
+                                ValuesIn(size_range_9_12),
+                                ValuesIn(size_range_13_16),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_13_16_256_9_12,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_13_16),
+                                ValuesIn(size_range_256),
+                                ValuesIn(size_range_9_12),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_9_12_13_16_256,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_9_12),
+                                ValuesIn(size_range_13_16),
+                                ValuesIn(size_range_256),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+//--- 512
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_512,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_512),
+                                ValuesIn(size_range_512),
+                                ValuesIn(size_range_512),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));
+
+//--- 1024
+INSTANTIATE_TEST_CASE_P(daily_blas3_sweep_1024,
+                        parameterized_gemm_sweep,
+                        Combine(ValuesIn(size_range_1024),
+                                ValuesIn(size_range_1024),
+                                ValuesIn(size_range_1024),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range)));

--- a/clients/gtest/gemm_strided_batched_gtest.cpp
+++ b/clients/gtest/gemm_strided_batched_gtest.cpp
@@ -38,12 +38,10 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc, stride_a, stride_b, stride_c};
 // add/delete as a group, in batched gemm, the matrix is much smaller than standard gemm
 // clang-format off
-const vector<vector<int>> matrix_size_range = {
+const vector<vector<int>> small_matrix_size_range = {
     { -1,  -1,  -1,  -1,   1,   1,      1,      1,     1},
     { 31,  33,  35, 101, 102, 103,   3605,   3605,   3605},
     { 59,  61,  63, 129, 131, 137,   8631,   8631,   8631},
-    {129, 130, 131, 132, 133, 134,  17554,  17554,  17554},
-    {501, 502, 103, 504, 605, 506, 340010, 340010, 340010},
     {  3,   3,   3,   3,   3,   3,      9,     9,      9},
     { 15,  15,  15,  15,  15,  15,    225,   225,    225},
     { 16,  16,  16,  16,  16,  16,    256,   256,    256},
@@ -54,26 +52,46 @@ const vector<vector<int>> matrix_size_range = {
     {127, 127, 127, 127, 127, 127,  16129, 16129,  16129},
     {128, 128, 128, 128, 128, 128,  16384, 16384,  16384},
     {129, 129, 129, 129, 129, 129,  16641, 16641,  16641},
-    {255, 255, 255, 255, 255, 255,  65025, 65025,  65025},
-    {256, 256, 256, 256, 256, 256,  65536, 65536,  65536},
-    {257, 257, 257, 257, 257, 257,  66049, 66049,  66049},
 };
 
-const vector<vector<int>> matrix_size_stride_a_range = {
-    {  3,   3,   3,   3,   3,   3, 9,     9,      9},
-    {  3,   3,   3,   3,   3,   3, 0,     9,      9},
-    { 15,  15,  15,  15,  15,  15, 0,   225,    225},
-    { 16,  16,  16,  16,  16,  16, 0,   256,    256},
-    { 17,  17,  17,  17,  17,  17, 0,   289,    289},
-    { 63,  63,  63,  63,  63,  63, 0,  3969,   3969},
-    { 64,  64,  64,  64,  64,  64, 0,  4096,   4096},
-    { 65,  65,  65,  65,  65,  65, 0,  4225,   4225},
-    {127, 127, 127, 127, 127, 127, 0, 16129,  16129},
-    {128, 128, 128, 128, 128, 128, 0, 16384,  16384},
-    {129, 129, 129, 129, 129, 129, 0, 16641,  16641},
-    {255, 255, 255, 255, 255, 255, 0, 65025,  65025},
-    {256, 256, 256, 256, 256, 256, 0, 65536,  65536},
-    {257, 257, 257, 257, 257, 257, 0, 66049,  66049},
+const vector<vector<int>> small_matrix_size_stride_a_range = {
+    {  3,   3,   3,   3,   3,   3,    9,      9,      9},
+    {  3,   3,   3,   3,   3,   3,    0,      9,      9},
+    { 15,  15,  15,  15,  15,  15,  225,      0,    225},
+    { 16,  16,  16,  16,  16,  16,    0,    256,    256},
+    { 17,  17,  17,  17,  17,  17,  289,      0,    289},
+    { 63,  63,  63,  63,  63,  63,    0,   3969,   3969},
+    { 64,  64,  64,  64,  64,  64, 4096,      0,   4096},
+    { 65,  65,  65,  65,  65,  65,     0,  4225,   4225},
+    {127, 127, 127, 127, 127, 127, 16129,     0,  16129},
+    {128, 128, 128, 128, 128, 128,     0, 16384,  16384},
+    {129, 129, 129, 129, 129, 129, 16641,     0,  16641},
+};
+const vector<vector<int>> medium_matrix_size_range = {
+    {129, 130, 131, 132, 133, 134,  17554,  17554,  17554},
+    {255, 255, 255, 255, 255, 255,  65025,  65025,  65025},
+    {256, 256, 256, 256, 256, 256,  65536,  65536,  65536},
+    {257, 257, 257, 257, 257, 257,  66049,  66049,  66049},
+    {501, 502, 103, 504, 605, 506, 340010, 340010, 340010},
+};
+
+const vector<vector<int>> medium_matrix_size_stride_a_range = {
+    {255, 255, 255, 255, 255, 255, 65025,     0, 65025},
+    {256, 256, 256, 256, 256, 256,     0, 65536, 65536},
+    {257, 257, 257, 257, 257, 257, 66049,     0, 66049},
+};
+
+const vector<vector<int>> large_matrix_size_range = {
+    {511, 511, 511,  511, 511, 511, 261121, 261121, 261121},
+    {512, 512, 512,  512, 512, 512, 262144, 262144, 262144},
+    {513, 513, 513,  513, 513, 513, 263169, 263169, 263169},
+    {513, 514, 515,  516, 517, 518, 266771, 266772, 266773},
+};
+const vector<vector<int>> large_matrix_size_stride_a_range = {
+    {511, 511, 511,  511, 511, 511,      0, 261121, 261121},
+    {512, 512, 512,  512, 512, 512, 262144,      0, 262144},
+    {513, 513, 513,  513, 513, 513,      0, 263169, 263169},
+    {513, 514, 515,  516, 517, 518, 266771,      0, 266773},
 };
 // clang-format on
 
@@ -95,14 +113,19 @@ const vector<vector<char>> transA_transB_range = {{'N', 'N'}, {'N', 'T'}, {'C', 
 const vector<vector<char>> transA_transB_stride_a_range = {{'N', 'N'}};
 
 // number of gemms in batched gemm
-const vector<int> batch_count_range = {
+const vector<int> small_batch_count_range = {
     -1, 0, 1, 3,
 };
-const vector<int> batch_count_stride_a_range = {
+const vector<int> medium_batch_count_range         = {63, 64, 65};
+const vector<int> small_batch_count_stride_a_range = {
     1, 3,
+};
+const vector<int> medium_batch_count_stride_a_range = {
+    31, 32, 33,
 };
 
 // clang-format off
+// vector of vector, each vector is a {M, N, K, lda, ldb, ldc, stride_a, stride_b, stride_c};
 gemm_strided_batched_tuple db_sb_1{ {12544, 64, 64, 12544, 64, 12544, 802816, 0, 802816}, {1, 0}, {'N', 'N'}, 16};
 gemm_strided_batched_tuple db_sb_2{ {12544, 64, 64, 12544, 64, 12544, 802816, 0, 802816}, {1, 0}, {'N', 'N'}, 8};
 gemm_strided_batched_tuple db_sb_3{ {3136, 256, 64, 3136, 64, 3136, 200704, 0, 802816}, {1, 0}, {'N', 'N'}, 16};
@@ -327,21 +350,64 @@ TEST_P(gemm_strided_batched, double)
 // The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB}, {batch_count}
 // }
 
+//--- small
 // tests with stride_a == 0
-INSTANTIATE_TEST_CASE_P(checkin_blas3_stride_a_zero,
+INSTANTIATE_TEST_CASE_P(quick_blas3_small_stride_zero,
                         gemm_strided_batched,
-                        Combine(ValuesIn(matrix_size_stride_a_range),
+                        Combine(ValuesIn(small_matrix_size_stride_a_range),
                                 ValuesIn(alpha_beta_stride_a_range),
                                 ValuesIn(transA_transB_stride_a_range),
-                                ValuesIn(batch_count_stride_a_range)));
+                                ValuesIn(small_batch_count_stride_a_range)));
 
-INSTANTIATE_TEST_CASE_P(checkin_blas3,
+INSTANTIATE_TEST_CASE_P(quick_blas3_small,
                         gemm_strided_batched,
-                        Combine(ValuesIn(matrix_size_range),
+                        Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(small_batch_count_range)));
+// tests with stride_a == 0
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_small_stride_zero,
+                        gemm_strided_batched,
+                        Combine(ValuesIn(small_matrix_size_stride_a_range),
+                                ValuesIn(alpha_beta_stride_a_range),
+                                ValuesIn(transA_transB_stride_a_range),
+                                ValuesIn(medium_batch_count_stride_a_range)));
+//--- medium
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_medium,
+                        gemm_strided_batched,
+                        Combine(ValuesIn(medium_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(small_batch_count_range)));
+// tests with stride_a == 0
+INSTANTIATE_TEST_CASE_P(nightly_blas3_medium_stride_zero,
+                        gemm_strided_batched,
+                        Combine(ValuesIn(medium_matrix_size_stride_a_range),
+                                ValuesIn(alpha_beta_stride_a_range),
+                                ValuesIn(transA_transB_stride_a_range),
+                                ValuesIn(medium_batch_count_stride_a_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas3_deepbench_sizes,
+INSTANTIATE_TEST_CASE_P(nightly_checkin_blas3_medium,
+                        gemm_strided_batched,
+                        Combine(ValuesIn(medium_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(medium_batch_count_range)));
+//--- large
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_large,
+                        gemm_strided_batched,
+                        Combine(ValuesIn(large_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(small_batch_count_range)));
+// tests with stride_a == 0
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3_large_stride_zero,
+                        gemm_strided_batched,
+                        Combine(ValuesIn(large_matrix_size_stride_a_range),
+                                ValuesIn(alpha_beta_stride_a_range),
+                                ValuesIn(transA_transB_stride_a_range),
+                                ValuesIn(small_batch_count_range)));
+
+INSTANTIATE_TEST_CASE_P(nightly_blas3_deepbench_sizes,
                         gemm_strided_batched,
                         ValuesIn(deepbench_sb_vec));

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -48,8 +48,11 @@ const vector<vector<int>> small_matrix_size_range = {
     {1, 0, 1},
     {-1, -1, -1},
     {10, 10, 2},
-    {300, 400, 400},
-    {600, 500, 601},
+    {100, 200, 200},
+};
+
+const vector<vector<int>> medium_matrix_size_range = {
+    {300, 400, 400}, {600, 500, 601},
 };
 
 const vector<vector<int>> large_matrix_size_range = {
@@ -59,6 +62,10 @@ const vector<vector<int>> large_matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> small_incx_incy_range = {
+    {2, 1}, {-1, -2}, {1, 1}, {-1, 3}, {3, -1}, {0, 1}, {1, 0}, {0, -1}, {10, 100},
+};
+
+const vector<vector<int>> medium_incx_incy_range = {
     {2, 1}, {-1, -2}, {1, 1}, {-1, 3}, {3, -1}, {0, 1}, {1, 0}, {0, -1}, {10, 100},
 };
 
@@ -205,14 +212,21 @@ TEST_P(parameterized_gemv, double)
 
 TEST(checkin_blas2_bad_arg, gemv_bad_arg_float) { testing_gemv_bad_arg<float>(); }
 
-INSTANTIATE_TEST_CASE_P(checkin_blas2,
+INSTANTIATE_TEST_CASE_P(quick_blas2,
                         parameterized_gemv,
                         Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(small_incx_incy_range),
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_blas2,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas2,
+                        parameterized_gemv,
+                        Combine(ValuesIn(medium_matrix_size_range),
+                                ValuesIn(medium_incx_incy_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_range)));
+
+INSTANTIATE_TEST_CASE_P(nightly_blas2,
                         parameterized_gemv,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(large_incx_incy_range),

--- a/clients/gtest/ger_gtest.cpp
+++ b/clients/gtest/ger_gtest.cpp
@@ -54,8 +54,11 @@ const vector<vector<int>> small_matrix_size_range = {
     {65, 65, 66},
     /*   {10, 10, 2},       */
     /*   {600,500, 500},    */
-    {1000, 1000, 1000},
+    /*   {1000, 1000, 1000}, */
 };
+
+const vector<vector<int>> medium_matrix_size_range = {
+    {10, 10, 2}, {600, 500, 500}, {1000, 1000, 1000}};
 
 const vector<vector<int>> large_matrix_size_range = {
     {2000, 2000, 2000}, {4011, 4011, 4011}, {8000, 8000, 8000}};
@@ -64,14 +67,16 @@ const vector<vector<int>> large_matrix_size_range = {
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> small_incx_incy_range = {
     {1, 1}, {-1, 1}, {1, -1}, {-1, -1}, {0, -1}, {0, 1}, {1, 0}, {2, 1}, {10, 99}};
-const vector<vector<int>> large_incx_incy_range = {
+const vector<vector<int>> medium_incx_incy_range = {{1, 1}, {-1, 1}, {1, -1}, {2, 1}, {10, 99}};
+const vector<vector<int>> large_incx_incy_range  = {
     {1, 1}, {-1, 1}, {1, 2},
 };
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}
-const vector<double> small_alpha_range = {-0.5, 2.0, 0.0};
-const vector<double> large_alpha_range = {
+const vector<double> small_alpha_range  = {-0.5, 2.0, 0.0};
+const vector<double> medium_alpha_range = {-0.5, 2.0, 0.0};
+const vector<double> large_alpha_range  = {
     0.6,
 };
 
@@ -200,13 +205,19 @@ TEST_P(parameterized_ger, parameterized_ger_float)
 
 TEST(checkin_blas2_bad_arg, ger_float) { testing_ger_bad_arg<float>(); }
 
-INSTANTIATE_TEST_CASE_P(checkin_blas2,
+INSTANTIATE_TEST_CASE_P(quick_blas2,
                         parameterized_ger,
                         Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(small_incx_incy_range),
                                 ValuesIn(small_alpha_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_rocblas_blas2,
+INSTANTIATE_TEST_CASE_P(pre_checkin_rocblas_blas2,
+                        parameterized_ger,
+                        Combine(ValuesIn(medium_matrix_size_range),
+                                ValuesIn(medium_incx_incy_range),
+                                ValuesIn(medium_alpha_range)));
+
+INSTANTIATE_TEST_CASE_P(nightly_rocblas_blas2,
                         parameterized_ger,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(large_incx_incy_range),

--- a/clients/gtest/logging_mode_gtest.cpp
+++ b/clients/gtest/logging_mode_gtest.cpp
@@ -28,5 +28,5 @@ README: This file contains testers to verify the correctness of
      BLAS set-get_logging_mode:
 =================================================================== */
 
-TEST(checkin_auxilliary, logging_float) { testing_logging<float>(); }
-TEST(checkin_auxilliary, logging_double) { testing_logging<double>(); }
+TEST(quick_auxilliary, logging_float) { testing_logging<float>(); }
+TEST(quick_auxilliary, logging_double) { testing_logging<double>(); }

--- a/clients/gtest/set_get_matrix_gtest.cpp
+++ b/clients/gtest/set_get_matrix_gtest.cpp
@@ -53,6 +53,10 @@ const vector<vector<int>> lda_ldb_ldc_range = {
     {3, 5, 4}, {3, 5, 5}, {5, 3, 3}, {5, 3, 4}, {5, 3, 5},    {5, 4, 3},   {5, 4, 4},
     {5, 4, 5}, {5, 5, 3}, {5, 5, 4}, {5, 5, 5}, {30, 30, 30}, {31, 32, 33}};
 
+// small sizes   {{M, N},{lda,ldb,ldc}}
+set_get_matrix_tuple gemm_small_values1{{30000, 21}, {30000, 30001, 30002}};
+set_get_matrix_tuple gemm_small_values11{{20, 30000}, {20, 21, 22}};
+
 // large sizes   {{M, N},{lda,ldb,ldc}}
 set_get_matrix_tuple gemm_values1{{300000, 21}, {300000, 300001, 300002}};
 set_get_matrix_tuple gemm_values2{{300001, 22}, {300001, 300001, 300010}};
@@ -76,7 +80,8 @@ set_get_matrix_tuple gemm_values21{{3, 3000222}, {4, 4, 4}};
 
 set_get_matrix_tuple gemm_values31{{16700, 16700}, {16700, 16700, 16700}};
 
-const vector<set_get_matrix_tuple> small_gemm_values_vec = {gemm_values1, gemm_values11};
+const vector<set_get_matrix_tuple> small_gemm_values_vec = {gemm_small_values1,
+                                                            gemm_small_values11};
 
 const vector<set_get_matrix_tuple> large_gemm_values_vec = {gemm_values1,
                                                             gemm_values2,
@@ -251,14 +256,14 @@ TEST_P(parameterized_set_matrix_get_matrix, double)
 // ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N}, {lda, ldb, ldc} }
 
-INSTANTIATE_TEST_CASE_P(checkin_auxilliary,
+INSTANTIATE_TEST_CASE_P(quick_auxilliary_1,
                         parameterized_set_matrix_get_matrix,
                         Combine(ValuesIn(M_N_range), ValuesIn(lda_ldb_ldc_range)));
 
-INSTANTIATE_TEST_CASE_P(checkin_auxilliary_2,
+INSTANTIATE_TEST_CASE_P(quick_auxilliary_2,
                         parameterized_set_matrix_get_matrix,
                         ValuesIn(small_gemm_values_vec));
 
-INSTANTIATE_TEST_CASE_P(daily_auxilliary,
+INSTANTIATE_TEST_CASE_P(pre_checkin_auxilliary,
                         parameterized_set_matrix_get_matrix,
                         ValuesIn(large_gemm_values_vec));

--- a/clients/gtest/set_get_pointer_mode_gtest.cpp
+++ b/clients/gtest/set_get_pointer_mode_gtest.cpp
@@ -24,7 +24,7 @@ README: This file contains testers to verify the correctness of
      BLAS set-get_pointer_mode:
 =================================================================== */
 
-TEST(checkin_auxilliary, set_pointer_mode_get_pointer_mode)
+TEST(quick_auxilliary, set_pointer_mode_get_pointer_mode)
 {
     rocblas_status status     = rocblas_status_success;
     rocblas_pointer_mode mode = rocblas_pointer_mode_device;

--- a/clients/gtest/set_get_vector_gtest.cpp
+++ b/clients/gtest/set_get_vector_gtest.cpp
@@ -38,7 +38,9 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 
 // vector of vector, each vector is a {M};
 // add/delete as a group
-const int small_M_range[] = {10, 600, 600000};
+const int small_M_range[] = {10, 600};
+
+const int medium_M_range[] = {600000};
 
 const int large_M_range[] = {1000000, 6000000};
 
@@ -62,6 +64,9 @@ const vector<vector<int>> small_incx_incy_incb_range = {{1, 1, 1},
                                                         {3, 3, 1},
                                                         {3, 3, 2},
                                                         {3, 3, 3}};
+
+const vector<vector<int>> medium_incx_incy_incb_range = {
+    {1, 1, 1}, {1, 1, 3}, {1, 3, 1}, {1, 3, 3}, {3, 1, 1}, {3, 1, 3}, {3, 3, 1}, {3, 3, 3}};
 
 const vector<vector<int>> large_incx_incy_incb_range = {
     {1, 1, 1}, {1, 1, 3}, {1, 3, 1}, {1, 3, 3}, {3, 1, 1}, {3, 1, 3}, {3, 3, 1}, {3, 3, 3}};
@@ -190,10 +195,14 @@ TEST_P(parameterized_set_vector_get_vector, double)
 // ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda}, {incx,incy} {alpha} }
 
-INSTANTIATE_TEST_CASE_P(checkin_auxiliary,
+INSTANTIATE_TEST_CASE_P(quick_auxiliary,
                         parameterized_set_vector_get_vector,
                         Combine(ValuesIn(small_M_range), ValuesIn(small_incx_incy_incb_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_auxiliary,
+INSTANTIATE_TEST_CASE_P(pre_checkin_auxiliary,
+                        parameterized_set_vector_get_vector,
+                        Combine(ValuesIn(medium_M_range), ValuesIn(medium_incx_incy_incb_range)));
+
+INSTANTIATE_TEST_CASE_P(nightly_auxiliary,
                         parameterized_set_vector_get_vector,
                         Combine(ValuesIn(large_M_range), ValuesIn(large_incx_incy_incb_range)));

--- a/clients/gtest/syr_gtest.cpp
+++ b/clients/gtest/syr_gtest.cpp
@@ -53,19 +53,22 @@ const vector<vector<int>> small_matrix_size_range = {{1, 1},
                                                      {65, 66},
                                                      {1000, 1000}};
 
-const vector<vector<int>> large_matrix_size_range = {{2000, 2000}, {4011, 4011}, {8000, 8000}};
+const vector<vector<int>> medium_matrix_size_range = {{1000, 1000}, {2011, 2011}, {3000, 3000}};
+const vector<vector<int>> large_matrix_size_range  = {{2000, 2000}, {4011, 4011}, {8000, 8000}};
 
 // vector of incx;
 // add/delete single values
-const vector<int> small_incx_range = {-1, 1, 0, 2, -2, 10, 99};
-const vector<int> large_incx_range = {
+const vector<int> small_incx_range  = {-1, 1, 0, 2, -2, 10, 99};
+const vector<int> medium_incx_range = {0, 2, -2};
+const vector<int> large_incx_range  = {
     1000,
 };
 
 // vector, each entry is  {alpha};
 // add/delete single values
-const vector<double> small_alpha_range = {-0.5, 2.0, 0.0};
-const vector<double> large_alpha_range = {
+const vector<double> small_alpha_range  = {-0.5, 2.0, 0.0};
+const vector<double> medium_alpha_range = {-0.5, 2.0};
+const vector<double> large_alpha_range  = {
     1000.6,
 };
 
@@ -192,14 +195,21 @@ TEST_P(parameterized_syr, parameterized_syr_float)
 
 TEST(checkin_blas2_bad_arg, syr_float) { testing_syr_bad_arg<float>(); }
 
-INSTANTIATE_TEST_CASE_P(checkin_blas2,
+INSTANTIATE_TEST_CASE_P(quick_blas2,
                         parameterized_syr,
                         Combine(ValuesIn(small_matrix_size_range),
                                 ValuesIn(small_incx_range),
                                 ValuesIn(small_alpha_range),
                                 ValuesIn(uplo_range)));
 
-INSTANTIATE_TEST_CASE_P(daily_rocblas_blas2,
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas2,
+                        parameterized_syr,
+                        Combine(ValuesIn(medium_matrix_size_range),
+                                ValuesIn(medium_incx_range),
+                                ValuesIn(medium_alpha_range),
+                                ValuesIn(uplo_range)));
+
+INSTANTIATE_TEST_CASE_P(nightly_rocblas_blas2,
                         parameterized_syr,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(large_incx_range),

--- a/clients/gtest/trsm_gtest.cpp
+++ b/clients/gtest/trsm_gtest.cpp
@@ -38,14 +38,20 @@ Yet, the goal of this file is to verify result correctness not argument-checkers
 Representative sampling is sufficient, endless brute-force sampling is not necessary
 =================================================================== */
 
+// THis function mainly test the scope of  full_side_uplo_transA_diag_range,.the scope of
+// matrix_size_range is small
+
 // vector of vector, each vector is a {M, N, lda, ldb};
 // add/delete as a group
-const vector<vector<int>> matrix_size_range = {
-    {-1, -1, 1, 1}, {10, 10, 20, 100}, {600, 500, 600, 600},
+const vector<vector<int>> small_matrix_size_range = {
+    {-1, -1, 1, 1}, {10, 10, 20, 100},
+};
+
+const vector<vector<int>> medium_matrix_size_range = {
+    {192, 192, 192, 192}, {600, 500, 600, 600}, {800, 700, 801, 701},
 };
 
 const vector<vector<int>> large_matrix_size_range = {
-    {192, 192, 192, 192},
     {640, 640, 960, 960},
     {1000, 1000, 1000, 1000},
     {1024, 1024, 1024, 1024},
@@ -141,7 +147,7 @@ class trsm_gtest : public ::TestWithParam<trsm_tuple>
     virtual void TearDown() {}
 };
 
-TEST_P(trsm_gtest, trsm_gtest_float)
+TEST_P(trsm_gtest, float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
@@ -171,7 +177,7 @@ TEST_P(trsm_gtest, trsm_gtest_float)
     }
 }
 
-TEST_P(trsm_gtest, trsm_gtest_double)
+TEST_P(trsm_gtest, double)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
@@ -206,22 +212,27 @@ TEST_P(trsm_gtest, trsm_gtest_double)
 // ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda, ldb}, alpha, {side, uplo, transA, diag} }
 
-// THis function mainly test the scope of matrix_size. the scope of side_uplo_transA_diag_range is
+// These function mainly test the scope of matrix_size. the scope of side_uplo_transA_diag_range is
 // small
 // Testing order: side_uplo_transA_xx first, alpha_range second, full_matrix_size last
 // i.e fix the matrix size and alpha, test all the side_uplo_transA_xx first.
 // INSTANTIATE_TEST_CASE_P(rocblas_trsm_matrix_size,
-INSTANTIATE_TEST_CASE_P(daily_blas3,
+INSTANTIATE_TEST_CASE_P(quick_blas3,
+                        trsm_gtest,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(alpha_range),
+                                ValuesIn(full_side_uplo_transA_diag_range)));
+
+INSTANTIATE_TEST_CASE_P(pre_checkin_blas3,
+                        trsm_gtest,
+                        Combine(ValuesIn(medium_matrix_size_range),
+                                ValuesIn(alpha_range),
+                                ValuesIn(full_side_uplo_transA_diag_range)));
+
+// THis function mainly test the scope of  full_side_uplo_transA_diag_range,.the scope of
+// matrix_size_range is small
+INSTANTIATE_TEST_CASE_P(nightly_blas3,
                         trsm_gtest,
                         Combine(ValuesIn(large_matrix_size_range),
                                 ValuesIn(alpha_range),
                                 ValuesIn(side_uplo_transA_diag_range)));
-
-// THis function mainly test the scope of  full_side_uplo_transA_diag_range,.the scope of
-// matrix_size_range is small
-
-INSTANTIATE_TEST_CASE_P(checkin_blas3,
-                        trsm_gtest,
-                        Combine(ValuesIn(matrix_size_range),
-                                ValuesIn(alpha_range),
-                                ValuesIn(full_side_uplo_transA_diag_range)));

--- a/clients/include/testing_gemm_sweep.hpp
+++ b/clients/include/testing_gemm_sweep.hpp
@@ -1,0 +1,237 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include <sys/time.h>
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <limits>
+
+#include "rocblas.hpp"
+#include "arg_check.h"
+#include "rocblas_test_unique_ptr.hpp"
+#include "utility.h"
+#include "cblas_interface.h"
+#include "norm.h"
+#include "unit.h"
+#include "flops.h"
+#include <typeinfo>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+rocblas_status testing_gemm_sweep(Arguments argus)
+{
+    rocblas_operation transA = char2rocblas_operation(argus.transA_option);
+    rocblas_operation transB = char2rocblas_operation(argus.transB_option);
+
+    rocblas_int M = argus.M;
+    rocblas_int N = argus.N;
+    rocblas_int K = argus.K;
+
+    // TODO: also test for lda,ldb,ldc one larger than min value
+    rocblas_int lda = transA == rocblas_operation_none ? M : K;
+    rocblas_int ldb = transB == rocblas_operation_none ? K : N;
+    rocblas_int ldc = M;
+
+    T h_alpha;
+    T h_beta;
+    if(is_same<T, rocblas_half>::value)
+    {
+        float alpha_float = argus.alpha;
+        float beta_float  = argus.beta;
+
+        h_alpha = float_to_half(alpha_float);
+        h_beta  = float_to_half(beta_float);
+    }
+    else
+    {
+        h_alpha = argus.alpha;
+        h_beta  = argus.beta;
+    }
+
+    const size_t safe_size = 100;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_gflops, cblas_gflops;
+
+    T rocblas_error = 0.0;
+
+    rocblas_status status = rocblas_status_success;
+
+    std::unique_ptr<rocblas_test::handle_struct> unique_ptr_handle(new rocblas_test::handle_struct);
+    rocblas_handle handle = unique_ptr_handle->handle;
+
+    rocblas_int A_row = transA == rocblas_operation_none ? M : K;
+    rocblas_int A_col = transA == rocblas_operation_none ? K : M;
+    rocblas_int B_row = transB == rocblas_operation_none ? K : N;
+    rocblas_int B_col = transB == rocblas_operation_none ? N : K;
+
+    // check here to prevent undefined memory allocation error
+    if(M < 0 || N < 0 || K < 0 || lda < A_row || ldb < B_row || ldc < M)
+    {
+        auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
+                                             rocblas_test::device_free};
+        T* dA = (T*)dA_managed.get();
+        T* dB = (T*)dB_managed.get();
+        T* dC = (T*)dC_managed.get();
+        if(!dA || !dB || !dC)
+        {
+            PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
+            return rocblas_status_memory_error;
+        }
+
+        status = rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc);
+
+        gemm_arg_check(status, M, N, K, lda, ldb, ldc);
+
+        return status;
+    }
+
+    const size_t size_A = static_cast<size_t>(lda) * static_cast<size_t>(A_col);
+    const size_t size_B = static_cast<size_t>(ldb) * static_cast<size_t>(B_col);
+    const size_t size_C = static_cast<size_t>(ldc) * static_cast<size_t>(N);
+
+    // allocate memory on device
+    auto dA_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_A),
+                                         rocblas_test::device_free};
+    auto dB_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_B),
+                                         rocblas_test::device_free};
+    auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * size_C),
+                                         rocblas_test::device_free};
+    auto d_alpha_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    auto d_beta_managed =
+        rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T)), rocblas_test::device_free};
+    T* dA      = (T*)dA_managed.get();
+    T* dB      = (T*)dB_managed.get();
+    T* dC      = (T*)dC_managed.get();
+    T* d_alpha = (T*)d_alpha_managed.get();
+    T* d_beta  = (T*)d_beta_managed.get();
+    if(!dA || !dB || !dC || !d_alpha || !d_beta)
+    {
+        PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
+        return rocblas_status_memory_error;
+    }
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
+    vector<T> hA(size_A);
+    vector<T> hB(size_B);
+    vector<T> hC_1(size_C);
+    vector<T> hC_2(size_C);
+    vector<T> hC_gold(size_C);
+
+    // Initial Data on CPU
+    srand(1);
+    rocblas_init<T>(hA, A_row, A_col, lda);
+    rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
+    rocblas_init<T>(hC_1, M, N, ldc);
+
+    //  rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
+    //  rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);
+    //  rocblas_init<T>(hC_1, M, N, ldc, 1.0);
+
+    //  std::cout << "------------------------------------------------" << std::endl;
+    //  for(int i = 0; i < size_A; i++){ cout << half_to_float(hA[i]) << "  "; }
+    //  std::cout << std::endl << "------------------------------------------------" << std::endl;
+    //  for(int i = 0; i < size_B; i++){ cout << half_to_float(hB[i]) << "  "; }
+    //  std::cout << std::endl << "------------------------------------------------" << std::endl;
+    //  for(int i = 0; i < size_C; i++){ cout << half_to_float(hC_1[i]) << "  "; }
+    //  std::cout << std::endl << "------------------------------------------------" << std::endl;
+
+    hC_2    = hC_1;
+    hC_gold = hC_1;
+
+    // copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * size_B, hipMemcpyHostToDevice));
+
+    if(argus.unit_check || argus.norm_check)
+    {
+        // ROCBLAS rocblas_pointer_mode_host
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
+
+        //      std::cout << std::endl << "------------------------------------------------" <<
+        //      std::endl;
+        //      std::cout << "alpha, beta = " << half_to_float(h_alpha) << ", " <<
+        //      half_to_float(h_beta);
+        //      std::cout << std::endl << "------------------------------------------------" <<
+        //      std::endl;
+        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+        //  std::cout << std::endl << "------------------------------------------------" <<
+        //  std::endl;
+        //  for(int i = 0; i < size_C; i++){ cout << half_to_float(hC_1[i]) << "  "; }
+        //  std::cout << std::endl << "------------------------------------------------" <<
+        //  std::endl;
+
+        // ROCBLAS rocblas_pointer_mode_device
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_2.data(), sizeof(T) * size_C, hipMemcpyHostToDevice));
+
+        CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+
+        CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
+
+        CHECK_ROCBLAS_ERROR(rocblas_gemm<T>(
+            handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_2.data(), dC, sizeof(T) * size_C, hipMemcpyDeviceToHost));
+
+        // CPU BLAS
+
+        cblas_gemm<T>(transA,
+                      transB,
+                      M,
+                      N,
+                      K,
+                      h_alpha,
+                      hA.data(),
+                      lda,
+                      hB.data(),
+                      ldb,
+                      h_beta,
+                      hC_gold.data(),
+                      ldc);
+
+//  std::cout << std::endl << "---gold---gold---gold---------------------------" << std::endl;
+//  for(int i = 0; i < size_C; i++){ std::cout << half_to_float(hC_gold[i]) << "  "; }
+//  std::cout << std::endl << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
+#ifndef NDEBUG
+// print_matrix(hC_gold, hC, min(M, 3), min(N, 3), ldc);
+#endif
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_1.data());
+            unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_2.data());
+        }
+
+        // if enable norm check, norm check is invasive
+        // any typeinfo(T) will not work here, because template deduction is matched
+        // in compilation time
+        if(argus.norm_check)
+        {
+            rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data());
+            rocblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_2.data());
+        }
+    }
+
+    return status;
+}


### PR DESCRIPTION
Add tests to sweep over a wider range of  sizes for gemm

Add Google-test  labels quick, pre_checkin, nightly with test times:
- quick: 35 sec
- quick + pre-checkin:  9min 41 sec
- nightly: 43 min