### PR TITLE
Removed git commit ID from librocblas.so filename. Fixed dirty commit IDs on Jenkins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,18 @@ include( ROCMInstallTargets )
 include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
-rocm_setup_version( VERSION 0.15.3.4 PARSE_VERSION )
+set ( VERSION_STRING "0.15.3." )
+# Check if BUILD_NUMBER is defined in a Jenkins envirnment
+if ($ENV{BUILD_NUMBER} )
+  string(CONCAT BUILD_VERSION ${VERSION_STRING} $ENV{BUILD_NUMBER}) 
+else ()
+  string(CONCAT BUILD_VERSION ${VERSION_STRING} "0") 
+endif ()
+rocm_setup_version( VERSION ${BUILD_VERSION} NO_GIT_TAG_VERSION )
+
+# Get the git tag version
+include ( cmake/version.cmake )
+rocm_get_git_commit_id ( rocblas_VERSION_COMMIT_ID )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,18 +129,7 @@ void checkout_and_version( project_paths paths )
       extensions: scm.extensions + [[$class: 'CleanCheckout']],
       userRemoteConfigs: scm.userRemoteConfigs
     ])
-
-    if( fileExists( 'CMakeLists.txt' ) )
-    {
-      def cmake_version_file = readFile( 'CMakeLists.txt' ).trim()
-      //echo "cmake_version_file:\n${cmake_version_file}"
-
-      cmake_version_file = cmake_version_file.replaceAll(/(\d+\.)(\d+\.)(\d+\.)\d+/, "\$1\$2\$3${env.BUILD_ID}")
-      //echo "cmake_version_file:\n${cmake_version_file}"
-      writeFile( file: 'CMakeLists.txt', text: cmake_version_file )
-    }
   }
-
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,51 @@
+###############################################################################
+# Copyright (C) 2018 Advanced Micro Devices, Inc.
+################################################################################
+
+# TODO: move this function to https://github.com/RadeonOpenCompute/rocm-cmake/blob/master/share/rocm/cmake/ROCMSetupVersion.cmake
+
+macro(rocm_set_parent VAR)
+  set(${VAR} ${ARGN} PARENT_SCOPE)
+  set(${VAR} ${ARGN})
+endmacro()
+
+function(rocm_get_git_commit_id OUTPUT_VERSION)
+  set(options)
+  set(oneValueArgs VERSION DIRECTORY)
+  set(multiValueArgs)
+
+  cmake_parse_arguments(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  set(_version ${PARSE_VERSION})
+
+  set(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  if(PARSE_DIRECTORY)
+    set(DIRECTORY ${PARSE_DIRECTORY})
+  endif()
+
+  find_program(GIT NAMES git)
+
+  if(GIT)
+    set(GIT_COMMAND ${GIT} describe --dirty --long --match [0-9]*)
+    execute_process(COMMAND ${GIT_COMMAND}
+      WORKING_DIRECTORY ${DIRECTORY}
+      OUTPUT_VARIABLE GIT_TAG_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE RESULT
+      ERROR_QUIET)
+    if(${RESULT} EQUAL 0)
+      set(_version ${GIT_TAG_VERSION})
+    else()
+      execute_process(COMMAND ${GIT_COMMAND} --always
+	WORKING_DIRECTORY ${DIRECTORY}
+	OUTPUT_VARIABLE GIT_TAG_VERSION
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	RESULT_VARIABLE RESULT
+	ERROR_QUIET)
+      if(${RESULT} EQUAL 0)
+	set(_version ${GIT_TAG_VERSION})
+      endif()
+    endif()
+  endif()
+  rocm_set_parent(${OUTPUT_VERSION} ${_version})
+endfunction()

--- a/library/include/rocblas-version.h.in
+++ b/library/include/rocblas-version.h.in
@@ -8,10 +8,11 @@
 #define ROCBLAS_VERSION_H_
 
 // clang-format off
-#define ROCBLAS_VERSION_MAJOR @rocblas_VERSION_MAJOR@
-#define ROCBLAS_VERSION_MINOR @rocblas_VERSION_MINOR@
-#define ROCBLAS_VERSION_PATCH @rocblas_VERSION_PATCH@
-#define ROCBLAS_VERSION_TWEAK @rocblas_VERSION_TWEAK@
+#define ROCBLAS_VERSION_MAJOR       @rocblas_VERSION_MAJOR@
+#define ROCBLAS_VERSION_MINOR       @rocblas_VERSION_MINOR@
+#define ROCBLAS_VERSION_PATCH       @rocblas_VERSION_PATCH@
+#define ROCBLAS_VERSION_TWEAK       @rocblas_VERSION_TWEAK@
+#define ROCBLAS_VERSION_COMMIT_ID   @rocblas_VERSION_COMMIT_ID@
 // clang-format on
 
 #endif

--- a/library/src/buildinfo.cpp
+++ b/library/src/buildinfo.cpp
@@ -13,12 +13,14 @@
 
 #define TO_STR2(x) #x
 #define TO_STR(x) TO_STR2(x)
-#define VERSION_STRING \
+// clang-format off
+#define VERSION_STRING                 \
     (TO_STR(ROCBLAS_VERSION_MAJOR) "." \
-TO_STR(ROCBLAS_VERSION_MINOR) "." \
-TO_STR(ROCBLAS_VERSION_PATCH) "." \
-TO_STR(ROCBLAS_VERSION_TWEAK))
-
+     TO_STR(ROCBLAS_VERSION_MINOR) "." \
+     TO_STR(ROCBLAS_VERSION_PATCH) "." \
+     TO_STR(ROCBLAS_VERSION_TWEAK) "-" \
+     TO_STR(ROCBLAS_VERSION_COMMIT_ID))
+// clang-format on
 /*******************************************************************************
  *! \brief   loads char* buf with the rocblas library version. size_t len
      is the maximum length of char* buf.


### PR DESCRIPTION
Summary of proposed changes:
-  Removed git commit ID from libocblas.so filename.-  
-  Fixed dirty commit IDs on Jenkins

