### PR TITLE
change gemm_ex solution_index from uint32_t to int32_t

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -200,7 +200,7 @@ int main(int argc, char* argv[])
          "extended precision gemm algorithm")
         
         ("solution_index",
-         po::value<uint32_t>(&argus.solution_index)->default_value(0),
+         po::value<int32_t>(&argus.solution_index)->default_value(0),
          "extended precision gemm solution index")
         
         ("flags",

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -43,7 +43,7 @@ void testing_gemm_ex_bad_arg()
     const float beta_float  = 1.0;
 
     rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
-    rocblas_int solution_index;
+    int32_t solution_index;
     rocblas_int flags;
     size_t* workspace_size = 0;
     void* workspace;
@@ -327,10 +327,10 @@ rocblas_status testing_gemm_ex_template(rocblas_operation transA,
                                         rocblas_datatype d_type,
                                         rocblas_datatype compute_type)
 {
-    rocblas_gemm_algo algo  = rocblas_gemm_algo_standard;
-    uint32_t solution_index = 0;
-    uint32_t flags          = 0;
-    size_t* workspace_size  = 0;
+    rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
+    int32_t solution_index = 0;
+    uint32_t flags         = 0;
+    size_t* workspace_size = 0;
     void* workspace;
 
     Td h_alpha_Td;

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -52,7 +52,7 @@ void testing_gemm_strided_batched_ex_bad_arg()
     const float beta_float  = 1.0;
 
     rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
-    rocblas_int solution_index;
+    int32_t solution_index;
     rocblas_int flags;
     size_t* workspace_size = 0;
     void* workspace;
@@ -376,10 +376,10 @@ rocblas_status testing_gemm_strided_batched_ex_template(rocblas_operation transA
                                                         rocblas_datatype d_type,
                                                         rocblas_datatype compute_type)
 {
-    rocblas_gemm_algo algo  = rocblas_gemm_algo_standard;
-    uint32_t solution_index = 0;
-    uint32_t flags          = 0;
-    size_t* workspace_size  = 0;
+    rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
+    int32_t solution_index = 0;
+    uint32_t flags         = 0;
+    size_t* workspace_size = 0;
     void* workspace;
 
     Td h_alpha_Td;

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -257,7 +257,7 @@ void testing_logging()
             double alpha_double     = static_cast<double>(alpha_float);
             double beta_double      = static_cast<double>(beta_float);
             rocblas_gemm_algo algo  = rocblas_gemm_algo_standard;
-            uint32_t solution_index = 0;
+            int32_t solution_index  = 0;
             uint32_t flags          = 0;
             size_t* workspace_size  = 0;
             void* workspace         = 0;
@@ -685,11 +685,11 @@ void testing_logging()
                 compute_type = rocblas_datatype_f64_r;
             }
 
-            rocblas_gemm_algo algo  = rocblas_gemm_algo_standard;
-            uint32_t solution_index = 0;
-            uint32_t flags          = 0;
-            size_t* workspace_size  = 0;
-            void* workspace         = 0;
+            rocblas_gemm_algo algo = rocblas_gemm_algo_standard;
+            int32_t solution_index = 0;
+            uint32_t flags         = 0;
+            size_t* workspace_size = 0;
+            void* workspace        = 0;
 
             trace_ofs2 << "rocblas_gemm_ex"
                        << "," << transA << "," << transB << "," << m << "," << n << "," << k << ","

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -528,10 +528,10 @@ class Arguments
 
     rocblas_int iters = 10;
 
-    uint32_t algo           = 0;
-    uint32_t solution_index = 0;
-    uint32_t flags          = 0;
-    size_t workspace_size   = 0;
+    uint32_t algo          = 0;
+    int32_t solution_index = 0;
+    uint32_t flags         = 0;
+    size_t workspace_size  = 0;
 
     Arguments& operator=(const Arguments& rhs)
     {

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1419,7 +1419,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(rocblas_handle handle,
                                               rocblas_int ldd,
                                               rocblas_datatype compute_type,
                                               rocblas_gemm_algo algo,
-                                              uint32_t solution_index,
+                                              int32_t solution_index,
                                               uint32_t flags,
                                               size_t* workspace_size,
                                               void* workspace);
@@ -1451,7 +1451,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle han
                                                               rocblas_int batch_count,
                                                               rocblas_datatype compute_type,
                                                               rocblas_gemm_algo algo,
-                                                              uint32_t solution_index,
+                                                              int32_t solution_index,
                                                               uint32_t flags,
                                                               size_t* workspace_size,
                                                               void* workspace);

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -99,7 +99,7 @@
               enumerant specifying the algorithm type.
     @param[in]
     solution_index
-              uint32_t
+              int32_t
               reserved for future use
     @param[in]
     flags     uint32_t
@@ -136,7 +136,7 @@ extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle handle,
                                           rocblas_int ldd,
                                           rocblas_datatype compute_type,
                                           rocblas_gemm_algo algo,
-                                          uint32_t solution_index,
+                                          int32_t solution_index,
                                           uint32_t flags,
                                           size_t* workspace_size,
                                           void* workspace)
@@ -542,7 +542,7 @@ extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle handle,
               enumerant specifying the algorithm type.
     @param[in]
     solution_index
-              uint32_t
+              int32_t
               reserved for future use
     @param[in]
     flags     uint32_t
@@ -584,7 +584,7 @@ extern "C" rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle handle,
                                                           rocblas_int batch_count,
                                                           rocblas_datatype compute_type,
                                                           rocblas_gemm_algo algo,
-                                                          uint32_t solution_index,
+                                                          int32_t solution_index,
                                                           uint32_t flags,
                                                           size_t* workspace_size,
                                                           void* workspace)


### PR DESCRIPTION
For gemm_ex and gemm_strided_batched_ex change solution_index from uint32_t to int32_t. 

This will enable setting positive values 0,1,2,3,... for solution indices, and negative value like -1 to use the default