### PR TITLE
Disable chunking of Matrix A along the Leading Dimension in CALL_TENS…

### DIFF
--- a/library/src/blas3/Tensile/gemm.cpp
+++ b/library/src/blas3/Tensile/gemm.cpp
@@ -287,104 +287,112 @@
 #define PRINT_RETURN_STATUS
 #endif
 
-#define CALL_TENSILE(PREC, TYPE, TRANS)                                                              \
-    PRINT_SOLUTION_NAME(PREC, TRANS)                                                                 \
-    TYPE alpha_h;                                                                                    \
-    TYPE beta_h;                                                                                     \
-    if(rocblas_pointer_mode_host == handle->pointer_mode)                                            \
-    {                                                                                                \
-        alpha_h = *alpha;                                                                            \
-        beta_h  = *beta;                                                                             \
-    }                                                                                                \
-    else                                                                                             \
-    {                                                                                                \
-        hipMemcpy(&alpha_h, alpha, sizeof(TYPE), hipMemcpyDeviceToHost);                             \
-        hipMemcpy(&beta_h, beta, sizeof(TYPE), hipMemcpyDeviceToHost);                               \
-    }                                                                                                \
-    unsigned int int_limit      = std::numeric_limits<int>::max() / sizeof(TYPE);                    \
-    unsigned int n_chunk_size_c = int_limit / strideC1;                                              \
-    unsigned int n_chunk_size_b = int_limit / strideB1;                                              \
-    unsigned int n_chunk_size   = n_chunk_size_c < n_chunk_size_b ? n_chunk_size_c : n_chunk_size_b; \
-    unsigned int m_chunk_size   = int_limit / strideA1;                                              \
-    unsigned int n_chunk_count  = ((sizeJ - 1) / n_chunk_size) + 1;                                  \
-    unsigned int m_chunk_count  = ((sizeI - 1) / m_chunk_size) + 1;                                  \
-    for(int n_chunk_iterator = 0; n_chunk_iterator < n_chunk_count; n_chunk_iterator++)              \
-    {                                                                                                \
-        unsigned int n_chunk_remaining = sizeJ - (n_chunk_size * n_chunk_iterator);                  \
-        unsigned int n_chunk_sizeJ =                                                                 \
-            n_chunk_size < n_chunk_remaining ? n_chunk_size : n_chunk_remaining;                     \
-        for(int m_chunk_iterator = 0; m_chunk_iterator < m_chunk_count; m_chunk_iterator++)          \
-        {                                                                                            \
-            unsigned int m_chunk_remaining = sizeI - (m_chunk_size * m_chunk_iterator);              \
-            unsigned int m_chunk_sizeI =                                                             \
-                m_chunk_size < m_chunk_remaining ? m_chunk_size : m_chunk_remaining;                 \
-                                                                                                     \
-            if(trans_a == rocblas_operation_none)                                                    \
-            {                                                                                        \
-                if(strideA1 * sizeL > int_limit)                                                     \
-                {                                                                                    \
-                    std::cerr << "rocBLAS ERROR: lda*k exceeds address limit" << std::endl;          \
-                }                                                                                    \
-            }                                                                                        \
-            else                                                                                     \
-            {                                                                                        \
-                if(strideA1 * m_chunk_sizeI > int_limit)                                             \
-                {                                                                                    \
-                    std::cerr << "rocBLAS ERROR: lda*m exceeds address limit" << std::endl;          \
-                }                                                                                    \
-            }                                                                                        \
-            if(trans_b == rocblas_operation_none)                                                    \
-            {                                                                                        \
-                if(strideB1 * n_chunk_sizeJ > int_limit)                                             \
-                {                                                                                    \
-                    std::cerr << "rocBLAS ERROR: ldb*n exceeds address limit" << std::endl;          \
-                }                                                                                    \
-            }                                                                                        \
-            else                                                                                     \
-            {                                                                                        \
-                if(strideB1 * sizeL > int_limit)                                                     \
-                {                                                                                    \
-                    std::cerr << "rocBLAS ERROR: ldb*k exceeds address limit" << std::endl;          \
-                }                                                                                    \
-            }                                                                                        \
-            if(strideC1 * n_chunk_sizeJ > int_limit)                                                 \
-            {                                                                                        \
-                std::cerr << "rocBLAS ERROR: ldc*n exceeds address limit" << std::endl;              \
-            }                                                                                        \
-                                                                                                     \
-            size_t C_offset =                                                                        \
-                n_chunk_iterator * n_chunk_size * strideC1 + m_chunk_iterator * m_chunk_size;        \
-            size_t B_offset = n_chunk_iterator * n_chunk_size;                                       \
-            size_t A_offset = m_chunk_iterator * m_chunk_size;                                       \
-            if(trans_b == rocblas_operation_none)                                                    \
-                B_offset *= strideB1;                                                                \
-            if(trans_a != rocblas_operation_none)                                                    \
-                A_offset *= strideA1;                                                                \
-                                                                                                     \
-            status = tensile_##TRANS##_##PREC##B(C + C_offset,                                       \
-                                                 A + A_offset,                                       \
-                                                 B + B_offset,                                       \
-                                                 alpha_h,                                            \
-                                                 beta_h,                                             \
-                                                 0,                                                  \
-                                                 0,                                                  \
-                                                 0,                                                  \
-                                                 strideC1,                                           \
-                                                 strideC2,                                           \
-                                                 strideA1,                                           \
-                                                 strideA2,                                           \
-                                                 strideB1,                                           \
-                                                 strideB2,                                           \
-                                                 m_chunk_sizeI,                                      \
-                                                 n_chunk_sizeJ,                                      \
-                                                 sizeK,                                              \
-                                                 sizeL,                                              \
-                                                 handle->rocblas_stream,                             \
-                                                 0,                                                  \
-                                                 nullptr,                                            \
-                                                 nullptr);                                           \
-        }                                                                                            \
-    }                                                                                                \
+#define CALL_TENSILE(PREC, TYPE, TRANS)                                                             \
+    PRINT_SOLUTION_NAME(PREC, TRANS)                                                                \
+    TYPE alpha_h;                                                                                   \
+    TYPE beta_h;                                                                                    \
+    if(rocblas_pointer_mode_host == handle->pointer_mode)                                           \
+    {                                                                                               \
+        alpha_h = *alpha;                                                                           \
+        beta_h  = *beta;                                                                            \
+    }                                                                                               \
+    else                                                                                            \
+    {                                                                                               \
+        hipMemcpy(&alpha_h, alpha, sizeof(TYPE), hipMemcpyDeviceToHost);                            \
+        hipMemcpy(&beta_h, beta, sizeof(TYPE), hipMemcpyDeviceToHost);                              \
+    }                                                                                               \
+    unsigned int int_limit      = std::numeric_limits<int>::max() / sizeof(TYPE);                   \
+    unsigned int n_chunk_size_c = int_limit / strideC1;                                             \
+    unsigned int n_chunk_size_b =                                                                   \
+        (trans_b == rocblas_operation_none) ? int_limit / strideB1 : n_chunk_size_c;                \
+    unsigned int n_chunk_size  = n_chunk_size_c < n_chunk_size_b ? n_chunk_size_c : n_chunk_size_b; \
+    unsigned int m_chunk_size  = int_limit / strideA1;                                              \
+    unsigned int n_chunk_count = ((sizeJ - 1) / n_chunk_size) + 1;                                  \
+    unsigned int m_chunk_count = ((sizeI - 1) / m_chunk_size) + 1;                                  \
+                                                                                                    \
+    if(trans_a == rocblas_operation_none)                                                           \
+    {                                                                                               \
+        m_chunk_size  = sizeI;                                                                      \
+        m_chunk_count = 1;                                                                          \
+    };                                                                                              \
+                                                                                                    \
+    for(int n_chunk_iterator = 0; n_chunk_iterator < n_chunk_count; n_chunk_iterator++)             \
+    {                                                                                               \
+        unsigned int n_chunk_remaining = sizeJ - (n_chunk_size * n_chunk_iterator);                 \
+        unsigned int n_chunk_sizeJ =                                                                \
+            n_chunk_size < n_chunk_remaining ? n_chunk_size : n_chunk_remaining;                    \
+        for(int m_chunk_iterator = 0; m_chunk_iterator < m_chunk_count; m_chunk_iterator++)         \
+        {                                                                                           \
+            unsigned int m_chunk_remaining = sizeI - (m_chunk_size * m_chunk_iterator);             \
+            unsigned int m_chunk_sizeI =                                                            \
+                m_chunk_size < m_chunk_remaining ? m_chunk_size : m_chunk_remaining;                \
+                                                                                                    \
+            if(trans_a == rocblas_operation_none)                                                   \
+            {                                                                                       \
+                if(strideA1 * sizeL > int_limit)                                                    \
+                {                                                                                   \
+                    std::cerr << "rocBLAS ERROR: lda*k exceeds address limit" << std::endl;         \
+                }                                                                                   \
+            }                                                                                       \
+            else                                                                                    \
+            {                                                                                       \
+                if(strideA1 * m_chunk_sizeI > int_limit)                                            \
+                {                                                                                   \
+                    std::cerr << "rocBLAS ERROR: lda*m exceeds address limit" << std::endl;         \
+                }                                                                                   \
+            }                                                                                       \
+            if(trans_b == rocblas_operation_none)                                                   \
+            {                                                                                       \
+                if(strideB1 * n_chunk_sizeJ > int_limit)                                            \
+                {                                                                                   \
+                    std::cerr << "rocBLAS ERROR: ldb*n exceeds address limit" << std::endl;         \
+                }                                                                                   \
+            }                                                                                       \
+            else                                                                                    \
+            {                                                                                       \
+                if(strideB1 * sizeL > int_limit)                                                    \
+                {                                                                                   \
+                    std::cerr << "rocBLAS ERROR: ldb*k exceeds address limit" << std::endl;         \
+                }                                                                                   \
+            }                                                                                       \
+            if(strideC1 * n_chunk_sizeJ > int_limit)                                                \
+            {                                                                                       \
+                std::cerr << "rocBLAS ERROR: ldc*n exceeds address limit" << std::endl;             \
+            }                                                                                       \
+                                                                                                    \
+            size_t C_offset =                                                                       \
+                n_chunk_iterator * n_chunk_size * strideC1 + m_chunk_iterator * m_chunk_size;       \
+            size_t B_offset = n_chunk_iterator * n_chunk_size;                                      \
+            size_t A_offset = m_chunk_iterator * m_chunk_size;                                      \
+            if(trans_b == rocblas_operation_none)                                                   \
+                B_offset *= strideB1;                                                               \
+            if(trans_a != rocblas_operation_none)                                                   \
+                A_offset *= strideA1;                                                               \
+                                                                                                    \
+            status = tensile_##TRANS##_##PREC##B(C + C_offset,                                      \
+                                                 A + A_offset,                                      \
+                                                 B + B_offset,                                      \
+                                                 alpha_h,                                           \
+                                                 beta_h,                                            \
+                                                 0,                                                 \
+                                                 0,                                                 \
+                                                 0,                                                 \
+                                                 strideC1,                                          \
+                                                 strideC2,                                          \
+                                                 strideA1,                                          \
+                                                 strideA2,                                          \
+                                                 strideB1,                                          \
+                                                 strideB2,                                          \
+                                                 m_chunk_sizeI,                                     \
+                                                 n_chunk_sizeJ,                                     \
+                                                 sizeK,                                             \
+                                                 sizeL,                                             \
+                                                 handle->rocblas_stream,                            \
+                                                 0,                                                 \
+                                                 nullptr,                                           \
+                                                 nullptr);                                          \
+        }                                                                                           \
+    }                                                                                               \
     PRINT_RETURN_STATUS
 
 #define CALL_HTENSILE(PREC, TYPE, TRANS)                                         \


### PR DESCRIPTION
This is re-submit for #366 
To solve the performance degrade in Dgemm (C += A*B ) caused by unnecessary chunking.

With matrix A, chunking should only be done with the other dimension when the Leading Dimension is the same as the Summation Dimension, more specifically,  Matrix A should only be chunked along the "m" dimension when trans_a is rocblas_operation_transpose.  When trans_a is rocblas_operation_none, it does not do any help to chunk A. 

The situation for B is different. Chunking of Matrix B  is acceptable even when the Lead Dimension is not the Summation Dimension, since in such case, chunking of B along the "n" dimension can make C chunked along the "n" dimension and thus chunks of C can fit into 32-bit offset space.  But when B is chunked along "n" dimension, StrideB should not be used for determining n_chunk_size_b. 

The patch has passed the testing of 

  ./rocblas-test --gtest_filter=nightly_blas3_chunk/parameterized_chunk_gemm*



-  
-  
-  
