### PR TITLE
cmake fix to properly list rocblas library in $ROCBLAS_LIBRARIES env …

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -196,7 +196,7 @@ rocm_install_targets(
 #         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 
 rocm_export_targets(
-  TARGETS rocblas-targets
+  TARGETS roc::rocblas
   PREFIX rocblas
   DEPENDS PACKAGE hip
   NAMESPACE roc::


### PR DESCRIPTION
Fixes cmake issue with ${ROCBLAS_LIBRARIES} environment variable that was previously pointing to librocsparse-targets.so.

Fixes "Using cmake find_package(rocblas) does not report the library" #364

Tested with integration into rocALUTION cmake procedure.