### PR TITLE
Fix HIP package directory for HIP/VDI runtime

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -35,7 +35,8 @@ if( NOT TARGET rocblas )
 endif( )
 
 # Hip headers required of all clients; clients use hip to allocate device memory
-find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
+list( APPEND CMAKE_PREFIX_PATH /opt/rocm )
+find_package( hip REQUIRED CONFIG PATHS ${CMAKE_PREFIX_PATH} )
 
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend


### PR DESCRIPTION
HIP may be installed to a directory other than /opt/rocm/hip.

Application should respect CMAKE_PREFIX_PATH and try to look for package from there first.
Unless it is not set then look in /opt/rocm.

resolves build failure with hip-clang and HIP/VDI runtime.

Summary of proposed changes:
-  find HIP at CMAKE_PREFIX_PATH
-  
-  
