### PR TITLE
make workspace_size argument an in/out pointer not an in scalar

### DIFF
--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -45,7 +45,7 @@ void testing_gemm_ex_bad_arg()
     rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
     rocblas_int solution_index;
     rocblas_int flags;
-    size_t workspace_size = 0;
+    size_t* workspace_size = 0;
     void* workspace;
 
     const size_t safe_size = 100;
@@ -330,7 +330,7 @@ rocblas_status testing_gemm_ex_template(rocblas_operation transA,
     rocblas_gemm_algo algo  = rocblas_gemm_algo_standard;
     uint32_t solution_index = 0;
     uint32_t flags          = 0;
-    size_t workspace_size   = 0;
+    size_t* workspace_size  = 0;
     void* workspace;
 
     Td h_alpha_Td;

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -259,8 +259,8 @@ void testing_logging()
             rocblas_gemm_algo algo  = rocblas_gemm_algo_standard;
             uint32_t solution_index = 0;
             uint32_t flags          = 0;
-            size_t workspace_size   = 0;
-            void* workspace         = NULL;
+            size_t* workspace_size  = 0;
+            void* workspace         = 0;
             rocblas_datatype a_type;
             rocblas_datatype b_type;
             rocblas_datatype c_type;
@@ -656,8 +656,8 @@ void testing_logging()
             rocblas_gemm_algo algo  = rocblas_gemm_algo_standard;
             uint32_t solution_index = 0;
             uint32_t flags          = 0;
-            size_t workspace_size   = 0;
-            void* workspace         = NULL;
+            size_t* workspace_size  = 0;
+            void* workspace         = 0;
 
             trace_ofs2 << "rocblas_gemm_ex"
                        << "," << transA << "," << transB << "," << m << "," << n << "," << k << ","

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1419,9 +1419,9 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(rocblas_handle handle,
                                               int ldd,
                                               rocblas_datatype compute_type,
                                               rocblas_gemm_algo algo,
-                                              uint32_t kernel_index,
+                                              uint32_t solution_index,
                                               uint32_t flags,
-                                              size_t workspace_size,
+                                              size_t* workspace_size,
                                               void* workspace);
 
 #ifdef __cplusplus

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -575,9 +575,9 @@ rocblas_status tensile_gemm_typecasting(rocblas_handle handle,
     @param[in]
     flags     uint32_t
               reserved for future use
-    @param[in]
+    @param[in/out]
     workspace_size   
-              size_t
+              size_t*
               size of workspace
     @parm[in]
     workspace void*
@@ -610,7 +610,7 @@ extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle handle,
                                           rocblas_gemm_algo algo,
                                           uint32_t solution_index,
                                           uint32_t flags,
-                                          size_t workspace_size,
+                                          size_t* workspace_size,
                                           void* workspace)
 {
     // handle, alpha, beta must not be null pointers for logging


### PR DESCRIPTION
With this change the function gemm_ex can be called to calculate the workspace. The user would then allocate the workspace and call gemm_ex again to carry out the calculation.