### PR TITLE
initialize matrices with trig functions sin and cos

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -435,6 +435,7 @@ int main(int argc, char* argv[])
     std::string c_type;
     std::string d_type;
     std::string compute_type;
+    std::string initialization;
 
     rocblas_int device_id;
     std::string datafile;
@@ -533,6 +534,10 @@ int main(int argc, char* argv[])
         ("compute_type",
          value<std::string>(&compute_type)->default_value("f32_r"), "Precision of computation, only applicable to BLAS_EX. "
          "Options: f16_r,f32_r,f64_r,i8_r,i32_r")
+
+        ("initialization",
+         value<std::string>(&initialization)->default_value("rand_int"), "Intialize with random integers or trig functions sin and cos. "
+         "Options: rand_int, trig_float")
 
         ("transposeA",
          value<char>(&arg.transA)->default_value('N'),
@@ -669,6 +674,20 @@ int main(int argc, char* argv[])
     if(arg.compute_type == static_cast<rocblas_datatype>(-1))
     {
         std::cerr << "Invalid value for --compute_type" << std::endl;
+        return -1;
+    }
+
+    if(initialization == "rand_int")
+    {
+        arg.initialization = rocblas_initialization_random_int;
+    }
+    else if(initialization == "trig_float")
+    {
+        arg.initialization = rocblas_initialization_trig_float;
+    }
+    else
+    {
+        std::cerr << "Invalid value for --initialization" << std::endl;
         return -1;
     }
 

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -15,6 +15,11 @@
 #include "rocblas.h"
 #include "rocblas_datatype2char.hpp"
 
+typedef enum rocblas_initialization_ {
+    rocblas_initialization_random_int = 111,
+    rocblas_initialization_trig_float = 222
+} rocblas_initialization;
+
 /* ============================================================================================ */
 /*! \brief Class used to parse command arguments in both client & gtest   */
 struct Arguments
@@ -68,6 +73,8 @@ struct Arguments
     char function[64];
     char name[64];
     char category[32];
+
+    rocblas_initialization initialization;
 
     private:
     /* =============================================================================================
@@ -176,6 +183,7 @@ struct Arguments
         print("unit_check", arg.unit_check);
         print("timing", arg.timing);
         print("iters", arg.iters);
+        print("initialization", arg.initialization);
 
         return str << " }\n";
     }

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -28,6 +28,16 @@ inline void rocblas_init(
                 A[i + j * lda + i_batch * stride] = random_generator<T>();
 }
 
+template <typename T>
+inline void rocblas_init_sin(
+    std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)
+{
+    for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
+        for(size_t i = 0; i < M; ++i)
+            for(size_t j                          = 0; j < N; ++j)
+                A[i + j * lda + i_batch * stride] = sin(i + j * lda + i_batch * stride);
+}
+
 // Initialize matrix so adjacent entries have alternating sign.
 // In gemm if either A or B are initialized with alernating
 // sign the reduction sum will be summing positive
@@ -45,6 +55,18 @@ inline void rocblas_init_alternating_sign(
             {
                 auto value                        = random_generator<T>();
                 A[i + j * lda + i_batch * stride] = (i ^ j) & 1 ? value : negate(value);
+            }
+}
+
+template <typename T>
+inline void rocblas_init_cos(
+    std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)
+{
+    for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
+        for(size_t i = 0; i < M; ++i)
+            for(size_t j = 0; j < N; ++j)
+            {
+                A[i + j * lda + i_batch * stride] = cos(i + j * lda + i_batch * stride);
             }
 }
 

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -245,10 +245,19 @@ void testing_gemm(const Arguments& arg)
     host_vector<T> hC_gold(size_C);
 
     // Initial Data on CPU
-    rocblas_seedrand();
-    rocblas_init<T>(hA, A_row, A_col, lda);
-    rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
-    rocblas_init<T>(hC_1, M, N, ldc);
+    if(arg.initialization == rocblas_initialization_random_int)
+    {
+        rocblas_seedrand();
+        rocblas_init<T>(hA, A_row, A_col, lda);
+        rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
+        rocblas_init<T>(hC_1, M, N, ldc);
+    }
+    else if(arg.initialization == rocblas_initialization_trig_float)
+    {
+        rocblas_init_sin<T>(hA, A_row, A_col, lda);
+        rocblas_init_cos<T>(hB, B_row, B_col, ldb);
+        rocblas_init_sin<T>(hC_1, M, N, ldc);
+    }
 
     hC_2    = hC_1;
     hC_gold = hC_1;


### PR DESCRIPTION
- Add option to initialize gemm matrices with trig functions sin and cos.
- This is an alternative to initializing with random integers in [1,10] and alternating sign random integers in  [1,10]
- This is only useful for rocblas-bench performance measurement, and it is cannot be used for correctness tests. 