### PR TITLE
Fix regression in PR#458 caused by change in Arguments data structure

### DIFF
--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -1,5 +1,5 @@
 # Data types are defined as either aliases to Python-recognized ctypes,
-# or classes defined with base clases and attributes.
+# or enums defined with c_int base clases and attributes.
 Datatypes:
   - rocblas_int: c_int
   - rocblas_datatype:
@@ -21,6 +21,11 @@ Datatypes:
         u32_c: 167
   - { half: f16_r, single: f32_r, double: f64_r }
   - { half complex: f16_c, single complex: f32_c, double complex: f64_c }
+  - rocblas_initialization:
+      bases: [ c_int ]
+      attr:
+        rocblas_initialization_random_int: 111
+        rocblas_initialization_trig_float: 222
 
 Real precisions: &real_precisions
   - &half_precision
@@ -107,6 +112,7 @@ Arguments:
   - function: c_char*64
   - name: c_char*64
   - category: c_char*32
+  - initialization: rocblas_initialization
 
 # These named dictionary lists [ {dict1}, {dict2}, etc. ] supply subsets of
 # test arguments in a structured way. The dictionaries are applied to the test
@@ -166,3 +172,4 @@ Defaults:
   solution_index: 0
   flags: 0
   workspace_size: 0
+  initialization: rocblas_initialization_random_int

--- a/clients/include/rocblas_data.hpp
+++ b/clients/include/rocblas_data.hpp
@@ -57,13 +57,16 @@ class RocBLAS_TestData
         ifs->clear();
         ifs->seekg(0);
 
+        // Validate the data file format
+        Arguments::validate(*ifs);
+
         // We create a filter iterator which will choose only the test cases we want right now.
         // This is to preserve Gtest structure while not creating no-op tests which "always pass".
         return iterator(filter, std::istream_iterator<Arguments>(*ifs));
     }
 
     // end() iterator
-    static iterator end() { return iterator(); }
+    static iterator end() { return {}; }
 };
 
 #endif


### PR DESCRIPTION
PR #458 broke tests because they were read in as binary and interpreted as binary data which, because of the `rocblas_initialize` entry added to the `Arguments` `struct`, were read in garbled, and thus rarely matched test criteria, reducing the number of tests.

Summary of proposed changes:
- Add the `rocblas_initialize` definition to the YAML file
- Enhance `rocblas_gentest.py` to handle `enum` `Arguments` besides `rocblas_datatype`
- Add code to detect a mismatch between input data and output data, giving a clear error message about the data being misformatted, and how to fix it