### PR TITLE
remove mcpu=gfx906 flag because gfx906 dot4 instructions removed from…

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -60,7 +60,7 @@ if( BUILD_WITH_TENSILE )
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
     # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument -mcpu=gfx906)
+    target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument)
   endif( )
 
   if( ROCBLAS_SHARED_LIBS )


### PR DESCRIPTION
- remove mcpu=gfx906 flag because gfx906 dot4 instruction for i8 gemm is removed from Tensile
- merge after Tensile PR#397  https://github.com/ROCmSoftwarePlatform/Tensile/pull/397 
