### PR TITLE
Fix incorrect chunking in CALL_TENSILE of gemm.cpp

### DIFF
--- a/library/src/blas3/Tensile/gemm.cpp
+++ b/library/src/blas3/Tensile/gemm.cpp
@@ -308,6 +308,19 @@
     unsigned int m_chunk_size   = int_limit / strideA1;                                              \
     unsigned int n_chunk_count  = ((sizeJ - 1) / n_chunk_size) + 1;                                  \
     unsigned int m_chunk_count  = ((sizeI - 1) / m_chunk_size) + 1;                                  \
+                                                                                                     \
+    if(trans_a == rocblas_operation_none)                                                            \
+    {                                                                                                \
+        m_chunk_size  = sizeI;                                                                       \
+        m_chunk_count = 1;                                                                           \
+    };                                                                                               \
+                                                                                                     \
+    if(trans_b == rocblas_operation_transpose)                                                       \
+    {                                                                                                \
+        n_chunk_size  = sizeJ;                                                                       \
+        n_chunk_count = 1;                                                                           \
+    };                                                                                               \
+                                                                                                     \
     for(int n_chunk_iterator = 0; n_chunk_iterator < n_chunk_count; n_chunk_iterator++)              \
     {                                                                                                \
         unsigned int n_chunk_remaining = sizeJ - (n_chunk_size * n_chunk_iterator);                  \


### PR DESCRIPTION
To solve the performance degrade in Dgemm (C += A*B ) caused by unnecessary chunking.

With either matrix A or B, chunking can only be done with the other dimension when the Leading Dimension is the same as the Summation Dimension, more specifically:

Matrix A can only be chunked along the "m" dimension when trans_a is rocblas_operation_transpose.
Matrix B can only be chunked along the "n" dimension when trans_b is rocblas_operation_none.

