### PR TITLE
Changed Int8 tests to properly pack the matrix to the expected format

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -786,8 +786,6 @@ void cblas_gemm<int8_t, int32_t>(rocblas_operation transA,
     // NOTE: This will not properly account for 32-bit integer overflow, however
     //       the result should be acceptable for testing.
 
-    // NOTE: Packing is always done along 'K' dimension, which means unpacking to
-    //       double depends on transpose mode
     size_t const sizeA = ((transA == rocblas_operation_none) ? k : m) * static_cast<size_t>(lda);
     size_t const sizeB = ((transB == rocblas_operation_none) ? n : k) * static_cast<size_t>(ldb);
     size_t const sizeC = n * static_cast<size_t>(ldc);
@@ -796,48 +794,14 @@ void cblas_gemm<int8_t, int32_t>(rocblas_operation transA,
     host_vector<double> B_double(sizeB);
     host_vector<double> C_double(sizeC);
 
-    if(transA == rocblas_operation_none)
+    for(int i = 0; i < sizeA; i++)
     {
-        for(int colBase = 0; colBase < k; colBase += 4)
-        {
-            for(int row = 0; row < m; row++)
-            {
-                for(int colOffset = 0; colOffset < 4; colOffset++)
-                {
-                    A_double[(colBase + colOffset) * lda + row] =
-                        static_cast<double>(A[colBase * lda + row * 4 + colOffset]);
-                }
-            }
-        }
-    }
-    else
-    {
-        for(int i = 0; i < sizeA; i++)
-        {
-            A_double[i] = static_cast<double>(A[i]);
-        }
+        A_double[i] = static_cast<double>(A[i]);
     }
 
-    if(transB == rocblas_operation_transpose)
+    for(int i = 0; i < sizeB; i++)
     {
-        for(int colBase = 0; colBase < k; colBase += 4)
-        {
-            for(int row = 0; row < n; row++)
-            {
-                for(int colOffset = 0; colOffset < 4; colOffset++)
-                {
-                    B_double[(colBase + colOffset) * ldb + row] =
-                        static_cast<double>(B[colBase * ldb + row * 4 + colOffset]);
-                }
-            }
-        }
-    }
-    else
-    {
-        for(int i = 0; i < sizeB; i++)
-        {
-            B_double[i] = static_cast<double>(B[i]);
-        }
+        B_double[i] = static_cast<double>(B[i]);
     }
 
     for(int i = 0; i < sizeC; i++)

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -253,7 +253,7 @@ const vector<vector<int>> deepbench_size_range = {
     {  256,    64,  3136,  3136,  3136,   256,   256},
     {   25,    64, 27920, 27920, 27920,    25,    25},
     {   27,    64,  2916,  2916,  2916,    27,    27},
-//    {   27,    64, 50176, 50176, 50176,    27,    27}, TODO: May cause int32 overflow for results
+    {   27,    64, 50176, 50176, 50176,    27,    27},
     {  288,    64,  1440,  1440,  1440,   288,   288},
     { 3200,   256,  1653,  1653,  1653,  3200,  3200},
     { 4608,   512,   196,   196,   196,  4608,  4608},
@@ -535,6 +535,16 @@ TEST_P(parameterized_gemm_ex, standard)
         else if(arg.ldc < arg.M || arg.ldd < arg.M)
         {
             EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else if((arg.a_type == rocblas_datatype_i8_r) &&
+                ((arg.K % 4 != 0) || (arg.transA_option == 'T' && arg.lda % 4 != 0) ||
+                 (arg.transB_option == 'N' && arg.ldb % 4 != 0)))
+        {
+            EXPECT_EQ(rocblas_status_invalid_size, status);
+        }
+        else
+        {
+            FAIL() << "Unexpected failure: " << status;
         }
     }
 }

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -686,14 +686,13 @@ inline void rocblas_packInt8(host_vector<T>& A, rocblas_int M, rocblas_int N, ro
 
     host_vector<T> temp(A);
 
-    size_t idx = 0;
     for(int colBase = 0; colBase < N; colBase += 4)
     {
         for(int row = 0; row < lda; row++)
         {
             for(int colOffset = 0; colOffset < 4; colOffset++)
             {
-                A[idx++] = temp[(colBase + colOffset) * lda + row];
+                A[(colBase * lda + 4 * row) + colOffset] = temp[(colBase + colOffset) * lda + row];
             }
         }
     }

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -659,6 +659,47 @@ void rocblas_print_vector(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_in
 };
 
 /* ============================================================================================ */
+/*! \brief  Packs matricies into groups of 4 in N */
+template <typename T>
+inline void rocblas_packInt8(host_vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
+{
+    /* Assumes original matrix provided in column major order, where N is a multiple of 4
+
+        ---------- N ----------
+   |  | 00 05 10 15 20 25 30 35      |00 05 10 15|20 25 30 35|
+   |  | 01 06 11 16 21 26 31 36      |01 06 11 16|21 26 31 36|
+   l  M 02 07 12 17 22 27 32 37  --> |02 07 12 17|22 27 32 37|
+   d  | 03 08 13 18 23 28 33 38      |03 08 13 18|23 28 33 38|
+   a  | 04 09 14 19 24 29 34 39      |04 09 14 19|24 29 34 39|
+   |    ** ** ** ** ** ** ** **      |** ** ** **|** ** ** **|
+   |    ** ** ** ** ** ** ** **      |** ** ** **|** ** ** **|
+
+     Input :  00 01 02 03 04 ** ** 05   ...  38 39 ** **
+     Output:  00 05 10 15 01 06 11 16   ...  ** ** ** **
+
+   */
+
+    if(N % 4 != 0)
+    {
+        std::cerr << "ERROR: dimension must be a multiple of 4 in order to pack" << std::endl;
+    }
+
+    host_vector<T> temp(A);
+
+    size_t idx = 0;
+    for(int colBase = 0; colBase < N; colBase += 4)
+    {
+        for(int row = 0; row < lda; row++)
+        {
+            for(int colOffset = 0; colOffset < 4; colOffset++)
+            {
+                A[idx++] = temp[(colBase + colOffset) * lda + row];
+            }
+        }
+    }
+}
+
+/* ============================================================================================ */
 /*! \brief  turn float -> 's', double -> 'd', rocblas_float_complex -> 'c', rocblas_double_complex
  * -> 'z' */
 template <typename T>

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -439,7 +439,7 @@ extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle handle,
             compute_type == rocblas_datatype_i32_r)
     {
         // For now, K must be a multiple of 4, and/or LDA/LDB based on transpose mode
-        if(k % 4 != 0 || (trans_a != rocblas_operation_none && lda % 4 != 0) ||
+        if(k % 4 != 0 || (trans_a == rocblas_operation_transpose && lda % 4 != 0) ||
            (trans_b == rocblas_operation_none && ldb % 4 != 0))
         {
             rb_status = rocblas_status_invalid_size;
@@ -951,7 +951,7 @@ extern "C" rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle handle,
             compute_type == rocblas_datatype_i32_r)
     {
         // For now, K must be a multiple of 4
-        if(k % 4 != 0 || ((trans_a != rocblas_operation_none) && (lda % 4 != 0)) ||
+        if(k % 4 != 0 || ((trans_a == rocblas_operation_transpose) && (lda % 4 != 0)) ||
            ((trans_b == rocblas_operation_none) && (ldb % 4 != 0)) || stride_a % 4 != 0 ||
            stride_b % 4 != 0)
         {


### PR DESCRIPTION
Summary of proposed changes:
-  Replaced Int8 testing cblas unpacking code with rocblas packing code. Matricies sent to compare should now be in the expected format, with overflow issues for larger sizes fixed.
-  Force a test fail if an unexpected error code is returned. 
-  Added invalid Int8 specific matrix sizes to expected errors.
