### PR TITLE
change midnight trigger 3 to 1am

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 // Mostly generated from snippet generator 'properties; set job properties'
 // Time-based triggers added to execute nightly tests, eg '30 2 * * *' means 2:30 AM
 properties([
-    pipelineTriggers([cron('0 3 * * *'), [$class: 'PeriodicFolderTrigger', interval: '5m']]),
+    pipelineTriggers([cron('0 1 * * *'), [$class: 'PeriodicFolderTrigger', interval: '5m']]),
     buildDiscarder(logRotator(
       artifactDaysToKeepStr: '',
       artifactNumToKeepStr: '',


### PR DESCRIPTION
- When CI resources are under stress the nightly testing that starts at 3am is not complete by the next day.
- This results in a backup in the CI queues in the day when people are trying to get pull requests to run in CI.
- There is often an idle period in CI from 1am to 3am.
- It should help reduce backup to trigger the nightly builds at 1am in place of 3am