### PR TITLE
Guard the CXX Compiler check if not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,14 @@ project( rocblas LANGUAGES CXX )
 # Main
 # ########################################################################
 
-# Determine if CXX Compiler is hcc, hip-clang or nvcc
-execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE)
-string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
-string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
+if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hcc$")
+  # Determine if CXX Compiler is hcc, hip-clang or nvcc
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_STRIP_TRAILING_WHITESPACE)
+  string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
+  string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
+endif()
 
 if( CXX_VERSION_STRING MATCHES "clang" )
   message( STATUS "Use hip-clang to build for amdgpu backend" )


### PR DESCRIPTION
It's possible for there not to have a CMAKE_CXX_COMPILER. We will run into REGEX errors if the number of arguments don't exceed 5.

Summary of proposed changes:
-  Add guard to check CMAKE_CXX_COMPILER is either hcc or hipcc
-  This will prevent having an empty arguments going into string(REGEX MATCH
