### PR TITLE
Linking README.md to readthedoc latest documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ programming language and optimized for AMD's GPUs.
 |**ROCm**     | **R**adeon **O**pen **C**ompute platfor**m**                |
 |**HIP**      | **H**eterogeneous-Compute **I**nterface for **P**ortability |
 
+## Documentation
+The latest rocBLAS documentation and API description can be found [here](https://rocblas.readthedocs.io/en/latest/).
+
 ## Prerequisites
 * A ROCm enabled platform, more information at [https://rocm.github.io/install.html](https://rocm.github.io/install.html).
 * Base software stack, which includes
@@ -24,7 +27,6 @@ sudo apt-get install rocblas
 rocBLAS Debian packages can also be downloaded from the 
 [rocBLAS releases tag](https://github.com/ROCmSoftwarePlatform/rocBLAS/releases). 
 These may be newer than the package from apt-get. 
-
 
 ## Building rocBLAS from source, exported functions, and additional information
 


### PR DESCRIPTION
Minor changes only to link README to the latest version of documentation at https://rocblas.readthedocs.io/en/latest/. 