### PR TITLE
TRSM optimizations - reduce copies and smaller trtri kernel sizes

### DIFF
--- a/library/src/blas3/rocblas_trsm.cpp
+++ b/library/src/blas3/rocblas_trsm.cpp
@@ -52,7 +52,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
             // left, lower no-transpose
             jb = min(BLOCK, m);
             rocblas_gemm_template<T>(
-                handle, transA, transB, jb, n, jb, alpha, invA, BLOCK, B, ldb, &zero, X, ldb);
+                handle, transA, transB, jb, n, jb, alpha, invA, BLOCK, B, ldb, &zero, X, m);
             if(BLOCK < m)
             {
                 rocblas_gemm_template<T>(handle,
@@ -65,7 +65,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                          A(BLOCK, 0),
                                          lda,
                                          X,
-                                         ldb,
+                                         m,
                                          alpha,
                                          B(BLOCK, 0),
                                          ldb);
@@ -87,7 +87,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              ldb,
                                              &zero,
                                              X(i, 0),
-                                             ldb);
+                                             m);
                     if(i + BLOCK >= m) // this condition is not necessary at all and can be changed
                                        // as if (i+BLOCK<m)
                         break;
@@ -102,7 +102,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              A(i + BLOCK, i),
                                              lda,
                                              X(i, 0),
-                                             ldb,
+                                             m,
                                              &one,
                                              B(i + BLOCK, 0),
                                              ldb);
@@ -141,7 +141,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                      ldb,
                                      &zero,
                                      X(i, 0),
-                                     ldb);
+                                     m);
             if(i - BLOCK >= 0)
             {
 
@@ -155,7 +155,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                          A(0, i),
                                          lda,
                                          X(i, 0),
-                                         ldb,
+                                         m,
                                          alpha,
                                          B,
                                          ldb);
@@ -177,7 +177,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              ldb,
                                              &zero,
                                              X(i, 0),
-                                             ldb);
+                                             m);
                     if(i - BLOCK < 0)
                         break;
                     rocblas_gemm_template<T>(handle,
@@ -190,7 +190,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              A(0, i),
                                              lda,
                                              X(i, 0),
-                                             ldb,
+                                             m,
                                              &one,
                                              B,
                                              ldb);
@@ -218,7 +218,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                      ldb,
                                      &zero,
                                      X(i, 0),
-                                     ldb);
+                                     m);
             if(i - BLOCK >= 0)
             {
                 rocblas_gemm_template<T>(handle,
@@ -231,7 +231,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                          A(i, 0),
                                          lda,
                                          X(i, 0),
-                                         ldb,
+                                         m,
                                          alpha,
                                          B,
                                          ldb);
@@ -252,7 +252,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              ldb,
                                              &zero,
                                              X(i, 0),
-                                             ldb);
+                                             m);
                     if(i - BLOCK < 0)
                         break;
                     rocblas_gemm_template<T>(handle,
@@ -265,7 +265,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              A(i, 0),
                                              lda,
                                              X(i, 0),
-                                             ldb,
+                                             m,
                                              &one,
                                              B,
                                              ldb);
@@ -277,7 +277,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
             // left, upper transpose
             jb = min(BLOCK, m);
             rocblas_gemm_template<T>(
-                handle, transA, transB, jb, n, jb, alpha, invA, BLOCK, B, ldb, &zero, X, ldb);
+                handle, transA, transB, jb, n, jb, alpha, invA, BLOCK, B, ldb, &zero, X, m);
             if(BLOCK < m)
             {
                 rocblas_gemm_template<T>(handle,
@@ -290,7 +290,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                          A(0, BLOCK),
                                          lda,
                                          X,
-                                         ldb,
+                                         m,
                                          alpha,
                                          B(BLOCK, 0),
                                          ldb);
@@ -312,7 +312,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              ldb,
                                              &zero,
                                              X(i, 0),
-                                             ldb);
+                                             m);
                     if(i + BLOCK >= m)
                         break;
                     rocblas_gemm_template<T>(handle,
@@ -325,7 +325,7 @@ rocblas_status rocblas_trsm_left(rocblas_handle handle,
                                              A(i, i + BLOCK),
                                              lda,
                                              X(i, 0),
-                                             ldb,
+                                             m,
                                              &one,
                                              B(i + BLOCK, 0),
                                              ldb);
@@ -382,7 +382,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                      BLOCK,
                                      &zero,
                                      X(0, i),
-                                     ldb);
+                                     m);
             if(i - BLOCK >= 0)
             {
                 rocblas_gemm_template<T>(handle,
@@ -393,7 +393,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                          jb,
                                          &negtive_one,
                                          X(0, i),
-                                         ldb,
+                                         m,
                                          A(i, 0),
                                          lda,
                                          alpha,
@@ -416,7 +416,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &zero,
                                              X(0, i),
-                                             ldb);
+                                             m);
                     if(i - BLOCK < 0)
                         break;
                     rocblas_gemm_template<T>(handle,
@@ -427,7 +427,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &negtive_one,
                                              X(0, i),
-                                             ldb,
+                                             m,
                                              A(i, 0),
                                              lda,
                                              &one,
@@ -441,7 +441,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
             // right, upper no-transpose
             jb = min(BLOCK, n);
             rocblas_gemm_template<T>(
-                handle, transB, transA, m, jb, jb, alpha, B, ldb, invA, BLOCK, &zero, X, ldb);
+                handle, transB, transA, m, jb, jb, alpha, B, ldb, invA, BLOCK, &zero, X, m);
             if(BLOCK < n)
             {
                 rocblas_gemm_template<T>(handle,
@@ -452,7 +452,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                          BLOCK,
                                          &negtive_one,
                                          X,
-                                         ldb,
+                                         m,
                                          A(0, BLOCK),
                                          lda,
                                          alpha,
@@ -476,7 +476,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &zero,
                                              X(0, i),
-                                             ldb);
+                                             m);
                     if(i + BLOCK >= n)
                         break;
                     rocblas_gemm_template<T>(handle,
@@ -487,7 +487,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &negtive_one,
                                              X(0, i),
-                                             ldb,
+                                             m,
                                              A(i, i + BLOCK),
                                              lda,
                                              &one,
@@ -504,7 +504,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
             // right, lower transpose
             jb = min(BLOCK, n);
             rocblas_gemm_template<T>(
-                handle, transB, transA, m, jb, jb, alpha, B, ldb, invA, BLOCK, &zero, X, ldb);
+                handle, transB, transA, m, jb, jb, alpha, B, ldb, invA, BLOCK, &zero, X, m);
             if(BLOCK < n)
             {
                 rocblas_gemm_template<T>(handle,
@@ -515,7 +515,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                          BLOCK,
                                          &negtive_one,
                                          X,
-                                         ldb,
+                                         m,
                                          A(BLOCK, 0),
                                          lda,
                                          alpha,
@@ -539,7 +539,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &zero,
                                              X(0, i),
-                                             ldb);
+                                             m);
                     if(i + BLOCK >= n)
                         break;
                     rocblas_gemm_template<T>(handle,
@@ -550,7 +550,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &negtive_one,
                                              X(0, i),
-                                             ldb,
+                                             m,
                                              A(BLOCK + i, i),
                                              lda,
                                              &one,
@@ -577,7 +577,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                      BLOCK,
                                      &zero,
                                      X(0, i),
-                                     ldb);
+                                     m);
             if(i - BLOCK >= 0)
             {
                 rocblas_gemm_template<T>(handle,
@@ -588,7 +588,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                          jb,
                                          &negtive_one,
                                          X(0, i),
-                                         ldb,
+                                         m,
                                          A(0, i),
                                          lda,
                                          alpha,
@@ -611,7 +611,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &zero,
                                              X(0, i),
-                                             ldb);
+                                             m);
                     if(i - BLOCK < 0)
                         break;
                     rocblas_gemm_template<T>(handle,
@@ -622,7 +622,7 @@ rocblas_status rocblas_trsm_right(rocblas_handle handle,
                                              BLOCK,
                                              &negtive_one,
                                              X(0, i),
-                                             ldb,
+                                             m,
                                              A(0, i),
                                              lda,
                                              &one,
@@ -1091,15 +1091,7 @@ rocblas_status rocblas_trsm_template(rocblas_handle handle,
         return rocblas_status_memory_error;
     }
 
-    // copy B to packed storage
-    auto packedB =
-        rocblas_unique_ptr{rocblas::device_malloc(m * n * sizeof(T)), rocblas::device_free};
-    if(!packedB)
-    {
-        return rocblas_status_memory_error;
-    }
-
-    // X is also packed size of B
+    // X is size of packed B
     auto X = rocblas_unique_ptr{rocblas::device_malloc(m * n * sizeof(T)), rocblas::device_free};
     if(!X)
     {
@@ -1109,30 +1101,8 @@ rocblas_status rocblas_trsm_template(rocblas_handle handle,
     hipStream_t rocblas_stream;
     RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
 
-    // copy B to packedB
-    {
-        rocblas_int blocksX = ((m - 1) / 128) + 1; // parameters for device kernel
-        rocblas_int blocksY = ((n - 1) / 8) + 1;
-        dim3 grid(blocksX, blocksY, 1);
-        dim3 threads(128, 8, 1);
-
-        hipLaunchKernelGGL(copy_void_ptr_matrix_trsm,
-                           dim3(grid),
-                           dim3(threads),
-                           0,
-                           rocblas_stream,
-                           m,
-                           n,
-                           sizeof(T),
-                           B,
-                           ldb,
-                           packedB.get(),
-                           m);
-    }
-
-    // intialize invA and X to be &zero
+    // intialize invA to &zero
     PRINT_IF_HIP_ERROR(hipMemsetAsync((T*)invA.get(), 0, BLOCK * k * sizeof(T), rocblas_stream));
-    PRINT_IF_HIP_ERROR(hipMemsetAsync((T*)X.get(), 0, m * n * sizeof(T), rocblas_stream));
 
     // batched trtri invert diagonal part (BLOCK*BLOCK) of A into invA
     rocblas_status status = rocblas_trtri_trsm_template<T, BLOCK>(
@@ -1140,33 +1110,13 @@ rocblas_status rocblas_trsm_template(rocblas_handle handle,
 
     if(side == rocblas_side_left)
     {
-        status = rocblas_trsm_left<T, BLOCK>(handle,
-                                             uplo,
-                                             transA,
-                                             m,
-                                             n,
-                                             alpha,
-                                             A,
-                                             lda,
-                                             (T*)packedB.get(),
-                                             m,
-                                             (T*)invA.get(),
-                                             (T*)X.get());
+        status = rocblas_trsm_left<T, BLOCK>(
+            handle, uplo, transA, m, n, alpha, A, lda, B, ldb, (T*)invA.get(), (T*)X.get());
     }
     else
     { // side == rocblas_side_right
-        status = rocblas_trsm_right<T, BLOCK>(handle,
-                                              uplo,
-                                              transA,
-                                              m,
-                                              n,
-                                              alpha,
-                                              A,
-                                              lda,
-                                              (T*)packedB.get(),
-                                              m,
-                                              (T*)invA.get(),
-                                              (T*)X.get());
+        status = rocblas_trsm_right<T, BLOCK>(
+            handle, uplo, transA, m, n, alpha, A, lda, B, ldb, (T*)invA.get(), (T*)X.get());
     }
 
 #ifndef NDEBUG

--- a/library/src/blas3/trtri_trsm.hpp
+++ b/library/src/blas3/trtri_trsm.hpp
@@ -206,7 +206,7 @@ rocblas_status rocblas_trtri_trsm_template(rocblas_handle handle,
 
     if(blocks > 0)
     {
-        constexpr rocblas_int IBD = 4;
+        constexpr rocblas_int IBD = 8;
         constexpr rocblas_int IB  = NB / IBD;
         dim3 grid(blocks * IBD, 1, 1);
         dim3 threads(IB, 1, 1);
@@ -252,20 +252,41 @@ rocblas_status rocblas_trtri_trsm_template(rocblas_handle handle,
                            lda,
                            invA);
 
-        constexpr rocblas_int JB = IB * 2;
+        constexpr rocblas_int JB = IB * 4;
         rocblas_int stride_A     = NB * lda + NB;
         rocblas_int stride_invA  = NB * NB;
         rocblas_int stride_C     = JB * JB;
 
+        for(int i = 0; i < blocks; i++)
+            trtri_strided_gemm_block<T>(
+                handle,
+                IB,
+                (const T*)(A + ((uplo == rocblas_fill_lower) ? IB + i * stride_A
+                                                             : IB * lda + i * stride_A)),
+                lda,
+                2 * IB * lda + 2 * IB,
+                (const T*)(invA + ((uplo == rocblas_fill_lower) ? 0 + i * stride_invA
+                                                                : IB * NB + IB + i * stride_invA)),
+                (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * NB + IB + i * stride_invA
+                                                                : 0 + i * stride_invA)),
+                (T*)(invA + ((uplo == rocblas_fill_lower) ? IB + i * stride_invA
+                                                          : IB * NB + i * stride_invA)),
+                NB,
+                2 * IB * NB + 2 * IB,
+                (T*)C_tmp,
+                IB,
+                IB * IB,
+                NB / JB * 2);
+
         trtri_strided_gemm_block<T>(
             handle,
-            IB,
-            (const T*)(A + ((uplo == rocblas_fill_lower) ? IB : IB * lda)),
+            IB * 2,
+            (const T*)(A + ((uplo == rocblas_fill_lower) ? IB * 2 : IB * 2 * lda)),
             lda,
             stride_A,
-            (const T*)(invA + ((uplo == rocblas_fill_lower) ? 0 : IB * NB + IB)),
-            (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * NB + IB : 0)),
-            (T*)(invA + ((uplo == rocblas_fill_lower) ? IB : IB * NB)),
+            (const T*)(invA + ((uplo == rocblas_fill_lower) ? 0 : IB * 2 * NB + IB * 2)),
+            (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * 2 * NB + IB * 2 : 0)),
+            (T*)(invA + ((uplo == rocblas_fill_lower) ? IB * 2 : IB * 2 * NB)),
             NB,
             stride_invA,
             (T*)C_tmp,
@@ -275,17 +296,17 @@ rocblas_status rocblas_trtri_trsm_template(rocblas_handle handle,
 
         trtri_strided_gemm_block<T>(
             handle,
-            IB,
-            (const T*)(A + ((uplo == rocblas_fill_lower) ? IB * 2 * lda + IB * 3
-                                                         : IB * 3 * lda + IB * 2)),
+            IB * 2,
+            (const T*)(A + ((uplo == rocblas_fill_lower) ? IB * 4 * lda + IB * 6
+                                                         : IB * 6 * lda + IB * 4)),
             lda,
             stride_A,
-            (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * 2 * NB + IB * 2
-                                                            : IB * 3 * NB + IB * 3)),
-            (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * 3 * NB + IB * 3
-                                                            : IB * 2 * NB + IB * 2)),
+            (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * 4 * NB + IB * 4
+                                                            : IB * 6 * NB + IB * 6)),
+            (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * 6 * NB + IB * 6
+                                                            : IB * 4 * NB + IB * 4)),
             (T*)(invA +
-                 ((uplo == rocblas_fill_lower) ? IB * 2 * NB + IB * 3 : IB * 3 * NB + IB * 2)),
+                 ((uplo == rocblas_fill_lower) ? IB * 4 * NB + IB * 6 : IB * 6 * NB + IB * 4)),
             NB,
             stride_invA,
             (T*)C_tmp,
@@ -308,7 +329,6 @@ rocblas_status rocblas_trtri_trsm_template(rocblas_handle handle,
             JB,
             stride_C,
             blocks);
-
     } // end if
 
     // the last digaonal block is handled seperately if n is not divisible by NB, or if there is


### PR DESCRIPTION
contributes towards #172044

Summary of proposed changes:
-  Send smaller sizes in to the trtri kernel
-  Remove packedB to avoid unnecessary memory allocation
-  Remove unnecessary hipMemsetAsync on X variable
