### PR TITLE
initialize matrices with trig functions sin and cos

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -468,6 +468,7 @@ int main(int argc, char* argv[])
     char c_type;
     char d_type;
     char compute_type;
+    std::string initialization;
 
     rocblas_int device_id;
     std::string datafile;
@@ -623,6 +624,10 @@ int main(int argc, char* argv[])
          value<rocblas_int>(&device_id)->default_value(0),
          "Set default device to be used for subsequent program runs")
 
+        ("initialization",
+         value<std::string>(&initialization)->default_value("rand_int"), "Intialize with random integers or trig functions sin and cos. "
+         "Options: rand_int, trig_float")
+
         ("help,h", "produces this help message")
 
         ("version", "Prints the version number");
@@ -708,6 +713,20 @@ int main(int argc, char* argv[])
     if(argus.M < 0 || argus.N < 0 || argus.K < 0)
     {
         printf("Invalid matrix dimension\n");
+    }
+
+    if(initialization == "rand_int")
+    {
+        argus.initialization = rocblas_initialization_random_int;
+    }
+    else if(initialization == "trig_float")
+    {
+        argus.initialization = rocblas_initialization_trig_float;
+    }
+    else
+    {
+        std::cerr << "Invalid value for --initialization" << std::endl;
+        return -1;
     }
 
     return run_bench_test(function.c_str(), precision, argus);

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -294,10 +294,19 @@ rocblas_status testing_gemm(Arguments const& argus)
     host_vector<T> hC_gold(size_C);
 
     // Initial Data on CPU
-    rocblas_seedrand();
-    rocblas_init<T>(hA, A_row, A_col, lda);
-    rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
-    rocblas_init<T>(hC_1, M, N, ldc);
+    if(argus.initialization == rocblas_initialization_random_int)
+    {
+        rocblas_seedrand();
+        rocblas_init<T>(hA, A_row, A_col, lda);
+        rocblas_init_alternating_sign<T>(hB, B_row, B_col, ldb);
+        rocblas_init<T>(hC_1, M, N, ldc);
+    }
+    else if(argus.initialization == rocblas_initialization_trig_float)
+    {
+        rocblas_init_sin<T>(hA, A_row, A_col, lda);
+        rocblas_init_cos<T>(hB, B_row, B_col, ldb);
+        rocblas_init_sin<T>(hC_1, M, N, ldc);
+    }
 
     //  rocblas_init<T>(hA, A_row, A_col, lda, 1.0);
     //  rocblas_init<T>(hB, B_row, B_col, ldb, 1.0);

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -35,6 +35,11 @@
 
 using namespace std;
 
+typedef enum rocblas_initialization_ {
+    rocblas_initialization_random_int = 111,
+    rocblas_initialization_trig_float = 222
+} rocblas_initialization;
+
 typedef rocblas_half half;
 
 /*!\file
@@ -430,6 +435,29 @@ void rocblas_init(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
     }
 };
 
+template <typename T>
+void rocblas_init_sin(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
+{
+    for(rocblas_int i = 0; i < M; ++i)
+    {
+        for(rocblas_int j = 0; j < N; ++j)
+        {
+            A[i + j * lda] = sin(i + j * lda);
+        }
+    }
+};
+template <typename T>
+void rocblas_init_cos(vector<T>& A, rocblas_int M, rocblas_int N, rocblas_int lda)
+{
+    for(rocblas_int i = 0; i < M; ++i)
+    {
+        for(rocblas_int j = 0; j < N; ++j)
+        {
+            A[i + j * lda] = cos(i + j * lda);
+        }
+    }
+};
+
 // initialize strided_batched matrix
 template <typename T>
 void rocblas_init(vector<T>& A,
@@ -446,6 +474,45 @@ void rocblas_init(vector<T>& A,
             for(rocblas_int j = 0; j < N; ++j)
             {
                 A[i + j * lda + i_batch * stride] = random_generator<T>();
+            }
+        }
+    }
+};
+
+template <typename T>
+void rocblas_init_sin(vector<T>& A,
+                      rocblas_int M,
+                      rocblas_int N,
+                      rocblas_int lda,
+                      rocblas_int stride,
+                      rocblas_int batch_count)
+{
+    for(rocblas_int i_batch = 0; i_batch < batch_count; i_batch++)
+    {
+        for(rocblas_int i = 0; i < M; ++i)
+        {
+            for(rocblas_int j = 0; j < N; ++j)
+            {
+                A[i + j * lda + i_batch * stride] = sin(i + j * lda + i_batch * stride);
+            }
+        }
+    }
+};
+template <typename T>
+void rocblas_init_cos(vector<T>& A,
+                      rocblas_int M,
+                      rocblas_int N,
+                      rocblas_int lda,
+                      rocblas_int stride,
+                      rocblas_int batch_count)
+{
+    for(rocblas_int i_batch = 0; i_batch < batch_count; i_batch++)
+    {
+        for(rocblas_int i = 0; i < M; ++i)
+        {
+            for(rocblas_int j = 0; j < N; ++j)
+            {
+                A[i + j * lda + i_batch * stride] = cos(i + j * lda + i_batch * stride);
             }
         }
     }
@@ -853,6 +920,8 @@ struct Arguments
     char function[32] = "";
     char namex[32]    = "";
     char category[32] = "";
+
+    rocblas_initialization initialization = rocblas_initialization_random_int;
 
     // Function to read Structures data from stream
     friend istream& operator>>(istream& s, Arguments& arg)


### PR DESCRIPTION
- Add option to initialize gemm matrices with trig functions sin and cos.
- This is an alternative to initializing with random integers in [1,10] and alternating sign random integers in [1,10]
- This is only useful for rocblas-bench performance measurement, and it is cannot be used for correctness tests.

