### PR TITLE
ROCM2.0 fix: half2 to rocblas_half2

### DIFF
--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -108,13 +108,13 @@ haxpy_mlt_8_device_scalar(int n_mlt_8, const _Float16* alpha, const half8* x, ha
 {
     int tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 
-    half2 alpha_h2;
+    rocblas_half2 alpha_h2;
     alpha_h2[0] = (*alpha);
     alpha_h2[1] = (*alpha);
 
-    half2 y0, y1, y2, y3;
-    half2 x0, x1, x2, x3;
-    half2 z0, z1, z2, z3;
+    rocblas_half2 y0, y1, y2, y3;
+    rocblas_half2 x0, x1, x2, x3;
+    rocblas_half2 z0, z1, z2, z3;
 
     if(tid * 8 < n_mlt_8)
     {
@@ -152,13 +152,14 @@ haxpy_mlt_8_device_scalar(int n_mlt_8, const _Float16* alpha, const half8* x, ha
     }
 }
 
-__global__ void haxpy_mlt_8_host_scalar(int n_mlt_8, const half2 alpha, const half8* x, half8* y)
+__global__ void
+haxpy_mlt_8_host_scalar(int n_mlt_8, const rocblas_half2 alpha, const half8* x, half8* y)
 {
     int tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 
-    half2 y0, y1, y2, y3;
-    half2 x0, x1, x2, x3;
-    half2 z0, z1, z2, z3;
+    rocblas_half2 y0, y1, y2, y3;
+    rocblas_half2 x0, x1, x2, x3;
+    rocblas_half2 z0, z1, z2, z3;
 
     if(tid * 8 < n_mlt_8)
     {
@@ -356,7 +357,7 @@ rocblas_status rocblas_axpy_half(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    if(1 != incx || 1 != incy) // slow code, no half8 or half2
+    if(1 != incx || 1 != incy) // slow code, no half8 or rocblas_half2
     {
         int blocks = ((n - 1) / NB_X) + 1;
 
@@ -401,7 +402,7 @@ rocblas_status rocblas_axpy_half(rocblas_handle handle,
                                incy);
         }
     }
-    else // half8 load-store and half2 arithmetic
+    else // half8 load-store and rocblas_half2 arithmetic
     {
         rocblas_int n_mlt_8 = (n / 8) * 8; // multiple of 8
         rocblas_int n_mod_8 = n - n_mlt_8; // n mod 8
@@ -446,7 +447,7 @@ rocblas_status rocblas_axpy_half(rocblas_handle handle,
                 return rocblas_status_success;
             }
 
-            half2 half2_alpha;
+            rocblas_half2 half2_alpha;
             half2_alpha[0] = *reinterpret_cast<const _Float16*>(alpha);
             half2_alpha[1] = *reinterpret_cast<const _Float16*>(alpha);
 

--- a/library/src/include/definitions.h
+++ b/library/src/include/definitions.h
@@ -16,10 +16,13 @@
 
 // half vectors
 typedef _Float16 half8 __attribute__((ext_vector_type(8)));
-typedef _Float16 half2 __attribute__((ext_vector_type(2)));
-extern "C" __device__ half2 llvm_fma_v2f16(half2, half2, half2) __asm("llvm.fma.v2f16");
+typedef _Float16 rocblas_half2 __attribute__((ext_vector_type(2)));
+extern "C" __device__ rocblas_half2 llvm_fma_v2f16(rocblas_half2,
+                                                   rocblas_half2,
+                                                   rocblas_half2) __asm("llvm.fma.v2f16");
 
-__device__ inline half2 rocblas_fmadd_half2(half2 multiplier, half2 multiplicand, half2 addend)
+__device__ inline rocblas_half2
+rocblas_fmadd_half2(rocblas_half2 multiplier, rocblas_half2 multiplicand, rocblas_half2 addend)
 {
     return llvm_fma_v2f16(multiplier, multiplicand, addend);
 };


### PR DESCRIPTION
- ROCm 2.0 has include file hip_fp16.h that defines half2
- change name in rocBLAS from half2 to rocblas_half2 
- rocBLAS was using half before it was a data-type in ROCm
