### PR TITLE
Library Versioning Enabled for rocblas-bench and rocblas-test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ include( ROCMInstallTargets )
 include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
-rocm_setup_version( VERSION 0.15.3.4 NO_GIT_TAG_VERSION )
+rocm_setup_version( VERSION 0.15.3.4 PARSE_VERSION )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -623,7 +623,9 @@ int main(int argc, char* argv[])
          value<rocblas_int>(&device_id)->default_value(0),
          "Set default device to be used for subsequent program runs")
 
-        ("help,h", "produces this help message");
+        ("help,h", "produces this help message")
+
+        ("version", "Prints the version number");
     // clang-format on
 
     variables_map vm;
@@ -636,6 +638,13 @@ int main(int argc, char* argv[])
         return 0;
     }
 
+    if(vm.find("version") != vm.end())
+    {
+        char blas_version[100];
+        rocblas_get_version_string(blas_version, 100);
+        std::cout << "rocBLAS version: " << blas_version << std::endl;
+        return 0;
+    }
     // Device Query
     rocblas_int device_count = query_device_property();
 

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -35,6 +35,11 @@ int main(int argc, char** argv)
     // Open data file
     RocBLAS_TestData::init(exepath() + GTEST_DATA);
 
+    // Print Version
+    char blas_version[100];
+    rocblas_get_version_string(blas_version, 100);
+    printf("rocBLAS version: %s\n\n", blas_version);
+
     // Device Query
 
     int device_id = 0;

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1456,6 +1456,15 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle han
                                                               size_t* workspace_size,
                                                               void* workspace);
 
+
+
+/*
+ * ===========================================================================
+ *    build information
+ * ===========================================================================
+ */
+ROCBLAS_EXPORT rocblas_status rocblas_get_version_string(char *buf, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set( rocblas_auxiliary_source
   utility.cpp
   rocblas_auxiliary.cpp
   status.cpp
+  buildinfo.cpp
 )
 
 set( rocblas_ex_source

--- a/library/src/buildinfo.cpp
+++ b/library/src/buildinfo.cpp
@@ -1,0 +1,39 @@
+/* ************************************************************************
+ * Copyright 2018 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <sstream>
+#include <string.h>
+#include "definitions.h"
+#include "rocblas-types.h"
+#include "rocblas-functions.h"
+#include "rocblas-version.h"
+
+#define TO_STR2(x) #x
+#define TO_STR(x) TO_STR2(x)
+#define VERSION_STRING \
+    (TO_STR(ROCBLAS_VERSION_MAJOR) "." \
+TO_STR(ROCBLAS_VERSION_MINOR) "." \
+TO_STR(ROCBLAS_VERSION_PATCH) "." \
+TO_STR(ROCBLAS_VERSION_TWEAK))
+
+/*******************************************************************************
+ *! \brief   loads char* buf with the rocblas library version. size_t len
+     is the maximum length of char* buf.
+ ******************************************************************************/
+extern "C" rocblas_status rocblas_get_version_string(char* buf, size_t len)
+{
+    std::string v(VERSION_STRING);
+    strcpy(buf, v.c_str());
+
+    if(buf == NULL)
+        return rocblas_status_internal_error;
+
+    size_t count = std::min(len - 1, v.length());
+    memcpy(buf, v.c_str(), count);
+    *(buf + count) = '\0';
+
+    return rocblas_status_success;
+}


### PR DESCRIPTION
Summary of proposed changes:
- Added API call for rocblas library version. 
- Added --version option to rocblas-bench
- Added printing of library version to rocblas-test by default
