### PR TITLE
gemm_strided_batched rocblas-bench bug fixes

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
          "BLAS-2 and BLAS-3: second dimension * leading dimension.")
 
         ("stride_d",
-         po::value<rocblas_int>(&argus.stride_c)->default_value(128*128),
+         po::value<rocblas_int>(&argus.stride_d)->default_value(128*128),
          "Specific stride of strided_batched matrix D, is only applicable to strided batched"
          "BLAS_EX: second dimension * leading dimension.")
 

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -210,15 +210,15 @@ double norm_check_general<rocblas_half>(char norm_type,
     // use triangle inequality ||a+b|| <= ||a|| + ||b|| to calculate upper limit for Frobenius norm
     // of strided batched matrix
 
-    std::unique_ptr<float[]> hCPU_float(new float[N * lda]() + (batch_count - 1) * stride_a);
-    std::unique_ptr<float[]> hGPU_float(new float[N * lda]() + (batch_count - 1) * stride_a);
+    std::unique_ptr<float[]> hCPU_float(new float[N * lda + (batch_count - 1) * stride_a]());
+    std::unique_ptr<float[]> hGPU_float(new float[N * lda + (batch_count - 1) * stride_a]());
     for(int i_batch = 0; i_batch < batch_count; i_batch++)
     {
         for(int i = 0; i < N * lda; i++)
         {
             int index         = i + i_batch * stride_a;
-            hCPU_float[index] = static_cast<float>(hCPU[index]);
-            hGPU_float[index] = static_cast<float>(hGPU[index]);
+            hCPU_float[index] = half_to_float(hCPU[index]);
+            hGPU_float[index] = half_to_float(hGPU[index]);
         }
     }
 

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -77,9 +77,9 @@ rocblas_status testing_gemm_strided_batched(Arguments argus)
                                              rocblas_test::device_free};
         auto dC_managed = rocblas_unique_ptr{rocblas_test::device_malloc(sizeof(T) * safe_size),
                                              rocblas_test::device_free};
-        T* dA           = (T*)dA_managed.get();
-        T* dB           = (T*)dB_managed.get();
-        T* dC           = (T*)dC_managed.get();
+        T* dA = (T*)dA_managed.get();
+        T* dB = (T*)dB_managed.get();
+        T* dC = (T*)dC_managed.get();
         if(!dA || !dB || !dC)
         {
             PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -442,6 +442,7 @@ class Arguments
     rocblas_int stride_a = 128 * 128; //  stride_a > transA_option == 'N' ? lda * K : lda * M
     rocblas_int stride_b = 128 * 128; //  stride_b > transB_option == 'N' ? ldb * N : ldb * K
     rocblas_int stride_c = 128 * 128; //  stride_c > ldc * N
+    rocblas_int stride_d = 128 * 128; //  stride_d > ldd * N
 
     rocblas_int norm_check = 0;
     rocblas_int unit_check = 1;


### PR DESCRIPTION
Summary of proposed changes:
-  In clients/common/norm.cpp, correct memory allocation, and switch to using half_to_float()
-  In clients/include/testing_gemm_strided_batched.hpp, declare rocblas_error as double, and print alpha and beta as float for half; clang-format changes
-  In clients/include/utility.h, add stride_d
-  In clients/benchmarks/client.cpp, correct typo stride_c -> stride_d
