### PR TITLE
fix for 96 test failures

### DIFF
--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HBH.yaml
@@ -43,7 +43,7 @@
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -74,21 +74,21 @@
     GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 32
+    LSCA: 16
     LSCB: 16
-    LSPA: 4
+    LSPA: 8
     LSPB: 8
-    LVCA: 16
+    LVCA: 8
     LVCB: 8
-    LVPA: 2
+    LVPA: 4
     LVPB: 4
-    LdsNumElements: 896
-    LdsNumElementsAlignedA: 256
+    LdsNumElements: 819
+    LdsNumElementsAlignedA: 128
     LdsNumElementsAlignedB: 128
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
+    LdsOffsetA_Blk: 256
+    LdsOffsetB: 128
+    LdsOffsetB_Blk: 384
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -102,9 +102,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 32
+    MacroTile0: 16
     MacroTile1: 16
-    MacroTileA: 32
+    MacroTileA: 16
     MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -113,15 +113,20 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 1
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -165,17 +170,24 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
     SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x08_PGR1_PLR1_TT04_02
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT016x016x08_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id002 [4, 2]
-    ThreadTile0: 4
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
     ThreadTile1: 2
-    ThreadTileA: 4
+    ThreadTileA: 2
     ThreadTileB: 2
     UnrollMemFence: false
     UseSgprForGRO: false
@@ -183,607 +195,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: &id001 [8, 8, 1]
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x08_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id003 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id001
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 4
-    LSPB: 8
-    LVCA: 32
-    LVCB: 16
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 128
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 16
-    MacroTileA: 64
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x08_PGR1_PLR1_TT04_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id005 [16, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 3
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x08_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id003
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id001
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 1
-    LVPB: 1
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT08_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id001
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -862,6 +283,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -905,14 +331,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 5
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT016x016x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id004 [2, 2]
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -923,15 +356,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id001
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1010,6 +444,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1053,14 +492,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 6
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x16_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -1071,21 +517,22 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id001
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 16
+    DepthU: 24
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -1093,778 +540,38 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
+    GlobalReadVectorWidth: 2
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
     GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
+    LSCA: 16
+    LSCB: 16
     LSPA: 8
     LSPB: 8
     LVCA: 8
     LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id003
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id001
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 16
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
     LVPA: 4
-    LVPB: 8
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x16_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id005
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 4
-    LSPB: 16
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 16
-    MacroTileA: 64
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 9
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x16_PGR1_PLR1_TT04_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id005
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 16
-    LVCA: 32
-    LVCB: 16
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 16
-    MacroTileA: 64
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x16_PGR1_PLR1_TT02_02
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id006 [32, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 4
-    LSPB: 16
-    LVCA: 64
-    LVCB: 16
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 6400
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 16
-    MacroTileA: 128
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x016x16_PGR1_PLR1_TT04_02
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id006
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 16
-    LSPA: 4
-    LSPB: 8
-    LVCA: 16
-    LVCB: 8
-    LVPA: 2
     LVPB: 4
     LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 384
     LdsOffsetA: 0
     LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -1877,306 +584,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
+    LoopUnroll: 24
+    MacroTile0: 16
     MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 12
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x16_PGR1_PLR1_TT04_02
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id001
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 13
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id003
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id001
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 16
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
+    MacroTileA: 16
     MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -2187,13 +598,18 @@
     NonTemporalC: 0
     NumElementsPerThread: 4
     NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 1
+    NumLoadsA: 3
+    NumLoadsB: 3
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
+    NumLoadsPerpendicularA: 3
+    NumLoadsPerpendicularB: 3
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2237,14 +653,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 14
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x16_PGR1_PLR1_TT02_02
-    SubGroup0: 16
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT016x016x24_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
     SubGroup1: 8
-    SubGroupA: 16
+    SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2255,15 +678,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
-    WorkGroupMapping: 8
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2342,6 +766,11 @@
     NumLoadsPerpendicularA: 6
     NumLoadsPerpendicularB: 3
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2385,14 +814,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 15
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 4
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x24_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -2403,15 +839,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id001
-    WorkGroupMapping: 1
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2490,6 +927,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 4
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2533,14 +975,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 16
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 5
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT016x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2551,15 +1000,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id001
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2638,6 +1088,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 2
     NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2681,14 +1136,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 17
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 6
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2699,163 +1161,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 4
-    LSPB: 16
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 6656
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 16
-    MacroTileA: 64
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 8
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 18
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x32_PGR1_PLR1_TT04_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id005
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2934,6 +1249,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2977,14 +1297,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 19
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 7
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2995,15 +1322,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id006
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3034,21 +1362,21 @@
     GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
+    LSCA: 16
     LSCB: 16
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
     LVCB: 8
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 12800
-    LdsNumElementsAlignedA: 4096
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -3062,9 +1390,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 32
-    MacroTile0: 128
+    MacroTile0: 16
     MacroTile1: 16
-    MacroTileA: 128
+    MacroTileA: 16
     MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -3073,156 +1401,8 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 8
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 20
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x016x32_PGR1_PLR1_TT04_02
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id006
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
     NumLoadsA: 4
     NumLoadsB: 4
     NumLoadsCoalescedA: 1
@@ -3230,6 +1410,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 4
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3273,162 +1458,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 21
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x32_PGR1_PLR1_TT04_04
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 8
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT016x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id003
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id001
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 16
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 22
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x32_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -3439,15 +1483,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3526,6 +1571,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3569,14 +1619,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 23
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 9
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -3587,15 +1644,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id006
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3674,6 +1732,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 8
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3717,14 +1780,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 24
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 10
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT016x016x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -3735,15 +1805,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id001
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 1
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3822,6 +1893,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 4
     NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3865,14 +1941,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 25
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 11
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -3883,15 +1966,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 1
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3970,6 +2054,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 2
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4013,14 +2102,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 26
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 12
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -4031,13 +2127,3673 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id006
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 1
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 64
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 16
+    LSCB: 16
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 64
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 8
+    NumLoadsB: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 8
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 13
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT016x016x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 1
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 64
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 16
+    LSPA: 8
+    LSPB: 16
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 64
+    MacroTile0: 32
+    MacroTile1: 16
+    MacroTileA: 32
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 8
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 4
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 14
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 1
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 8
+    LVPB: 8
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 15
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x08_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 4
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 8
+    LVPB: 8
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 16
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 8
+    LVPB: 8
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 17
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 64
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 8
+    LVPB: 8
+    LdsNumElements: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 64
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 18
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 1
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 0
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 19
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 5
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 0
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 20
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 5
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 0
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 21
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 4
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 0
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 22
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x08_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id002 [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: &id001 [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 1
+    LVPB: 1
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT08_08
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id006 [8, 8]
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id001
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id001
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 8
+    LSPB: 16
+    LVCA: 16
+    LVCB: 8
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 3584
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x16_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: &id003 [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 4
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id001
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 8
+    LSPB: 16
+    LVCA: 16
+    LVCB: 8
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 3584
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 5
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x16_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id003
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 6
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id001
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 8
+    LSPB: 16
+    LVCA: 16
+    LVCB: 8
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 7
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id003
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 32
+    LSPA: 8
+    LSPB: 32
+    LVCA: 32
+    LVCB: 8
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 13312
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 32
+    MacroTileA: 128
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 8
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 32
+    SubGroup1: 8
+    SubGroupA: 32
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: &id004 [32, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 4
+    LSPB: 32
+    LVCA: 32
+    LVCB: 4
+    LVPA: 1
+    LVPB: 8
+    LdsNumElements: 12800
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 16
+    MacroTileA: 128
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 8
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 9
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x016x32_PGR1_PLR1_TT04_04
+    SubGroup0: 32
+    SubGroup1: 4
+    SubGroupA: 32
+    SubGroupB: 4
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: &id005 [32, 4, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 10
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id001
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 8
+    LSPB: 16
+    LVCA: 16
+    LVCB: 8
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 11
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id003
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 32
+    LSPA: 8
+    LSPB: 32
+    LVCA: 32
+    LVCB: 8
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 13312
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 32
+    MacroTileA: 128
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 12
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x032x32_PGR1_PLR1_TT04_04
+    SubGroup0: 32
+    SubGroup1: 8
+    SubGroupA: 32
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id004
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 4
+    LSPB: 32
+    LVCA: 32
+    LVCB: 4
+    LVPA: 1
+    LVPB: 8
+    LdsNumElements: 12800
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 16
+    MacroTileA: 128
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 8
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 13
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x016x32_PGR1_PLR1_TT04_04
+    SubGroup0: 32
+    SubGroup1: 4
+    SubGroupA: 32
+    SubGroupB: 4
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id005
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
     AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -4068,7 +5824,7 @@
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
     GuaranteeNoPartialB: false
-    InnerUnroll: 1
+    InnerUnroll: 2
     KernelLanguage: Assembly
     LSCA: 32
     LSCB: 32
@@ -4087,7 +5843,7 @@
     LdsOffsetB_Blk: 6144
     LdsPadA: 0
     LdsPadB: 0
-    LocalDotLayout: 1
+    LocalDotLayout: 2
     LocalRead2A: true
     LocalRead2B: true
     LocalSplitU: 1
@@ -4097,7 +5853,7 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 64
+    LoopUnroll: 32
     MacroTile0: 32
     MacroTile1: 32
     MacroTileA: 32
@@ -4161,14 +5917,161 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 27
+    SolutionIndex: 14
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x64_PGR1_PLR1_TT04_04
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id003
+    ThreadTile: *id002
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id001
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 64
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 8
+    NumLoadsB: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 8
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 15
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x64_PGR1_PLR1_TT04_04
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id002
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -4185,7 +6088,6 @@
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -4201,41 +6103,41 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
+    GlobalReadVectorWidth: 4
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
     GuaranteeNoPartialB: false
-    InnerUnroll: 1
+    InnerUnroll: 2
     KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 16
+    LSCA: 64
+    LSCB: 32
     LSPA: 8
     LSPB: 16
     LVCA: 16
     LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 14336
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 2048
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
     LdsPadA: 0
     LdsPadB: 0
-    LocalDotLayout: 1
+    LocalDotLayout: 2
     LocalRead2A: true
     LocalRead2B: true
     LocalSplitU: 1
@@ -4245,11 +6147,11 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
+    LoopUnroll: 32
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -4257,8 +6159,8 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
     NumLoadsA: 8
     NumLoadsB: 4
     NumLoadsCoalescedA: 1
@@ -4309,327 +6211,30 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 28
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x016x64_PGR1_PLR1_TT02_02
+    SolutionIndex: 16
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x64_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id005
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 13312
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 64
-    MacroTile1: 16
-    MacroTileA: 64
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 8
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 29
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x016x64_PGR1_PLR1_TT02_02
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id006
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 64
-    LSPA: 8
-    LSPB: 4
-    LVCA: 8
-    LVCB: 16
-    LVPA: 2
-    LVPB: 1
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 64
-    MacroTileA: 32
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 30
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x064x08_PGR1_PLR1_TT04_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id008 [4, 8]
+    ThreadTile: *id002
     ThreadTile0: 4
-    ThreadTile1: 8
+    ThreadTile1: 4
     ThreadTileA: 4
-    ThreadTileB: 8
+    ThreadTileB: 4
     UnrollMemFence: false
     UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id007 [8, 8, 1]
+    WorkGroup: *id003
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -4645,41 +6250,41 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
+    GlobalReadVectorWidth: 8
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
+    GlobalWriteVectorWidth: 8
+    GuaranteeNoPartialA: false
     GuaranteeNoPartialB: false
-    InnerUnroll: 1
+    InnerUnroll: 2
     KernelLanguage: Assembly
-    LSCA: 16
+    LSCA: 64
     LSCB: 64
     LSPA: 8
-    LSPB: 2
+    LSPB: 8
     LVCA: 8
-    LVCB: 32
-    LVPA: 4
+    LVCB: 8
+    LVPA: 1
     LVPB: 1
-    LdsNumElements: 1920
-    LdsNumElementsAlignedA: 384
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
     LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
-    LocalDotLayout: 1
+    LocalDotLayout: 2
     LocalRead2A: true
     LocalRead2B: true
     LocalSplitU: 1
@@ -4689,10 +6294,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 48
+    LoopUnroll: 4
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 48
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -4701,161 +6306,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 48
-    NumGlobalWriteVectorsPerThread: 24
-    NumLoadsA: 3
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 3
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 31
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT048x064x08_PGR1_PLR1_TT06_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: [6, 8]
-    ThreadTile0: 6
-    ThreadTile1: 8
-    ThreadTileA: 6
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id007
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 2
-    LSPB: 8
-    LVCA: 32
-    LVCB: 8
-    LVPA: 1
-    LVPB: 4
-    LdsNumElements: 1920
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 48
-    MacroTileA: 64
-    MacroTileB: 48
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 48
-    NumGlobalWriteVectorsPerThread: 24
-    NumLoadsA: 4
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 3
-    NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 64
     PerformanceSyncLocation: -1
@@ -4901,31 +6358,30 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 32
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x048x08_PGR1_PLR1_TT08_06
+    SolutionIndex: 17
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT08_08
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: [8, 6]
+    ThreadTile: *id006
     ThreadTile0: 8
-    ThreadTile1: 6
+    ThreadTile1: 8
     ThreadTileA: 8
-    ThreadTileB: 6
+    ThreadTileB: 8
     UnrollMemFence: false
     UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id007
+    VectorWidth: 8
+    WorkGroup: *id001
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -4933,7 +6389,7 @@
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 8
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -4941,7 +6397,448 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 8
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 8
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 1
+    LVPB: 1
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 18
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT08_08
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id006
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 8
+    WorkGroup: *id001
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 8
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 8
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 1
+    LVPB: 1
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 19
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT08_08
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id006
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 8
+    WorkGroup: *id001
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 8
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 8
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 64
+    LSPA: 8
+    LSPB: 16
+    LVCA: 16
+    LVCB: 8
+    LVPA: 1
+    LVPB: 2
+    LdsNumElements: 14336
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 4
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 20
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x064x32_PGR1_PLR1_TT08_08
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id006
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 8
+    WorkGroup: *id003
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
     GlobalLoadVectorWidthB: 4
     GlobalRead2A: true
     GlobalRead2B: true
@@ -4954,28 +6851,28 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: true
+    GuaranteeNoPartialA: false
     GuaranteeNoPartialB: false
-    InnerUnroll: 1
+    InnerUnroll: 2
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
+    LSCB: 64
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
     LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
+    LVPB: 4
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
     LdsNumElementsAlignedB: 1024
     LdsOffsetA: 0
     LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
     LdsPadA: 0
     LdsPadB: 0
-    LocalDotLayout: 1
+    LocalDotLayout: 2
     LocalRead2A: true
     LocalRead2B: true
     LocalSplitU: 1
@@ -4987,9 +6884,9 @@
     LoopTail: true
     LoopUnroll: 8
     MacroTile0: 64
-    MacroTile1: 128
+    MacroTile1: 64
     MacroTileA: 64
-    MacroTileB: 128
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -4997,8 +6894,8 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
     NumLoadsA: 1
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
@@ -5049,31 +6946,30 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 33
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
+    SolutionIndex: 21
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id008
+    ThreadTile: &id008 [4, 4]
     ThreadTile0: 4
-    ThreadTile1: 8
+    ThreadTile1: 4
     ThreadTileA: 4
-    ThreadTileB: 8
+    ThreadTileB: 4
     UnrollMemFence: false
     UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id009 [16, 16, 1]
+    WorkGroup: &id007 [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -5104,7 +7000,448 @@
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
     GuaranteeNoPartialB: false
-    InnerUnroll: 1
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 128
+    LSPA: 16
+    LSPB: 8
+    LVCA: 16
+    LVCB: 32
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 5120
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 22
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id009 [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id007
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 64
+    LSPA: 8
+    LSPB: 16
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 23
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x064x16_PGR1_PLR1_TT08_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id010 [8, 4]
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id007
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 128
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 24
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x16_PGR1_PLR1_TT08_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id011 [8, 8]
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id007
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
     KernelLanguage: Assembly
     LSCA: 64
     LSCB: 64
@@ -5114,16 +7451,16 @@
     LVCB: 16
     LVPA: 4
     LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
+    LdsNumElements: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
     LdsPadA: 0
     LdsPadB: 0
-    LocalDotLayout: 1
+    LocalDotLayout: 2
     LocalRead2A: true
     LocalRead2B: true
     LocalSplitU: 1
@@ -5147,6 +7484,1325 @@
     NonTemporalC: 0
     NumElementsPerThread: 16
     NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 25
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x32_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id008
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id007
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 128
+    LSPA: 16
+    LSPB: 8
+    LVCA: 16
+    LVCB: 32
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 14336
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 4096
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 10240
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 26
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x32_PGR1_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id009
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id007
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 64
+    LSPA: 8
+    LSPB: 16
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 14336
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 4
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 27
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x064x32_PGR1_PLR1_TT08_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id010
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id007
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 8
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 8
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 128
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 16384
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 4096
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 28
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x32_PGR1_PLR1_TT08_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id011
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 8
+    WorkGroup: *id007
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 29
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id012 [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: &id013 [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 30
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x32_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id012
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id013
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 64
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 16384
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 4096
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 31
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x64_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id012
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id013
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 32
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: &id017 [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: &id014 [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 33
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: &id016 [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: *id014
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 128
+    LSCB: 128
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 32
     NumLoadsA: 1
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
@@ -5198,1622 +8854,6 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 34
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id010 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id009
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 128
-    LSPA: 16
-    LSPB: 8
-    LVCA: 16
-    LVCB: 32
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 35
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id008
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id009
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 8
-    LSPB: 16
-    LVCA: 32
-    LVCB: 16
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 36
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x064x16_PGR1_PLR1_TT08_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id009
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 37
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x32_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id010
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id009
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 8
-    LVPB: 8
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 38
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id011 [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id012 [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 8
-    LVPB: 8
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 39
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x32_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id011
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id012
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 8
-    LVPB: 8
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 40
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x64_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id011
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id012
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 41
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id016 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id013 [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 42
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id014 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 43
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id014
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 44
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id014
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 45
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
@@ -6831,161 +8871,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 46
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id014
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -7105,7 +8996,7 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 47
+    SolutionIndex: 35
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x08_PGR0_PLR0_TT08_08
     SubGroup0: 16
     SubGroup1: 16
@@ -7123,13 +9014,449 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 36
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id016
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: *id014
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 8
+    LSPB: 4
+    LVCA: 32
+    LVCB: 64
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 3584
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 2560
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 37
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id017
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: *id014
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 38
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id016
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: *id014
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -7211,7 +9538,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: false
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -7249,14 +9576,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 48
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR0_PLR0_TT04_08
+    SolutionIndex: 39
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR0_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id016
+    ThreadTile: *id017
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -7267,453 +9594,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 49
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id014
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 4
-    LVCA: 32
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 50
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 51
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id014
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -7833,14 +9719,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 52
+    SolutionIndex: 40
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id014
+    ThreadTile: *id016
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -7851,13 +9737,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -7981,14 +9866,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 53
+    SolutionIndex: 41
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id016
+    ThreadTile: *id017
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -7999,13 +9884,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -8129,14 +10013,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 54
+    SolutionIndex: 42
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id014
+    ThreadTile: *id016
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -8147,13 +10031,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -8273,14 +10156,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 55
+    SolutionIndex: 43
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR0_PLR0_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id016
+    ThreadTile: *id017
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -8291,13 +10174,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -8417,14 +10299,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 56
+    SolutionIndex: 44
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id014
+    ThreadTile: *id016
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -8435,13 +10317,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -8565,14 +10446,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 57
+    SolutionIndex: 45
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR0_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id014
+    ThreadTile: *id016
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -8583,13 +10464,155 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 8
+    LSPB: 4
+    LVCA: 32
+    LVCB: 64
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 3072
+    LdsOffsetA: 0
+    LdsOffsetB: 1024
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 46
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR0_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id017
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: *id014
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -8709,14 +10732,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 58
+    SolutionIndex: 47
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id014
+    ThreadTile: *id016
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -8727,13 +10750,159 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id013
+    WorkGroup: *id014
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 8
+    LSPB: 4
+    LVCA: 32
+    LVCB: 64
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 5120
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 48
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id017
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: *id014
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -8807,6 +10976,1452 @@
     NonTemporalC: 0
     NumElementsPerThread: 16
     NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 49
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id016
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: *id014
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 128
+    LSCB: 128
+    LSPA: 2
+    LSPB: 2
+    LVCA: 128
+    LVCB: 128
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1024
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 64
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 50
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR0_PLR0_TT08_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: &id019 [8, 8]
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: &id018 [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 4
+    LSPB: 2
+    LVCA: 64
+    LVCB: 128
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 51
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: &id020 [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 52
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: &id021 [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 128
+    LSCB: 128
+    LSPA: 2
+    LSPB: 2
+    LVCA: 128
+    LVCB: 128
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 64
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 53
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR0_TT08_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id019
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 4
+    LSPB: 2
+    LVCA: 64
+    LVCB: 128
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 54
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR1_PLR0_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id020
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 55
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id021
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 128
+    LSCB: 128
+    LSPA: 2
+    LSPB: 2
+    LVCA: 128
+    LVCB: 128
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1024
+    LdsOffsetA: 0
+    LdsOffsetB: 512
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 64
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 56
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR0_PLR1_TT08_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id019
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 4
+    LSPB: 2
+    LVCA: 64
+    LVCB: 128
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 57
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id020
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 819
+    LdsOffsetA: 0
+    LdsOffsetB: 256
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 58
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id021
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 128
+    LSCB: 128
+    LSPA: 2
+    LSPB: 2
+    LVCA: 128
+    LVCB: 128
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 64
     NumLoadsA: 2
     NumLoadsB: 2
     NumLoadsCoalescedA: 1
@@ -8858,30 +12473,29 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 59
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id014
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
+    ThreadTile: *id019
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
     UnrollMemFence: false
     UseSgprForGRO: 0
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id013
+    VectorWidth: 1
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -8914,17 +12528,21 @@
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Source
-    LSCA: 128
+    LSCA: 64
     LSCB: 128
-    LSPA: 2
+    LSPA: 4
     LSPB: 2
-    LVCA: 128
+    LVCA: 64
     LVCB: 128
-    LVPA: 2
+    LVPA: 4
     LVPB: 2
-    LdsNumElements: 1024
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetB: 512
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -8938,9 +12556,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 128
+    MacroTile0: 64
     MacroTile1: 128
-    MacroTileA: 128
+    MacroTileA: 64
     MacroTileB: 128
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -8949,21 +12567,21 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 1
     NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 2
     NumThreads: 256
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
     PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -9002,16 +12620,16 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 60
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR0_PLR0_TT08_08
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR1_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id018 [8, 8]
-    ThreadTile0: 8
+    ThreadTile: *id020
+    ThreadTile0: 4
     ThreadTile1: 8
-    ThreadTileA: 8
+    ThreadTileA: 4
     ThreadTileB: 8
     UnrollMemFence: false
     UseSgprForGRO: 0
@@ -9019,13 +12637,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: &id017 [16, 16, 1]
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -9059,16 +12676,20 @@
     InnerUnroll: 1
     KernelLanguage: Source
     LSCA: 64
-    LSCB: 128
+    LSCB: 64
     LSPA: 4
-    LSPB: 2
+    LSPB: 4
     LVCA: 64
-    LVCB: 128
+    LVCB: 64
     LVPA: 4
-    LVPB: 2
-    LdsNumElements: 819
+    LVPB: 4
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
     LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -9083,9 +12704,9 @@
     LoopTail: true
     LoopUnroll: 4
     MacroTile0: 64
-    MacroTile1: 128
+    MacroTile1: 64
     MacroTileA: 64
-    MacroTileB: 128
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -9093,21 +12714,21 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsA: 1
-    NumLoadsB: 2
+    NumLoadsB: 1
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
+    NumLoadsPerpendicularB: 1
     NumThreads: 256
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
     PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -9146,1333 +12767,13 @@
       UseBeta: true
       UseInitialStrides: false
     SolutionIndex: 61
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id019 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 62
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id020 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 2
-    LSPB: 2
-    LVCA: 128
-    LVCB: 128
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 63
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR0_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id018
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 64
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 65
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 66
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 67
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 2
-    LSPB: 2
-    LVCA: 128
-    LVCB: 128
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 68
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id018
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 69
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 70
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    ThreadTile: *id021
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -10483,13 +12784,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -10609,14 +12909,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 71
+    SolutionIndex: 62
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR0_PLR0_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id019
+    ThreadTile: *id020
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -10627,13 +12927,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -10753,14 +13052,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 72
+    SolutionIndex: 63
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    ThreadTile: *id021
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -10771,13 +13070,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -10901,14 +13199,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 73
+    SolutionIndex: 64
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    ThreadTile: *id021
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -10919,13 +13217,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -11045,14 +13342,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 74
+    SolutionIndex: 65
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x08_PGR0_PLR1_TT08_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id018
+    ThreadTile: *id019
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -11063,13 +13360,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -11189,14 +13485,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 75
+    SolutionIndex: 66
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR0_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id019
+    ThreadTile: *id020
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -11207,13 +13503,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -11333,14 +13628,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 76
+    SolutionIndex: 67
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    ThreadTile: *id021
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -11351,13 +13646,159 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 128
+    LSPA: 4
+    LSPB: 2
+    LVCA: 64
+    LVCB: 128
+    LVPA: 4
+    LVPB: 2
+    LdsNumElements: 3584
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 2560
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 32
+    NumLoadsA: 2
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 68
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id020
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -11481,14 +13922,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 77
+    SolutionIndex: 69
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    ThreadTile: *id021
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -11499,13 +13940,302 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsOffsetA: 0
+    LdsOffsetB: 1024
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 70
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id021
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: false
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: false
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 1
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Source
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 64
+    LVCB: 64
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 71
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR0_TT04_04
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id021
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 1
+    WorkGroup: *id018
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -11587,7 +14317,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: false
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -11625,14 +14355,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 78
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR0_PLR0_TT04_08
+    SolutionIndex: 72
+    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR0_PLR1_TT04_08
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id019
+    ThreadTile: *id020
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -11643,305 +14373,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 79
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 80
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id017
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -12061,14 +14498,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 81
+    SolutionIndex: 73
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    ThreadTile: *id021
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -12079,13 +14516,12 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
@@ -12209,14 +14645,14 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 82
+    SolutionIndex: 74
     SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    ThreadTile: *id021
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -12227,7 +14663,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id017
+    WorkGroup: *id018
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12361,7 +14797,7 @@
     SubGroupA: 8
     SubGroupB: 32
     SuppresssNoLoadLoop: true
-    ThreadTile: &id021 [8, 4]
+    ThreadTile: &id022 [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -12372,7 +14808,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id022 [8, 32, 1]
+    WorkGroup: &id023 [8, 32, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
@@ -12508,7 +14944,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: &id024 [8, 8]
+    ThreadTile: &id025 [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -12519,7 +14955,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id023 [16, 16, 1]
+    WorkGroup: &id024 [16, 16, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
@@ -12655,7 +15091,7 @@
     SubGroupA: 8
     SubGroupB: 32
     SuppresssNoLoadLoop: true
-    ThreadTile: *id021
+    ThreadTile: *id022
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -12666,7 +15102,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id022
+    WorkGroup: *id023
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
@@ -12802,7 +15238,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id021
+    ThreadTile: *id022
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -12813,7 +15249,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
@@ -12949,7 +15385,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id025
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -12960,7 +15396,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
@@ -13096,7 +15532,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id021
+    ThreadTile: *id022
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -13107,7 +15543,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id024
     WorkGroupMapping: 64
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
@@ -13250,7 +15686,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id024
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
@@ -13386,7 +15822,7 @@
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id025
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -13533,7 +15969,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id025
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -13544,13753 +15980,262 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id023
+    WorkGroup: *id024
     WorkGroupMapping: 64
     WorkGroupMappingType: B
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x08_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id026 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id025 [8, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 16
-    LVCB: 16
-    LVPA: 1
-    LVPB: 1
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT08_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id030 [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id025
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 3
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id027 [16, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 5
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id027
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 6
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x32_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id025
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x32_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id027
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 32
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 13312
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 32
-    MacroTileA: 128
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x032x32_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id028 [32, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 4
-    LSPB: 32
-    LVCA: 32
-    LVCB: 4
-    LVPA: 1
-    LVPB: 8
-    LdsNumElements: 12800
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 16
-    MacroTileA: 128
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 8
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 9
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x016x32_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 4
-    SubGroupA: 32
-    SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id029 [32, 4, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x32_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x32_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id027
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 32
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 13312
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 32
-    MacroTileA: 128
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 12
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x032x32_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 4
-    LSPB: 32
-    LVCA: 32
-    LVCB: 4
-    LVPA: 1
-    LVPB: 8
-    LdsNumElements: 12800
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 16
-    MacroTileA: 128
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 8
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 13
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x016x32_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 4
-    SubGroupA: 32
-    SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id029
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 8
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 8
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 14
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x64_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id025
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 8
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 8
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 15
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT032x032x64_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 14336
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 8
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 4
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 16
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x032x64_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id027
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 1
-    LVPB: 1
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 17
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT08_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id030
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 1
-    LVPB: 1
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 18
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT08_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id030
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id025
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 1
-    LVPB: 1
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 19
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT08_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id030
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 1
-    LVPB: 2
-    LdsNumElements: 14336
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 20
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x064x32_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id030
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id027
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 21
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id032 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id031 [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 128
-    LSPA: 16
-    LSPB: 8
-    LVCA: 16
-    LVCB: 32
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 22
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id033 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id031
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 8
-    LSPB: 16
-    LVCA: 32
-    LVCB: 16
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 23
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x064x16_PGR1_PLR1_TT08_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id034 [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id031
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 128
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 24
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x16_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id035 [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id031
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 25
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x32_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id032
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id031
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 128
-    LSPA: 16
-    LSPB: 8
-    LVCA: 16
-    LVCB: 32
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 14336
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 10240
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 26
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x32_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id033
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id031
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 8
-    LSPB: 16
-    LVCA: 32
-    LVCB: 16
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 14336
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 27
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x064x32_PGR1_PLR1_TT08_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id034
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id031
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 128
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 16384
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 28
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x32_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id035
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id031
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 29
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id036 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id037 [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 30
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x32_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id036
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id037
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 16
-    LSPB: 16
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 16384
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 31
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x64_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id036
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id037
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 32
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id041 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id038 [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 33
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id040 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 34
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id039 [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 35
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x08_PGR0_PLR0_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id039
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 36
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 4
-    LVCA: 32
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 37
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id041
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 38
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 4
-    LVCA: 32
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 39
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id041
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 40
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 4
-    LVCA: 32
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 41
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id041
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 42
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 4
-    LVCA: 32
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3072
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 43
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id041
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 44
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 45
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 4
-    LVCA: 32
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3072
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 46
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id041
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 47
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 8
-    LSPB: 4
-    LVCA: 32
-    LVCB: 64
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 48
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id041
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 49
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id040
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id038
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 2
-    LSPB: 2
-    LVCA: 128
-    LVCB: 128
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 50
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR0_PLR0_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id043 [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: &id042 [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 51
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id044 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 52
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id045 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 2
-    LSPB: 2
-    LVCA: 128
-    LVCB: 128
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 53
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR0_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id043
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 54
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id044
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 55
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 2
-    LSPB: 2
-    LVCA: 128
-    LVCB: 128
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 56
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR0_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id043
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 57
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id044
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 58
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 2
-    LSPB: 2
-    LVCA: 128
-    LVCB: 128
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 59
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id043
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 60
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x04_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id044
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 61
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x04_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 62
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id044
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 63
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 64
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 128
-    LSPA: 2
-    LSPB: 2
-    LVCA: 128
-    LVCB: 128
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 65
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT128x128x08_PGR0_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id043
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 66
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id044
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 67
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 68
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id044
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 69
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 70
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 71
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 128
-    LSPA: 4
-    LSPB: 2
-    LVCA: 64
-    LVCB: 128
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 3072
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 4
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 8
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 72
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x128x16_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id044
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 73
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 74
-    SolutionNameMin: Cijk_Ailk_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id045
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id042
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
 - [2, 3, 0, 1]
-- - - [2368, 1024, 1, 1]
-    - [65, 135.921]
-  - - [128, 256, 1, 1280]
-    - [25, 1519.68]
-  - - [32, 5056, 1, 1280]
-    - [59, 1321.43]
-  - - [448, 1, 1, 256]
-    - [77, 3.34953]
-  - - [5056, 1408, 1, 3328]
-    - [35, 10050.4]
-  - - [2368, 64, 1, 1]
-    - [65, 12.5457]
-  - - [5056, 1856, 1, 3328]
-    - [34, 10336.3]
-  - - [704, 64, 1, 1]
-    - [67, 3.83129]
-  - - [448, 3584, 1, 3328]
-    - [34, 8595.33]
-  - - [704, 64, 1, 3328]
-    - [25, 2184.53]
-  - - [5056, 4288, 1, 32]
-    - [41, 3762.28]
-  - - [5888, 256, 1, 256]
-    - [36, 8316.29]
-  - - [448, 3584, 1, 32]
-    - [57, 2038.9]
-  - - [5888, 704, 1, 1]
-    - [67, 173.874]
-  - - [6784, 6784, 1, 1280]
-    - [33, 10307.1]
-  - - [448, 1, 1, 1]
-    - [74, 0.0486957]
-  - - [1408, 3584, 1, 3328]
-    - [34, 9898.39]
-  - - [448, 448, 1, 3328]
-    - [15, 5656.7]
-  - - [1024, 2368, 1, 3328]
-    - [34, 9278.24]
-  - - [1, 4288, 1, 1280]
-    - [82, 34.5284]
-  - - [6784, 64, 1, 32]
-    - [46, 923.779]
-  - - [64, 64, 1, 1280]
-    - [16, 170.667]
-  - - [448, 3584, 1, 1]
-    - [61, 108.489]
-  - - [448, 64, 1, 1]
-    - [74, 2.61606]
-  - - [32, 1408, 1, 32]
-    - [49, 96.3765]
-  - - [64, 1024, 1, 1280]
-    - [40, 2995.93]
-  - - [1, 1408, 1, 3328]
-    - [82, 17.5158]
-  - - [32, 3584, 1, 1280]
-    - [54, 1246.61]
-  - - [1024, 1, 1, 3328]
-    - [82, 12.9243]
-  - - [2944, 128, 1, 32]
-    - [52, 837.404]
-  - - [1408, 5056, 1, 1]
-    - [66, 205.985]
-  - - [1024, 64, 1, 1280]
-    - [40, 3004.52]
-  - - [64, 5056, 1, 3328]
-    - [39, 7229.37]
-  - - [5888, 4288, 1, 3328]
-    - [33, 10342.9]
-  - - [1, 2368, 1, 1280]
-    - [82, 27.2184]
-  - - [704, 1024, 1, 1]
-    - [61, 60.8865]
-  - - [2368, 1408, 1, 32]
-    - [41, 2744.15]
-  - - [256, 1856, 1, 1280]
-    - [37, 7345.1]
-  - - [1024, 2944, 1, 1]
-    - [62, 152.564]
-  - - [2944, 3584, 1, 3328]
-    - [34, 10239.7]
-  - - [2368, 2944, 1, 1280]
-    - [34, 10080.6]
-  - - [256, 1408, 1, 1]
-    - [62, 32.4144]
-  - - [1, 1024, 1, 3328]
-    - [82, 12.8154]
-  - - [3584, 1408, 1, 32]
-    - [41, 3144.09]
-  - - [6784, 1856, 1, 32]
-    - [41, 3579.56]
-  - - [5056, 256, 1, 256]
-    - [34, 8283.75]
-  - - [1856, 2368, 1, 256]
-    - [34, 9326.28]
-  - - [2368, 1024, 1, 3328]
-    - [34, 9276.53]
-  - - [3584, 4288, 1, 32]
-    - [41, 3639.6]
-  - - [1024, 1024, 1, 1280]
-    - [34, 9108.15]
-  - - [32, 2944, 1, 3328]
-    - [59, 1144.25]
-  - - [704, 1408, 1, 3328]
-    - [34, 8803.43]
-  - - [1408, 704, 1, 256]
-    - [34, 7516.45]
-  - - [704, 64, 1, 32]
-    - [49, 91.4843]
-  - - [5888, 1, 1, 3328]
-    - [82, 49.2047]
-  - - [2368, 32, 1, 256]
-    - [54, 566.55]
-  - - [6784, 128, 1, 3328]
-    - [11, 8159.8]
-  - - [2944, 1856, 1, 1]
-    - [62, 191.856]
-  - - [32, 448, 1, 3328]
-    - [54, 170.054]
-  - - [5056, 1, 1, 3328]
-    - [82, 42.7673]
-  - - [2368, 3584, 1, 1280]
-    - [34, 10083.2]
-  - - [4288, 5056, 1, 1]
-    - [67, 245.029]
-  - - [128, 4288, 1, 3328]
-    - [8, 7285.5]
-  - - [1408, 4288, 1, 1280]
-    - [36, 9839.08]
-  - - [1856, 704, 1, 1280]
-    - [34, 9324.7]
-  - - [448, 5888, 1, 256]
-    - [34, 8483.45]
-  - - [1, 5888, 1, 3328]
-    - [82, 49.523]
-  - - [1024, 128, 1, 32]
-    - [52, 264.792]
-  - - [32, 4288, 1, 1280]
-    - [59, 1117.85]
-  - - [1024, 5056, 1, 1]
-    - [67, 188.13]
-  - - [704, 3584, 1, 1280]
-    - [34, 9510.05]
-  - - [1856, 5056, 1, 256]
-    - [4, 9829.33]
-  - - [1408, 1024, 1, 1280]
-    - [34, 8751.39]
-  - - [5056, 5888, 1, 3328]
-    - [35, 10498.4]
-  - - [3584, 3584, 1, 1280]
-    - [34, 10328.7]
-  - - [2368, 3584, 1, 32]
-    - [41, 3361.15]
-  - - [5056, 5056, 1, 1]
-    - [62, 249.445]
-  - - [1024, 6784, 1, 1280]
-    - [34, 10048.7]
-  - - [1024, 3584, 1, 1]
-    - [61, 165.614]
-  - - [256, 5056, 1, 1]
-    - [65, 95.1718]
-  - - [32, 5056, 1, 32]
-    - [54, 407.024]
-  - - [5888, 32, 1, 32]
-    - [57, 456.766]
-  - - [64, 128, 1, 3328]
-    - [17, 386.819]
-  - - [256, 5056, 1, 32]
-    - [44, 1849.05]
-  - - [5056, 64, 1, 32]
-    - [54, 779.721]
-  - - [256, 128, 1, 256]
-    - [28, 1028.02]
-  - - [128, 6784, 1, 32]
-    - [52, 1536.91]
-  - - [64, 128, 1, 1]
-    - [62, 0.687248]
-  - - [64, 2368, 1, 1280]
-    - [39, 5009.98]
-  - - [128, 704, 1, 32]
-    - [52, 183.902]
-  - - [64, 6784, 1, 3328]
-    - [39, 7384.19]
-  - - [2944, 256, 1, 1280]
-    - [37, 8414.95]
-  - - [2944, 4288, 1, 256]
-    - [36, 9641.13]
-  - - [1024, 1024, 1, 3328]
-    - [37, 9320.68]
-  - - [5056, 704, 1, 32]
-    - [56, 2666.24]
-  - - [1856, 4288, 1, 3328]
-    - [34, 10172.2]
-  - - [1, 1856, 1, 256]
-    - [77, 13.78]
-  - - [6784, 4288, 1, 32]
-    - [41, 3739.05]
-  - - [4288, 1024, 1, 3328]
-    - [34, 10076.8]
-  - - [256, 128, 1, 1]
-    - [66, 3.30323]
-  - - [3584, 448, 1, 3328]
-    - [34, 8588.69]
-  - - [2944, 448, 1, 256]
-    - [34, 7289.32]
-  - - [3584, 2368, 1, 3328]
-    - [34, 10203.0]
-  - - [4288, 1856, 1, 1]
-    - [67, 212.568]
-  - - [1856, 2944, 1, 1]
-    - [77, 169.061]
-  - - [32, 4288, 1, 3328]
-    - [59, 1168.99]
-  - - [1, 3584, 1, 3328]
-    - [82, 45.4556]
-  - - [256, 32, 1, 3328]
-    - [59, 101.214]
-  - - [1856, 2368, 1, 32]
-    - [41, 2915.43]
-  - - [4288, 1856, 1, 32]
-    - [41, 3336.91]
-  - - [5056, 64, 1, 3328]
-    - [39, 7233.26]
-  - - [6784, 1, 1, 1280]
-    - [82, 54.9868]
-  - - [32, 2368, 1, 256]
-    - [54, 565.229]
-  - - [1408, 64, 1, 1]
-    - [67, 7.36209]
-  - - [1, 1, 1, 3328]
-    - [82, 0.0124812]
-  - - [5056, 2368, 1, 256]
-    - [30, 9823.68]
-  - - [1408, 5888, 1, 256]
-    - [33, 9771.26]
-  - - [5056, 6784, 1, 1]
-    - [62, 256.122]
-  - - [32, 448, 1, 1280]
-    - [54, 158.848]
-  - - [32, 448, 1, 32]
-    - [48, 31.8578]
-  - - [1024, 1408, 1, 3328]
-    - [34, 8889.66]
-  - - [256, 5056, 1, 1280]
-    - [34, 9237.01]
-  - - [704, 2368, 1, 1]
-    - [61, 107.971]
-  - - [64, 1024, 1, 32]
-    - [49, 135.126]
-  - - [1024, 256, 1, 256]
-    - [13, 4660.34]
-  - - [128, 1, 1, 1]
-    - [82, 0.0131148]
-  - - [3584, 4288, 1, 1280]
-    - [34, 10292.2]
-  - - [1856, 128, 1, 32]
-    - [59, 536.877]
-  - - [1856, 128, 1, 1280]
-    - [20, 6251.79]
-  - - [128, 2944, 1, 3328]
-    - [6, 7119.08]
-  - - [1, 6784, 1, 3328]
-    - [82, 56.0172]
-  - - [2368, 4288, 1, 1]
-    - [76, 214.763]
-  - - [4288, 448, 1, 3328]
-    - [34, 9056.51]
-  - - [4288, 32, 1, 3328]
-    - [59, 1160.91]
-  - - [32, 2944, 1, 256]
-    - [59, 619.026]
-  - - [256, 1856, 1, 1]
-    - [76, 41.5329]
-  - - [704, 6784, 1, 1280]
-    - [34, 9731.91]
-  - - [2368, 4288, 1, 32]
-    - [41, 3513.49]
-  - - [3584, 6784, 1, 1]
-    - [61, 252.218]
-  - - [704, 5056, 1, 1280]
-    - [34, 9745.17]
-  - - [256, 3584, 1, 3328]
-    - [37, 8160.82]
-  - - [3584, 6784, 1, 32]
-    - [41, 3834.99]
-  - - [3584, 6784, 1, 1280]
-    - [34, 10381.1]
-  - - [4288, 4288, 1, 3328]
-    - [34, 10331.3]
-  - - [3584, 64, 1, 1280]
-    - [20, 6066.14]
-  - - [64, 1856, 1, 256]
-    - [39, 3305.29]
-  - - [3584, 64, 1, 32]
-    - [54, 566.36]
-  - - [448, 1, 1, 1280]
-    - [82, 5.16055]
-  - - [256, 4288, 1, 1280]
-    - [34, 7872.55]
-  - - [1408, 3584, 1, 1]
-    - [66, 187.733]
-  - - [4288, 1856, 1, 3328]
-    - [34, 10161.0]
-  - - [1856, 2944, 1, 1280]
-    - [34, 10119.8]
-  - - [4288, 256, 1, 256]
-    - [34, 7053.67]
-  - - [128, 5888, 1, 32]
-    - [54, 1382.87]
-  - - [128, 5888, 1, 1280]
-    - [37, 8426.71]
-  - - [1408, 128, 1, 3328]
-    - [19, 6140.31]
-  - - [3584, 256, 1, 256]
-    - [34, 7126.24]
-  - - [32, 6784, 1, 3328]
-    - [59, 1800.05]
-  - - [32, 3584, 1, 256]
-    - [54, 806.597]
-  - - [256, 2368, 1, 32]
-    - [52, 1230.88]
-  - - [448, 128, 1, 3328]
-    - [29, 2761.01]
-  - - [64, 2944, 1, 3328]
-    - [40, 6592.18]
-  - - [64, 4288, 1, 3328]
-    - [39, 6187.74]
-  - - [5056, 1024, 1, 3328]
-    - [35, 10145.9]
-  - - [2368, 64, 1, 3328]
-    - [40, 5333.81]
-  - - [1856, 256, 1, 256]
-    - [34, 6033.47]
-  - - [3584, 704, 1, 1]
-    - [62, 139.554]
-  - - [256, 704, 1, 256]
-    - [13, 3258.29]
-  - - [448, 5056, 1, 1]
-    - [65, 130.477]
-  - - [5888, 5888, 1, 256]
-    - [33, 9891.16]
-  - - [3584, 704, 1, 32]
-    - [54, 2298.99]
-  - - [448, 6784, 1, 3328]
-    - [34, 9766.11]
-  - - [6784, 4288, 1, 1]
-    - [61, 253.219]
-  - - [5056, 704, 1, 1]
-    - [62, 162.977]
-  - - [1408, 2368, 1, 32]
-    - [41, 2732.9]
-  - - [448, 5056, 1, 32]
-    - [41, 2347.24]
-  - - [4288, 4288, 1, 1280]
-    - [34, 10247.7]
-  - - [6784, 1408, 1, 1]
-    - [69, 220.292]
-  - - [1856, 5888, 1, 3328]
-    - [35, 10365.7]
-  - - [1024, 704, 1, 1]
-    - [64, 59.6768]
-  - - [5056, 5888, 1, 1]
-    - [62, 254.008]
-  - - [2944, 1024, 1, 256]
-    - [35, 9007.38]
-  - - [448, 1408, 1, 3328]
-    - [37, 7212.92]
-  - - [5056, 32, 1, 3328]
-    - [59, 1359.98]
-  - - [2368, 4288, 1, 3328]
-    - [34, 10350.8]
-  - - [1024, 704, 1, 32]
-    - [51, 1264.73]
-  - - [448, 2944, 1, 256]
-    - [34, 7327.29]
-  - - [2944, 6784, 1, 256]
-    - [33, 9865.8]
-  - - [2368, 2368, 1, 1280]
-    - [35, 9930.14]
-  - - [5888, 128, 1, 3328]
-    - [37, 8596.77]
-  - - [256, 256, 1, 32]
-    - [49, 134.433]
-  - - [1024, 1, 1, 256]
-    - [77, 7.65607]
-  - - [3584, 3584, 1, 32]
-    - [41, 3670.02]
-  - - [2944, 448, 1, 1]
-    - [70, 94.208]
-  - - [128, 32, 1, 32]
-    - [52, 8.57801]
-  - - [5056, 64, 1, 1280]
-    - [39, 6903.13]
-  - - [2944, 2944, 1, 1280]
-    - [35, 10052.5]
-  - - [1, 2368, 1, 256]
-    - [77, 17.4198]
-  - - [64, 6784, 1, 1]
-    - [62, 40.806]
-  - - [2944, 32, 1, 1280]
-    - [59, 1039.54]
-  - - [64, 1408, 1, 3328]
-    - [25, 4179.11]
-  - - [256, 448, 1, 1280]
-    - [28, 4633.86]
-  - - [2368, 2944, 1, 1]
-    - [68, 178.57]
-  - - [6784, 4288, 1, 1280]
-    - [34, 10228.7]
-  - - [2944, 704, 1, 256]
-    - [36, 8914.31]
-  - - [5888, 1856, 1, 256]
-    - [36, 9861.82]
-  - - [704, 2944, 1, 3328]
-    - [34, 9770.98]
-  - - [5888, 256, 1, 1]
-    - [62, 102.96]
-  - - [704, 704, 1, 32]
-    - [52, 1054.5]
-  - - [256, 4288, 1, 256]
-    - [34, 7139.69]
-  - - [5056, 6784, 1, 32]
-    - [41, 3831.32]
-  - - [5056, 128, 1, 1]
-    - [65, 56.969]
-  - - [448, 5056, 1, 1280]
-    - [34, 9440.33]
-  - - [448, 448, 1, 256]
-    - [9, 4014.08]
-  - - [256, 5888, 1, 3328]
-    - [34, 9292.36]
-  - - [704, 448, 1, 1280]
-    - [37, 4875.63]
-  - - [448, 64, 1, 256]
-    - [16, 899.514]
-  - - [1024, 704, 1, 1280]
-    - [37, 8054.7]
-  - - [5888, 1024, 1, 1]
-    - [61, 198.333]
-  - - [5888, 448, 1, 32]
-    - [57, 2436.79]
-  - - [6784, 2944, 1, 256]
-    - [33, 9738.02]
-  - - [1024, 256, 1, 1]
-    - [77, 24.8242]
-  - - [5888, 256, 1, 32]
-    - [55, 1983.33]
-  - - [2368, 448, 1, 256]
-    - [34, 6885.93]
-  - - [4288, 256, 1, 3328]
-    - [37, 7984.87]
-  - - [4288, 2944, 1, 256]
-    - [33, 9661.9]
-  - - [704, 4288, 1, 3328]
-    - [34, 9701.8]
-  - - [448, 5888, 1, 3328]
-    - [34, 9221.31]
-  - - [128, 256, 1, 3328]
-    - [28, 1654.31]
-  - - [2368, 5056, 1, 32]
-    - [41, 3536.96]
-  - - [32, 128, 1, 1280]
-    - [54, 45.3536]
-  - - [1408, 4288, 1, 1]
-    - [67, 197.046]
-  - - [1408, 1856, 1, 3328]
-    - [34, 9989.08]
-  - - [4288, 64, 1, 256]
-    - [38, 4798.81]
-  - - [2944, 5888, 1, 3328]
-    - [34, 10336.1]
-  - - [128, 6784, 1, 3328]
-    - [11, 8157.96]
-  - - [448, 4288, 1, 3328]
-    - [34, 9070.9]
-  - - [704, 2368, 1, 256]
-    - [34, 8009.96]
-  - - [1, 64, 1, 3328]
-    - [82, 0.799279]
-  - - [4288, 128, 1, 1]
-    - [62, 50.8207]
-  - - [704, 256, 1, 32]
-    - [52, 355.121]
-  - - [4288, 3584, 1, 3328]
-    - [34, 10385.9]
-  - - [2368, 1024, 1, 1280]
-    - [34, 9150.31]
-  - - [1408, 1024, 1, 1]
-    - [61, 95.8638]
-  - - [1408, 1024, 1, 256]
-    - [35, 7954.71]
-  - - [5056, 3584, 1, 1]
-    - [62, 245.938]
-  - - [448, 1024, 1, 256]
-    - [34, 5848.63]
-  - - [6784, 6784, 1, 3328]
-    - [36, 10350.0]
-  - - [1408, 256, 1, 1280]
-    - [37, 5577.53]
-  - - [6784, 32, 1, 32]
-    - [54, 493.382]
-  - - [64, 1024, 1, 3328]
-    - [40, 3230.21]
-  - - [2368, 2944, 1, 3328]
-    - [34, 10207.3]
-  - - [448, 448, 1, 1280]
-    - [15, 5325.48]
-  - - [5056, 3584, 1, 32]
-    - [41, 3734.3]
-  - - [5056, 3584, 1, 1280]
-    - [33, 10306.5]
-  - - [1024, 256, 1, 1280]
-    - [21, 6278.9]
-  - - [1856, 1856, 1, 256]
-    - [35, 8904.0]
-  - - [32, 5888, 1, 256]
-    - [59, 1230.47]
-  - - [256, 1408, 1, 32]
-    - [54, 833.406]
-  - - [2944, 1, 1, 3328]
-    - [82, 36.9666]
-  - - [32, 704, 1, 3328]
-    - [54, 265.561]
-  - - [5888, 4288, 1, 1]
-    - [61, 249.681]
-  - - [1024, 128, 1, 256]
-    - [17, 3615.78]
-  - - [32, 1856, 1, 3328]
-    - [54, 704.306]
-  - - [5056, 704, 1, 256]
-    - [36, 9170.82]
-  - - [448, 256, 1, 256]
-    - [22, 3163.81]
-  - - [2368, 5056, 1, 256]
-    - [30, 9836.29]
-  - - [1024, 5056, 1, 256]
-    - [36, 9548.99]
-  - - [32, 1024, 1, 3328]
-    - [59, 408.006]
-  - - [5888, 448, 1, 256]
-    - [34, 8474.88]
-  - - [6784, 5056, 1, 1280]
-    - [4, 10192.9]
-  - - [704, 6784, 1, 32]
-    - [55, 2961.82]
-  - - [4288, 6784, 1, 1280]
-    - [34, 10397.1]
-  - - [64, 1, 1, 256]
-    - [77, 0.477389]
-  - - [1856, 64, 1, 1280]
-    - [40, 4823.72]
-  - - [128, 1408, 1, 1]
-    - [76, 13.9062]
-  - - [1024, 64, 1, 32]
-    - [49, 129.774]
-  - - [1024, 64, 1, 3328]
-    - [40, 3245.59]
-  - - [704, 6784, 1, 3328]
-    - [34, 9848.76]
-  - - [5888, 4288, 1, 1280]
-    - [33, 10286.6]
-  - - [5888, 3584, 1, 1280]
-    - [34, 10310.9]
-  - - [5888, 128, 1, 1280]
-    - [37, 8403.22]
-  - - [1024, 2944, 1, 256]
-    - [36, 8973.86]
-  - - [1, 2944, 1, 1280]
-    - [82, 32.5754]
-  - - [32, 1024, 1, 256]
-    - [54, 230.456]
-  - - [2944, 1856, 1, 1280]
-    - [34, 10110.4]
-  - - [3584, 1, 1, 1280]
-    - [82, 42.3516]
-  - - [256, 3584, 1, 32]
-    - [49, 1575.11]
-  - - [1024, 2368, 1, 1]
-    - [62, 135.921]
-  - - [2944, 3584, 1, 1280]
-    - [34, 10135.7]
-  - - [64, 1, 1, 1]
-    - [82, 0.00761905]
-  - - [1856, 4288, 1, 256]
-    - [34, 9502.72]
-  - - [256, 128, 1, 3328]
-    - [28, 1648.31]
-  - - [1, 1856, 1, 3328]
-    - [82, 23.2139]
-  - - [1408, 704, 1, 1]
-    - [70, 76.0147]
-  - - [2368, 2944, 1, 32]
-    - [41, 3101.84]
-  - - [128, 4288, 1, 32]
-    - [49, 1125.87]
-  - - [128, 704, 1, 1280]
-    - [25, 3855.06]
-  - - [64, 64, 1, 1]
-    - [67, 0.343624]
-  - - [1, 1408, 1, 1]
-    - [62, 0.128467]
-  - - [128, 2368, 1, 1280]
-    - [10, 6146.6]
-  - - [2944, 32, 1, 32]
-    - [49, 186.55]
-  - - [448, 1856, 1, 1]
-    - [65, 66.2013]
-  - - [4288, 704, 1, 256]
-    - [4, 8986.05]
-  - - [1856, 1024, 1, 256]
-    - [4, 8207.48]
-  - - [448, 1856, 1, 32]
-    - [49, 1484.8]
-  - - [448, 1856, 1, 3328]
-    - [37, 7397.33]
-  - - [448, 448, 1, 32]
-    - [49, 360.007]
-  - - [1024, 448, 1, 256]
-    - [13, 5895.61]
-  - - [6784, 1, 1, 256]
-    - [82, 43.5046]
-  - - [1024, 5056, 1, 32]
-    - [41, 3133.04]
-  - - [1024, 4288, 1, 1]
-    - [69, 178.783]
-  - - [704, 256, 1, 3328]
-    - [27, 4565.97]
-  - - [704, 1856, 1, 32]
-    - [54, 1866.61]
-  - - [1408, 5888, 1, 1280]
-    - [35, 10201.9]
-  - - [32, 704, 1, 1280]
-    - [54, 249.618]
-  - - [5056, 1856, 1, 256]
-    - [4, 9819.68]
-  - - [6784, 704, 1, 1280]
-    - [34, 9584.21]
-  - - [704, 1408, 1, 32]
-    - [49, 1645.2]
-  - - [5888, 1024, 1, 256]
-    - [34, 9546.66]
-  - - [64, 2944, 1, 1]
-    - [62, 14.4491]
-  - - [64, 2944, 1, 32]
-    - [52, 352.179]
-  - - [64, 2944, 1, 1280]
-    - [40, 6114.92]
-  - - [6784, 1856, 1, 3328]
-    - [3, 10003.4]
-  - - [64, 704, 1, 3328]
-    - [24, 2184.53]
-  - - [2368, 5888, 1, 1280]
-    - [33, 10251.1]
-  - - [1, 6784, 1, 256]
-    - [82, 43.2446]
-  - - [6784, 6784, 1, 32]
-    - [41, 3859.34]
-  - - [256, 1, 1, 1280]
-    - [82, 2.95527]
-  - - [5888, 128, 1, 32]
-    - [57, 1345.83]
-  - - [6784, 256, 1, 256]
-    - [37, 8221.08]
-  - - [2368, 3584, 1, 3328]
-    - [34, 10195.1]
-  - - [128, 4288, 1, 1280]
-    - [8, 7053.67]
-  - - [128, 128, 1, 256]
-    - [16, 519.097]
-  - - [5888, 1024, 1, 1280]
-    - [34, 10187.9]
-  - - [1856, 704, 1, 3328]
-    - [34, 9502.72]
-  - - [5888, 6784, 1, 3328]
-    - [34, 10270.6]
-  - - [6784, 448, 1, 1]
-    - [67, 149.569]
-  - - [6784, 1856, 1, 1]
-    - [62, 233.515]
-  - - [128, 32, 1, 1280]
-    - [59, 46.8784]
-  - - [2944, 2368, 1, 1280]
-    - [34, 10076.1]
-  - - [4288, 448, 1, 1]
-    - [65, 119.467]
-  - - [6784, 448, 1, 32]
-    - [48, 2355.99]
-  - - [6784, 448, 1, 3328]
-    - [34, 9596.36]
-  - - [1, 6784, 1, 1]
-    - [77, 0.731034]
-  - - [448, 3584, 1, 1280]
-    - [34, 8475.79]
-  - - [1408, 6784, 1, 1280]
-    - [34, 10150.1]
-  - - [5056, 5888, 1, 1280]
-    - [33, 10444.1]
-  - - [32, 2944, 1, 32]
-    - [52, 171.287]
-  - - [1, 256, 1, 256]
-    - [77, 1.8963]
-  - - [5056, 2944, 1, 32]
-    - [41, 3693.51]
-  - - [32, 6784, 1, 256]
-    - [59, 1397.75]
-  - - [64, 5056, 1, 256]
-    - [39, 5393.07]
-  - - [4288, 6784, 1, 1]
-    - [62, 253.749]
-  - - [448, 704, 1, 1280]
-    - [37, 4904.05]
-  - - [64, 2368, 1, 1]
-    - [72, 12.4632]
-  - - [1, 4288, 1, 3328]
-    - [82, 36.1022]
-  - - [5056, 4288, 1, 1]
-    - [67, 245.472]
-  - - [2368, 5888, 1, 32]
-    - [41, 3688.57]
-  - - [128, 3584, 1, 1280]
-    - [19, 7210.25]
-  - - [2944, 6784, 1, 1]
-    - [61, 243.799]
-  - - [1, 256, 1, 1]
-    - [62, 0.0231884]
-  - - [5888, 1024, 1, 3328]
-    - [34, 10285.8]
-  - - [6784, 5888, 1, 256]
-    - [33, 9932.5]
-  - - [704, 128, 1, 1280]
-    - [25, 3774.32]
-  - - [4288, 128, 1, 256]
-    - [10, 6014.95]
-  - - [32, 3584, 1, 3328]
-    - [59, 1403.65]
-  - - [6784, 64, 1, 256]
-    - [39, 5937.45]
-  - - [1024, 1, 1, 1280]
-    - [82, 11.804]
-  - - [4288, 2368, 1, 32]
-    - [41, 3486.35]
-  - - [704, 3584, 1, 1]
-    - [67, 137.726]
-  - - [704, 1856, 1, 3328]
-    - [34, 9497.74]
-  - - [2944, 128, 1, 1280]
-    - [12, 6851.49]
-  - - [1, 2368, 1, 3328]
-    - [82, 29.4848]
-  - - [6784, 704, 1, 32]
-    - [41, 2916.6]
-  - - [4288, 1, 1, 1280]
-    - [82, 35.0398]
-  - - [704, 5888, 1, 256]
-    - [35, 9461.12]
-  - - [2944, 256, 1, 1]
-    - [61, 62.8053]
-  - - [64, 448, 1, 256]
-    - [25, 873.813]
-  - - [1408, 448, 1, 1280]
-    - [37, 7072.56]
-  - - [1408, 128, 1, 32]
-    - [52, 349.949]
-  - - [3584, 5056, 1, 32]
-    - [41, 3713.26]
-  - - [1024, 32, 1, 1280]
-    - [59, 366.123]
-  - - [128, 2368, 1, 1]
-    - [62, 28.4872]
-  - - [6784, 1856, 1, 1280]
-    - [34, 9972.16]
-  - - [5056, 5056, 1, 3328]
-    - [30, 10464.7]
-  - - [128, 2944, 1, 1280]
-    - [6, 6843.71]
-  - - [128, 6784, 1, 1]
-    - [62, 70.9438]
-  - - [5888, 1408, 1, 256]
-    - [33, 9767.66]
-  - - [2368, 1024, 1, 32]
-    - [55, 2430.91]
-  - - [256, 256, 1, 3328]
-    - [24, 3184.93]
-  - - [64, 4288, 1, 1]
-    - [76, 25.7925]
-  - - [4288, 1024, 1, 256]
-    - [34, 9299.09]
-  - - [3584, 32, 1, 32]
-    - [54, 292.199]
-  - - [3584, 64, 1, 1]
-    - [72, 21.2385]
-  - - [704, 32, 1, 1280]
-    - [59, 246.882]
-  - - [32, 4288, 1, 32]
-    - [59, 322.861]
-  - - [32, 6784, 1, 1280]
-    - [59, 1768.54]
-  - - [64, 1408, 1, 1]
-    - [67, 7.71507]
-  - - [4288, 5888, 1, 1280]
-    - [34, 10317.3]
-  - - [256, 1024, 1, 256]
-    - [37, 4963.67]
-  - - [5056, 5888, 1, 256]
-    - [33, 10092.5]
-  - - [1408, 128, 1, 1280]
-    - [19, 5790.33]
-  - - [1024, 5888, 1, 1280]
-    - [34, 10218.1]
-  - - [64, 1024, 1, 1]
-    - [72, 5.57279]
-  - - [32, 32, 1, 32]
-    - [49, 2.12228]
-  - - [64, 128, 1, 256]
-    - [5, 231.986]
-  - - [5888, 5056, 1, 1280]
-    - [36, 10264.5]
-  - - [5888, 2944, 1, 1]
-    - [71, 239.687]
-  - - [64, 4288, 1, 1280]
-    - [39, 5941.69]
-  - - [704, 2944, 1, 1]
-    - [70, 122.783]
-  - - [1408, 4288, 1, 3328]
-    - [34, 9920.62]
-  - - [704, 2944, 1, 32]
-    - [41, 2375.45]
-  - - [1, 5888, 1, 1280]
-    - [82, 47.1512]
-  - - [2944, 4288, 1, 3328]
-    - [34, 10274.4]
-  - - [256, 2944, 1, 256]
-    - [34, 7220.73]
-  - - [704, 448, 1, 32]
-    - [54, 759.981]
-  - - [5056, 2944, 1, 256]
-    - [33, 9837.17]
-  - - [704, 1024, 1, 256]
-    - [34, 7011.75]
-  - - [2368, 1856, 1, 256]
-    - [34, 9326.28]
-  - - [64, 3584, 1, 1]
-    - [67, 16.6698]
-  - - [1024, 128, 1, 1280]
-    - [17, 5190.97]
-  - - [2368, 4288, 1, 1280]
-    - [34, 10246.2]
-  - - [3584, 448, 1, 256]
-    - [34, 7749.66]
-  - - [256, 6784, 1, 256]
-    - [34, 8307.1]
-  - - [1024, 32, 1, 32]
-    - [49, 69.3503]
-  - - [4288, 704, 1, 1]
-    - [67, 150.336]
-  - - [128, 64, 1, 32]
-    - [52, 16.5495]
-  - - [64, 1, 1, 1280]
-    - [82, 0.735104]
-  - - [6784, 5888, 1, 3328]
-    - [35, 10275.0]
-  - - [256, 5888, 1, 1]
-    - [67, 105.26]
-  - - [6784, 3584, 1, 256]
-    - [33, 9852.38]
-  - - [1408, 1856, 1, 256]
-    - [36, 9189.44]
-  - - [128, 1408, 1, 256]
-    - [19, 4032.98]
-  - - [2944, 2944, 1, 32]
-    - [41, 3372.43]
-  - - [2944, 2944, 1, 3328]
-    - [35, 10121.1]
-  - - [1, 2944, 1, 256]
-    - [77, 20.4356]
-  - - [448, 32, 1, 1280]
-    - [59, 160.179]
-  - - [3584, 1, 1, 256]
-    - [82, 31.3355]
-  - - [704, 32, 1, 3328]
-    - [59, 280.588]
-  - - [256, 448, 1, 3328]
-    - [25, 5043.36]
-  - - [2368, 64, 1, 256]
-    - [39, 3702.03]
-  - - [64, 448, 1, 1280]
-    - [24, 1325.87]
-  - - [1408, 448, 1, 3328]
-    - [37, 7220.86]
-  - - [2368, 6784, 1, 3328]
-    - [35, 10371.0]
-  - - [4288, 3584, 1, 32]
-    - [41, 3592.8]
-  - - [5888, 64, 1, 3328]
-    - [39, 7321.91]
-  - - [3584, 704, 1, 1280]
-    - [34, 9501.1]
-  - - [448, 5056, 1, 3328]
-    - [34, 9574.04]
-  - - [4288, 448, 1, 256]
-    - [4, 8307.13]
-  - - [5056, 256, 1, 1280]
-    - [34, 9224.67]
-  - - [704, 448, 1, 3328]
-    - [37, 5042.39]
-  - - [2944, 5888, 1, 32]
-    - [41, 3703.9]
-  - - [3584, 5056, 1, 256]
-    - [36, 9927.45]
-  - - [6784, 1, 1, 3328]
-    - [82, 56.6468]
-  - - [64, 256, 1, 1]
-    - [65, 1.43217]
-  - - [1856, 448, 1, 3328]
-    - [37, 7397.33]
-  - - [3584, 2368, 1, 256]
-    - [32, 9552.63]
-  - - [128, 1024, 1, 1280]
-    - [25, 5269.23]
-  - - [4288, 256, 1, 32]
-    - [56, 1682.34]
-  - - [4288, 256, 1, 1280]
-    - [34, 7837.42]
-  - - [448, 5056, 1, 256]
-    - [34, 8701.42]
-  - - [128, 1856, 1, 1]
-    - [73, 22.497]
-  - - [128, 1856, 1, 32]
-    - [54, 565.638]
-  - - [1408, 1856, 1, 1]
-    - [71, 121.887]
-  - - [128, 2944, 1, 1]
-    - [76, 35.6848]
-  - - [3584, 32, 1, 256]
-    - [59, 981.288]
-  - - [448, 2368, 1, 1280]
-    - [34, 7608.17]
-  - - [3584, 256, 1, 1]
-    - [72, 71.2348]
-  - - [1408, 1856, 1, 1280]
-    - [34, 9856.66]
-  - - [3584, 4288, 1, 3328]
-    - [34, 10396.2]
-  - - [448, 128, 1, 256]
-    - [17, 1714.96]
-  - - [448, 4288, 1, 32]
-    - [41, 2266.7]
-  - - [448, 4288, 1, 1280]
-    - [34, 8945.4]
-  - - [64, 3584, 1, 256]
-    - [9, 4675.18]
-  - - [6784, 1408, 1, 1280]
-    - [34, 9979.75]
-  - - [1024, 4288, 1, 3328]
-    - [34, 10080.1]
-  - - [1, 6784, 1, 1280]
-    - [82, 55.0426]
-  - - [5056, 1024, 1, 256]
-    - [33, 9571.06]
-  - - [2368, 448, 1, 32]
-    - [42, 1443.35]
-  - - [256, 1, 1, 256]
-    - [77, 1.923]
-  - - [32, 2944, 1, 1280]
-    - [59, 1034.54]
-  - - [5056, 1024, 1, 1]
-    - [62, 188.13]
-  - - [2368, 256, 1, 256]
-    - [34, 5968.82]
-  - - [1, 5056, 1, 1]
-    - [72, 0.540171]
-  - - [4288, 32, 1, 32]
-    - [54, 347.382]
-  - - [1856, 3584, 1, 32]
-    - [41, 3305.29]
-  - - [5056, 3584, 1, 3328]
-    - [35, 10371.5]
-  - - [1856, 256, 1, 32]
-    - [51, 964.743]
-  - - [4288, 5056, 1, 256]
-    - [33, 9927.93]
-  - - [1856, 5888, 1, 256]
-    - [35, 9886.91]
-  - - [256, 256, 1, 256]
-    - [19, 2016.49]
-  - - [2368, 3584, 1, 1]
-    - [67, 216.062]
-  - - [4288, 2368, 1, 256]
-    - [34, 9647.49]
-  - - [448, 1, 1, 3328]
-    - [82, 5.59496]
-  - - [1856, 256, 1, 1280]
-    - [37, 7338.01]
-  - - [1024, 6784, 1, 1]
-    - [71, 187.145]
-  - - [1408, 2944, 1, 3328]
-    - [34, 10097.7]
-  - - [32, 1856, 1, 32]
-    - [52, 120.593]
-  - - [256, 1, 1, 1]
-    - [62, 0.0336842]
-  - - [6784, 5056, 1, 3328]
-    - [34, 10296.1]
-  - - [6784, 5056, 1, 1]
-    - [61, 258.438]
-  - - [5888, 3584, 1, 32]
-    - [41, 3783.52]
-  - - [5888, 3584, 1, 3328]
-    - [34, 10392.4]
-  - - [1, 256, 1, 3328]
-    - [82, 3.19041]
-  - - [1024, 6784, 1, 256]
-    - [34, 9451.45]
-  - - [6784, 5888, 1, 32]
-    - [41, 3918.02]
-  - - [1408, 1, 1, 1280]
-    - [82, 15.966]
-  - - [2368, 6784, 1, 32]
-    - [41, 3673.99]
-  - - [6784, 64, 1, 1]
-    - [73, 39.0446]
-  - - [2368, 32, 1, 32]
-    - [49, 158.693]
-  - - [3584, 1408, 1, 3328]
-    - [34, 9903.05]
-  - - [2944, 1408, 1, 1280]
-    - [35, 9989.82]
-  - - [1856, 64, 1, 1]
-    - [76, 10.0324]
-  - - [3584, 1024, 1, 1]
-    - [61, 164.427]
-  - - [256, 32, 1, 256]
-    - [54, 62.4152]
-  - - [2944, 1856, 1, 3328]
-    - [34, 10228.4]
-  - - [128, 1024, 1, 3328]
-    - [25, 5715.51]
-  - - [1408, 128, 1, 1]
-    - [67, 13.5711]
-  - - [2944, 3584, 1, 32]
-    - [41, 3564.63]
-  - - [3584, 1024, 1, 32]
-    - [41, 2723.57]
-  - - [4288, 6784, 1, 3328]
-    - [34, 10489.5]
-  - - [256, 128, 1, 1280]
-    - [25, 1533.01]
-  - - [6784, 5056, 1, 256]
-    - [4, 9904.32]
-  - - [1408, 32, 1, 3328]
-    - [54, 538.91]
-  - - [1856, 3584, 1, 1280]
-    - [35, 10024.5]
-  - - [256, 5888, 1, 256]
-    - [35, 8301.98]
-  - - [5056, 32, 1, 256]
-    - [59, 1078.61]
-  - - [2368, 1408, 1, 1]
-    - [62, 160.295]
-  - - [448, 2368, 1, 256]
-    - [34, 6942.26]
-  - - [64, 1408, 1, 1280]
-    - [28, 3855.06]
-  - - [3584, 32, 1, 1280]
-    - [59, 1378.67]
-  - - [128, 2368, 1, 3328]
-    - [10, 6400.57]
-  - - [3584, 1024, 1, 256]
-    - [35, 9478.61]
-  - - [256, 64, 1, 256]
-    - [16, 514.008]
-  - - [2368, 448, 1, 3328]
-    - [34, 7730.24]
-  - - [3584, 2368, 1, 1]
-    - [67, 214.316]
-  - - [1, 1, 1, 1]
-    - [72, 8.99281e-05]
-  - - [1024, 1856, 1, 32]
-    - [56, 2165.86]
-  - - [32, 1024, 1, 32]
-    - [52, 67.5629]
-  - - [4288, 1, 1, 256]
-    - [82, 28.4681]
-  - - [1856, 128, 1, 3328]
-    - [20, 6664.08]
-  - - [5888, 2368, 1, 1]
-    - [61, 224.305]
-  - - [5888, 128, 1, 1]
-    - [64, 58.88]
-  - - [704, 256, 1, 1280]
-    - [27, 4362.46]
-  - - [704, 4288, 1, 256]
-    - [4, 8986.05]
-  - - [5888, 2368, 1, 32]
-    - [41, 3598.14]
-  - - [5888, 2368, 1, 1280]
-    - [36, 10245.9]
-  - - [128, 256, 1, 256]
-    - [17, 970.904]
-  - - [2944, 5056, 1, 3328]
-    - [34, 10425.8]
-  - - [6784, 704, 1, 3328]
-    - [34, 9673.25]
-  - - [1856, 1856, 1, 32]
-    - [41, 2707.06]
-  - - [4288, 2944, 1, 32]
-    - [41, 3541.06]
-  - - [128, 448, 1, 1]
-    - [67, 4.77867]
-  - - [2944, 64, 1, 1]
-    - [67, 14.72]
-  - - [704, 64, 1, 256]
-    - [25, 1373.14]
-  - - [256, 2368, 1, 3328]
-    - [37, 6937.62]
-  - - [704, 1, 1, 1]
-    - [62, 0.0647059]
-  - - [128, 448, 1, 1280]
-    - [29, 2527.56]
-  - - [5056, 5056, 1, 256]
-    - [30, 9973.43]
-  - - [5888, 64, 1, 1]
-    - [78, 31.1947]
-  - - [6784, 6784, 1, 256]
-    - [33, 9998.12]
-  - - [256, 3584, 1, 1]
-    - [70, 70.3607]
-  - - [2368, 2944, 1, 256]
-    - [31, 9513.2]
-  - - [448, 32, 1, 32]
-    - [49, 30.5021]
-  - - [5888, 3584, 1, 1]
-    - [64, 243.791]
-  - - [5888, 128, 1, 256]
-    - [7, 7264.23]
-  - - [3584, 704, 1, 3328]
-    - [34, 9653.5]
-  - - [4288, 704, 1, 3328]
-    - [34, 9693.56]
-  - - [4288, 2944, 1, 1280]
-    - [34, 10146.3]
-  - - [448, 3584, 1, 256]
-    - [34, 7749.66]
-  - - [704, 32, 1, 256]
-    - [54, 171.234]
-  - - [6784, 256, 1, 32]
-    - [41, 2098.74]
-  - - [1856, 128, 1, 1]
-    - [79, 21.2114]
-  - - [1856, 32, 1, 32]
-    - [49, 125.697]
-  - - [2368, 5056, 1, 1280]
-    - [30, 10294.6]
-  - - [704, 1856, 1, 1280]
-    - [37, 9328.86]
-  - - [1408, 1408, 1, 1280]
-    - [34, 9231.5]
-  - - [448, 1024, 1, 3328]
-    - [37, 7317.52]
-  - - [32, 704, 1, 32]
-    - [52, 47.4274]
-  - - [3584, 448, 1, 1]
-    - [72, 106.757]
-  - - [6784, 1024, 1, 3328]
-    - [37, 9948.61]
-  - - [5888, 1856, 1, 32]
-    - [41, 3508.23]
-  - - [5888, 704, 1, 3328]
-    - [36, 10072.3]
-  - - [5056, 1, 1, 256]
-    - [82, 33.4281]
-  - - [448, 6784, 1, 256]
-    - [35, 9080.81]
-  - - [1024, 128, 1, 1]
-    - [72, 10.996]
-  - - [128, 64, 1, 256]
-    - [8, 216.648]
-  - - [128, 5056, 1, 1]
-    - [76, 57.7829]
-  - - [1856, 128, 1, 256]
-    - [9, 4751.36]
-  - - [64, 704, 1, 1]
-    - [67, 3.88414]
-  - - [2944, 5888, 1, 256]
-    - [33, 9819.38]
-  - - [1408, 64, 1, 256]
-    - [39, 2645.49]
-  - - [128, 5056, 1, 32]
-    - [51, 1268.96]
-  - - [128, 5056, 1, 1280]
-    - [11, 7965.14]
-  - - [448, 32, 1, 3328]
-    - [59, 177.546]
-  - - [1856, 1408, 1, 32]
-    - [41, 2568.3]
-  - - [64, 704, 1, 32]
-    - [52, 92.899]
-  - - [1, 5888, 1, 256]
-    - [82, 37.0169]
-  - - [64, 2368, 1, 32]
-    - [52, 297.161]
-  - - [5888, 64, 1, 32]
-    - [52, 842.083]
-  - - [2368, 256, 1, 1]
-    - [62, 54.1257]
-  - - [5888, 64, 1, 1280]
-    - [39, 7068.36]
-  - - [5056, 1, 1, 1]
-    - [76, 0.509677]
-  - - [5888, 2944, 1, 1280]
-    - [34, 10201.9]
-  - - [256, 1408, 1, 256]
-    - [34, 4766.25]
-  - - [448, 5888, 1, 1]
-    - [62, 142.124]
-  - - [3584, 1408, 1, 1]
-    - [69, 186.072]
-  - - [32, 6784, 1, 32]
-    - [52, 504.856]
-  - - [32, 1856, 1, 1280]
-    - [54, 643.38]
-  - - [448, 5888, 1, 32]
-    - [45, 2259.38]
-  - - [5056, 704, 1, 1280]
-    - [36, 9725.2]
-  - - [1856, 6784, 1, 1]
-    - [67, 233.862]
-  - - [5056, 64, 1, 1]
-    - [62, 32.1016]
-  - - [1, 5888, 1, 1]
-    - [65, 0.579528]
-  - - [2368, 1024, 1, 256]
-    - [35, 8573.99]
-  - - [1856, 6784, 1, 32]
-    - [41, 3612.94]
-  - - [1856, 6784, 1, 1280]
-    - [34, 10156.7]
-  - - [64, 3584, 1, 3328]
-    - [15, 6399.76]
-  - - [5888, 5056, 1, 3328]
-    - [36, 10315.0]
-  - - [1, 2944, 1, 3328]
-    - [82, 36.6239]
-  - - [1408, 6784, 1, 32]
-    - [41, 3518.18]
-  - - [32, 5888, 1, 1280]
-    - [59, 1534.18]
-  - - [448, 256, 1, 1]
-    - [76, 9.62148]
-  - - [3584, 5888, 1, 3328]
-    - [34, 10419.3]
-  - - [4288, 1408, 1, 256]
-    - [33, 9406.04]
-  - - [448, 64, 1, 1280]
-    - [28, 1314.48]
-  - - [128, 448, 1, 32]
-    - [43, 116.435]
-  - - [6784, 2368, 1, 256]
-    - [36, 9776.8]
-  - - [1408, 448, 1, 32]
-    - [49, 1224.82]
-  - - [1856, 1408, 1, 1280]
-    - [34, 9849.7]
-  - - [448, 256, 1, 3328]
-    - [25, 5048.7]
-  - - [1856, 2368, 1, 1]
-    - [67, 177.218]
-  - - [1408, 5056, 1, 3328]
-    - [34, 10054.8]
-  - - [128, 704, 1, 3328]
-    - [25, 4151.34]
-  - - [5056, 128, 1, 1280]
-    - [11, 7916.43]
-  - - [5056, 4288, 1, 256]
-    - [33, 9918.0]
-  - - [5056, 5056, 1, 32]
-    - [41, 3690.1]
-  - - [1856, 704, 1, 256]
-    - [34, 8329.08]
-  - - [2368, 256, 1, 32]
-    - [51, 1212.42]
-  - - [64, 256, 1, 256]
-    - [24, 514.008]
-  - - [448, 5888, 1, 1280]
-    - [34, 9101.83]
-  - - [704, 704, 1, 3328]
-    - [37, 7884.37]
-  - - [128, 6784, 1, 256]
-    - [2, 7161.67]
-  - - [5056, 448, 1, 256]
-    - [34, 8701.42]
-  - - [4288, 5888, 1, 1]
-    - [62, 249.879]
-  - - [1856, 5056, 1, 1280]
-    - [30, 10265.5]
-  - - [704, 1856, 1, 1]
-    - [65, 92.8]
-  - - [2368, 32, 1, 3328]
-    - [54, 896.298]
-  - - [3584, 1856, 1, 256]
-    - [36, 9562.49]
-  - - [256, 3584, 1, 256]
-    - [34, 7126.24]
-  - - [2944, 1408, 1, 1]
-    - [66, 173.292]
-  - - [4288, 5888, 1, 32]
-    - [41, 3711.54]
-  - - [4288, 5888, 1, 3328]
-    - [34, 10413.1]
-  - - [1, 1024, 1, 1]
-    - [62, 0.0914286]
-  - - [32, 64, 1, 32]
-    - [49, 4.22268]
-  - - [1408, 2368, 1, 1]
-    - [75, 138.003]
-  - - [2944, 2368, 1, 256]
-    - [32, 9501.02]
-  - - [1024, 1856, 1, 256]
-    - [36, 8163.41]
-  - - [2944, 64, 1, 3328]
-    - [39, 6510.05]
-  - - [1024, 5888, 1, 32]
-    - [41, 3241.57]
-  - - [1024, 5888, 1, 3328]
-    - [34, 10321.8]
-  - - [5056, 2368, 1, 32]
-    - [41, 3536.96]
-  - - [1408, 2368, 1, 1280]
-    - [34, 9790.11]
-  - - [256, 1, 1, 3328]
-    - [82, 3.1952]
-  - - [128, 1024, 1, 32]
-    - [52, 273.067]
-  - - [5056, 6784, 1, 3328]
-    - [34, 10470.4]
-  - - [448, 704, 1, 1]
-    - [70, 27.7634]
-  - - [448, 704, 1, 32]
-    - [54, 729.23]
-  - - [448, 704, 1, 3328]
-    - [37, 5034.65]
-  - - [1408, 2944, 1, 256]
-    - [36, 9467.87]
-  - - [3584, 4288, 1, 1]
-    - [62, 240.128]
-  - - [2368, 128, 1, 32]
-    - [54, 709.015]
-  - - [5056, 1408, 1, 1280]
-    - [35, 9967.76]
-  - - [2368, 128, 1, 3328]
-    - [10, 6403.82]
-  - - [704, 5056, 1, 32]
-    - [55, 2780.8]
-  - - [32, 2368, 1, 32]
-    - [49, 155.438]
-  - - [1408, 1, 1, 256]
-    - [77, 10.5518]
-  - - [256, 1856, 1, 32]
-    - [54, 1010.93]
-  - - [448, 1408, 1, 1]
-    - [67, 53.6381]
-  - - [5056, 4288, 1, 1280]
-    - [34, 10329.4]
-  - - [1408, 256, 1, 256]
-    - [37, 4669.77]
-  - - [128, 256, 1, 1]
-    - [61, 3.30323]
-  - - [256, 4288, 1, 32]
-    - [56, 1695.33]
-  - - [64, 64, 1, 3328]
-    - [26, 201.411]
-  - - [256, 256, 1, 1]
-    - [76, 5.53514]
-  - - [1408, 1, 1, 1]
-    - [62, 0.129412]
-  - - [448, 1408, 1, 256]
-    - [34, 6229.97]
-  - - [5888, 5888, 1, 1]
-    - [69, 259.806]
-  - - [128, 2944, 1, 32]
-    - [54, 866.28]
-  - - [32, 1024, 1, 1280]
-    - [59, 362.829]
-  - - [32, 256, 1, 32]
-    - [52, 17.3376]
-  - - [2944, 704, 1, 1280]
-    - [34, 9617.52]
-  - - [1024, 3584, 1, 1280]
-    - [34, 10046.2]
-  - - [704, 6784, 1, 256]
-    - [34, 9151.49]
-  - - [1856, 448, 1, 1]
-    - [65, 66.6256]
-  - - [128, 704, 1, 1]
-    - [77, 7.4596]
-  - - [5056, 256, 1, 32]
-    - [54, 1842.47]
-  - - [4288, 1, 1, 3328]
-    - [82, 36.3227]
-  - - [5056, 1024, 1, 1280]
-    - [35, 10054.3]
-  - - [704, 704, 1, 1]
-    - [62, 43.3231]
-  - - [1856, 448, 1, 1280]
-    - [37, 7277.79]
-  - - [3584, 6784, 1, 256]
-    - [33, 9981.31]
-  - - [64, 1856, 1, 1280]
-    - [40, 4848.33]
-  - - [1856, 1408, 1, 256]
-    - [35, 9179.36]
-  - - [4288, 4288, 1, 32]
-    - [41, 3742.89]
-  - - [128, 1, 1, 256]
-    - [77, 0.977566]
-  - - [32, 64, 1, 3328]
-    - [54, 24.2934]
-  - - [5888, 448, 1, 1]
-    - [67, 142.124]
-  - - [128, 5888, 1, 256]
-    - [7, 7330.47]
-  - - [3584, 256, 1, 3328]
-    - [37, 8157.33]
-  - - [5056, 5056, 1, 1280]
-    - [30, 10409.2]
-  - - [2368, 1, 1, 256]
-    - [77, 17.4198]
-  - - [6784, 1408, 1, 3328]
-    - [34, 10055.6]
-  - - [1408, 1408, 1, 1]
-    - [74, 118.004]
-  - - [32, 64, 1, 256]
-    - [54, 15.3121]
-  - - [2368, 1, 1, 1280]
-    - [82, 27.1793]
-  - - [32, 3584, 1, 32]
-    - [49, 210.437]
-  - - [2368, 5056, 1, 1]
-    - [62, 231.668]
-  - - [1, 3584, 1, 1]
-    - [72, 0.367213]
-  - - [256, 2944, 1, 3328]
-    - [37, 8615.67]
-  - - [1408, 64, 1, 3328]
-    - [25, 4146.75]
-  - - [1, 128, 1, 3328]
-    - [82, 1.61016]
-  - - [32, 256, 1, 256]
-    - [54, 61.1058]
-  - - [5888, 1408, 1, 32]
-    - [41, 3483.32]
-  - - [704, 256, 1, 1]
-    - [62, 13.9062]
-  - - [1, 448, 1, 1]
-    - [75, 0.0523364]
-  - - [256, 6784, 1, 3328]
-    - [34, 9280.27]
-  - - [64, 5888, 1, 256]
-    - [39, 5688.03]
-  - - [1856, 1, 1, 1]
-    - [62, 0.170588]
-  - - [1024, 256, 1, 3328]
-    - [37, 6633.33]
-  - - [704, 704, 1, 256]
-    - [37, 6395.05]
-  - - [448, 1024, 1, 32]
-    - [54, 981.288]
-  - - [6784, 2368, 1, 1280]
-    - [36, 10130.9]
-  - - [128, 1856, 1, 1280]
-    - [20, 6272.42]
-  - - [256, 2368, 1, 256]
-    - [34, 5987.24]
-  - - [1024, 448, 1, 32]
-    - [51, 941.03]
-  - - [6784, 1024, 1, 256]
-    - [34, 9332.41]
-  - - [1408, 6784, 1, 3328]
-    - [34, 10255.2]
-  - - [2944, 1408, 1, 3328]
-    - [34, 10101.8]
-  - - [1856, 32, 1, 256]
-    - [54, 451.436]
-  - - [704, 2368, 1, 32]
-    - [54, 2051.78]
-  - - [448, 256, 1, 32]
-    - [58, 216.392]
-  - - [704, 6784, 1, 1]
-    - [62, 183.126]
-  - - [2368, 6784, 1, 256]
-    - [33, 9943.22]
-  - - [1856, 64, 1, 256]
-    - [39, 3248.79]
-  - - [1856, 3584, 1, 3328]
-    - [35, 10101.8]
-  - - [1, 704, 1, 3328]
-    - [82, 8.78944]
-  - - [5056, 1408, 1, 32]
-    - [41, 3350.05]
-  - - [64, 1, 1, 3328]
-    - [82, 0.799279]
-  - - [5056, 4288, 1, 3328]
-    - [34, 10445.7]
-  - - [4288, 2368, 1, 1]
-    - [62, 224.646]
-  - - [704, 448, 1, 256]
-    - [37, 4119.41]
-  - - [448, 64, 1, 3328]
-    - [25, 1447.52]
-  - - [2368, 256, 1, 1280]
-    - [37, 6792.25]
-  - - [256, 32, 1, 1280]
-    - [54, 90.833]
-  - - [2368, 448, 1, 1280]
-    - [34, 7591.16]
-  - - [6784, 2944, 1, 32]
-    - [41, 3750.63]
-  - - [64, 4288, 1, 32]
-    - [59, 649.543]
-  - - [3584, 1856, 1, 1]
-    - [69, 199.877]
-  - - [128, 448, 1, 3328]
-    - [26, 2790.07]
-  - - [5888, 2368, 1, 3328]
-    - [36, 10313.1]
-  - - [2368, 704, 1, 1280]
-    - [34, 8785.62]
-  - - [1024, 1408, 1, 1280]
-    - [34, 8751.39]
-  - - [4288, 64, 1, 1280]
-    - [39, 5965.91]
-  - - [2368, 6784, 1, 1]
-    - [67, 241.935]
-  - - [2944, 5056, 1, 32]
-    - [41, 3652.73]
-  - - [5056, 256, 1, 3328]
-    - [34, 9403.49]
-  - - [448, 448, 1, 1]
-    - [67, 14.5017]
-  - - [256, 2368, 1, 1280]
-    - [34, 6782.75]
-  - - [704, 2368, 1, 3328]
-    - [34, 8910.47]
-  - - [3584, 2944, 1, 256]
-    - [33, 9583.92]
-  - - [64, 6784, 1, 256]
-    - [38, 5837.66]
-  - - [3584, 1024, 1, 1280]
-    - [36, 10039.4]
-  - - [1408, 256, 1, 32]
-    - [54, 838.251]
-  - - [64, 1024, 1, 256]
-    - [19, 1997.29]
-  - - [1408, 32, 1, 32]
-    - [49, 99.0242]
-  - - [128, 3584, 1, 256]
-    - [34, 5967.51]
-  - - [4288, 2944, 1, 1]
-    - [62, 233.775]
-  - - [5056, 3584, 1, 256]
-    - [33, 9946.18]
-  - - [2368, 704, 1, 256]
-    - [34, 8046.2]
-  - - [1856, 1856, 1, 1280]
-    - [34, 9447.34]
-  - - [64, 32, 1, 32]
-    - [52, 4.42811]
-  - - [1856, 1024, 1, 1]
-    - [68, 115.887]
-  - - [4288, 2944, 1, 3328]
-    - [34, 10256.3]
-  - - [1024, 128, 1, 3328]
-    - [28, 5727.52]
-  - - [4288, 128, 1, 3328]
-    - [14, 7216.42]
-  - - [4288, 704, 1, 32]
-    - [56, 2520.88]
-  - - [1856, 1024, 1, 32]
-    - [41, 2190.83]
-  - - [1, 448, 1, 3328]
-    - [82, 5.6]
-  - - [6784, 2368, 1, 32]
-    - [41, 3620.17]
-  - - [5888, 5056, 1, 1]
-    - [66, 255.403]
-  - - [128, 6784, 1, 1280]
-    - [11, 8012.47]
-  - - [704, 5888, 1, 1]
-    - [62, 175.049]
-  - - [6784, 6784, 1, 1]
-    - [66, 265.474]
-  - - [1856, 32, 1, 1280]
-    - [59, 658.996]
-  - - [3584, 1024, 1, 3328]
-    - [34, 10171.4]
-  - - [5888, 448, 1, 3328]
-    - [34, 9207.37]
-  - - [704, 5888, 1, 32]
-    - [41, 2945.05]
-  - - [704, 5888, 1, 1280]
-    - [35, 9982.3]
-  - - [1024, 6784, 1, 3328]
-    - [34, 10171.3]
-  - - [704, 2944, 1, 1280]
-    - [34, 9628.69]
-  - - [4288, 6784, 1, 256]
-    - [33, 10035.3]
-  - - [3584, 256, 1, 32]
-    - [49, 1561.71]
-  - - [1408, 1408, 1, 32]
-    - [41, 2285.26]
-  - - [1408, 1408, 1, 3328]
-    - [34, 9352.52]
-  - - [1024, 64, 1, 256]
-    - [39, 1997.29]
-  - - [4288, 64, 1, 32]
-    - [54, 627.273]
-  - - [5888, 6784, 1, 32]
-    - [41, 3929.58]
-  - - [1024, 2944, 1, 3328]
-    - [34, 9689.39]
-  - - [64, 704, 1, 1280]
-    - [16, 2008.07]
-  - - [2944, 1856, 1, 256]
-    - [34, 9461.58]
-  - - [128, 5056, 1, 3328]
-    - [11, 8131.14]
-  - - [704, 1408, 1, 1]
-    - [69, 74.641]
-  - - [6784, 5056, 1, 32]
-    - [41, 3847.44]
-  - - [1024, 448, 1, 3328]
-    - [37, 7306.31]
-  - - [5888, 1408, 1, 1]
-    - [61, 212.79]
-  - - [2944, 4288, 1, 1280]
-    - [3, 10150.4]
-  - - [64, 32, 1, 3328]
-    - [59, 25.4699]
-  - - [1024, 4288, 1, 256]
-    - [34, 9305.24]
-  - - [128, 2368, 1, 256]
-    - [10, 4948.64]
-  - - [2368, 64, 1, 32]
-    - [49, 303.104]
-  - - [1408, 1, 1, 3328]
-    - [82, 17.5368]
-  - - [64, 1408, 1, 32]
-    - [49, 182.969]
-  - - [2368, 5888, 1, 1]
-    - [62, 222.019]
-  - - [448, 1856, 1, 256]
-    - [34, 6521.47]
-  - - [1856, 6784, 1, 3328]
-    - [34, 10249.7]
-  - - [3584, 128, 1, 256]
-    - [1, 5919.38]
-  - - [1024, 448, 1, 1280]
-    - [37, 7084.97]
-  - - [1024, 2368, 1, 32]
-    - [55, 2430.91]
-  - - [128, 5888, 1, 1]
-    - [69, 64.0871]
-  - - [64, 5056, 1, 1]
-    - [72, 30.8763]
-  - - [32, 2368, 1, 1280]
-    - [59, 841.371]
-  - - [2368, 2368, 1, 3328]
-    - [34, 10027.0]
-  - - [64, 448, 1, 1]
-    - [64, 2.9377]
-  - - [3584, 5888, 1, 32]
-    - [41, 3786.92]
-  - - [3584, 5888, 1, 1280]
-    - [34, 10321.0]
-  - - [64, 5056, 1, 32]
-    - [54, 756.922]
-  - - [6784, 704, 1, 256]
-    - [34, 9021.84]
-  - - [1408, 704, 1, 32]
-    - [52, 1638.4]
-  - - [1408, 704, 1, 1280]
-    - [37, 8628.79]
-  - - [2368, 5888, 1, 256]
-    - [33, 9890.69]
-  - - [2944, 64, 1, 32]
-    - [49, 360.605]
-  - - [1, 1408, 1, 256]
-    - [77, 10.5271]
-  - - [64, 2944, 1, 256]
-    - [39, 4369.07]
-  - - [5888, 5888, 1, 32]
-    - [41, 3861.71]
-  - - [1856, 1408, 1, 3328]
-    - [34, 9995.51]
-  - - [1024, 1024, 1, 32]
-    - [41, 1619.42]
-  - - [4288, 1024, 1, 1]
-    - [67, 175.356]
-  - - [2944, 5056, 1, 1280]
-    - [34, 10321.0]
-  - - [6784, 2944, 1, 1280]
-    - [37, 10061.5]
-  - - [6784, 256, 1, 3328]
-    - [37, 9140.54]
-  - - [5056, 128, 1, 3328]
-    - [11, 8133.59]
-  - - [128, 128, 1, 1280]
-    - [24, 762.047]
-  - - [128, 4288, 1, 1]
-    - [72, 49.3583]
-  - - [1408, 5056, 1, 32]
-    - [41, 3224.85]
-  - - [2944, 128, 1, 3328]
-    - [6, 7115.85]
-  - - [5888, 1856, 1, 1280]
-    - [36, 10280.5]
-  - - [256, 64, 1, 1280]
-    - [24, 764.268]
-  - - [5888, 256, 1, 1280]
-    - [34, 9131.86]
-  - - [1856, 5056, 1, 1]
-    - [62, 194.204]
-  - - [3584, 1856, 1, 1280]
-    - [36, 10019.8]
-  - - [704, 3584, 1, 256]
-    - [35, 8901.91]
-  - - [1856, 5056, 1, 32]
-    - [41, 3456.33]
-  - - [1856, 5056, 1, 3328]
-    - [34, 10355.2]
-  - - [1024, 2944, 1, 32]
-    - [41, 2691.66]
-  - - [1408, 6784, 1, 256]
-    - [34, 9593.84]
-  - - [1024, 2368, 1, 1280]
-    - [34, 9150.31]
-  - - [1856, 3584, 1, 1]
-    - [62, 202.802]
-  - - [2944, 5888, 1, 1280]
-    - [34, 10241.1]
-  - - [1, 1856, 1, 1]
-    - [67, 0.166906]
-  - - [3584, 3584, 1, 256]
-    - [33, 9810.07]
-  - - [1856, 2368, 1, 3328]
-    - [34, 10097.3]
-  - - [5888, 704, 1, 256]
-    - [36, 9434.2]
-  - - [64, 448, 1, 32]
-    - [55, 64.7955]
-  - - [6784, 4288, 1, 256]
-    - [4, 9893.43]
-  - - [128, 64, 1, 3328]
-    - [24, 387.258]
-  - - [1, 5056, 1, 1280]
-    - [82, 41.3155]
-  - - [32, 64, 1, 1280]
-    - [59, 23.0598]
-  - - [1408, 2368, 1, 3328]
-    - [34, 9933.42]
-  - - [1024, 3584, 1, 256]
-    - [36, 9440.56]
-  - - [2944, 128, 1, 256]
-    - [0, 5608.66]
-  - - [6784, 128, 1, 1]
-    - [62, 71.8834]
-  - - [1408, 256, 1, 3328]
-    - [37, 5756.1]
-  - - [448, 32, 1, 256]
-    - [54, 108.709]
-  - - [5056, 6784, 1, 1280]
-    - [33, 10401.6]
-  - - [64, 2368, 1, 256]
-    - [39, 3673.99]
-  - - [2944, 256, 1, 256]
-    - [34, 7286.18]
-  - - [1, 128, 1, 256]
-    - [77, 0.961502]
-  - - [32, 256, 1, 1280]
-    - [59, 91.9804]
-  - - [5888, 1, 1, 256]
-    - [82, 38.4522]
-  - - [32, 128, 1, 3328]
-    - [59, 50.502]
-  - - [6784, 128, 1, 256]
-    - [0, 7180.17]
-  - - [6784, 64, 1, 1280]
-    - [39, 7169.06]
-  - - [4288, 1024, 1, 32]
-    - [41, 2956.84]
-  - - [2944, 448, 1, 1280]
-    - [34, 8023.8]
-  - - [6784, 32, 1, 1280]
-    - [59, 1742.8]
-  - - [2944, 64, 1, 1280]
-    - [39, 6114.92]
-  - - [704, 448, 1, 1]
-    - [65, 29.4209]
-  - - [32, 128, 1, 32]
-    - [52, 8.48912]
-  - - [1, 128, 1, 1]
-    - [62, 0.0115942]
-  - - [32, 4288, 1, 256]
-    - [54, 869.488]
-  - - [5888, 1, 1, 1]
-    - [67, 0.603279]
-  - - [5888, 1856, 1, 3328]
-    - [36, 10359.8]
-  - - [32, 2368, 1, 3328]
-    - [54, 891.987]
-  - - [2368, 3584, 1, 256]
-    - [31, 9579.58]
-  - - [4288, 1408, 1, 3328]
-    - [34, 9916.3]
-  - - [1856, 32, 1, 3328]
-    - [54, 705.312]
-  - - [2944, 32, 1, 256]
-    - [54, 685.149]
-  - - [128, 64, 1, 1]
-    - [82, 0.716084]
-  - - [256, 1024, 1, 3328]
-    - [37, 6653.56]
-  - - [32, 448, 1, 256]
-    - [54, 106.687]
-  - - [1856, 64, 1, 32]
-    - [52, 238.762]
-  - - [1856, 64, 1, 3328]
-    - [40, 5245.66]
-  - - [256, 5056, 1, 256]
-    - [34, 8283.75]
-  - - [5888, 2944, 1, 3328]
-    - [34, 10319.3]
-  - - [2368, 1408, 1, 3328]
-    - [34, 9922.76]
-  - - [5888, 704, 1, 32]
-    - [52, 2754.25]
-  - - [2944, 704, 1, 1]
-    - [62, 98.5065]
-  - - [6784, 1856, 1, 256]
-    - [36, 9480.36]
-  - - [1, 704, 1, 256]
-    - [77, 5.26347]
-  - - [1856, 1856, 1, 1]
-    - [68, 130.482]
-  - - [5888, 32, 1, 256]
-    - [59, 1245.73]
-  - - [2368, 1856, 1, 1]
-    - [62, 177.218]
-  - - [128, 704, 1, 256]
-    - [25, 2597.82]
-  - - [256, 1408, 1, 3328]
-    - [37, 5749.48]
-  - - [2944, 128, 1, 1]
-    - [72, 35.6848]
-  - - [32, 256, 1, 3328]
-    - [59, 101.758]
-  - - [2944, 704, 1, 3328]
-    - [34, 9776.52]
-  - - [2368, 1856, 1, 32]
-    - [41, 2881.97]
-  - - [3584, 128, 1, 1280]
-    - [23, 7147.06]
-  - - [1024, 5056, 1, 3328]
-    - [34, 10158.4]
-  - - [256, 32, 1, 32]
-    - [49, 17.3376]
-  - - [64, 256, 1, 3328]
-    - [24, 828.158]
-  - - [256, 6784, 1, 1]
-    - [62, 113.659]
-  - - [1024, 3584, 1, 32]
-    - [41, 2884.1]
-  - - [256, 6784, 1, 32]
-    - [54, 2111.49]
-  - - [2944, 1408, 1, 32]
-    - [41, 2998.3]
-  - - [1024, 32, 1, 256]
-    - [54, 250.257]
-  - - [4288, 3584, 1, 1]
-    - [63, 221.316]
-  - - [1, 704, 1, 1]
-    - [70, 0.0642336]
-  - - [5056, 448, 1, 3328]
-    - [34, 9548.81]
-  - - [3584, 64, 1, 256]
-    - [20, 4705.15]
-  - - [64, 1856, 1, 32]
-    - [49, 242.416]
-  - - [64, 1856, 1, 3328]
-    - [25, 5245.66]
-  - - [5888, 5888, 1, 3328]
-    - [36, 10244.5]
-  - - [6784, 3584, 1, 32]
-    - [41, 3827.45]
-  - - [4288, 1856, 1, 256]
-    - [3, 9463.88]
-  - - [1856, 2944, 1, 256]
-    - [34, 9461.58]
-  - - [4288, 256, 1, 1]
-    - [71, 82.6602]
-  - - [64, 128, 1, 32]
-    - [49, 16.3025]
-  - - [704, 1, 1, 1280]
-    - [82, 7.94919]
-  - - [1024, 2368, 1, 256]
-    - [36, 8526.88]
-  - - [2944, 5888, 1, 1]
-    - [69, 247.631]
-  - - [1024, 1856, 1, 3328]
-    - [34, 8978.27]
-  - - [5888, 1024, 1, 32]
-    - [41, 3245.93]
-  - - [3584, 256, 1, 1280]
-    - [37, 8000.04]
-  - - [1024, 1, 1, 1]
-    - [65, 0.0927536]
-  - - [1408, 5056, 1, 1280]
-    - [36, 9982.61]
-  - - [5056, 6784, 1, 256]
-    - [33, 10053.1]
-  - - [256, 1856, 1, 256]
-    - [37, 6033.47]
-  - - [1856, 256, 1, 1]
-    - [65, 41.2444]
-  - - [5888, 32, 1, 1280]
-    - [59, 1559.57]
-  - - [256, 704, 1, 1]
-    - [62, 13.4898]
-  - - [256, 128, 1, 32]
-    - [52, 66.534]
-  - - [1408, 1856, 1, 32]
-    - [49, 2442.29]
-  - - [2944, 5056, 1, 1]
-    - [66, 226.627]
-  - - [448, 128, 1, 1]
-    - [67, 4.77867]
-  - - [256, 704, 1, 32]
-    - [58, 316.182]
-  - - [256, 704, 1, 1280]
-    - [27, 4342.75]
-  - - [1, 2368, 1, 1]
-    - [76, 0.208451]
-  - - [5888, 5888, 1, 1280]
-    - [36, 10185.4]
-  - - [256, 2944, 1, 1280]
-    - [37, 8403.22]
-  - - [2944, 256, 1, 3328]
-    - [37, 8601.49]
-  - - [5056, 2944, 1, 1280]
-    - [34, 10301.8]
-  - - [704, 1024, 1, 3328]
-    - [37, 8250.14]
-  - - [2368, 1856, 1, 1280]
-    - [34, 9978.73]
-  - - [448, 2944, 1, 1]
-    - [61, 94.7494]
-  - - [6784, 2944, 1, 1]
-    - [66, 251.918]
-  - - [2944, 1024, 1, 32]
-    - [41, 2679.69]
-  - - [2944, 1024, 1, 1280]
-    - [34, 9558.96]
-  - - [1408, 64, 1, 32]
-    - [52, 182.044]
-  - - [2368, 4288, 1, 256]
-    - [34, 9658.96]
-  - - [448, 1856, 1, 1280]
-    - [37, 7281.78]
-  - - [2368, 448, 1, 1]
-    - [65, 80.8585]
-  - - [448, 2944, 1, 32]
-    - [50, 1870.8]
-  - - [448, 2944, 1, 1280]
-    - [34, 8014.66]
-  - - [2944, 6784, 1, 1280]
-    - [34, 10289.6]
-  - - [256, 6784, 1, 1280]
-    - [34, 9155.61]
-  - - [5056, 128, 1, 256]
-    - [0, 6903.13]
-  - - [3584, 2368, 1, 32]
-    - [41, 3394.76]
-  - - [704, 32, 1, 32]
-    - [49, 47.6783]
-  - - [6784, 3584, 1, 3328]
-    - [3, 10224.4]
-  - - [128, 32, 1, 256]
-    - [54, 30.9132]
-  - - [128, 1408, 1, 1280]
-    - [19, 5767.17]
-  - - [64, 32, 1, 1280]
-    - [59, 23.456]
-  - - [128, 1856, 1, 3328]
-    - [15, 6646.15]
-  - - [2944, 2944, 1, 256]
-    - [33, 9636.82]
-  - - [5056, 2368, 1, 1280]
-    - [30, 10292.4]
-  - - [448, 128, 1, 32]
-    - [52, 118.848]
-  - - [32, 5056, 1, 3328]
-    - [59, 1330.41]
-  - - [448, 2944, 1, 3328]
-    - [34, 8145.3]
-  - - [2944, 1024, 1, 1]
-    - [80, 135.551]
-  - - [256, 4288, 1, 1]
-    - [77, 82.1653]
-  - - [2368, 128, 1, 1280]
-    - [10, 6154.4]
-  - - [3584, 704, 1, 256]
-    - [36, 8882.33]
-  - - [2368, 5888, 1, 3328]
-    - [35, 10321.0]
-  - - [1408, 3584, 1, 32]
-    - [41, 3119.8]
-  - - [2944, 4288, 1, 32]
-    - [41, 3551.02]
-  - - [5888, 1408, 1, 1280]
-    - [35, 10191.7]
-  - - [3584, 5056, 1, 1280]
-    - [35, 10307.9]
-  - - [5888, 6784, 1, 1280]
-    - [36, 10215.2]
-  - - [64, 1856, 1, 1]
-    - [67, 10.1699]
-  - - [704, 128, 1, 32]
-    - [49, 189.709]
-  - - [128, 3584, 1, 3328]
-    - [19, 7445.99]
-  - - [256, 4288, 1, 3328]
-    - [34, 7996.06]
-  - - [256, 2368, 1, 1]
-    - [65, 51.5483]
-  - - [1, 1408, 1, 1280]
-    - [82, 16.2305]
-  - - [6784, 1408, 1, 32]
-    - [41, 3495.65]
-  - - [1856, 704, 1, 32]
-    - [57, 1821.08]
-  - - [1024, 1856, 1, 1]
-    - [62, 118.784]
-  - - [704, 5056, 1, 3328]
-    - [34, 9864.24]
-  - - [1024, 3584, 1, 3328]
-    - [34, 10174.1]
-  - - [5888, 256, 1, 3328]
-    - [34, 9271.75]
-  - - [1856, 1408, 1, 1]
-    - [60, 112.253]
-  - - [2944, 448, 1, 32]
-    - [57, 1825.48]
-  - - [128, 448, 1, 256]
-    - [16, 1731.14]
-  - - [128, 1024, 1, 1]
-    - [77, 11.0703]
-  - - [32, 32, 1, 256]
-    - [54, 7.76493]
-  - - [4288, 5056, 1, 1280]
-    - [34, 10334.9]
-  - - [1856, 1856, 1, 3328]
-    - [34, 9555.31]
-  - - [3584, 1856, 1, 3328]
-    - [36, 10100.7]
-  - - [4288, 2368, 1, 3328]
-    - [34, 10331.0]
-  - - [256, 64, 1, 32]
-    - [49, 32.9327]
-  - - [1, 1024, 1, 1280]
-    - [82, 11.7785]
-  - - [32, 1408, 1, 256]
-    - [54, 341.657]
-  - - [1024, 32, 1, 3328]
-    - [54, 392.047]
-  - - [5888, 3584, 1, 256]
-    - [32, 9936.48]
-  - - [5888, 448, 1, 1280]
-    - [34, 9082.24]
-  - - [704, 5888, 1, 3328]
-    - [34, 10099.5]
-  - - [1024, 1408, 1, 256]
-    - [36, 7913.78]
-  - - [3584, 2944, 1, 1280]
-    - [3, 10117.5]
-  - - [1, 5056, 1, 256]
-    - [82, 33.3592]
-  - - [256, 1024, 1, 1]
-    - [80, 22.9147]
-  - - [32, 32, 1, 3328]
-    - [59, 12.7235]
-  - - [5056, 128, 1, 32]
-    - [59, 1256.64]
-  - - [2368, 1, 1, 3328]
-    - [82, 29.815]
-  - - [4288, 1856, 1, 1280]
-    - [34, 10048.6]
-  - - [3584, 5888, 1, 1]
-    - [66, 246.987]
-  - - [5888, 4288, 1, 256]
-    - [33, 9927.83]
-  - - [1024, 2944, 1, 1280]
-    - [34, 9564.64]
-  - - [6784, 1, 1, 1]
-    - [77, 0.700826]
-  - - [1408, 64, 1, 1280]
-    - [25, 3844.78]
-  - - [1, 256, 1, 1280]
-    - [82, 2.94042]
-  - - [2944, 3584, 1, 256]
-    - [34, 9589.35]
-  - - [1, 128, 1, 1280]
-    - [82, 1.46915]
-  - - [1024, 256, 1, 32]
-    - [59, 599.186]
-  - - [5888, 1, 1, 1280]
-    - [82, 47.3645]
-  - - [2368, 32, 1, 1280]
-    - [59, 827.023]
-  - - [5888, 1856, 1, 1]
-    - [62, 225.788]
-  - - [6784, 128, 1, 1280]
-    - [11, 8012.47]
-  - - [6784, 2368, 1, 3328]
-    - [34, 10150.3]
+- - - [64, 448, 1, 3328]
+    - [10, 1447.52]
   - - [1, 64, 1, 256]
-    - [77, 0.475174]
-  - - [704, 128, 1, 1]
-    - [72, 7.66258]
-  - - [1408, 4288, 1, 32]
-    - [41, 3224.3]
-  - - [32, 1408, 1, 3328]
-    - [54, 533.541]
-  - - [256, 448, 1, 256]
-    - [17, 3033.07]
-  - - [1856, 1024, 1, 1280]
-    - [34, 8850.03]
-  - - [1024, 448, 1, 1]
-    - [62, 41.5536]
-  - - [4288, 3584, 1, 1280]
-    - [34, 10267.7]
-  - - [448, 1024, 1, 1280]
-    - [37, 7084.97]
-  - - [5056, 1856, 1, 1]
-    - [67, 200.855]
-  - - [5888, 2368, 1, 256]
-    - [36, 9836.18]
-  - - [1408, 1024, 1, 32]
-    - [55, 1981.84]
-  - - [32, 704, 1, 256]
-    - [54, 171.234]
-  - - [2944, 1, 1, 256]
-    - [82, 21.1229]
-  - - [704, 1024, 1, 32]
-    - [54, 1360.18]
-  - - [5056, 1856, 1, 32]
-    - [41, 3427.92]
-  - - [5056, 1856, 1, 1280]
-    - [30, 10262.0]
-  - - [1, 64, 1, 1]
-    - [70, 0.0057971]
-  - - [1408, 5888, 1, 3328]
-    - [35, 10274.6]
-  - - [1408, 704, 1, 3328]
-    - [37, 8814.72]
-  - - [5056, 704, 1, 3328]
-    - [34, 9837.36]
-  - - [704, 64, 1, 1280]
-    - [25, 2030.69]
-  - - [1, 704, 1, 1280]
-    - [82, 8.12695]
-  - - [1408, 256, 1, 1]
-    - [80, 32.8876]
-  - - [5888, 4288, 1, 32]
-    - [41, 3783.85]
-  - - [1408, 3584, 1, 256]
-    - [36, 9350.36]
-  - - [1408, 6784, 1, 1]
-    - [71, 204.449]
-  - - [6784, 256, 1, 1]
-    - [61, 112.481]
-  - - [2944, 1, 1, 1]
-    - [67, 0.24698]
-  - - [256, 1856, 1, 3328]
-    - [37, 7567.25]
-  - - [4288, 128, 1, 1280]
-    - [8, 7025.46]
-  - - [128, 128, 1, 1]
-    - [72, 1.8789]
-  - - [6784, 256, 1, 1280]
-    - [34, 9013.06]
-  - - [128, 4288, 1, 256]
-    - [10, 6119.74]
-  - - [2368, 6784, 1, 1280]
-    - [35, 10308.5]
-  - - [128, 128, 1, 32]
-    - [46, 42.0103]
-  - - [128, 128, 1, 3328]
-    - [24, 829.166]
-  - - [128, 1408, 1, 32]
-    - [49, 356.879]
-  - - [6784, 128, 1, 32]
-    - [57, 1530.14]
-  - - [1408, 448, 1, 1]
-    - [73, 55.1385]
-  - - [2368, 704, 1, 3328]
-    - [34, 8912.76]
-  - - [704, 128, 1, 3328]
-    - [25, 4188.45]
-  - - [2944, 1856, 1, 32]
-    - [41, 3117.87]
-  - - [1024, 64, 1, 1]
-    - [62, 5.53514]
-  - - [1408, 32, 1, 1280]
-    - [59, 500.622]
-  - - [704, 1, 1, 256]
-    - [77, 5.27588]
-  - - [1856, 2944, 1, 3328]
-    - [34, 10219.6]
-  - - [3584, 2944, 1, 1]
-    - [66, 215.508]
-  - - [5888, 64, 1, 256]
-    - [39, 5714.99]
-  - - [64, 5056, 1, 1280]
-    - [39, 6949.46]
-  - - [1408, 2944, 1, 1]
-    - [60, 152.395]
-  - - [4288, 1408, 1, 32]
-    - [41, 3215.71]
-  - - [5888, 2944, 1, 256]
-    - [33, 9795.1]
-  - - [128, 64, 1, 1280]
-    - [17, 341.333]
-  - - [1408, 2944, 1, 32]
-    - [41, 2998.3]
-  - - [1, 3584, 1, 1280]
-    - [82, 43.3112]
-  - - [64, 64, 1, 32]
-    - [52, 8.11089]
-  - - [448, 1408, 1, 32]
-    - [59, 1261.57]
-  - - [128, 5056, 1, 256]
-    - [11, 6723.82]
-  - - [1, 1, 1, 1280]
-    - [82, 0.0114531]
-  - - [64, 704, 1, 256]
-    - [17, 1399.8]
-  - - [3584, 1408, 1, 1280]
-    - [36, 9809.29]
-  - - [5888, 6784, 1, 256]
-    - [33, 9922.48]
-  - - [6784, 5888, 1, 1]
-    - [66, 264.181]
-  - - [64, 4288, 1, 256]
-    - [39, 4772.73]
-  - - [1, 448, 1, 1280]
-    - [82, 5.05857]
-  - - [1024, 1024, 1, 1]
-    - [61, 78.959]
-  - - [6784, 5888, 1, 1280]
-    - [33, 10217.4]
-  - - [1024, 4288, 1, 32]
-    - [41, 2971.85]
-  - - [1856, 1, 1, 1280]
-    - [82, 21.3948]
-  - - [3584, 5888, 1, 256]
-    - [32, 9945.26]
-  - - [5056, 2368, 1, 1]
-    - [62, 230.242]
-  - - [256, 1408, 1, 1280]
-    - [37, 5588.34]
-  - - [64, 256, 1, 32]
-    - [54, 47.1482]
-  - - [64, 5888, 1, 3328]
-    - [39, 7328.76]
-  - - [6784, 64, 1, 3328]
-    - [38, 7285.89]
-  - - [5056, 448, 1, 1]
-    - [67, 129.879]
-  - - [2944, 448, 1, 3328]
-    - [34, 8141.67]
-  - - [1856, 6784, 1, 256]
-    - [33, 9652.98]
-  - - [4288, 32, 1, 1280]
-    - [59, 1138.13]
-  - - [448, 1408, 1, 1280]
-    - [34, 7072.56]
-  - - [5056, 448, 1, 32]
-    - [57, 2311.31]
-  - - [3584, 2944, 1, 32]
-    - [41, 3546.65]
-  - - [2368, 128, 1, 1]
-    - [72, 28.9221]
-  - - [128, 3584, 1, 32]
-    - [58, 991.896]
-  - - [3584, 1856, 1, 32]
-    - [41, 3229.08]
-  - - [4288, 64, 1, 3328]
-    - [39, 6174.35]
-  - - [5056, 64, 1, 256]
-    - [39, 5478.67]
-  - - [64, 448, 1, 3328]
-    - [25, 1449.28]
-  - - [4288, 1408, 1, 1280]
-    - [35, 9831.07]
-  - - [32, 5056, 1, 256]
-    - [59, 1089.97]
-  - - [704, 128, 1, 256]
-    - [17, 2574.63]
-  - - [704, 5056, 1, 1]
-    - [62, 163.576]
-  - - [256, 1024, 1, 32]
-    - [54, 613.202]
-  - - [256, 1024, 1, 1280]
-    - [37, 6374.32]
-  - - [2368, 128, 1, 256]
-    - [10, 4948.64]
-  - - [2368, 1408, 1, 1280]
-    - [34, 9802.7]
-  - - [128, 256, 1, 32]
-    - [53, 74.8983]
-  - - [64, 6784, 1, 32]
-    - [49, 909.269]
-  - - [6784, 32, 1, 256]
-    - [59, 1432.33]
-  - - [5056, 2944, 1, 1]
-    - [67, 232.286]
-  - - [3584, 128, 1, 1]
-    - [73, 40.6695]
-  - - [1024, 4288, 1, 1280]
-    - [34, 9960.95]
-  - - [1856, 4288, 1, 1]
-    - [62, 213.023]
-  - - [128, 2944, 1, 256]
-    - [0, 5407.45]
-  - - [3584, 4288, 1, 256]
-    - [33, 9816.01]
-  - - [3584, 128, 1, 32]
-    - [54, 1002.74]
-  - - [3584, 128, 1, 3328]
-    - [23, 7451.81]
-  - - [704, 5056, 1, 256]
-    - [35, 9163.44]
-  - - [1856, 4288, 1, 32]
-    - [41, 3336.91]
-  - - [5056, 1, 1, 1280]
-    - [82, 41.3156]
-  - - [64, 256, 1, 1280]
-    - [24, 762.047]
-  - - [4288, 1024, 1, 1280]
-    - [34, 9944.03]
-  - - [1, 4288, 1, 256]
-    - [82, 28.2337]
-  - - [2944, 3584, 1, 1]
-    - [61, 227.399]
-  - - [4288, 6784, 1, 32]
-    - [41, 3762.02]
-  - - [4288, 4288, 1, 256]
-    - [33, 9801.47]
-  - - [3584, 3584, 1, 1]
-    - [69, 237.169]
-  - - [3584, 1408, 1, 256]
-    - [36, 9344.95]
-  - - [704, 3584, 1, 3328]
-    - [34, 9647.28]
-  - - [5056, 448, 1, 1280]
-    - [34, 9413.35]
-  - - [1408, 2944, 1, 1280]
-    - [35, 9988.32]
-  - - [5888, 704, 1, 1280]
-    - [36, 9977.8]
-  - - [64, 64, 1, 256]
-    - [40, 137.971]
-  - - [704, 1408, 1, 1280]
-    - [34, 8633.48]
-  - - [4288, 5888, 1, 256]
-    - [33, 9943.73]
-  - - [3584, 3584, 1, 3328]
-    - [34, 10435.2]
-  - - [2944, 6784, 1, 32]
-    - [41, 3784.39]
-  - - [448, 64, 1, 32]
-    - [49, 57.344]
-  - - [5056, 256, 1, 1]
-    - [65, 91.9273]
-  - - [64, 6784, 1, 1280]
-    - [39, 7110.35]
-  - - [2944, 2368, 1, 3328]
-    - [34, 10197.3]
-  - - [1, 4288, 1, 1]
-    - [72, 0.432258]
-  - - [1408, 128, 1, 256]
-    - [23, 4061.39]
-  - - [1024, 1856, 1, 1280]
-    - [34, 8850.03]
-  - - [1024, 5888, 1, 256]
-    - [34, 9565.59]
-  - - [704, 1408, 1, 256]
-    - [34, 7698.89]
-  - - [6784, 2944, 1, 3328]
-    - [3, 10137.1]
-  - - [1408, 2368, 1, 256]
-    - [34, 9103.46]
-  - - [1024, 1408, 1, 1]
-    - [64, 99.5713]
-  - - [64, 128, 1, 1280]
-    - [17, 344.021]
-  - - [1408, 5056, 1, 256]
-    - [36, 9543.49]
-  - - [1024, 1408, 1, 32]
-    - [55, 1928.82]
-  - - [4288, 128, 1, 32]
-    - [58, 1081.51]
-  - - [6784, 704, 1, 1]
-    - [67, 182.01]
-  - - [448, 704, 1, 256]
-    - [34, 4187.78]
-  - - [704, 3584, 1, 32]
-    - [55, 2504.35]
-  - - [1856, 256, 1, 3328]
-    - [37, 7575.95]
-  - - [6784, 448, 1, 256]
-    - [4, 8971.9]
-  - - [4288, 4288, 1, 1]
-    - [70, 239.913]
-  - - [256, 2944, 1, 1]
-    - [72, 58.88]
-  - - [64, 2368, 1, 3328]
-    - [40, 5356.47]
-  - - [256, 704, 1, 3328]
-    - [27, 4582.71]
-  - - [1, 2944, 1, 1]
-    - [62, 0.231447]
-  - - [1024, 1024, 1, 256]
-    - [36, 8065.97]
-  - - [4288, 704, 1, 1280]
-    - [34, 9564.36]
-  - - [3584, 1, 1, 1]
-    - [76, 0.36129]
-  - - [256, 2944, 1, 32]
-    - [57, 1395.67]
-  - - [6784, 4288, 1, 3328]
-    - [34, 10300.4]
-  - - [5056, 2944, 1, 3328]
-    - [34, 10400.6]
-  - - [704, 1024, 1, 1280]
-    - [37, 8060.33]
-  - - [256, 3584, 1, 1280]
-    - [34, 8004.4]
-  - - [2368, 1856, 1, 3328]
-    - [34, 10097.3]
-  - - [1856, 4288, 1, 1280]
-    - [34, 10066.9]
-  - - [1, 1024, 1, 256]
-    - [77, 7.55023]
-  - - [2944, 1024, 1, 3328]
-    - [34, 9694.63]
-  - - [2944, 256, 1, 32]
-    - [51, 1364.1]
-  - - [128, 1, 1, 3328]
-    - [82, 1.59234]
-  - - [5888, 5056, 1, 32]
-    - [41, 3804.44]
-  - - [4288, 1408, 1, 1]
-    - [67, 196.023]
-  - - [3584, 448, 1, 32]
-    - [47, 1840.27]
-  - - [3584, 448, 1, 1280]
-    - [34, 8459.04]
-  - - [2944, 6784, 1, 3328]
-    - [34, 10380.4]
-  - - [1856, 2368, 1, 1280]
-    - [34, 9975.9]
-  - - [6784, 1024, 1, 1280]
-    - [34, 9889.58]
-  - - [6784, 3584, 1, 1280]
-    - [36, 10160.7]
-  - - [1, 5056, 1, 3328]
-    - [82, 42.3625]
-  - - [4288, 64, 1, 1]
-    - [62, 27.2254]
-  - - [128, 2368, 1, 32]
-    - [54, 725.998]
-  - - [128, 1408, 1, 3328]
-    - [19, 6155.43]
-  - - [2944, 32, 1, 3328]
-    - [54, 1121.65]
-  - - [704, 1856, 1, 256]
-    - [34, 8329.08]
-  - - [2944, 2944, 1, 1]
-    - [61, 216.678]
-  - - [1408, 4288, 1, 256]
-    - [36, 9396.89]
-  - - [5888, 5056, 1, 256]
-    - [36, 9925.3]
-  - - [256, 5056, 1, 3328]
-    - [34, 9410.06]
-  - - [2368, 64, 1, 1280]
-    - [39, 5020.36]
-  - - [1856, 448, 1, 32]
-    - [52, 1421.35]
-  - - [1408, 448, 1, 256]
-    - [34, 6210.8]
-  - - [32, 128, 1, 256]
-    - [54, 30.696]
-  - - [448, 1024, 1, 1]
-    - [81, 39.2767]
-  - - [448, 6784, 1, 1]
-    - [67, 151.962]
-  - - [704, 2944, 1, 256]
-    - [4, 8902.34]
-  - - [1408, 1408, 1, 256]
-    - [35, 8549.71]
-  - - [448, 6784, 1, 32]
-    - [41, 2671.85]
-  - - [1, 64, 1, 1280]
-    - [82, 0.736161]
-  - - [2944, 2368, 1, 1]
-    - [62, 205.041]
-  - - [4288, 448, 1, 32]
-    - [57, 2140.42]
-  - - [4288, 448, 1, 1280]
-    - [34, 8911.68]
-  - - [2944, 704, 1, 32]
-    - [52, 2252.8]
-  - - [1024, 704, 1, 256]
-    - [34, 7011.75]
-  - - [448, 4288, 1, 1]
-    - [65, 119.467]
-  - - [3584, 5056, 1, 1]
-    - [61, 239.692]
-  - - [2368, 2368, 1, 1]
-    - [62, 193.093]
-  - - [64, 5888, 1, 1]
-    - [67, 35.4165]
-  - - [1408, 3584, 1, 1280]
-    - [35, 9815.26]
-  - - [6784, 448, 1, 1280]
-    - [36, 9493.89]
-  - - [3584, 5056, 1, 3328]
-    - [36, 10374.6]
-  - - [2368, 2368, 1, 32]
-    - [41, 3163.57]
-  - - [64, 5888, 1, 32]
-    - [54, 837.404]
-  - - [1856, 448, 1, 256]
-    - [34, 6505.53]
-  - - [3584, 2368, 1, 1280]
-    - [34, 10078.0]
-  - - [128, 1024, 1, 256]
-    - [17, 3554.49]
-  - - [3584, 64, 1, 3328]
-    - [20, 6456.05]
-  - - [5888, 2944, 1, 32]
-    - [41, 3696.01]
-  - - [2944, 1, 1, 1280]
-    - [82, 33.5977]
-  - - [1856, 2944, 1, 32]
-    - [41, 3158.42]
-  - - [5056, 1408, 1, 1]
-    - [62, 205.509]
-  - - [5888, 1408, 1, 3328]
-    - [35, 10270.3]
-  - - [448, 4288, 1, 256]
-    - [4, 8307.13]
-  - - [6784, 1024, 1, 1]
-    - [66, 207.74]
-  - - [256, 448, 1, 1]
-    - [62, 9.55733]
-  - - [128, 5888, 1, 3328]
-    - [37, 8615.67]
-  - - [6784, 1024, 1, 32]
-    - [41, 3272.94]
-  - - [256, 448, 1, 32]
-    - [49, 202.093]
-  - - [6784, 3584, 1, 1]
-    - [66, 242.944]
-  - - [2944, 2368, 1, 32]
-    - [55, 3201.56]
-  - - [3584, 6784, 1, 3328]
-    - [34, 10471.0]
-  - - [448, 128, 1, 1280]
-    - [29, 2570.04]
-  - - [64, 3584, 1, 32]
-    - [54, 542.902]
-  - - [64, 3584, 1, 1280]
-    - [18, 5996.76]
-  - - [6784, 1408, 1, 256]
-    - [34, 9445.61]
-  - - [5056, 1024, 1, 32]
-    - [41, 3142.55]
-  - - [1024, 5056, 1, 1280]
-    - [36, 10058.0]
-  - - [4288, 3584, 1, 256]
-    - [33, 9823.85]
-  - - [1408, 1024, 1, 3328]
-    - [34, 8884.39]
-  - - [2368, 256, 1, 3328]
-    - [37, 6939.53]
-  - - [448, 6784, 1, 1280]
-    - [34, 9640.7]
-  - - [1856, 5888, 1, 1]
-    - [62, 203.579]
-  - - [256, 5888, 1, 32]
-    - [55, 2057.79]
-  - - [3584, 1, 1, 3328]
-    - [82, 45.4695]
-  - - [4288, 32, 1, 256]
-    - [59, 930.278]
-  - - [256, 64, 1, 1]
-    - [65, 1.91402]
-  - - [4288, 5056, 1, 32]
-    - [41, 3649.85]
-  - - [4288, 5056, 1, 3328]
-    - [34, 10437.5]
-  - - [1856, 5888, 1, 32]
-    - [41, 3431.12]
-  - - [1856, 5888, 1, 1280]
-    - [35, 10295.0]
-  - - [256, 256, 1, 1280]
-    - [26, 2962.08]
-  - - [704, 2368, 1, 1280]
-    - [34, 8788.52]
-  - - [5056, 32, 1, 1280]
-    - [59, 1293.69]
-  - - [4288, 2368, 1, 1280]
-    - [34, 10216.6]
-  - - [2944, 5056, 1, 256]
-    - [33, 9818.92]
-  - - [32, 1856, 1, 256]
-    - [54, 416.786]
+    - [20, 0.446193]
+  - - [3584, 64, 1, 1280]
+    - [17, 5816.19]
+  - - [64, 128, 1, 256]
+    - [1, 211.406]
   - - [64, 5888, 1, 1280]
-    - [39, 7043.59]
-  - - [1, 1856, 1, 1280]
-    - [82, 20.898]
-  - - [2944, 4288, 1, 1]
-    - [62, 233.775]
-  - - [5056, 5888, 1, 32]
-    - [41, 3769.51]
-  - - [704, 4288, 1, 1]
-    - [62, 152.155]
-  - - [704, 1, 1, 3328]
-    - [82, 8.80264]
-  - - [448, 256, 1, 1280]
-    - [25, 4645.59]
-  - - [5888, 6784, 1, 1]
-    - [66, 256.184]
-  - - [2368, 5056, 1, 3328]
-    - [34, 10368.7]
-  - - [704, 704, 1, 1280]
-    - [37, 7654.3]
-  - - [128, 32, 1, 3328]
-    - [59, 51.5251]
-  - - [1024, 6784, 1, 32]
-    - [41, 3311.95]
-  - - [2368, 1408, 1, 256]
-    - [34, 9111.24]
-  - - [3584, 2944, 1, 3328]
-    - [34, 10236.6]
-  - - [128, 1856, 1, 256]
-    - [9, 4781.24]
-  - - [32, 32, 1, 1280]
-    - [54, 11.362]
-  - - [1408, 5888, 1, 1]
-    - [61, 215.444]
-  - - [1, 3584, 1, 256]
-    - [82, 31.4214]
-  - - [704, 4288, 1, 32]
-    - [41, 2648.03]
-  - - [1408, 5888, 1, 32]
-    - [41, 3501.71]
-  - - [5888, 32, 1, 3328]
-    - [59, 1572.02]
-  - - [6784, 2368, 1, 1]
-    - [61, 224.867]
-  - - [1856, 1, 1, 3328]
-    - [82, 23.1861]
-  - - [5056, 1408, 1, 256]
-    - [33, 9539.5]
-  - - [1, 1, 1, 256]
-    - [77, 0.00730594]
-  - - [2944, 1408, 1, 256]
-    - [35, 9461.12]
-  - - [4288, 1, 1, 1]
-    - [67, 0.442975]
-  - - [2368, 2368, 1, 256]
-    - [35, 9444.08]
-  - - [1, 448, 1, 256]
-    - [77, 3.31852]
-  - - [1856, 704, 1, 1]
-    - [69, 91.2447]
-  - - [3584, 32, 1, 3328]
-    - [59, 1464.85]
-  - - [128, 3584, 1, 1]
-    - [70, 42.794]
-  - - [1856, 1, 1, 256]
-    - [77, 13.8766]
-  - - [32, 5888, 1, 32]
-    - [59, 425.799]
-  - - [1024, 5888, 1, 1]
-    - [69, 178.593]
-  - - [6784, 32, 1, 3328]
-    - [59, 1816.71]
-  - - [2368, 704, 1, 1]
-    - [72, 107.971]
-  - - [1408, 32, 1, 256]
-    - [54, 347.42]
-  - - [448, 2368, 1, 1]
-    - [82, 74.0827]
-  - - [1856, 3584, 1, 256]
-    - [33, 9592.65]
+    - [17, 7027.17]
+  - - [64, 4288, 1, 1280]
+    - [18, 5870.2]
+  - - [3584, 64, 1, 3328]
+    - [17, 6228.49]
+  - - [64, 1024, 1, 3328]
+    - [18, 3296.64]
+  - - [1, 64, 1, 1280]
+    - [22, 0.688638]
+  - - [704, 64, 1, 3328]
+    - [10, 2159.37]
+  - - [64, 448, 1, 1280]
+    - [6, 1325.87]
+  - - [64, 704, 1, 3328]
+    - [11, 2197.34]
+  - - [64, 64, 1, 1280]
+    - [9, 182.044]
+  - - [64, 5056, 1, 256]
+    - [0, 4907.44]
+  - - [64, 4288, 1, 3328]
+    - [17, 6241.87]
+  - - [1856, 64, 1, 3328]
+    - [18, 5478.29]
+  - - [1, 64, 1, 1]
+    - [19, 0.00601504]
+  - - [448, 64, 1, 1280]
+    - [5, 1325.87]
+  - - [5888, 64, 1, 1280]
+    - [17, 6970.3]
   - - [2944, 64, 1, 256]
-    - [39, 4400.96]
-  - - [2368, 704, 1, 32]
-    - [54, 2051.78]
-  - - [256, 5888, 1, 1280]
-    - [34, 9135.32]
-  - - [448, 2368, 1, 32]
-    - [56, 1664.1]
-  - - [448, 2368, 1, 3328]
-    - [34, 7734.3]
+    - [1, 3915.14]
+  - - [64, 1856, 1, 256]
+    - [12, 3276.8]
+  - - [64, 1024, 1, 1280]
+    - [18, 3066.01]
+  - - [64, 256, 1, 1280]
+    - [10, 777.89]
+  - - [704, 64, 1, 1280]
+    - [3, 1877.33]
+  - - [64, 128, 1, 1280]
+    - [5, 352.344]
+  - - [2368, 64, 1, 256]
+    - [5, 3464.05]
+  - - [2368, 64, 1, 3328]
+    - [18, 5297.95]
+  - - [64, 1408, 1, 3328]
+    - [11, 4165.18]
+  - - [1856, 64, 1, 1280]
+    - [18, 4848.33]
+  - - [64, 3584, 1, 1280]
+    - [4, 6016.42]
+  - - [448, 64, 1, 3328]
+    - [10, 1449.28]
+  - - [5888, 64, 1, 3328]
+    - [17, 7352.84]
+  - - [128, 64, 1, 256]
+    - [16, 211.406]
+  - - [64, 128, 1, 3328]
+    - [6, 393.974]
+  - - [64, 256, 1, 3328]
+    - [13, 827.153]
+  - - [4288, 64, 1, 3328]
+    - [17, 6204.57]
+  - - [64, 2944, 1, 256]
+    - [16, 4158.15]
+  - - [6784, 64, 1, 256]
+    - [17, 5962.93]
+  - - [1024, 64, 1, 1280]
+    - [18, 3120.76]
+  - - [64, 2368, 1, 1280]
+    - [6, 5009.98]
+  - - [64, 3584, 1, 3328]
+    - [17, 6220.39]
+  - - [64, 6784, 1, 3328]
+    - [17, 7454.3]
+  - - [3584, 64, 1, 256]
+    - [17, 4369.07]
+  - - [64, 1856, 1, 3328]
+    - [18, 5448.09]
+  - - [448, 64, 1, 256]
+    - [5, 841.747]
+  - - [64, 5056, 1, 3328]
+    - [17, 7213.88]
+  - - [256, 64, 1, 256]
+    - [1, 509.017]
+  - - [4288, 64, 1, 1280]
+    - [17, 6031.47]
+  - - [1, 1, 1, 1]
+    - [21, 9.92063e-05]
+  - - [5056, 64, 1, 1280]
+    - [18, 6893.99]
+  - - [1024, 64, 1, 3328]
+    - [17, 3245.59]
+  - - [1408, 64, 1, 256]
+    - [16, 2507.46]
   - - [64, 1408, 1, 256]
-    - [39, 2621.44]
-  - - [5056, 32, 1, 32]
-    - [54, 417.528]
-  - - [1024, 704, 1, 3328]
-    - [37, 8227.51]
-  - - [32, 5888, 1, 3328]
-    - [59, 1570.13]
+    - [7, 2551.84]
+  - - [64, 2368, 1, 3328]
+    - [6, 5306.9]
+  - - [64, 448, 1, 256]
+    - [5, 882.215]
+  - - [64, 6784, 1, 1280]
+    - [18, 7139.58]
+  - - [64, 1856, 1, 1280]
+    - [14, 4848.33]
+  - - [64, 6784, 1, 256]
+    - [17, 5912.18]
+  - - [64, 5056, 1, 1280]
+    - [18, 6741.33]
+  - - [64, 4288, 1, 256]
+    - [16, 4671.18]
+  - - [128, 64, 1, 1280]
+    - [5, 344.926]
+  - - [5888, 64, 1, 256]
+    - [16, 5153.26]
+  - - [64, 5888, 1, 3328]
+    - [17, 7436.53]
+  - - [64, 1024, 1, 256]
+    - [11, 1906.5]
+  - - [5056, 64, 1, 3328]
+    - [17, 7351.77]
+  - - [256, 64, 1, 1280]
+    - [10, 766.503]
+  - - [64, 256, 1, 256]
+    - [5, 499.322]
+  - - [704, 64, 1, 256]
+    - [5, 1310.72]
+  - - [64, 1408, 1, 1280]
+    - [18, 3865.39]
+  - - [1, 1, 1, 256]
+    - [20, 0.00683761]
+  - - [64, 704, 1, 256]
+    - [8, 1347.47]
+  - - [64, 2944, 1, 3328]
+    - [18, 6570.08]
+  - - [64, 64, 1, 256]
+    - [1, 107.436]
+  - - [1856, 64, 1, 256]
+    - [17, 3393.83]
+  - - [128, 64, 1, 3328]
+    - [17, 392.612]
+  - - [2944, 64, 1, 1280]
+    - [17, 5922.78]
+  - - [4288, 64, 1, 256]
+    - [18, 4573.87]
+  - - [1, 1, 1, 1280]
+    - [22, 0.0107311]
+  - - [64, 2944, 1, 1280]
+    - [18, 6190.26]
+  - - [1408, 64, 1, 1280]
+    - [18, 3875.79]
+  - - [6784, 64, 1, 3328]
+    - [17, 7414.52]
+  - - [1024, 64, 1, 256]
+    - [18, 2076.39]
+  - - [64, 2368, 1, 256]
+    - [7, 3619.15]
+  - - [64, 3584, 1, 256]
+    - [2, 4475.63]
+  - - [2944, 64, 1, 3328]
+    - [18, 6559.08]
+  - - [2368, 64, 1, 1280]
+    - [5, 4898.65]
   - - [256, 64, 1, 3328]
-    - [24, 828.158]
-  - - [32, 1408, 1, 1280]
-    - [54, 499.581]
-  - - [64, 32, 1, 256]
-    - [54, 15.5299]
-  - - [1856, 1024, 1, 3328]
-    - [34, 8981.33]
-  - - [2368, 1, 1, 1]
-    - [65, 0.206993]
-  - - [5056, 2368, 1, 3328]
-    - [30, 10360.1]
-  - - [128, 1, 1, 1280]
-    - [82, 1.4938]
-  - - [704, 4288, 1, 1280]
-    - [34, 9570.05]
-  - - [704, 256, 1, 256]
-    - [13, 3353.0]
-  - - [3136, 256, 64, 64]
-    - [84, 17694.4]
-  - - [784, 512, 64, 128]
-    - [85, 18837.8]
-  - - [784, 128, 64, 512]
-    - [83, 20717.8]
-  - - [3136, 64, 128, 64]
-    - [89, 15383.3]
-  - - [196, 256, 128, 1024]
-    - [84, 17751.8]
-  - - [196, 256, 64, 1024]
-    - [84, 17162.5]
-  - - [196, 1024, 128, 256]
-    - [84, 16832.2]
-  - - [784, 128, 256, 512]
-    - [83, 21422.4]
-  - - [3136, 64, 64, 256]
-    - [88, 19953.5]
-  - - [3136, 64, 256, 256]
-    - [86, 20976.9]
-  - - [3136, 256, 256, 64]
-    - [91, 18870.2]
-  - - [3136, 64, 128, 256]
-    - [90, 20843.9]
-  - - [784, 128, 128, 512]
-    - [83, 21204.1]
-  - - [784, 512, 128, 128]
-    - [83, 19252.5]
-  - - [784, 512, 256, 128]
-    - [85, 19261.6]
-  - - [196, 1024, 64, 256]
-    - [84, 16634.6]
-  - - [3136, 64, 64, 64]
-    - [89, 14979.7]
-  - - [196, 1024, 256, 256]
-    - [87, 16995.7]
-  - - [196, 256, 256, 1024]
-    - [84, 18063.8]
-  - - [3136, 256, 128, 64]
-    - [90, 18163.6]
-  - - [3136, 64, 256, 64]
-    - [89, 15640.9]
+    - [10, 828.158]
+  - - [64, 64, 1, 3328]
+    - [17, 202.608]
+  - - [1, 1, 1, 3328]
+    - [22, 0.0115076]
+  - - [64, 5888, 1, 256]
+    - [17, 5481.19]
+  - - [64, 704, 1, 1280]
+    - [13, 1980.48]
+  - - [6784, 64, 1, 1280]
+    - [17, 7038.31]
+  - - [5056, 64, 1, 256]
+    - [15, 4622.63]
+  - - [1408, 64, 1, 3328]
+    - [18, 4128.48]
   - - [4096, 7133, 1, 4096]
-    - [116, 18834.1]
+    - [47, 18834.1]
   - - [512, 16, 1, 512]
-    - [101, 264.792]
+    - [32, 264.792]
   - - [2048, 7133, 1, 2048]
-    - [111, 18669.8]
+    - [42, 18669.8]
   - - [2560, 7133, 1, 2560]
-    - [114, 18330.9]
+    - [45, 18330.9]
   - - [1024, 1024, 1, 1024]
-    - [114, 14385.6]
+    - [45, 14385.6]
   - - [3072, 7435, 1, 1024]
-    - [111, 18501.2]
+    - [42, 18501.2]
   - - [1024, 32, 1, 512]
-    - [95, 900.065]
+    - [26, 900.065]
   - - [1760, 7133, 1, 1760]
-    - [114, 17490.3]
+    - [45, 17490.3]
   - - [7680, 5481, 1, 2560]
-    - [111, 18657.2]
+    - [42, 18657.2]
   - - [1024, 16, 1, 512]
-    - [95, 444.312]
+    - [26, 444.312]
   - - [512, 32, 1, 512]
-    - [100, 516.54]
+    - [31, 516.54]
+  - - [3136, 256, 64, 64]
+    - [99, 17694.4]
+  - - [784, 512, 64, 128]
+    - [100, 18837.8]
+  - - [784, 128, 64, 512]
+    - [98, 20717.8]
+  - - [3136, 64, 128, 64]
+    - [104, 15383.3]
+  - - [196, 256, 128, 1024]
+    - [99, 17751.8]
+  - - [196, 256, 64, 1024]
+    - [99, 17162.5]
+  - - [196, 1024, 128, 256]
+    - [99, 16832.2]
+  - - [784, 128, 256, 512]
+    - [98, 21422.4]
+  - - [3136, 64, 64, 256]
+    - [103, 19953.5]
+  - - [3136, 64, 256, 256]
+    - [101, 20976.9]
+  - - [3136, 256, 256, 64]
+    - [106, 18870.2]
+  - - [3136, 64, 128, 256]
+    - [105, 20843.9]
+  - - [784, 128, 128, 512]
+    - [98, 21204.1]
+  - - [784, 512, 128, 128]
+    - [98, 19252.5]
+  - - [784, 512, 256, 128]
+    - [100, 19261.6]
+  - - [196, 1024, 64, 256]
+    - [99, 16634.6]
+  - - [3136, 64, 64, 64]
+    - [104, 14979.7]
+  - - [196, 1024, 256, 256]
+    - [102, 16995.7]
+  - - [196, 256, 256, 1024]
+    - [99, 18063.8]
+  - - [3136, 256, 128, 64]
+    - [105, 18163.6]
+  - - [3136, 64, 256, 64]
+    - [104, 15640.9]
 - null

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HBH.yaml
@@ -43,451 +43,7 @@
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 8
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 896
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 128
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x08_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id002 [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id001 [16, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 8
-    LSPA: 4
-    LSPB: 16
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 128
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 16
-    MacroTileA: 64
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x08_PGR1_PLR1_TT04_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id003 [4, 2]
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id001
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 8
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 32
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 32
-    MacroTileA: 128
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x032x08_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id004 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id005 [32, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -566,6 +122,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -609,14 +170,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 3
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT016x016x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -627,15 +195,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: &id006 [8, 8, 1]
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -649,34 +218,34 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
+    GlobalReadVectorWidth: 4
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 32
     LSCB: 16
-    LSPA: 4
-    LSPB: 8
-    LVCA: 16
-    LVCB: 8
+    LSPA: 8
+    LSPB: 16
+    LVCA: 8
+    LVCB: 4
     LVPA: 2
     LVPB: 4
-    LdsNumElements: 1664
+    LdsNumElements: 2048
     LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 128
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
     LdsOffsetA_Blk: 1024
     LdsOffsetB: 512
@@ -695,9 +264,9 @@
     LoopTail: true
     LoopUnroll: 16
     MacroTile0: 32
-    MacroTile1: 8
+    MacroTile1: 32
     MacroTileA: 32
-    MacroTileB: 8
+    MacroTileB: 32
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -705,15 +274,20 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 4
-    NumLoadsB: 1
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -757,33 +331,202 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x008x16_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 4
-    SubGroupA: 16
-    SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id007 [16, 4, 1]
+    VectorWidth: 4
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 16
+    LSPA: 4
+    LSPB: 16
+    LVCA: 16
+    LVCB: 4
+    LVPA: 1
+    LVPB: 4
+    LdsNumElements: 3328
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 16
+    MacroTileA: 64
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 4
+    SubGroupA: 16
+    SubGroupB: 4
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [16, 4, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -862,6 +605,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 1
     NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -905,14 +653,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 5
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -923,15 +678,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id001
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1010,6 +766,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1053,14 +814,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 6
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 4
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x16_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id003
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -1071,15 +839,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id001
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1093,34 +862,34 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 1
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
+    GlobalReadVectorWidth: 2
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
     LSCB: 16
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 4096
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 3200
     LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedB: 128
     LdsOffsetA: 0
     LdsOffsetA_Blk: 2048
     LdsOffsetB: 1024
@@ -1139,9 +908,9 @@
     LoopTail: true
     LoopUnroll: 16
     MacroTile0: 64
-    MacroTile1: 64
+    MacroTile1: 8
     MacroTileA: 64
-    MacroTileB: 64
+    MacroTileB: 8
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -1149,15 +918,20 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 4
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1201,33 +975,41 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 5
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x008x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 32
+    SubGroup1: 4
+    SubGroupA: 32
+    SubGroupB: 4
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
     UnrollMemFence: false
-    UseSgprForGRO: false
+    UseSgprForGRO: 1
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
+    VectorWidth: 2
+    WorkGroup: [32, 4, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1306,6 +1088,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1349,14 +1136,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 8
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 6
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -1367,15 +1161,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1454,6 +1249,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1497,14 +1297,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 9
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 7
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x016x16_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id003
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -1515,163 +1322,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 6656
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 32
-    MacroTileA: 128
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id005
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1750,6 +1410,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 4
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1793,14 +1458,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 11
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 8
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT016x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -1811,15 +1483,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id006
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1898,6 +1571,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -1941,14 +1619,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 12
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 9
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x008x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 4
     SubGroupA: 16
     SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -1959,15 +1644,338 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id007
+    WorkGroup: [16, 4, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 32
+    LSPA: 8
+    LSPB: 8
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 3584
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 32
+    MacroTile1: 16
+    MacroTileA: 32
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 4
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 10
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 6656
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 32
+    MacroTile0: 64
+    MacroTile1: 16
+    MacroTileA: 64
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 8
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 11
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x32_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
+    ThreadTile0: 4
+    ThreadTile1: 2
+    ThreadTileA: 4
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2046,6 +2054,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 1
     NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2089,14 +2102,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 13
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 12
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x008x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 4
     SubGroupA: 32
     SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2110,12 +2130,13 @@
     WorkGroup: [32, 4, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2194,6 +2215,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2237,14 +2263,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 14
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 13
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2255,15 +2288,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2342,6 +2376,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2385,14 +2424,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 15
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 14
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x016x32_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id003
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -2403,15 +2449,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id005
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2490,6 +2537,11 @@
     NumLoadsPerpendicularA: 16
     NumLoadsPerpendicularB: 4
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2533,14 +2585,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 16
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 15
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x008x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 4
     SubGroupA: 16
     SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id002
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2551,15 +2610,177 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id007
+    WorkGroup: [16, 4, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 1
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 64
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 12800
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 64
+    MacroTile0: 64
+    MacroTile1: 8
+    MacroTileA: 64
+    MacroTileB: 8
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 16
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 16
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 16
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x008x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 32
+    SubGroup1: 4
+    SubGroupA: 32
+    SubGroupB: 4
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [32, 4, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 1
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2587,7 +2808,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
@@ -2638,6 +2859,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2681,14 +2907,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
     SolutionIndex: 17
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x032x08_PGR1_PLR1_TT08_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id009 [8, 4]
+    SuppressNoLoadLoop: true
+    ThreadTile: [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -2699,15 +2932,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id008 [8, 8, 1]
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2735,7 +2969,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 32
@@ -2786,6 +3020,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2829,14 +3068,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
     SolutionIndex: 18
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x032x08_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id010 [4, 4]
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -2847,15 +3093,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id008
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -2883,7 +3130,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
@@ -2934,6 +3181,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2977,14 +3229,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
     SolutionIndex: 19
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x032x08_PGR1_PLR1_TT08_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id009
+    SuppressNoLoadLoop: true
+    ThreadTile: [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -2995,21 +3254,22 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id008
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 8
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -3018,7 +3278,7 @@
     ExpandPointerSwap: true
     FractionalLoad: 0
     GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
@@ -3034,17 +3294,17 @@
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 8
+    LSCA: 32
+    LSCB: 16
     LSPA: 4
-    LSPB: 16
-    LVCA: 32
+    LSPB: 8
+    LVCA: 16
     LVCB: 8
     LVPA: 2
-    LVPB: 16
-    LdsNumElements: 1664
+    LVPB: 4
+    LdsNumElements: 1792
     LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 128
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
     LdsOffsetA_Blk: 1024
     LdsOffsetB: 512
@@ -3061,10 +3321,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
+    LoopUnroll: 16
+    MacroTile0: 32
     MacroTile1: 16
-    MacroTileA: 64
+    MacroTileA: 32
     MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -3075,13 +3335,18 @@
     NonTemporalC: 0
     NumElementsPerThread: 8
     NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
+    NumLoadsA: 4
+    NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3125,14 +3390,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
     SolutionIndex: 20
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x08_PGR1_PLR1_TT04_02
-    SubGroup0: 16
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x16_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
     SubGroup1: 8
-    SubGroupA: 16
+    SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id012 [4, 2]
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -3143,15 +3415,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: &id011 [16, 8, 1]
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3179,7 +3452,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 32
@@ -3230,6 +3503,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3273,14 +3551,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
     SolutionIndex: 21
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id010
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -3291,15 +3576,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id008
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3327,7 +3613,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 8
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
@@ -3378,6 +3664,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3421,13 +3712,20 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
     SolutionIndex: 22
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR1_PLR1_TT08_08
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
+    SuppressNoLoadLoop: true
     ThreadTile: [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
@@ -3439,163 +3737,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id008
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 16
-    LSPA: 8
-    LSPB: 16
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 23
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x16_PGR1_PLR1_TT02_02
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id013 [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id011
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3674,6 +3825,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3717,14 +3873,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 24
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 23
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x16_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 8
     SubGroupA: 16
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id012
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -3735,15 +3898,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id011
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3822,6 +3986,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -3865,14 +4034,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 25
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 24
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id013
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -3883,15 +4059,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: &id014 [32, 8, 1]
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -3970,6 +4147,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4013,14 +4195,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 26
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 25
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x016x16_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id012
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -4031,15 +4220,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id014
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -4054,7 +4244,7 @@
     ExpandPointerSwap: true
     FractionalLoad: 0
     GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthB: 4
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
@@ -4070,21 +4260,21 @@
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
+    LSCA: 64
     LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 6656
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 512
+    LSPA: 4
+    LSPB: 16
+    LVCA: 16
+    LVCB: 4
+    LVPA: 1
+    LVPB: 4
+    LdsNumElements: 3328
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4098,10 +4288,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 32
-    MacroTileA: 128
-    MacroTileB: 32
+    MacroTile0: 64
+    MacroTile1: 16
+    MacroTileA: 64
+    MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -4111,13 +4301,18 @@
     NonTemporalC: 0
     NumElementsPerThread: 16
     NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
+    NumLoadsA: 4
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4161,14 +4356,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 27
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id010
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 26
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 4
+    SubGroupA: 16
+    SubGroupB: 4
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -4179,21 +4381,22 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id014
+    WorkGroup: [16, 4, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 24
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -4202,7 +4405,7 @@
     ExpandPointerSwap: true
     FractionalLoad: 0
     GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthB: 1
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
@@ -4218,21 +4421,21 @@
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 8
+    LSCA: 64
+    LSCB: 16
     LSPA: 4
-    LSPB: 16
-    LVCA: 16
-    LVCB: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
     LVPA: 2
     LVPB: 8
     LdsNumElements: 3200
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 384
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 128
     LdsOffsetA: 0
     LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4245,11 +4448,11 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 32
-    MacroTile1: 16
-    MacroTileA: 32
-    MacroTileB: 16
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 8
+    MacroTileA: 64
+    MacroTileB: 8
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -4257,15 +4460,20 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 6
-    NumLoadsB: 3
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 4
+    NumLoadsB: 1
     NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 3
-    NumLoadsPerpendicularA: 6
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
-    NumThreads: 64
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4309,17 +4517,24 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 28
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x24_PGR1_PLR1_TT04_02
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id012
-    ThreadTile0: 4
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 27
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x008x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 32
+    SubGroup1: 4
+    SubGroupA: 32
+    SubGroupB: 4
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
     ThreadTile1: 2
-    ThreadTileA: 4
+    ThreadTileA: 2
     ThreadTileB: 2
     UnrollMemFence: false
     UseSgprForGRO: 1
@@ -4327,15 +4542,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id008
-    WorkGroupMapping: 1
+    WorkGroup: [32, 4, 1]
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -4414,6 +4630,11 @@
     NumLoadsPerpendicularA: 3
     NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4457,14 +4678,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 29
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 28
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT016x016x24_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id013
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -4475,15 +4703,499 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id008
-    WorkGroupMapping: 8
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 24
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 8
+    LSPA: 4
+    LSPB: 16
+    LVCA: 16
+    LVCB: 4
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 3200
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 24
+    MacroTile0: 32
+    MacroTile1: 16
+    MacroTileA: 32
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 6
+    NumLoadsB: 3
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 3
+    NumLoadsPerpendicularA: 6
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 29
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x24_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
+    ThreadTile0: 4
+    ThreadTile1: 2
+    ThreadTileA: 4
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 24
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 16
+    LSCB: 8
+    LSPA: 8
+    LSPB: 16
+    LVCA: 8
+    LVCB: 4
+    LVPA: 4
+    LVPB: 8
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 24
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 3
+    NumLoadsB: 3
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 3
+    NumLoadsPerpendicularA: 3
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 30
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT016x016x24_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 24
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 8
+    LSPA: 4
+    LSPB: 16
+    LVCA: 16
+    LVCB: 4
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 3200
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 24
+    MacroTile0: 32
+    MacroTile1: 16
+    MacroTileA: 32
+    MacroTileB: 16
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 6
+    NumLoadsB: 3
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 3
+    NumLoadsPerpendicularA: 6
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 31
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x016x24_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
+    ThreadTile0: 4
+    ThreadTile1: 2
+    ThreadTileA: 4
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -4511,7 +5223,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 32
@@ -4562,6 +5274,11 @@
     NumLoadsPerpendicularA: 3
     NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4605,14 +5322,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 30
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 32
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x032x24_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id010
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -4623,15 +5347,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id008
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -4645,38 +5370,38 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
+    GlobalReadVectorWidth: 4
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 16
+    LSCA: 32
     LSCB: 32
     LSPA: 8
-    LSPB: 4
+    LSPB: 8
     LVCA: 8
-    LVCB: 16
-    LVPA: 4
+    LVCB: 8
+    LVPA: 2
     LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
+    LdsNumElements: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4690,10 +5415,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 32
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
+    MacroTile0: 32
+    MacroTile1: 32
+    MacroTileA: 32
+    MacroTileB: 32
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -4701,8 +5426,8 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
     NumLoadsA: 4
     NumLoadsB: 4
     NumLoadsCoalescedA: 1
@@ -4710,6 +5435,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 4
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4753,33 +5483,41 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 31
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT016x016x32_PGR1_PLR1_TT02_02
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 33
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x032x32_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id013
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id008
+    VectorWidth: 4
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -4858,6 +5596,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4901,14 +5644,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 32
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 34
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id013
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -4919,15 +5669,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id014
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5006,6 +5757,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -5049,14 +5805,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 33
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 35
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x016x32_PGR1_PLR1_TT04_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 8
     SubGroupA: 32
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id012
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 2]
     ThreadTile0: 4
     ThreadTile1: 2
     ThreadTileA: 4
@@ -5067,15 +5830,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id014
+    WorkGroup: [32, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5154,6 +5918,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -5197,14 +5966,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 34
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 36
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x008x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 4
     SubGroupA: 16
     SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id013
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -5215,15 +5991,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: &id015 [16, 4, 1]
+    WorkGroup: [16, 4, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5302,6 +6079,11 @@
     NumLoadsPerpendicularA: 8
     NumLoadsPerpendicularB: 1
     NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -5345,14 +6127,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 35
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 37
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x008x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 32
     SubGroup1: 4
     SubGroupA: 32
     SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id013
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -5366,12 +6155,13 @@
     WorkGroup: [32, 4, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5450,6 +6240,11 @@
     NumLoadsPerpendicularA: 16
     NumLoadsPerpendicularB: 4
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -5493,14 +6288,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 36
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 38
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x008x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 4
     SubGroupA: 16
     SubGroupB: 4
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id013
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -5511,15 +6313,177 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id015
+    WorkGroup: [16, 4, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 1
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 64
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 12800
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 64
+    MacroTile0: 64
+    MacroTile1: 8
+    MacroTileA: 64
+    MacroTileB: 8
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
+    NumLoadsA: 16
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 16
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 39
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x008x64_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 32
+    SubGroup1: 4
+    SubGroupA: 32
+    SubGroupB: 4
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [32, 4, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 1
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5598,6 +6562,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -5641,14 +6610,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 37
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 40
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id018 [4, 4]
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -5659,15 +6635,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id016 [16, 16, 1]
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5695,7 +6672,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
@@ -5746,6 +6723,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -5789,33 +6771,41 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 38
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 41
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
+    SuppressNoLoadLoop: true
     ThreadTile: [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
     ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: false
+    UseSgprForGRO: 1
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id016
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5894,6 +6884,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -5937,14 +6932,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 39
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 42
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x08_PGR1_PLR1_TT08_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id017 [8, 4]
+    SuppressNoLoadLoop: true
+    ThreadTile: [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -5955,15 +6957,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id016
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -5991,7 +6994,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
@@ -6038,6 +7041,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 2
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -6081,14 +7089,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 40
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 43
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x032x16_PGR0_PLR1_TT08_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id017
+    SuppressNoLoadLoop: false
+    ThreadTile: [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -6099,159 +7114,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id020 [8, 8, 1]
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 41
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id018
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id016
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -6279,7 +7151,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
@@ -6330,6 +7202,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -6373,14 +7250,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 42
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 44
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id018
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -6391,15 +7275,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id016
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -6427,7 +7312,168 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 16
+    LSPA: 16
+    LSPB: 64
+    LVCA: 16
+    LVCB: 4
+    LVPA: 4
+    LVPB: 16
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 2048
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 5120
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 1
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 45
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 0
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 128
@@ -6478,6 +7524,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -6521,14 +7572,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 43
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 46
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x16_PGR1_PLR1_TT08_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id017
+    SuppressNoLoadLoop: true
+    ThreadTile: [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -6539,15 +7597,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id016
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -6575,7 +7634,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 8
     GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 128
@@ -6626,6 +7685,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -6669,14 +7733,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 44
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 47
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x16_PGR1_PLR1_TT08_08
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id019 [8, 8]
+    SuppressNoLoadLoop: true
+    ThreadTile: [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -6687,21 +7758,22 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id016
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 32
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -6709,182 +7781,34 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: false
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
+    GlobalReadVectorWidth: 2
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 32
-    LSPA: 8
+    LSCB: 16
+    LSPA: 4
     LSPB: 16
-    LVCA: 8
-    LVCB: 4
-    LVPA: 1
-    LVPB: 2
-    LdsNumElements: 4096
-    LdsOffsetA: 0
-    LdsOffsetB: 2048
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 45
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x32_PGR0_PLR1_TT08_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id020
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 16
-    LSPB: 32
-    LVCA: 16
+    LVCA: 32
     LVCB: 8
-    LVPA: 4
+    LVPA: 2
     LVPB: 8
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
+    LdsNumElements: 1536
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
+    LdsOffsetB: 1024
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -6897,11 +7821,11 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 32
+    LoopUnroll: 16
     MacroTile0: 64
-    MacroTile1: 64
+    MacroTile1: 32
     MacroTileA: 64
-    MacroTileB: 64
+    MacroTileB: 32
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -6910,20 +7834,25 @@
     NonTemporalB: 0
     NonTemporalC: 0
     NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsA: 4
     NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 2
-    NumThreads: 256
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
     PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -6961,662 +7890,82 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 46
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x32_PGR1_PLR1_TT04_04
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 48
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x032x16_PGR0_PLR0_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id018
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: false
+    UseSgprForGRO: 1
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id016
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 32
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 14336
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 47
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x32_PGR1_PLR1_TT08_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id017
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id016
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
     DisableKernelPieces: 0
     EdgeType: ShiftPtr
     ExpandPointerSwap: false
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 32
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 8192
-    LdsOffsetA: 0
-    LdsOffsetB: 4096
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 48
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x32_PGR0_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id016
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 32
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 16384
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 49
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x32_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id019
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id016
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 16
-    LSPB: 32
-    LVCA: 16
-    LVCB: 8
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 16384
-    LdsOffsetA: 0
-    LdsOffsetB: 8192
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 50
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x64_PGR0_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id016
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
     FractionalLoad: 0
     GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
+    GlobalReadVectorWidth: 2
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
+    GlobalWriteVectorWidth: 2
     GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 8
+    LSCB: 16
     LSPA: 8
-    LSPB: 128
+    LSPB: 32
     LVCA: 32
-    LVCB: 2
+    LVCB: 8
     LVPA: 4
-    LVPB: 32
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
+    LVPB: 16
+    LdsNumElements: 3072
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
+    LdsOffsetB: 1024
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -7629,7 +7978,7 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
+    LoopUnroll: 16
     MacroTile0: 64
     MacroTile1: 128
     MacroTileA: 64
@@ -7642,20 +7991,25 @@
     NonTemporalB: 0
     NonTemporalC: 0
     NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 2
+    NumLoadsB: 4
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 4
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
     PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -7693,39 +8047,47 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 51
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 49
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_PGR0_PLR0_TT04_08
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id022 [4, 8]
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
     ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: false
+    UseSgprForGRO: 1
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id021 [16, 16, 1]
-    WorkGroupMapping: 1
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 32
+    DepthU: 16
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -7750,169 +8112,21 @@
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 8
-    LSPB: 16
-    LVCA: 32
-    LVCB: 16
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 7232
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1152
+    LSCA: 32
+    LSCB: 16
+    LSPA: 16
+    LSPB: 32
+    LVCA: 16
+    LVCB: 8
+    LVPA: 8
+    LVPB: 16
+    LdsNumElements: 6720
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 2176
     LdsOffsetA: 0
     LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 2
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 64
-    MacroTile1: 32
-    MacroTileA: 64
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 4
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 52
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x032x32_PGR1_PLR1_TT04_02
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: [4, 2]
-    ThreadTile0: 4
-    ThreadTile1: 2
-    ThreadTileA: 4
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id021
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 3104
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 640
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
     LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
+    LdsOffsetB_Blk: 4608
     LdsPadA: 0
     LdsPadB: 4
     LocalDotLayout: 1
@@ -7925,158 +8139,10 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 53
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id023 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id021
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 128
-    LVCA: 32
-    LVCB: 2
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 3616
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1152
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
+    LoopUnroll: 16
+    MacroTile0: 32
     MacroTile1: 128
-    MacroTileA: 64
+    MacroTileA: 32
     MacroTileB: 128
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -8085,459 +8151,20 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
+    NumElementsPerThread: 16
     NumGlobalWriteVectorsPerThread: 8
     NumLoadsA: 1
-    NumLoadsB: 1
+    NumLoadsB: 4
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
+    NumLoadsPerpendicularB: 4
     NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 54
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id022
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id021
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 6208
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1152
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 55
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id023
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id021
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 6720
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 640
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 32
-    MacroTileA: 128
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 56
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id023
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -8581,33 +8208,41 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 57
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id024 [4, 4]
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 50
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x128x16_PGR1_PLR0_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: false
+    UseSgprForGRO: 1
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [16, 16, 1]
+    VectorWidth: 2
+    WorkGroup: [8, 32, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -8635,7 +8270,7 @@
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 4
     GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 32
@@ -8682,6 +8317,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 2
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -8725,20 +8365,27 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 58
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 51
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT032x128x16_PGR0_PLR0_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 32
     SubGroupA: 8
     SubGroupB: 32
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id024
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: false
+    UseSgprForGRO: 1
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
@@ -8746,156 +8393,13 @@
     WorkGroup: [8, 32, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 2624
-    LdsOffsetA: 0
-    LdsOffsetB: 2048
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 32
-    MacroTileA: 128
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 59
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x032x16_PGR0_PLR0_TT04_04
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id024
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
+    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -8910,33 +8414,37 @@
     ExpandPointerSwap: false
     FractionalLoad: false
     GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthB: 1
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
+    GlobalReadVectorWidth: 1
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
+    GlobalWriteVectorWidth: 1
     GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Source
     LSCA: 64
     LSCB: 4
     LSPA: 4
-    LSPB: 128
+    LSPB: 64
     LVCA: 64
-    LVCB: 2
+    LVCB: 4
     LVPA: 4
     LVPB: 64
-    LdsNumElements: 819
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
     LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -8951,9 +8459,9 @@
     LoopTail: true
     LoopUnroll: 4
     MacroTile0: 64
-    MacroTile1: 128
+    MacroTile1: 64
     MacroTileA: 64
-    MacroTileB: 128
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -8961,7 +8469,7 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
+    NumElementsPerThread: 16
     NumGlobalWriteVectorsPerThread: 16
     NumLoadsA: 1
     NumLoadsB: 1
@@ -8970,590 +8478,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 60
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id027 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id025 [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 61
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id026 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 62
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 63
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -9597,14 +8526,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 64
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 52
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -9614,16 +8550,17 @@
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
+    VectorWidth: 1
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 5
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
+    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -9637,321 +8574,29 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: false
     FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
+    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthB: 1
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
+    GlobalReadVectorWidth: 1
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
+    GlobalWriteVectorWidth: 1
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Source
     LSCA: 64
     LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 65
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 66
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x08_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id027
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
+    LSPA: 4
+    LSPB: 32
+    LVCA: 64
+    LVCB: 8
     LVPA: 4
     LVPB: 32
     LdsNumElements: 2048
@@ -9986,306 +8631,19 @@
     NonTemporalB: 0
     NonTemporalC: 0
     NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 67
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 68
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
     NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
+    NumLoadsA: 2
     NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -10329,1178 +8687,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 69
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id027
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 70
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 53
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 16
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
-    LVCB: 8
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 4096
-    LdsOffsetA: 0
-    LdsOffsetB: 2048
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 71
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x16_PGR0_PLR0_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 72
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 73
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 74
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id027
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 16
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 75
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id026
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id025
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 76
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id029 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: &id028 [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 77
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id030 [4, 4]
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -11511,2791 +8712,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id028
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 78
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x04_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id029
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 79
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 4
-    LSPA: 2
-    LSPB: 64
-    LVCA: 128
-    LVCB: 4
-    LVPA: 2
-    LVPB: 64
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 80
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x04_PGR0_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id031 [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 81
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x04_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id029
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 82
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 4
-    LSPA: 2
-    LSPB: 64
-    LVCA: 128
-    LVCB: 4
-    LVPA: 2
-    LVPB: 64
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 83
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id031
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 84
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x04_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id029
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 4
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 4
-    LVPB: 64
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 85
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x04_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
-    LVCB: 8
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 86
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
-    LVCB: 8
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 87
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x08_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id029
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
-    LVCB: 8
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 88
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 8
-    LSPA: 2
-    LSPB: 32
-    LVCA: 128
-    LVCB: 8
-    LVPA: 2
-    LVPB: 32
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 89
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x08_PGR0_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id031
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
-    LVCB: 8
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 90
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x08_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id029
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
-    LVCB: 8
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 91
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 8
-    LSPA: 4
-    LSPB: 32
-    LVCA: 64
-    LVCB: 8
-    LVPA: 4
-    LVPB: 32
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 92
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 16
-    LSPA: 4
-    LSPB: 16
-    LVCA: 64
-    LVCB: 16
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 93
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 16
-    LSPA: 4
-    LSPB: 16
-    LVCA: 64
-    LVCB: 16
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 94
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 128
-    LSCB: 16
-    LSPA: 2
-    LSPB: 16
-    LVCA: 128
-    LVCB: 16
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 8192
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 8
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 8
-    NumLoadsPerpendicularB: 8
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 95
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x16_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id031
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 64
-    LSCB: 16
-    LSPA: 4
-    LSPB: 16
-    LVCA: 64
-    LVCB: 16
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 4
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 8
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 96
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id029
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id028
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -14374,6 +8800,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 4
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -14417,14 +8848,21 @@
       TransposeB: false
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 97
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 54
     SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -14435,1757 +8873,10 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id028
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 64
-    LVCA: 16
-    LVCB: 2
-    LVPA: 1
-    LVPB: 8
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x16_EPS1_GRVW08_LPB00_PGR1_PLR1_SNLL1_TT08_08_VW08_WG16_08_01_WGM01
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id033 [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: &id037 [16, 8, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 7232
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2176
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG08_32_01_WGM01
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id032 [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id035 [8, 32, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 7232
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1152
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG16_16_01_WGM01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id032
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id034 [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 12352
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 2176
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 10240
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 3
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_08_VW04_WG16_16_01_WGM01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id033
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id034
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 16
-    LSPA: 16
-    LSPB: 64
-    LVCA: 16
-    LVCB: 4
-    LVPA: 4
-    LVPB: 16
-    LdsNumElements: 7232
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2176
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG08_32_01_WGM08
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id032
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id035
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 16
-    LSPA: 8
-    LSPB: 64
-    LVCA: 32
-    LVCB: 4
-    LVPA: 2
-    LVPB: 16
-    LdsNumElements: 7232
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1152
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 5
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG16_16_01_WGM08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id032
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id034
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 256
-    LSCB: 16
-    LSPA: 4
-    LSPB: 64
-    LVCA: 64
-    LVCB: 4
-    LVPA: 1
-    LVPB: 16
-    LdsNumElements: 13376
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 1152
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 256
-    MacroTile1: 64
-    MacroTileA: 256
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 6
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT256x064x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_08_VW04_WG32_08_01_WGM64
-    SubGroup0: 32
-    SubGroup1: 8
-    SubGroupA: 32
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id033
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 64
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 16
-    LSPB: 32
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 6272
-    LdsOffsetA: 0
-    LdsOffsetB: 2048
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x32_EPS0_GRVW04_LPB04_PGR0_PLR0_SNLL0_TT08_04_VW04_WG08_32_01_WGM01
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id032
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id035
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 16
-    LSPB: 32
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 4224
-    LdsOffsetA: 0
-    LdsOffsetB: 2048
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x32_EPS0_GRVW04_LPB04_PGR0_PLR0_SNLL0_TT04_04_VW04_WG16_16_01_WGM01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id036 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id034
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 32
-    LSPA: 8
-    LSPB: 32
-    LVCA: 32
-    LVCB: 8
-    LVPA: 2
-    LVPB: 8
-    LdsNumElements: 14464
-    LdsNumElementsAlignedA: 4096
-    LdsNumElementsAlignedB: 2176
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 4096
-    LdsOffsetB_Blk: 12288
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 9
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x32_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG16_16_01_WGM01
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id032
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id034
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 32
-    LSPA: 16
-    LSPB: 32
-    LVCA: 16
-    LVCB: 8
-    LVPA: 4
-    LVPB: 8
-    LdsNumElements: 4224
-    LdsOffsetA: 0
-    LdsOffsetB: 2048
-    LdsPadA: 0
-    LdsPadB: 4
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x32_EPS0_GRVW04_LPB04_PGR0_PLR0_SNLL0_TT04_04_VW04_WG16_16_01_WGM08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id036
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id034
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 8
-    GlobalLoadVectorWidthB: 8
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 8
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 2
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 32
-    LSPA: 8
-    LSPB: 32
-    LVCA: 16
-    LVCB: 4
-    LVPA: 1
-    LVPB: 4
-    LdsNumElements: 6400
-    LdsOffsetA: 0
-    LdsOffsetB: 4096
-    LdsPadA: 0
-    LdsPadB: 8
-    LocalDotLayout: 2
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [3, 1, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 0
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: false
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: false
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x32_EPS0_GRVW08_LPB08_PGR0_PLR1_SNLL0_TT08_08_VW08_WG16_08_01_WGM01
-    SubGroup0: 16
-    SubGroup1: 8
-    SubGroupA: 16
-    SubGroupB: 8
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id033
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 8
-    WorkGroup: *id037
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
@@ -16315,7 +9006,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: false
-    ThreadTile: &id038 [4, 4]
+    ThreadTile: &id001 [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16326,7 +9017,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id039 [8, 8, 1]
+    WorkGroup: &id002 [8, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16462,7 +9153,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16473,7 +9164,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id039
+    WorkGroup: *id002
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16609,7 +9300,7 @@
     SubGroupA: 16
     SubGroupB: 4
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16620,7 +9311,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id040 [16, 4, 1]
+    WorkGroup: &id003 [16, 4, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16756,7 +9447,7 @@
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16767,7 +9458,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id041 [16, 8, 1]
+    WorkGroup: &id004 [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16903,7 +9594,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16914,7 +9605,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id043 [16, 16, 1]
+    WorkGroup: &id006 [16, 16, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17050,7 +9741,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17061,7 +9752,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id039
+    WorkGroup: *id002
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17197,7 +9888,7 @@
     SubGroupA: 16
     SubGroupB: 4
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17208,7 +9899,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id040
+    WorkGroup: *id003
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17344,7 +10035,7 @@
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17355,7 +10046,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id041
+    WorkGroup: *id004
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17491,7 +10182,7 @@
     SubGroupA: 32
     SubGroupB: 4
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17638,7 +10329,7 @@
     SubGroupA: 32
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id038
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17785,7 +10476,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: &id042 [8, 8]
+    ThreadTile: &id005 [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -17796,7 +10487,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id039
+    WorkGroup: *id002
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17932,7 +10623,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id042
+    ThreadTile: *id005
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -17943,7 +10634,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id043
+    WorkGroup: *id006
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18079,7 +10770,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: &id047 [4, 4]
+    ThreadTile: &id010 [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -18090,7 +10781,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id044 [8, 8, 1]
+    WorkGroup: &id007 [8, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18226,7 +10917,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: &id046 [8, 4]
+    ThreadTile: &id009 [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -18237,7 +10928,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id044
+    WorkGroup: *id007
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18373,7 +11064,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: &id045 [8, 8]
+    ThreadTile: &id008 [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -18384,7 +11075,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id044
+    WorkGroup: *id007
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18520,7 +11211,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id045
+    ThreadTile: *id008
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -18531,7 +11222,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id048 [16, 16, 1]
+    WorkGroup: &id011 [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18667,7 +11358,7 @@
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id046
+    ThreadTile: *id009
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -18678,7 +11369,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id049 [16, 8, 1]
+    WorkGroup: &id012 [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18814,7 +11505,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id047
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -18825,7 +11516,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id044
+    WorkGroup: *id007
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18961,7 +11652,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id046
+    ThreadTile: *id009
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -18972,7 +11663,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id044
+    WorkGroup: *id007
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19108,7 +11799,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id047
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -19119,7 +11810,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id048
+    WorkGroup: *id011
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19255,7 +11946,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id046
+    ThreadTile: *id009
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -19266,7 +11957,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id048
+    WorkGroup: *id011
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19402,7 +12093,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id045
+    ThreadTile: *id008
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -19413,7 +12104,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id048
+    WorkGroup: *id011
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19549,7 +12240,7 @@
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id047
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -19560,7 +12251,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id049
+    WorkGroup: *id012
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19696,7 +12387,7 @@
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id046
+    ThreadTile: *id009
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -19707,7 +12398,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id049
+    WorkGroup: *id012
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19843,7 +12534,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id046
+    ThreadTile: *id009
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -19854,7 +12545,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id048
+    WorkGroup: *id011
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19990,7 +12681,7 @@
     SubGroupA: 32
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id047
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -20137,7 +12828,7 @@
     SubGroupA: 16
     SubGroupB: 4
     SuppresssNoLoadLoop: true
-    ThreadTile: *id047
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -20284,7 +12975,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id045
+    ThreadTile: *id008
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -20295,7 +12986,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id044
+    WorkGroup: *id007
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20431,7 +13122,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id045
+    ThreadTile: *id008
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -20442,7 +13133,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id048
+    WorkGroup: *id011
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20578,7 +13269,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id045
+    ThreadTile: *id008
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -20589,7 +13280,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id044
+    WorkGroup: *id007
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20725,7 +13416,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id045
+    ThreadTile: *id008
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -20736,7 +13427,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id048
+    WorkGroup: *id011
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -21158,7 +13849,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: &id051 [4, 8]
+    ThreadTile: &id014 [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -21169,7 +13860,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id050 [16, 16, 1]
+    WorkGroup: &id013 [16, 16, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -21316,7 +14007,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id050
+    WorkGroup: *id013
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -21452,7 +14143,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: &id053 [8, 8]
+    ThreadTile: &id016 [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -21463,7 +14154,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id050
+    WorkGroup: *id013
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -21599,7 +14290,7 @@
     SubGroupA: 32
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id051
+    ThreadTile: *id014
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -21610,7 +14301,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id052 [32, 8, 1]
+    WorkGroup: &id015 [32, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -21746,7 +14437,7 @@
     SubGroupA: 32
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id051
+    ThreadTile: *id014
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -21757,7 +14448,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id052
+    WorkGroup: *id015
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -21904,7 +14595,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id054 [32, 16, 1]
+    WorkGroup: &id017 [32, 16, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -22040,7 +14731,7 @@
     SubGroupA: 32
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id053
+    ThreadTile: *id016
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -22051,7 +14742,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id054
+    WorkGroup: *id017
     WorkGroupMapping: 1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -22183,7 +14874,7 @@
     SubGroupA: 16
     SubGroupB: 8
     SuppresssNoLoadLoop: false
-    ThreadTile: &id055 [8, 4]
+    ThreadTile: &id018 [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -22330,7 +15021,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: &id057 [4, 8]
+    ThreadTile: &id020 [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -22341,7 +15032,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id056 [16, 16, 1]
+    WorkGroup: &id019 [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -22477,7 +15168,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id055
+    ThreadTile: *id018
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
@@ -22488,7 +15179,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id056
+    WorkGroup: *id019
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -22624,7 +15315,7 @@
     SubGroupA: 32
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id057
+    ThreadTile: *id020
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -22767,7 +15458,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id060 [4, 8]
+    ThreadTile: &id023 [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -22778,7 +15469,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: &id058 [16, 16, 1]
+    WorkGroup: &id021 [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -22910,7 +15601,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id059 [4, 4]
+    ThreadTile: &id022 [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -22921,7 +15612,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -23057,7 +15748,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -23068,7 +15759,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -23200,7 +15891,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -23211,7 +15902,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -23347,7 +16038,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -23358,7 +16049,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -23490,7 +16181,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id060
+    ThreadTile: *id023
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -23501,7 +16192,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -23633,7 +16324,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -23644,7 +16335,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -23780,7 +16471,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id060
+    ThreadTile: *id023
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -23791,7 +16482,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -23927,7 +16618,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -23938,7 +16629,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -24070,7 +16761,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id060
+    ThreadTile: *id023
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -24081,7 +16772,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -24213,7 +16904,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -24224,7 +16915,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -24360,7 +17051,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -24371,7 +17062,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -24514,7 +17205,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -24646,7 +17337,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id060
+    ThreadTile: *id023
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -24657,7 +17348,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -24793,7 +17484,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -24804,7 +17495,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -24936,7 +17627,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -24947,7 +17638,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -25083,7 +17774,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id059
+    ThreadTile: *id022
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -25094,7 +17785,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id058
+    WorkGroup: *id021
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -25226,7 +17917,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id064 [8, 8]
+    ThreadTile: &id027 [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -25237,7 +17928,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: &id061 [16, 16, 1]
+    WorkGroup: &id024 [16, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -25369,7 +18060,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id062 [4, 8]
+    ThreadTile: &id025 [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -25380,7 +18071,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -25512,7 +18203,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id063 [4, 4]
+    ThreadTile: &id026 [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -25523,7 +18214,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -25659,7 +18350,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id062
+    ThreadTile: *id025
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -25670,7 +18361,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -25806,7 +18497,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -25817,7 +18508,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -25949,7 +18640,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id062
+    ThreadTile: *id025
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -25960,7 +18651,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -26092,7 +18783,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -26103,7 +18794,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -26239,7 +18930,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id062
+    ThreadTile: *id025
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -26250,7 +18941,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -26386,7 +19077,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -26397,7 +19088,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -26529,7 +19220,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -26540,7 +19231,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -26676,7 +19367,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id062
+    ThreadTile: *id025
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -26687,7 +19378,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -26823,7 +19514,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -26834,7 +19525,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -26966,7 +19657,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id062
+    ThreadTile: *id025
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -26977,7 +19668,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -27109,7 +19800,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -27120,7 +19811,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -27256,7 +19947,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -27267,7 +19958,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -27399,7 +20090,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -27410,7 +20101,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -27546,7 +20237,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id064
+    ThreadTile: *id027
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -27557,7 +20248,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -27693,7 +20384,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id062
+    ThreadTile: *id025
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -27704,7 +20395,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -27840,7 +20531,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id063
+    ThreadTile: *id026
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -27851,3120 +20542,3478 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id061
+    WorkGroup: *id024
     WorkGroupMapping: 8
     WorkGroupMappingType: B
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 8
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 8
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 8
+    LSPB: 64
+    LVCA: 16
+    LVCB: 2
+    LVPA: 1
+    LVPB: 8
+    LdsNumElements: 7168
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1024
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x16_EPS1_GRVW08_LPB00_PGR1_PLR1_SNLL1_TT08_08_VW08_WG16_08_01_WGM01
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id029 [8, 8]
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 8
+    WorkGroup: &id033 [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 16
+    LSPA: 16
+    LSPB: 64
+    LVCA: 16
+    LVCB: 4
+    LVPA: 4
+    LVPB: 16
+    LdsNumElements: 7232
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 2176
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 5120
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG08_32_01_WGM01
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppresssNoLoadLoop: true
+    ThreadTile: &id028 [8, 4]
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: &id031 [8, 32, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 8
+    LSPB: 64
+    LVCA: 32
+    LVCB: 4
+    LVPA: 2
+    LVPB: 16
+    LdsNumElements: 7232
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1152
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG16_16_01_WGM01
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id028
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: &id030 [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 8
+    LSPB: 64
+    LVCA: 32
+    LVCB: 4
+    LVPA: 2
+    LVPB: 16
+    LdsNumElements: 12352
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2176
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 10240
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 128
+    MacroTile1: 128
+    MacroTileA: 128
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x128x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_08_VW04_WG16_16_01_WGM01
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id029
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id030
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 16
+    LSPA: 16
+    LSPB: 64
+    LVCA: 16
+    LVCB: 4
+    LVPA: 4
+    LVPB: 16
+    LdsNumElements: 7232
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 2176
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 5120
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 4
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG08_32_01_WGM08
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id028
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id031
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 16
+    LSPA: 8
+    LSPB: 64
+    LVCA: 32
+    LVCB: 4
+    LVPA: 2
+    LVPB: 16
+    LdsNumElements: 7232
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 1152
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 5
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG16_16_01_WGM08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id028
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id030
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 256
+    LSCB: 16
+    LSPA: 4
+    LSPB: 64
+    LVCA: 64
+    LVCB: 4
+    LVPA: 1
+    LVPB: 16
+    LdsNumElements: 13376
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 1152
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 256
+    MacroTile1: 64
+    MacroTileA: 256
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 6
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT256x064x16_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_08_VW04_WG32_08_01_WGM64
+    SubGroup0: 32
+    SubGroup1: 8
+    SubGroupA: 32
+    SubGroupB: 8
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id029
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 64
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 16
+    LSPB: 32
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsNumElements: 6272
+    LdsOffsetA: 0
+    LdsOffsetB: 2048
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 7
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x128x32_EPS0_GRVW04_LPB04_PGR0_PLR0_SNLL0_TT08_04_VW04_WG08_32_01_WGM01
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id028
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id031
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 16
+    LSPB: 32
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsNumElements: 4224
+    LdsOffsetA: 0
+    LdsOffsetB: 2048
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 8
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x32_EPS0_GRVW04_LPB04_PGR0_PLR0_SNLL0_TT04_04_VW04_WG16_16_01_WGM01
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: &id032 [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id030
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 32
+    LSPA: 8
+    LSPB: 32
+    LVCA: 32
+    LVCB: 8
+    LVPA: 2
+    LVPB: 8
+    LdsNumElements: 14464
+    LdsNumElementsAlignedA: 4096
+    LdsNumElementsAlignedB: 2176
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 8192
+    LdsOffsetB: 4096
+    LdsOffsetB_Blk: 12288
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 9
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x32_EPS1_GRVW04_LPB04_PGR1_PLR1_SNLL1_TT08_04_VW04_WG16_16_01_WGM01
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: true
+    ThreadTile: *id028
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id030
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 4
+    GlobalLoadVectorWidthB: 4
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 4
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 16
+    LSPB: 32
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsNumElements: 4224
+    LdsOffsetA: 0
+    LdsOffsetB: 2048
+    LdsPadA: 0
+    LdsPadB: 4
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 256
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 10
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT064x064x32_EPS0_GRVW04_LPB04_PGR0_PLR0_SNLL0_TT04_04_VW04_WG16_16_01_WGM08
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id032
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 4
+    WorkGroup: *id030
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 32
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: false
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 8
+    GlobalLoadVectorWidthB: 8
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 8
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 8
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 2
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 32
+    LSPA: 8
+    LSPB: 32
+    LVCA: 16
+    LVCB: 4
+    LVPA: 1
+    LVPB: 4
+    LdsNumElements: 6400
+    LdsOffsetA: 0
+    LdsOffsetB: 4096
+    LdsPadA: 0
+    LdsPadB: 8
+    LocalDotLayout: 2
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 16
+    MacroTile0: 128
+    MacroTile1: 64
+    MacroTileA: 128
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 2
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 64
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: false
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 4
+      DestDataType: 4
+      HighPrecisionAccumulate: true
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseInitialStrides: false
+    SolutionIndex: 11
+    SolutionNameMin: Cijk_Ailk_Bljk_HBH_MT128x064x32_EPS0_GRVW08_LPB08_PGR0_PLR1_SNLL0_TT08_08_VW08_WG16_08_01_WGM01
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppresssNoLoadLoop: false
+    ThreadTile: *id029
+    ThreadTile0: 8
+    ThreadTile1: 8
+    ThreadTileA: 8
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 2
+    VectorStore: true
+    VectorWidth: 8
+    WorkGroup: *id033
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
 - [2, 3, 0, 1]
-- - - [1856, 3584, 1, 1]
-    - [82, 200.359]
-  - - [128, 256, 1, 1280]
-    - [16, 1420.83]
-  - - [448, 1, 1, 256]
-    - [92, 3.15771]
-  - - [5056, 1408, 1, 3328]
-    - [39, 9833.76]
-  - - [5056, 1856, 1, 3328]
-    - [37, 10082.2]
-  - - [5888, 128, 1, 1]
-    - [77, 58.5143]
-  - - [448, 3584, 1, 3328]
-    - [42, 8495.84]
-  - - [704, 64, 1, 3328]
-    - [12, 2046.21]
-  - - [5056, 4288, 1, 32]
-    - [60, 3610.35]
-  - - [5888, 256, 1, 256]
-    - [19, 8093.04]
-  - - [32, 5056, 1, 1280]
-    - [70, 1235.05]
-  - - [1856, 256, 1, 1]
-    - [85, 42.7281]
-  - - [448, 1, 1, 1]
-    - [80, 0.0491228]
-  - - [1408, 3584, 1, 3328]
-    - [42, 9858.4]
-  - - [448, 448, 1, 3328]
-    - [15, 5338.42]
-  - - [1024, 2368, 1, 3328]
-    - [42, 9200.38]
-  - - [4288, 64, 1, 3328]
-    - [8, 5646.08]
-  - - [1, 4288, 1, 1280]
-    - [97, 30.7108]
-  - - [2368, 64, 1, 1]
-    - [77, 12.6293]
-  - - [256, 128, 1, 256]
-    - [5, 936.229]
-  - - [448, 64, 1, 1]
-    - [80, 2.63529]
-  - - [32, 1408, 1, 32]
-    - [65, 96.3765]
-  - - [448, 3584, 1, 32]
-    - [67, 2000.79]
-  - - [64, 1024, 1, 1280]
-    - [12, 2752.17]
-  - - [704, 128, 1, 1280]
-    - [13, 3449.26]
-  - - [1, 1408, 1, 3328]
-    - [97, 15.6319]
-  - - [32, 3584, 1, 1280]
-    - [70, 1229.9]
-  - - [4288, 6784, 1, 3328]
-    - [38, 10171.7]
-  - - [2944, 128, 1, 32]
-    - [67, 780.999]
-  - - [64, 6784, 1, 1]
-    - [86, 41.1152]
-  - - [448, 128, 1, 256]
-    - [34, 1668.19]
-  - - [64, 5056, 1, 3328]
-    - [8, 6618.04]
-  - - [5888, 4288, 1, 3328]
-    - [37, 10189.2]
-  - - [1, 2368, 1, 1280]
-    - [97, 23.5915]
-  - - [704, 1024, 1, 1]
-    - [82, 61.3007]
-  - - [2368, 1408, 1, 32]
-    - [60, 2710.69]
-  - - [256, 1856, 1, 1280]
-    - [42, 7071.79]
-  - - [1024, 2944, 1, 1]
-    - [76, 131.3]
-  - - [2368, 2944, 1, 1280]
-    - [42, 9887.62]
-  - - [1, 1024, 1, 3328]
-    - [97, 11.2278]
-  - - [3584, 1408, 1, 32]
-    - [60, 3053.72]
-  - - [6784, 1856, 1, 32]
-    - [60, 3483.02]
-  - - [5056, 256, 1, 256]
-    - [42, 8105.43]
-  - - [1856, 2368, 1, 256]
-    - [37, 9344.87]
-  - - [2368, 1024, 1, 3328]
-    - [42, 9046.91]
-  - - [3584, 4288, 1, 32]
-    - [60, 3648.24]
-  - - [1024, 1024, 1, 1280]
-    - [42, 8938.31]
-  - - [3584, 3584, 1, 1]
-    - [84, 237.169]
-  - - [32, 2944, 1, 3328]
-    - [75, 1118.13]
-  - - [704, 1408, 1, 3328]
-    - [42, 8632.04]
-  - - [1408, 704, 1, 256]
-    - [18, 7516.45]
-  - - [704, 64, 1, 32]
-    - [68, 89.2198]
-  - - [2368, 32, 1, 256]
-    - [70, 556.154]
-  - - [2944, 256, 1, 1]
-    - [76, 62.3894]
-  - - [1408, 2368, 1, 1]
-    - [82, 154.359]
-  - - [32, 448, 1, 3328]
-    - [75, 171.471]
-  - - [5056, 1, 1, 3328]
-    - [97, 36.726]
-  - - [2944, 256, 1, 32]
-    - [68, 1299.42]
-  - - [5056, 6784, 1, 1280]
-    - [19, 10163.3]
-  - - [4288, 5056, 1, 1]
-    - [77, 242.616]
-  - - [5056, 4288, 1, 1]
-    - [77, 242.616]
-  - - [128, 4288, 1, 3328]
-    - [24, 6976.09]
-  - - [5056, 128, 1, 256]
-    - [9, 6767.77]
-  - - [1408, 4288, 1, 1280]
-    - [43, 9784.27]
-  - - [1856, 704, 1, 1280]
-    - [42, 9173.31]
-  - - [4288, 1024, 1, 3328]
-    - [43, 9343.79]
-  - - [1, 5888, 1, 3328]
-    - [97, 42.5318]
-  - - [1024, 128, 1, 32]
-    - [65, 266.136]
-  - - [1024, 2368, 1, 32]
-    - [68, 2400.82]
-  - - [256, 704, 1, 1]
-    - [92, 13.4095]
-  - - [128, 448, 1, 1280]
-    - [12, 2440.17]
-  - - [704, 3584, 1, 1280]
-    - [42, 9441.11]
-  - - [1856, 5056, 1, 256]
-    - [19, 9643.09]
-  - - [1408, 1024, 1, 1280]
-    - [42, 8610.93]
-  - - [2368, 3584, 1, 1]
-    - [82, 214.316]
-  - - [5056, 5888, 1, 3328]
-    - [37, 10232.9]
-  - - [3584, 3584, 1, 1280]
-    - [43, 9987.88]
-  - - [2368, 3584, 1, 32]
-    - [60, 3404.98]
-  - - [2944, 2368, 1, 1]
-    - [82, 203.604]
-  - - [704, 4288, 1, 1]
-    - [77, 147.978]
-  - - [1024, 6784, 1, 1280]
-    - [42, 10036.9]
-  - - [1024, 3584, 1, 1]
-    - [76, 142.913]
-  - - [6784, 128, 1, 256]
-    - [1, 7088.59]
-  - - [2944, 2368, 1, 1280]
-    - [37, 9866.63]
-  - - [32, 5056, 1, 32]
-    - [70, 401.968]
-  - - [5888, 32, 1, 32]
-    - [70, 454.014]
-  - - [64, 128, 1, 3328]
-    - [12, 372.038]
-  - - [256, 5056, 1, 32]
-    - [61, 1849.05]
-  - - [5056, 64, 1, 32]
-    - [70, 752.521]
-  - - [128, 6784, 1, 32]
-    - [68, 1523.42]
-  - - [64, 128, 1, 1]
-    - [82, 0.678146]
-  - - [64, 2368, 1, 1280]
-    - [8, 4523.94]
-  - - [128, 704, 1, 32]
-    - [65, 182.044]
-  - - [64, 6784, 1, 3328]
-    - [6, 6762.16]
-  - - [2944, 256, 1, 1280]
-    - [42, 8098.47]
-  - - [5056, 704, 1, 1]
-    - [77, 162.382]
-  - - [2944, 4288, 1, 256]
-    - [37, 9568.07]
-  - - [1024, 1024, 1, 3328]
-    - [42, 9121.87]
-  - - [5888, 1, 1, 256]
-    - [97, 34.6991]
-  - - [5056, 704, 1, 32]
-    - [63, 2656.29]
-  - - [5056, 704, 1, 1280]
-    - [42, 9529.91]
-  - - [1856, 4288, 1, 3328]
-    - [37, 10093.4]
-  - - [1, 1856, 1, 256]
-    - [92, 13.1108]
-  - - [6784, 4288, 1, 32]
-    - [60, 3765.67]
-  - - [448, 5888, 1, 256]
-    - [42, 8415.79]
-  - - [1408, 64, 1, 256]
-    - [5, 2485.85]
-  - - [5888, 5056, 1, 256]
-    - [39, 9927.37]
-  - - [3584, 448, 1, 3328]
-    - [42, 8372.3]
-  - - [2944, 448, 1, 256]
-    - [42, 7214.56]
-  - - [3584, 2368, 1, 3328]
-    - [42, 9974.16]
-  - - [4288, 1856, 1, 1]
-    - [82, 209.435]
-  - - [1856, 2944, 1, 1]
-    - [77, 189.724]
-  - - [32, 4288, 1, 3328]
-    - [75, 1115.53]
-  - - [1, 3584, 1, 3328]
-    - [97, 39.1324]
-  - - [256, 32, 1, 3328]
-    - [75, 99.9083]
-  - - [1856, 2368, 1, 32]
-    - [60, 2896.22]
-  - - [4288, 1856, 1, 32]
-    - [60, 3278.49]
-  - - [5056, 64, 1, 3328]
-    - [8, 6618.04]
-  - - [6784, 1, 1, 1280]
-    - [97, 47.3578]
-  - - [1408, 256, 1, 1280]
-    - [42, 5405.03]
-  - - [1408, 64, 1, 1]
-    - [82, 7.50933]
-  - - [1, 1, 1, 3328]
-    - [97, 0.0109908]
-  - - [5056, 2368, 1, 256]
-    - [19, 9709.16]
-  - - [704, 704, 1, 256]
-    - [42, 6219.49]
-  - - [5056, 6784, 1, 1]
-    - [77, 254.753]
-  - - [32, 448, 1, 1280]
-    - [75, 157.647]
-  - - [32, 448, 1, 32]
-    - [63, 35.1804]
-  - - [1856, 64, 1, 256]
-    - [14, 3141.39]
-  - - [1024, 1408, 1, 3328]
-    - [42, 8770.08]
-  - - [256, 5056, 1, 1280]
-    - [42, 9099.02]
-  - - [704, 2368, 1, 1]
-    - [77, 108.533]
-  - - [64, 1024, 1, 32]
-    - [65, 133.068]
-  - - [1024, 256, 1, 256]
-    - [21, 4712.7]
-  - - [128, 1, 1, 1]
-    - [97, 0.0124031]
-  - - [3584, 4288, 1, 1280]
-    - [37, 10089.9]
-  - - [2368, 5888, 1, 32]
-    - [60, 3586.57]
-  - - [1856, 128, 1, 32]
-    - [75, 572.453]
-  - - [1856, 128, 1, 1280]
-    - [15, 5957.82]
-  - - [128, 2944, 1, 3328]
-    - [26, 6988.95]
-  - - [1, 6784, 1, 3328]
-    - [97, 48.767]
-  - - [3584, 2368, 1, 1]
-    - [81, 213.454]
-  - - [4288, 32, 1, 3328]
-    - [75, 1126.32]
-  - - [32, 2944, 1, 256]
-    - [70, 604.14]
-  - - [256, 1856, 1, 1]
-    - [82, 42.122]
-  - - [1408, 3584, 1, 1]
-    - [76, 184.44]
-  - - [704, 6784, 1, 1280]
-    - [37, 9696.1]
-  - - [2368, 4288, 1, 32]
-    - [60, 3495.35]
-  - - [704, 5056, 1, 1280]
-    - [42, 9688.8]
-  - - [256, 3584, 1, 3328]
-    - [42, 7998.36]
-  - - [3584, 6784, 1, 32]
-    - [60, 3720.56]
-  - - [3584, 6784, 1, 1280]
-    - [42, 10182.5]
-  - - [4288, 4288, 1, 3328]
-    - [37, 10111.7]
-  - - [3584, 64, 1, 1280]
-    - [15, 5825.42]
-  - - [64, 1856, 1, 256]
-    - [5, 3090.32]
-  - - [3584, 64, 1, 32]
-    - [73, 501.368]
-  - - [448, 1, 1, 1280]
-    - [97, 4.59487]
-  - - [704, 128, 1, 3328]
-    - [13, 3671.56]
-  - - [64, 1856, 1, 1]
-    - [82, 10.24]
-  - - [4288, 1856, 1, 3328]
-    - [42, 9944.56]
-  - - [1856, 2944, 1, 1280]
-    - [42, 10046.5]
-  - - [4288, 256, 1, 256]
-    - [42, 6955.9]
-  - - [128, 5888, 1, 32]
-    - [65, 1389.24]
-  - - [128, 5888, 1, 1280]
-    - [10, 8175.34]
-  - - [1408, 128, 1, 3328]
-    - [25, 5582.52]
-  - - [3584, 256, 1, 256]
-    - [42, 6973.9]
-  - - [32, 6784, 1, 3328]
-    - [75, 1743.41]
-  - - [64, 64, 1, 1280]
-    - [14, 176.647]
-  - - [32, 3584, 1, 256]
-    - [70, 784.191]
-  - - [2944, 5056, 1, 3328]
-    - [43, 10070.9]
-  - - [704, 256, 1, 32]
-    - [65, 343.284]
-  - - [448, 128, 1, 3328]
-    - [34, 2598.6]
-  - - [64, 4288, 1, 3328]
-    - [8, 5623.83]
-  - - [5888, 32, 1, 256]
-    - [75, 1179.9]
-  - - [5056, 1024, 1, 3328]
-    - [43, 9929.34]
-  - - [2368, 64, 1, 3328]
-    - [5, 4768.96]
-  - - [1856, 256, 1, 256]
-    - [42, 5985.97]
-  - - [256, 704, 1, 256]
-    - [21, 3295.52]
-  - - [5888, 5888, 1, 256]
-    - [39, 9850.76]
-  - - [3584, 704, 1, 32]
-    - [68, 2426.09]
-  - - [448, 6784, 1, 3328]
-    - [42, 9706.88]
-  - - [6784, 4288, 1, 1]
-    - [78, 249.398]
-  - - [3584, 6784, 1, 1]
-    - [81, 257.999]
-  - - [1408, 2368, 1, 32]
-    - [66, 2640.91]
-  - - [448, 5056, 1, 32]
-    - [70, 2311.31]
-  - - [6784, 1408, 1, 1]
-    - [76, 221.518]
-  - - [1856, 5888, 1, 3328]
-    - [42, 10122.9]
-  - - [5056, 5888, 1, 1]
-    - [77, 251.604]
-  - - [2944, 1024, 1, 256]
-    - [43, 8866.64]
-  - - [448, 1408, 1, 3328]
-    - [42, 7025.6]
-  - - [5056, 32, 1, 3328]
-    - [75, 1312.0]
-  - - [2368, 4288, 1, 3328]
-    - [37, 10087.5]
-  - - [1024, 704, 1, 32]
-    - [65, 1360.18]
-  - - [448, 2944, 1, 256]
-    - [37, 7264.23]
-  - - [2944, 6784, 1, 256]
-    - [39, 9699.61]
-  - - [2368, 2368, 1, 1280]
-    - [43, 9739.34]
-  - - [5888, 128, 1, 3328]
-    - [10, 8362.88]
-  - - [256, 256, 1, 32]
-    - [68, 131.072]
-  - - [1024, 1, 1, 256]
-    - [92, 7.26563]
-  - - [3584, 3584, 1, 32]
-    - [60, 3608.16]
-  - - [2944, 448, 1, 1]
-    - [77, 93.1435]
-  - - [128, 32, 1, 32]
-    - [65, 8.40205]
-  - - [5056, 64, 1, 1280]
-    - [8, 6368.2]
-  - - [1024, 1, 1, 3328]
-    - [97, 11.3203]
-  - - [2944, 2944, 1, 1280]
-    - [39, 9849.01]
-  - - [1, 2368, 1, 256]
-    - [92, 16.1915]
-  - - [1408, 5056, 1, 1]
-    - [84, 206.943]
-  - - [2944, 32, 1, 1280]
-    - [75, 1033.83]
-  - - [64, 1408, 1, 3328]
-    - [13, 3704.21]
-  - - [256, 448, 1, 1280]
-    - [32, 4218.41]
-  - - [2368, 6784, 1, 1]
-    - [91, 228.97]
-  - - [6784, 4288, 1, 1280]
-    - [42, 10217.9]
-  - - [2944, 704, 1, 256]
-    - [43, 8749.66]
-  - - [5888, 1856, 1, 256]
-    - [43, 9721.99]
-  - - [704, 2944, 1, 3328]
-    - [42, 9678.85]
-  - - [5888, 256, 1, 1]
-    - [82, 100.221]
-  - - [704, 704, 1, 32]
-    - [70, 1032.53]
-  - - [256, 4288, 1, 256]
-    - [42, 6983.56]
-  - - [5056, 6784, 1, 32]
-    - [60, 3866.96]
-  - - [5056, 128, 1, 1]
-    - [79, 58.6203]
-  - - [448, 5056, 1, 1280]
-    - [42, 9364.71]
-  - - [448, 448, 1, 256]
-    - [6, 4090.78]
-  - - [256, 5888, 1, 3328]
-    - [42, 9166.03]
-  - - [704, 448, 1, 1280]
-    - [42, 4707.34]
-  - - [448, 64, 1, 256]
-    - [12, 890.781]
-  - - [5888, 1024, 1, 1]
-    - [76, 200.443]
-  - - [5888, 448, 1, 32]
-    - [70, 2420.02]
-  - - [6784, 2944, 1, 256]
-    - [37, 9706.96]
-  - - [1024, 256, 1, 1]
-    - [77, 23.9182]
-  - - [5888, 256, 1, 32]
-    - [66, 2009.77]
-  - - [2368, 448, 1, 256]
-    - [37, 6749.04]
-  - - [4288, 256, 1, 3328]
-    - [42, 7772.85]
-  - - [4288, 2944, 1, 256]
-    - [37, 9559.01]
-  - - [448, 5888, 1, 3328]
-    - [42, 9155.91]
-  - - [128, 256, 1, 3328]
-    - [12, 1533.35]
-  - - [2368, 5056, 1, 32]
-    - [60, 3452.81]
-  - - [32, 128, 1, 1280]
-    - [75, 45.1661]
-  - - [1408, 4288, 1, 1]
-    - [76, 196.533]
-  - - [1408, 1856, 1, 3328]
-    - [42, 9900.83]
-  - - [4288, 64, 1, 256]
-    - [0, 4526.71]
-  - - [3584, 1024, 1, 3328]
-    - [42, 9914.45]
-  - - [2944, 5888, 1, 3328]
-    - [38, 9952.18]
-  - - [128, 6784, 1, 3328]
-    - [9, 8075.89]
-  - - [448, 4288, 1, 3328]
-    - [42, 8985.23]
-  - - [704, 2368, 1, 256]
-    - [37, 7997.95]
-  - - [1, 64, 1, 3328]
-    - [97, 0.704525]
-  - - [4288, 128, 1, 1]
-    - [77, 45.1368]
-  - - [256, 2368, 1, 32]
-    - [70, 1224.66]
-  - - [4288, 3584, 1, 3328]
-    - [42, 10174.5]
-  - - [1408, 1024, 1, 1]
-    - [82, 100.684]
-  - - [64, 1024, 1, 1]
-    - [82, 5.49799]
-  - - [1408, 1024, 1, 256]
-    - [43, 7900.23]
-  - - [5056, 3584, 1, 1]
-    - [77, 243.558]
-  - - [448, 1024, 1, 256]
-    - [42, 5802.4]
-  - - [6784, 6784, 1, 3328]
-    - [39, 10321.8]
-  - - [6784, 32, 1, 32]
-    - [70, 501.938]
-  - - [2368, 2944, 1, 3328]
-    - [42, 9974.2]
-  - - [128, 3584, 1, 3328]
-    - [24, 7144.92]
-  - - [5056, 3584, 1, 32]
-    - [60, 3728.54]
-  - - [5056, 3584, 1, 1280]
-    - [42, 10063.6]
-  - - [1856, 1856, 1, 256]
-    - [19, 8875.33]
-  - - [32, 5888, 1, 256]
-    - [75, 1116.54]
-  - - [256, 1408, 1, 32]
-    - [70, 833.406]
-  - - [2944, 1, 1, 3328]
-    - [97, 32.4941]
-  - - [32, 704, 1, 3328]
-    - [75, 268.991]
-  - - [5888, 4288, 1, 1]
-    - [76, 252.074]
-  - - [1024, 128, 1, 256]
-    - [8, 3437.95]
-  - - [32, 1856, 1, 3328]
-    - [70, 696.759]
-  - - [5056, 704, 1, 256]
-    - [43, 9025.48]
-  - - [2368, 5056, 1, 256]
-    - [19, 9716.55]
-  - - [3584, 704, 1, 1]
-    - [82, 137.726]
-  - - [1024, 5056, 1, 256]
-    - [43, 9521.55]
-  - - [32, 1024, 1, 3328]
-    - [75, 391.709]
-  - - [5888, 448, 1, 256]
-    - [42, 8340.95]
-  - - [6784, 5056, 1, 1280]
-    - [39, 10200.7]
-  - - [4288, 6784, 1, 1280]
-    - [42, 10212.5]
-  - - [64, 1, 1, 256]
-    - [92, 0.453097]
-  - - [2944, 3584, 1, 3328]
-    - [39, 9807.91]
-  - - [128, 1408, 1, 1]
-    - [82, 14.1686]
-  - - [1024, 64, 1, 32]
-    - [65, 131.731]
-  - - [1024, 64, 1, 3328]
-    - [12, 2979.56]
-  - - [704, 6784, 1, 3328]
-    - [42, 9814.7]
-  - - [2944, 1856, 1, 1]
-    - [77, 187.125]
-  - - [5888, 4288, 1, 1280]
-    - [42, 10142.2]
-  - - [5888, 3584, 1, 1280]
-    - [37, 10125.7]
-  - - [3584, 1408, 1, 1280]
-    - [39, 9592.53]
-  - - [1024, 2944, 1, 256]
-    - [43, 8932.31]
-  - - [1, 2944, 1, 1280]
-    - [97, 29.3849]
-  - - [32, 1024, 1, 256]
-    - [70, 244.423]
-  - - [2944, 1856, 1, 1280]
-    - [37, 9867.38]
-  - - [3584, 1, 1, 1280]
-    - [97, 37.6273]
-  - - [256, 3584, 1, 32]
-    - [65, 1575.11]
-  - - [1024, 2368, 1, 1]
-    - [77, 134.713]
-  - - [2944, 3584, 1, 1280]
-    - [43, 9755.03]
-  - - [64, 1, 1, 1]
-    - [97, 0.00661157]
-  - - [1856, 4288, 1, 256]
-    - [37, 9538.29]
-  - - [256, 128, 1, 3328]
-    - [12, 1536.81]
-  - - [1, 1856, 1, 3328]
-    - [97, 20.4366]
-  - - [704, 5888, 1, 1]
-    - [91, 165.541]
-  - - [2368, 2944, 1, 32]
-    - [60, 3276.8]
-  - - [128, 4288, 1, 32]
-    - [70, 1125.87]
-  - - [448, 256, 1, 256]
-    - [5, 3008.21]
-  - - [64, 64, 1, 1]
-    - [82, 0.341333]
-  - - [1, 1408, 1, 1]
-    - [82, 0.123944]
-  - - [128, 2368, 1, 1280]
-    - [8, 6009.5]
-  - - [5888, 64, 1, 3328]
-    - [26, 6973.4]
-  - - [4288, 704, 1, 256]
-    - [19, 8821.92]
-  - - [1856, 1024, 1, 256]
-    - [19, 8065.97]
-  - - [448, 1856, 1, 32]
-    - [65, 1484.8]
-  - - [448, 1856, 1, 3328]
-    - [42, 7246.99]
-  - - [448, 448, 1, 32]
-    - [68, 356.807]
-  - - [1024, 448, 1, 256]
-    - [42, 5689.95]
-  - - [6784, 1, 1, 256]
-    - [97, 39.7597]
-  - - [704, 6784, 1, 32]
-    - [60, 3042.0]
-  - - [1024, 4288, 1, 1]
-    - [84, 177.626]
-  - - [704, 256, 1, 3328]
-    - [21, 4228.61]
-  - - [704, 1856, 1, 32]
-    - [61, 1880.03]
-  - - [1408, 5888, 1, 1280]
-    - [43, 10156.6]
-  - - [32, 704, 1, 1280]
-    - [75, 244.041]
-  - - [5056, 1856, 1, 256]
-    - [19, 9661.71]
-  - - [6784, 704, 1, 1280]
-    - [42, 9542.32]
-  - - [704, 1408, 1, 32]
-    - [67, 1605.23]
-  - - [5888, 1024, 1, 256]
-    - [37, 9471.67]
-  - - [64, 2944, 1, 1]
-    - [77, 14.361]
-  - - [64, 2944, 1, 32]
-    - [64, 350.541]
-  - - [64, 2944, 1, 1280]
-    - [8, 5551.85]
-  - - [6784, 1856, 1, 3328]
-    - [37, 9994.83]
-  - - [2368, 5888, 1, 1280]
-    - [42, 10013.7]
-  - - [1, 6784, 1, 256]
-    - [97, 38.3548]
-  - - [6784, 6784, 1, 32]
-    - [60, 3878.86]
-  - - [256, 1, 1, 1280]
-    - [92, 2.6684]
-  - - [5888, 128, 1, 32]
-    - [68, 1357.95]
-  - - [6784, 256, 1, 256]
-    - [42, 8208.94]
-  - - [2368, 3584, 1, 3328]
-    - [42, 9969.65]
-  - - [128, 4288, 1, 1280]
-    - [6, 6823.48]
-  - - [128, 128, 1, 256]
-    - [12, 494.611]
-  - - [5888, 1024, 1, 1280]
-    - [37, 9965.79]
-  - - [1856, 704, 1, 3328]
-    - [42, 9342.65]
-  - - [5888, 6784, 1, 3328]
-    - [42, 10263.4]
-  - - [6784, 448, 1, 1]
-    - [82, 147.25]
-  - - [6784, 1856, 1, 1]
-    - [81, 231.454]
-  - - [128, 32, 1, 1280]
-    - [75, 45.1972]
-  - - [32, 1856, 1, 32]
-    - [61, 123.733]
-  - - [128, 256, 1, 1]
-    - [77, 2.76757]
-  - - [6784, 448, 1, 32]
-    - [65, 2532.69]
-  - - [6784, 448, 1, 3328]
-    - [42, 9523.35]
-  - - [1, 6784, 1, 1]
-    - [77, 0.718644]
-  - - [448, 3584, 1, 1280]
-    - [42, 8379.03]
-  - - [1408, 6784, 1, 1280]
-    - [37, 10123.2]
-  - - [3584, 1856, 1, 3328]
-    - [43, 9901.21]
-  - - [32, 2944, 1, 32]
-    - [68, 160.354]
-  - - [5888, 704, 1, 1]
-    - [77, 172.141]
-  - - [3584, 1856, 1, 1]
-    - [82, 198.921]
-  - - [1, 256, 1, 256]
-    - [92, 1.79256]
-  - - [5056, 2944, 1, 32]
-    - [66, 3535.6]
-  - - [32, 6784, 1, 256]
-    - [75, 1354.16]
-  - - [64, 5056, 1, 256]
-    - [8, 5075.83]
-  - - [4288, 6784, 1, 1]
-    - [82, 251.294]
-  - - [2944, 64, 1, 256]
-    - [8, 3992.92]
-  - - [1, 4288, 1, 3328]
-    - [97, 31.0822]
-  - - [1024, 6784, 1, 1]
-    - [81, 205.771]
-  - - [256, 32, 1, 1280]
-    - [70, 92.6304]
-  - - [128, 3584, 1, 1280]
-    - [6, 6924.56]
-  - - [1, 256, 1, 1]
-    - [82, 0.0233577]
-  - - [3584, 4288, 1, 1]
-    - [76, 232.008]
-  - - [5888, 1024, 1, 3328]
-    - [42, 10084.8]
-  - - [6784, 5888, 1, 256]
-    - [39, 9889.46]
-  - - [4288, 6784, 1, 256]
-    - [19, 9831.78]
-  - - [2368, 3584, 1, 256]
-    - [37, 9449.59]
-  - - [32, 3584, 1, 3328]
-    - [75, 1336.42]
-  - - [1024, 1, 1, 1280]
-    - [97, 10.516]
-  - - [4288, 2368, 1, 32]
-    - [60, 3462.57]
-  - - [704, 3584, 1, 1]
-    - [77, 135.945]
-  - - [704, 1856, 1, 3328]
-    - [42, 9358.74]
-  - - [2944, 128, 1, 1280]
-    - [26, 6759.32]
-  - - [1, 2368, 1, 3328]
-    - [97, 26.0743]
-  - - [6784, 704, 1, 32]
-    - [65, 2881.41]
-  - - [4288, 1, 1, 1280]
-    - [97, 30.7384]
-  - - [704, 5888, 1, 256]
-    - [37, 9334.61]
-  - - [2368, 3584, 1, 1280]
-    - [42, 9894.38]
-  - - [64, 448, 1, 256]
-    - [12, 873.813]
-  - - [1408, 448, 1, 1280]
-    - [42, 6879.72]
-  - - [1408, 128, 1, 32]
-    - [65, 348.259]
-  - - [3584, 5056, 1, 32]
-    - [60, 3646.02]
-  - - [1024, 32, 1, 1280]
-    - [75, 362.578]
-  - - [128, 2368, 1, 1]
-    - [82, 28.4872]
-  - - [448, 448, 1, 1280]
-    - [15, 5049.16]
-  - - [6784, 1856, 1, 1280]
-    - [37, 9940.66]
-  - - [5056, 5056, 1, 3328]
-    - [42, 10230.9]
-  - - [128, 704, 1, 1280]
-    - [13, 3441.03]
-  - - [128, 2944, 1, 1280]
-    - [26, 6662.22]
-  - - [2368, 5056, 1, 1]
-    - [77, 229.536]
-  - - [5888, 1408, 1, 256]
-    - [43, 9622.41]
-  - - [2368, 1024, 1, 32]
-    - [66, 2412.77]
-  - - [256, 256, 1, 3328]
-    - [12, 2979.56]
-  - - [64, 4288, 1, 1]
-    - [85, 25.7925]
-  - - [4288, 1024, 1, 256]
-    - [37, 9213.72]
-  - - [3584, 32, 1, 32]
-    - [72, 279.727]
-  - - [3584, 64, 1, 1]
-    - [92, 21.0824]
-  - - [704, 32, 1, 1280]
-    - [75, 244.537]
-  - - [64, 64, 1, 3328]
-    - [12, 185.21]
-  - - [64, 1408, 1, 1]
-    - [77, 7.61081]
-  - - [4288, 5888, 1, 1280]
-    - [42, 10137.6]
-  - - [1856, 2944, 1, 3328]
-    - [42, 10171.2]
-  - - [256, 1024, 1, 256]
-    - [42, 4766.25]
-  - - [5056, 5888, 1, 256]
-    - [19, 9886.16]
-  - - [1408, 128, 1, 1280]
-    - [8, 5349.88]
-  - - [1024, 5888, 1, 1280]
-    - [42, 10175.0]
-  - - [1024, 448, 1, 1]
-    - [82, 40.96]
-  - - [32, 32, 1, 32]
-    - [65, 2.07919]
-  - - [5056, 1, 1, 1280]
-    - [97, 35.7157]
-  - - [5888, 5056, 1, 1280]
-    - [39, 10248.6]
-  - - [5888, 2944, 1, 1]
-    - [78, 238.896]
-  - - [64, 4288, 1, 1280]
-    - [8, 5468.13]
-  - - [448, 704, 1, 1280]
-    - [42, 4716.14]
-  - - [1408, 4288, 1, 3328]
-    - [42, 9878.08]
-  - - [704, 2944, 1, 32]
-    - [60, 2341.89]
-  - - [1, 5888, 1, 1280]
-    - [97, 41.4283]
-  - - [2944, 4288, 1, 3328]
-    - [37, 10021.4]
-  - - [256, 2944, 1, 256]
-    - [42, 7135.28]
-  - - [704, 448, 1, 32]
-    - [70, 742.099]
-  - - [5056, 2944, 1, 256]
-    - [37, 9710.81]
-  - - [704, 1024, 1, 256]
-    - [42, 6906.79]
-  - - [2368, 1856, 1, 256]
-    - [37, 9204.21]
-  - - [64, 3584, 1, 1]
-    - [77, 16.6698]
-  - - [1024, 128, 1, 1280]
-    - [32, 4702.13]
-  - - [2368, 4288, 1, 1280]
-    - [42, 10042.9]
-  - - [256, 6784, 1, 256]
-    - [42, 8257.73]
-  - - [1024, 32, 1, 32]
-    - [65, 71.624]
-  - - [1024, 1408, 1, 1]
-    - [77, 100.684]
-  - - [128, 64, 1, 32]
-    - [72, 18.0044]
-  - - [64, 1, 1, 1280]
-    - [97, 0.654313]
-  - - [6784, 5888, 1, 3328]
-    - [42, 10264.2]
-  - - [256, 5888, 1, 1]
-    - [86, 102.4]
-  - - [2944, 2944, 1, 1]
-    - [78, 217.113]
-  - - [6784, 3584, 1, 256]
-    - [43, 9823.77]
-  - - [1408, 1856, 1, 256]
-    - [43, 9139.17]
-  - - [128, 1408, 1, 256]
-    - [8, 3923.24]
-  - - [2944, 2944, 1, 32]
-    - [60, 3442.76]
-  - - [2944, 2944, 1, 3328]
-    - [37, 9863.83]
-  - - [1, 2944, 1, 256]
-    - [92, 19.9593]
-  - - [448, 32, 1, 1280]
-    - [75, 158.409]
-  - - [3584, 1, 1, 256]
-    - [97, 28.1789]
-  - - [704, 32, 1, 3328]
-    - [75, 269.61]
-  - - [256, 448, 1, 3328]
-    - [14, 4518.01]
-  - - [2368, 64, 1, 256]
-    - [8, 3344.6]
-  - - [64, 448, 1, 1280]
-    - [16, 1253.42]
-  - - [1408, 448, 1, 3328]
-    - [42, 7012.46]
-  - - [2368, 6784, 1, 3328]
-    - [38, 10105.1]
-  - - [4288, 3584, 1, 32]
-    - [60, 3524.81]
-  - - [256, 2368, 1, 1]
-    - [85, 54.5151]
-  - - [32, 4288, 1, 1280]
-    - [75, 1074.1]
-  - - [6784, 704, 1, 256]
-    - [37, 9048.55]
-  - - [3584, 704, 1, 1280]
-    - [42, 9297.6]
-  - - [448, 5056, 1, 3328]
-    - [42, 9489.19]
-  - - [4288, 448, 1, 256]
-    - [19, 8131.32]
-  - - [5056, 256, 1, 1280]
-    - [42, 8968.98]
-  - - [704, 448, 1, 3328]
-    - [42, 4852.18]
-  - - [2944, 5888, 1, 32]
-    - [60, 3670.57]
-  - - [3584, 5056, 1, 256]
-    - [43, 9778.45]
-  - - [6784, 1, 1, 3328]
-    - [97, 48.1595]
-  - - [4288, 256, 1, 1]
-    - [82, 79.7767]
-  - - [64, 256, 1, 1]
-    - [82, 1.49489]
-  - - [1856, 448, 1, 3328]
-    - [42, 7251.55]
-  - - [3584, 2368, 1, 256]
-    - [37, 9433.18]
-  - - [4288, 4288, 1, 256]
-    - [37, 9670.97]
-  - - [4288, 256, 1, 1280]
-    - [42, 7629.73]
-  - - [4288, 4288, 1, 1280]
-    - [42, 10065.0]
-  - - [4288, 704, 1, 1280]
-    - [42, 9364.09]
-  - - [128, 1856, 1, 32]
-    - [75, 569.025]
-  - - [256, 1856, 1, 32]
-    - [70, 1016.33]
-  - - [1408, 1856, 1, 1]
-    - [77, 140.8]
-  - - [2368, 704, 1, 1]
-    - [77, 108.533]
-  - - [3584, 32, 1, 256]
-    - [70, 819.2]
-  - - [6784, 128, 1, 3328]
-    - [20, 8099.43]
-  - - [3584, 256, 1, 1]
-    - [79, 73.0497]
-  - - [1408, 1856, 1, 1280]
-    - [42, 9755.48]
-  - - [3584, 4288, 1, 3328]
-    - [22, 9837.75]
-  - - [448, 4288, 1, 32]
-    - [60, 2208.07]
-  - - [448, 4288, 1, 1280]
-    - [42, 8865.41]
-  - - [64, 3584, 1, 256]
-    - [6, 4503.09]
-  - - [6784, 1408, 1, 1280]
-    - [42, 9960.88]
-  - - [3584, 704, 1, 256]
-    - [43, 8709.85]
-  - - [1, 6784, 1, 1280]
-    - [97, 47.607]
-  - - [5056, 1024, 1, 256]
-    - [19, 9381.37]
-  - - [2368, 448, 1, 32]
-    - [67, 1632.1]
-  - - [256, 1, 1, 256]
-    - [97, 2.1672]
-  - - [32, 2944, 1, 1280]
-    - [75, 1005.56]
-  - - [448, 3584, 1, 1]
-    - [81, 107.328]
-  - - [2368, 256, 1, 256]
-    - [42, 5807.98]
-  - - [1, 5056, 1, 1]
-    - [91, 0.544828]
-  - - [4288, 32, 1, 32]
-    - [70, 356.405]
-  - - [1856, 3584, 1, 32]
-    - [60, 3093.91]
-  - - [5056, 3584, 1, 3328]
-    - [43, 10177.5]
-  - - [1856, 256, 1, 32]
-    - [68, 979.662]
-  - - [4288, 5056, 1, 256]
-    - [37, 9765.81]
-  - - [1856, 5888, 1, 256]
-    - [19, 9673.58]
-  - - [256, 256, 1, 256]
-    - [14, 1941.81]
-  - - [128, 1856, 1, 1]
-    - [77, 22.6687]
-  - - [4288, 2368, 1, 256]
-    - [37, 9601.88]
-  - - [448, 1, 1, 3328]
-    - [97, 4.91736]
-  - - [1856, 256, 1, 1280]
-    - [42, 7071.75]
-  - - [256, 2944, 1, 1]
-    - [76, 63.6541]
-  - - [1408, 2944, 1, 3328]
-    - [42, 10026.1]
-  - - [4288, 128, 1, 256]
-    - [6, 5854.55]
-  - - [5888, 3584, 1, 1]
-    - [76, 247.219]
-  - - [256, 1, 1, 1]
-    - [77, 0.0336842]
-  - - [6784, 5056, 1, 3328]
-    - [41, 10071.9]
-  - - [6784, 5056, 1, 1]
-    - [81, 257.044]
-  - - [5888, 3584, 1, 32]
-    - [60, 3743.25]
-  - - [5888, 3584, 1, 3328]
-    - [37, 10187.3]
-  - - [32, 1024, 1, 1280]
-    - [75, 361.329]
-  - - [1, 256, 1, 3328]
-    - [97, 2.83536]
-  - - [1024, 6784, 1, 256]
-    - [37, 9536.6]
-  - - [6784, 5888, 1, 32]
-    - [60, 3857.48]
-  - - [1408, 1, 1, 1280]
-    - [97, 14.1153]
-  - - [2368, 6784, 1, 32]
-    - [60, 3701.5]
-  - - [6784, 64, 1, 1]
-    - [82, 40.2015]
-  - - [2368, 32, 1, 32]
-    - [65, 157.867]
-  - - [5056, 1408, 1, 1280]
-    - [39, 9767.73]
-  - - [3584, 1408, 1, 3328]
-    - [42, 9678.41]
-  - - [2944, 3584, 1, 1]
-    - [76, 226.617]
-  - - [2944, 1408, 1, 1280]
-    - [43, 9776.3]
-  - - [256, 1408, 1, 1]
-    - [88, 33.3748]
-  - - [3584, 1024, 1, 1]
-    - [76, 165.019]
-  - - [256, 32, 1, 256]
-    - [75, 65.7002]
-  - - [2944, 1856, 1, 3328]
-    - [42, 9985.72]
-  - - [128, 1024, 1, 3328]
-    - [14, 5139.11]
-  - - [1408, 128, 1, 1]
-    - [82, 13.8209]
-  - - [2944, 3584, 1, 32]
-    - [60, 3522.97]
-  - - [3584, 1024, 1, 32]
-    - [60, 2872.81]
-  - - [6784, 64, 1, 256]
-    - [6, 5624.95]
-  - - [256, 128, 1, 1280]
-    - [36, 1428.58]
-  - - [6784, 5056, 1, 256]
-    - [43, 9893.6]
-  - - [1408, 32, 1, 3328]
-    - [75, 539.065]
-  - - [1856, 3584, 1, 1280]
-    - [19, 9971.0]
-  - - [256, 5888, 1, 256]
-    - [43, 8217.12]
-  - - [5056, 32, 1, 256]
-    - [75, 1039.63]
-  - - [1024, 4288, 1, 3328]
-    - [42, 10040.2]
-  - - [448, 2368, 1, 256]
-    - [42, 6844.28]
-  - - [64, 1408, 1, 1280]
-    - [13, 3449.26]
-  - - [3584, 32, 1, 1280]
-    - [75, 1245.76]
-  - - [128, 2368, 1, 3328]
-    - [8, 6214.45]
-  - - [3584, 1024, 1, 256]
-    - [43, 9298.54]
-  - - [256, 64, 1, 256]
-    - [12, 499.322]
-  - - [32, 1408, 1, 256]
-    - [70, 336.082]
-  - - [2368, 448, 1, 3328]
-    - [42, 7525.91]
-  - - [2368, 1408, 1, 1]
-    - [77, 158.467]
-  - - [1, 1, 1, 1]
-    - [93, 8.62069e-05]
-  - - [1024, 1856, 1, 32]
-    - [60, 2190.83]
-  - - [32, 1024, 1, 32]
-    - [65, 68.6241]
-  - - [4288, 1, 1, 256]
-    - [97, 25.6478]
-  - - [1856, 128, 1, 3328]
-    - [15, 6314.91]
-  - - [5888, 2368, 1, 1]
-    - [81, 215.699]
-  - - [2368, 2368, 1, 1]
-    - [82, 190.47]
-  - - [704, 256, 1, 1280]
-    - [21, 4049.98]
-  - - [704, 4288, 1, 256]
-    - [42, 8878.68]
-  - - [5888, 2368, 1, 32]
-    - [60, 3509.83]
-  - - [5888, 2368, 1, 1280]
-    - [43, 10064.7]
-  - - [128, 256, 1, 256]
-    - [12, 989.223]
-  - - [32, 4288, 1, 32]
-    - [75, 271.715]
-  - - [6784, 704, 1, 3328]
-    - [42, 9632.44]
-  - - [1856, 1856, 1, 32]
-    - [60, 2675.52]
-  - - [4288, 2944, 1, 32]
-    - [60, 3528.69]
-  - - [256, 5056, 1, 1]
-    - [81, 95.7349]
-  - - [704, 64, 1, 256]
-    - [12, 1360.18]
-  - - [256, 2368, 1, 3328]
-    - [42, 6748.26]
-  - - [704, 1, 1, 1]
-    - [77, 0.0642336]
-  - - [64, 2944, 1, 3328]
-    - [25, 5871.24]
-  - - [5056, 5056, 1, 256]
-    - [19, 9862.79]
-  - - [5888, 64, 1, 1]
-    - [93, 32.0435]
-  - - [6784, 6784, 1, 256]
-    - [43, 9975.1]
-  - - [256, 1856, 1, 256]
-    - [42, 5825.42]
-  - - [5888, 64, 1, 32]
-    - [67, 837.404]
-  - - [2368, 2944, 1, 256]
-    - [37, 9412.85]
-  - - [448, 32, 1, 32]
-    - [65, 30.023]
-  - - [704, 64, 1, 1]
-    - [92, 3.75467]
-  - - [3584, 704, 1, 3328]
-    - [43, 9401.02]
-  - - [4288, 704, 1, 3328]
-    - [42, 9466.3]
-  - - [4288, 2944, 1, 1280]
-    - [42, 9971.95]
-  - - [448, 3584, 1, 256]
-    - [42, 7703.18]
-  - - [704, 32, 1, 256]
-    - [70, 170.425]
-  - - [6784, 256, 1, 32]
-    - [61, 2055.27]
-  - - [1856, 128, 1, 1]
-    - [79, 22.6687]
-  - - [1856, 32, 1, 32]
-    - [68, 129.113]
-  - - [2368, 5056, 1, 1280]
-    - [42, 10067.4]
-  - - [1408, 6784, 1, 3328]
-    - [42, 10216.2]
-  - - [1408, 1408, 1, 1280]
-    - [42, 9125.27]
-  - - [448, 1024, 1, 3328]
-    - [42, 7023.95]
-  - - [32, 704, 1, 32]
-    - [65, 47.6783]
-  - - [1024, 5056, 1, 1]
-    - [77, 187.043]
-  - - [5888, 1856, 1, 32]
-    - [60, 3469.25]
-  - - [5888, 704, 1, 3328]
-    - [19, 9814.35]
-  - - [5056, 1, 1, 256]
-    - [97, 30.2415]
-  - - [448, 6784, 1, 256]
-    - [42, 8938.92]
-  - - [1024, 128, 1, 1]
-    - [82, 10.9227]
-  - - [128, 64, 1, 256]
-    - [5, 216.648]
-  - - [1024, 64, 1, 1280]
-    - [12, 2744.96]
-  - - [1024, 256, 1, 1280]
-    - [21, 5890.88]
-  - - [128, 5056, 1, 32]
-    - [70, 1262.77]
-  - - [128, 5056, 1, 1280]
-    - [9, 7904.34]
-  - - [1856, 1408, 1, 32]
-    - [60, 2555.74]
-  - - [64, 704, 1, 32]
-    - [65, 91.4843]
-  - - [64, 704, 1, 3328]
-    - [34, 2059.7]
-  - - [64, 2368, 1, 32]
-    - [68, 295.711]
-  - - [2944, 32, 1, 3328]
-    - [75, 1112.42]
-  - - [2368, 256, 1, 1]
-    - [79, 53.7418]
-  - - [5888, 64, 1, 1280]
-    - [26, 6744.2]
-  - - [5056, 1, 1, 1]
-    - [79, 0.513821]
-  - - [5888, 2944, 1, 1280]
-    - [42, 10060.5]
-  - - [32, 2368, 1, 256]
-    - [70, 551.098]
-  - - [3584, 1408, 1, 1]
-    - [81, 184.44]
-  - - [32, 6784, 1, 1280]
-    - [75, 1669.11]
-  - - [32, 6784, 1, 32]
-    - [70, 501.938]
-  - - [448, 5888, 1, 32]
-    - [70, 2414.48]
-  - - [1856, 6784, 1, 1]
-    - [82, 230.775]
-  - - [5056, 64, 1, 1]
-    - [77, 32.1016]
-  - - [1, 5888, 1, 1]
-    - [92, 0.598374]
-  - - [2368, 1024, 1, 256]
-    - [43, 8370.51]
-  - - [1856, 6784, 1, 32]
-    - [60, 3517.07]
-  - - [1856, 6784, 1, 1280]
-    - [42, 9953.93]
-  - - [64, 3584, 1, 3328]
-    - [28, 5986.22]
-  - - [1408, 448, 1, 256]
-    - [42, 6079.85]
-  - - [5888, 5056, 1, 3328]
-    - [38, 10062.4]
-  - - [1, 2944, 1, 3328]
-    - [97, 32.2121]
-  - - [1408, 6784, 1, 32]
-    - [60, 3435.93]
-  - - [32, 5888, 1, 1280]
-    - [75, 1449.35]
-  - - [448, 256, 1, 1]
-    - [77, 9.49404]
-  - - [3584, 5888, 1, 3328]
-    - [43, 10126.0]
-  - - [4288, 1408, 1, 256]
-    - [43, 9217.56]
-  - - [448, 64, 1, 1280]
-    - [16, 1260.31]
-  - - [128, 448, 1, 32]
-    - [65, 115.846]
-  - - [6784, 2368, 1, 256]
-    - [43, 9774.93]
-  - - [1408, 448, 1, 32]
-    - [68, 1249.08]
-  - - [1856, 1408, 1, 1280]
-    - [42, 9750.91]
-  - - [448, 256, 1, 3328]
-    - [14, 4522.29]
-  - - [1856, 2368, 1, 1]
-    - [82, 172.76]
-  - - [1408, 5056, 1, 3328]
-    - [42, 10016.0]
-  - - [128, 704, 1, 3328]
-    - [35, 3693.26]
-  - - [5056, 128, 1, 1280]
-    - [9, 7898.31]
-  - - [5056, 4288, 1, 256]
-    - [37, 9772.69]
-  - - [5056, 5056, 1, 32]
-    - [60, 3718.27]
-  - - [1856, 704, 1, 256]
-    - [42, 8230.7]
-  - - [64, 256, 1, 256]
-    - [11, 489.989]
-  - - [448, 5888, 1, 1280]
-    - [42, 9049.14]
-  - - [704, 704, 1, 3328]
-    - [42, 7588.38]
-  - - [128, 6784, 1, 256]
-    - [1, 7161.67]
-  - - [5056, 448, 1, 256]
-    - [42, 8487.45]
-  - - [4288, 5888, 1, 1]
-    - [77, 247.916]
-  - - [1856, 5056, 1, 1280]
-    - [42, 10046.4]
-  - - [2368, 4288, 1, 1]
-    - [82, 221.897]
-  - - [2368, 32, 1, 3328]
-    - [75, 906.87]
-  - - [3584, 1856, 1, 256]
-    - [43, 9401.98]
-  - - [256, 3584, 1, 256]
-    - [42, 7023.95]
-  - - [64, 704, 1, 1]
-    - [86, 3.80541]
-  - - [4288, 5888, 1, 32]
-    - [60, 3788.11]
-  - - [4288, 5888, 1, 3328]
-    - [43, 10118.1]
-  - - [1, 1024, 1, 1]
-    - [77, 0.0934307]
-  - - [1024, 2944, 1, 3328]
-    - [42, 9630.6]
-  - - [1024, 5888, 1, 1]
-    - [76, 180.302]
-  - - [6784, 128, 1, 1280]
-    - [9, 7966.53]
-  - - [2944, 2368, 1, 256]
-    - [37, 9424.78]
-  - - [1024, 1856, 1, 256]
-    - [42, 8108.99]
-  - - [2944, 64, 1, 3328]
-    - [25, 5880.05]
-  - - [1024, 5888, 1, 32]
-    - [71, 3029.8]
-  - - [1024, 5888, 1, 3328]
-    - [42, 10290.4]
-  - - [5056, 2368, 1, 32]
-    - [60, 3445.35]
-  - - [1408, 2368, 1, 1280]
-    - [42, 9722.31]
-  - - [256, 1, 1, 3328]
-    - [97, 2.87361]
-  - - [128, 1024, 1, 32]
-    - [65, 268.866]
-  - - [5056, 6784, 1, 3328]
-    - [42, 10284.6]
-  - - [32, 64, 1, 32]
-    - [65, 4.17959]
-  - - [448, 704, 1, 32]
-    - [75, 725.039]
-  - - [448, 704, 1, 3328]
-    - [42, 4839.66]
-  - - [1408, 2944, 1, 256]
-    - [39, 9400.77]
-  - - [64, 6784, 1, 256]
-    - [7, 5535.31]
-  - - [1024, 704, 1, 1]
-    - [79, 59.2842]
-  - - [2368, 128, 1, 32]
-    - [75, 713.186]
-  - - [3584, 448, 1, 256]
-    - [42, 7634.51]
-  - - [2368, 128, 1, 3328]
-    - [8, 6223.66]
-  - - [704, 1856, 1, 1280]
-    - [42, 9181.37]
-  - - [704, 5056, 1, 32]
-    - [60, 2808.22]
-  - - [32, 2368, 1, 32]
-    - [65, 152.314]
-  - - [1408, 1, 1, 256]
-    - [92, 9.99024]
-  - - [4288, 256, 1, 32]
-    - [63, 1708.53]
-  - - [448, 1408, 1, 1]
-    - [94, 54.3779]
-  - - [5056, 4288, 1, 1280]
-    - [42, 10165.6]
-  - - [5888, 1, 1, 3328]
-    - [97, 42.2822]
-  - - [1408, 256, 1, 256]
-    - [42, 4650.94]
-  - - [4288, 448, 1, 1]
-    - [79, 116.567]
-  - - [1024, 448, 1, 32]
-    - [68, 991.896]
-  - - [5888, 6784, 1, 1280]
-    - [37, 10190.5]
-  - - [256, 256, 1, 1]
-    - [77, 5.35425]
-  - - [1856, 64, 1, 1280]
-    - [14, 4329.26]
-  - - [1408, 1, 1, 1]
-    - [77, 0.127536]
-  - - [448, 1408, 1, 256]
-    - [42, 6116.69]
-  - - [5888, 5888, 1, 1]
-    - [84, 259.34]
-  - - [128, 2944, 1, 32]
-    - [65, 851.598]
-  - - [448, 32, 1, 3328]
-    - [75, 171.078]
-  - - [32, 256, 1, 32]
-    - [65, 17.156]
-  - - [2944, 704, 1, 1280]
-    - [42, 9388.79]
-  - - [1024, 3584, 1, 1280]
-    - [42, 9988.14]
-  - - [1856, 448, 1, 1]
-    - [79, 68.3789]
-  - - [2368, 2944, 1, 1]
-    - [77, 202.657]
-  - - [5056, 256, 1, 32]
-    - [63, 1849.05]
-  - - [4288, 1, 1, 3328]
-    - [97, 31.0606]
-  - - [5056, 1024, 1, 1280]
-    - [43, 9852.22]
-  - - [704, 704, 1, 1]
-    - [82, 44.5698]
-  - - [1856, 448, 1, 1280]
-    - [42, 7106.74]
-  - - [3584, 6784, 1, 256]
-    - [43, 9808.91]
-  - - [1856, 1024, 1, 1]
-    - [82, 119.984]
-  - - [64, 1856, 1, 1280]
-    - [14, 4349.07]
-  - - [1856, 1408, 1, 256]
-    - [19, 9040.43]
-  - - [4288, 4288, 1, 32]
-    - [60, 3582.45]
-  - - [128, 1, 1, 256]
-    - [92, 0.906195]
-  - - [32, 64, 1, 3328]
-    - [75, 24.6733]
-  - - [5888, 448, 1, 1]
-    - [77, 139.715]
-  - - [128, 5888, 1, 256]
-    - [10, 7177.75]
-  - - [3584, 256, 1, 3328]
-    - [42, 7885.97]
-  - - [5056, 5056, 1, 1280]
-    - [42, 10164.3]
-  - - [2368, 1, 1, 256]
-    - [92, 16.545]
-  - - [6784, 1408, 1, 3328]
-    - [42, 10034.3]
-  - - [1408, 1408, 1, 1]
-    - [85, 120.295]
-  - - [32, 64, 1, 256]
-    - [70, 15.2056]
-  - - [2368, 1, 1, 1280]
-    - [97, 23.889]
-  - - [32, 3584, 1, 32]
-    - [65, 215.377]
-  - - [128, 6784, 1, 1]
-    - [79, 70.9438]
-  - - [1, 3584, 1, 1]
-    - [91, 0.28535]
-  - - [1, 128, 1, 3328]
-    - [97, 1.41092]
-  - - [32, 256, 1, 256]
-    - [70, 60.4018]
-  - - [5888, 1408, 1, 32]
-    - [60, 3411.65]
-  - - [704, 256, 1, 1]
-    - [82, 13.9925]
-  - - [448, 2944, 1, 3328]
-    - [42, 8043.8]
-  - - [1, 448, 1, 1]
-    - [96, 0.0495575]
-  - - [64, 5888, 1, 256]
-    - [8, 5359.39]
-  - - [1856, 1, 1, 1]
-    - [82, 0.171852]
-  - - [1024, 256, 1, 3328]
-    - [30, 6171.58]
-  - - [448, 1024, 1, 32]
-    - [70, 965.794]
-  - - [6784, 2368, 1, 1280]
-    - [39, 10103.9]
-  - - [128, 1856, 1, 1280]
-    - [15, 6033.47]
-  - - [256, 2368, 1, 256]
-    - [37, 5790.64]
-  - - [2944, 1408, 1, 1]
-    - [76, 172.141]
-  - - [6784, 1024, 1, 256]
-    - [37, 9379.67]
-  - - [5056, 1408, 1, 32]
-    - [60, 3217.56]
-  - - [2944, 1408, 1, 3328]
-    - [43, 9875.62]
-  - - [1856, 32, 1, 256]
-    - [70, 451.436]
-  - - [704, 2368, 1, 32]
-    - [67, 2045.49]
-  - - [448, 256, 1, 32]
-    - [61, 228.235]
-  - - [704, 6784, 1, 1]
-    - [82, 179.817]
-  - - [2368, 6784, 1, 256]
-    - [19, 9734.22]
-  - - [256, 1408, 1, 256]
-    - [42, 4669.77]
-  - - [256, 4288, 1, 1280]
-    - [42, 7754.37]
-  - - [1856, 1856, 1, 1]
-    - [77, 156.579]
-  - - [1856, 3584, 1, 3328]
-    - [42, 10053.4]
-  - - [1, 704, 1, 3328]
-    - [97, 7.76622]
-  - - [256, 128, 1, 1]
-    - [87, 3.2]
-  - - [64, 1, 1, 3328]
-    - [97, 0.704898]
-  - - [256, 2944, 1, 3328]
-    - [42, 8374.04]
-  - - [704, 1856, 1, 1]
-    - [81, 93.8667]
-  - - [704, 448, 1, 256]
-    - [42, 4037.02]
-  - - [448, 64, 1, 3328]
-    - [12, 1337.17]
-  - - [704, 6784, 1, 256]
-    - [37, 9184.49]
-  - - [2368, 448, 1, 1280]
-    - [42, 7386.35]
-  - - [6784, 2944, 1, 32]
-    - [66, 3577.63]
-  - - [64, 4288, 1, 32]
-    - [70, 634.525]
-  - - [128, 704, 1, 1]
-    - [82, 7.66258]
-  - - [128, 448, 1, 3328]
-    - [12, 2612.83]
-  - - [5888, 2368, 1, 3328]
-    - [43, 10115.6]
-  - - [2368, 704, 1, 1280]
-    - [42, 8562.81]
-  - - [1024, 1408, 1, 1280]
-    - [42, 8627.03]
-  - - [1408, 5888, 1, 256]
-    - [39, 9728.26]
-  - - [4288, 64, 1, 1280]
-    - [8, 5441.03]
-  - - [128, 5056, 1, 1]
-    - [77, 57.7829]
-  - - [2944, 5056, 1, 32]
-    - [60, 3588.88]
-  - - [448, 448, 1, 1]
-    - [91, 14.5017]
-  - - [256, 2368, 1, 1280]
-    - [42, 6598.18]
-  - - [704, 2368, 1, 3328]
-    - [42, 8818.69]
-  - - [3584, 2944, 1, 256]
-    - [37, 9511.03]
-  - - [5056, 256, 1, 3328]
-    - [42, 9109.17]
-  - - [3584, 1024, 1, 1280]
-    - [43, 9829.3]
-  - - [1408, 256, 1, 32]
-    - [70, 833.406]
-  - - [64, 1024, 1, 256]
-    - [14, 1923.99]
-  - - [1408, 32, 1, 32]
-    - [68, 95.3566]
-  - - [128, 3584, 1, 256]
-    - [9, 5734.4]
-  - - [704, 1408, 1, 1]
-    - [77, 75.5512]
-  - - [5056, 3584, 1, 256]
-    - [19, 9753.77]
-  - - [2368, 704, 1, 256]
-    - [37, 7879.81]
-  - - [1856, 1856, 1, 1280]
-    - [43, 9360.7]
-  - - [32, 5888, 1, 32]
-    - [70, 376.832]
-  - - [2368, 2368, 1, 3328]
-    - [43, 9813.99]
-  - - [4288, 704, 1, 1]
-    - [85, 146.826]
-  - - [4288, 2944, 1, 3328]
-    - [42, 10052.5]
-  - - [1024, 128, 1, 3328]
-    - [32, 5129.44]
-  - - [4288, 128, 1, 3328]
-    - [6, 6961.2]
-  - - [4288, 704, 1, 32]
-    - [63, 2526.15]
-  - - [1856, 1024, 1, 32]
-    - [60, 2190.83]
-  - - [1, 448, 1, 3328]
-    - [97, 4.97379]
-  - - [2944, 6784, 1, 1]
-    - [81, 251.411]
-  - - [6784, 2368, 1, 32]
-    - [60, 3556.06]
-  - - [5888, 5056, 1, 1]
-    - [81, 255.227]
-  - - [128, 6784, 1, 1280]
-    - [1, 8054.28]
-  - - [6784, 6784, 1, 1]
-    - [76, 267.823]
-  - - [1856, 32, 1, 1280]
-    - [75, 659.453]
-  - - [5888, 448, 1, 3328]
-    - [37, 8909.1]
-  - - [704, 5888, 1, 32]
-    - [60, 2945.05]
-  - - [704, 5888, 1, 1280]
-    - [42, 9940.41]
-  - - [1024, 6784, 1, 3328]
-    - [42, 10136.0]
-  - - [704, 2944, 1, 1280]
-    - [42, 9545.54]
-  - - [3584, 256, 1, 32]
-    - [65, 1542.02]
-  - - [1408, 1408, 1, 32]
-    - [60, 2298.51]
-  - - [1024, 64, 1, 256]
-    - [3, 1872.46]
-  - - [4288, 64, 1, 32]
-    - [70, 673.453]
-  - - [5888, 6784, 1, 32]
-    - [60, 3800.59]
-  - - [5888, 128, 1, 256]
-    - [2, 7199.18]
-  - - [64, 704, 1, 1280]
-    - [12, 1937.89]
-  - - [2944, 1856, 1, 256]
-    - [37, 9390.44]
-  - - [128, 5056, 1, 3328]
-    - [9, 8099.33]
-  - - [4288, 2944, 1, 1]
-    - [77, 231.037]
-  - - [6784, 5056, 1, 32]
-    - [60, 3747.6]
-  - - [64, 1024, 1, 3328]
-    - [12, 2950.54]
-  - - [3584, 128, 1, 1]
-    - [92, 40.6695]
+- - - [1024, 1024, 1, 3328]
+    - [21, 9231.92]
   - - [2944, 4288, 1, 1280]
-    - [42, 9978.85]
-  - - [64, 32, 1, 3328]
-    - [75, 24.6661]
-  - - [1024, 4288, 1, 256]
-    - [37, 9317.58]
-  - - [128, 2368, 1, 256]
-    - [8, 4801.65]
-  - - [2368, 64, 1, 32]
-    - [68, 304.627]
-  - - [1408, 1, 1, 3328]
-    - [97, 15.5572]
-  - - [64, 1408, 1, 32]
-    - [68, 182.044]
-  - - [2368, 5888, 1, 1]
-    - [82, 219.502]
-  - - [1408, 1856, 1, 32]
-    - [70, 2252.8]
-  - - [256, 4288, 1, 32]
-    - [63, 1708.53]
-  - - [1856, 6784, 1, 3328]
-    - [42, 10026.6]
-  - - [3584, 128, 1, 256]
-    - [18, 5734.4]
-  - - [1024, 448, 1, 1280]
-    - [42, 6840.66]
-  - - [128, 5888, 1, 1]
-    - [84, 63.2268]
-  - - [32, 2368, 1, 1280]
-    - [75, 814.248]
-  - - [64, 32, 1, 32]
-    - [65, 4.26667]
-  - - [1408, 704, 1, 1]
-    - [79, 74.641]
-  - - [64, 448, 1, 1]
-    - [95, 2.54184]
-  - - [3584, 5888, 1, 32]
-    - [60, 3733.32]
-  - - [3584, 5888, 1, 1280]
-    - [42, 10136.9]
-  - - [448, 5888, 1, 1]
-    - [86, 111.395]
-  - - [64, 5056, 1, 32]
-    - [70, 743.871]
-  - - [2944, 64, 1, 1]
-    - [79, 15.0013]
-  - - [1408, 704, 1, 32]
-    - [68, 1645.2]
-  - - [1408, 704, 1, 1280]
-    - [42, 8449.47]
+    - [44, 10205.8]
+  - - [2368, 64, 1, 3328]
+    - [37, 4925.44]
   - - [2368, 5888, 1, 256]
-    - [19, 9680.39]
-  - - [2944, 64, 1, 32]
-    - [65, 307.618]
-  - - [1, 1408, 1, 256]
-    - [92, 9.79478]
-  - - [64, 2944, 1, 256]
-    - [8, 4019.54]
-  - - [5888, 5888, 1, 32]
-    - [60, 3855.27]
-  - - [1856, 1408, 1, 3328]
-    - [42, 9896.32]
-  - - [1024, 1024, 1, 32]
-    - [65, 1698.1]
-  - - [4288, 1024, 1, 1]
-    - [77, 174.797]
-  - - [704, 4288, 1, 3328]
-    - [42, 9640.72]
-  - - [2944, 5056, 1, 1280]
-    - [43, 10018.8]
-  - - [6784, 2944, 1, 1280]
-    - [39, 10023.0]
-  - - [6784, 256, 1, 3328]
-    - [42, 9041.02]
-  - - [5056, 128, 1, 3328]
-    - [9, 8062.95]
-  - - [128, 128, 1, 1280]
-    - [16, 722.16]
-  - - [128, 4288, 1, 1]
-    - [85, 49.0057]
-  - - [1408, 5056, 1, 32]
-    - [60, 3265.53]
-  - - [2944, 128, 1, 3328]
-    - [26, 6979.61]
-  - - [5888, 1856, 1, 1280]
-    - [43, 10094.1]
-  - - [64, 128, 1, 256]
-    - [3, 225.986]
-  - - [5888, 256, 1, 1280]
-    - [42, 8886.24]
-  - - [1856, 5056, 1, 1]
-    - [77, 220.074]
-  - - [3584, 1856, 1, 1280]
-    - [43, 9822.83]
-  - - [704, 3584, 1, 256]
-    - [42, 8766.6]
-  - - [1856, 5056, 1, 32]
-    - [60, 3421.67]
-  - - [1856, 5056, 1, 3328]
-    - [42, 10123.2]
-  - - [1024, 2944, 1, 32]
-    - [60, 2644.44]
-  - - [1408, 6784, 1, 256]
-    - [37, 9672.78]
-  - - [1024, 2368, 1, 1280]
-    - [42, 9083.89]
-  - - [448, 6784, 1, 1]
-    - [82, 150.756]
-  - - [5888, 128, 1, 1280]
-    - [10, 8175.34]
-  - - [2944, 5888, 1, 1280]
-    - [42, 10061.2]
-  - - [1, 1856, 1, 1]
-    - [77, 0.169343]
-  - - [3584, 3584, 1, 256]
-    - [37, 9710.41]
-  - - [1856, 2368, 1, 3328]
-    - [42, 10029.2]
-  - - [5888, 704, 1, 256]
-    - [19, 9275.86]
-  - - [64, 448, 1, 32]
-    - [68, 76.4587]
-  - - [6784, 4288, 1, 256]
-    - [43, 9872.44]
-  - - [128, 64, 1, 3328]
-    - [12, 371.633]
-  - - [2944, 64, 1, 1280]
-    - [8, 5562.1]
-  - - [1, 5056, 1, 1280]
-    - [97, 35.6999]
-  - - [32, 64, 1, 1280]
-    - [75, 22.583]
-  - - [1408, 2368, 1, 3328]
-    - [42, 9858.58]
-  - - [1024, 3584, 1, 256]
-    - [43, 9387.73]
-  - - [2944, 128, 1, 256]
-    - [9, 5506.22]
-  - - [6784, 128, 1, 1]
-    - [76, 66.5914]
-  - - [1408, 256, 1, 3328]
-    - [42, 5541.26]
-  - - [448, 32, 1, 256]
-    - [70, 107.942]
-  - - [1, 5888, 1, 256]
-    - [97, 34.8274]
-  - - [64, 2368, 1, 256]
-    - [25, 3344.6]
-  - - [448, 1856, 1, 256]
-    - [42, 6426.96]
-  - - [2944, 256, 1, 256]
-    - [42, 7114.23]
-  - - [1, 128, 1, 256]
-    - [92, 0.892375]
-  - - [32, 256, 1, 1280]
-    - [75, 88.4426]
-  - - [32, 128, 1, 3328]
-    - [75, 48.9496]
-  - - [6784, 64, 1, 1280]
-    - [6, 6616.02]
-  - - [4288, 1024, 1, 32]
-    - [60, 2912.71]
-  - - [2944, 1, 1, 1280]
-    - [92, 28.7395]
-  - - [1408, 64, 1, 3328]
-    - [35, 3693.26]
-  - - [2944, 448, 1, 1280]
-    - [42, 7827.37]
-  - - [6784, 32, 1, 1280]
-    - [75, 1686.94]
-  - - [1024, 704, 1, 1280]
-    - [42, 7835.83]
-  - - [704, 448, 1, 1]
-    - [91, 29.6421]
-  - - [32, 128, 1, 32]
-    - [65, 8.35918]
-  - - [1, 128, 1, 1]
-    - [77, 0.0115108]
-  - - [5888, 1, 1, 1]
-    - [85, 0.598374]
-  - - [5888, 1856, 1, 3328]
-    - [43, 9891.85]
-  - - [32, 2368, 1, 3328]
-    - [70, 883.735]
-  - - [4288, 1408, 1, 3328]
-    - [43, 9720.94]
-  - - [1856, 64, 1, 1]
-    - [79, 9.9651]
-  - - [1856, 32, 1, 3328]
-    - [75, 710.586]
-  - - [2944, 32, 1, 256]
-    - [70, 682.049]
-  - - [128, 64, 1, 1]
-    - [91, 0.726241]
-  - - [256, 1024, 1, 3328]
-    - [30, 6220.87]
-  - - [32, 448, 1, 256]
-    - [70, 105.703]
-  - - [1856, 64, 1, 32]
-    - [65, 241.186]
-  - - [1856, 64, 1, 3328]
-    - [14, 4683.81]
-  - - [256, 5056, 1, 256]
-    - [42, 8201.73]
-  - - [5888, 2944, 1, 3328]
-    - [38, 9955.75]
-  - - [2368, 1408, 1, 3328]
-    - [37, 9607.28]
-  - - [5888, 704, 1, 32]
-    - [63, 2772.68]
-  - - [2944, 704, 1, 1]
-    - [82, 123.958]
-  - - [6784, 1856, 1, 256]
-    - [37, 9552.28]
-  - - [1, 704, 1, 256]
-    - [92, 4.95121]
-  - - [448, 5056, 1, 1]
-    - [77, 129.879]
-  - - [3584, 448, 1, 32]
-    - [70, 2007.04]
-  - - [2368, 1856, 1, 1]
-    - [77, 176.648]
-  - - [128, 704, 1, 256]
-    - [13, 2464.6]
-  - - [256, 1408, 1, 3328]
-    - [42, 5535.12]
-  - - [2944, 128, 1, 1]
-    - [85, 36.5147]
-  - - [32, 256, 1, 3328]
-    - [75, 97.843]
-  - - [2944, 704, 1, 3328]
-    - [19, 9429.04]
-  - - [704, 1024, 1, 32]
-    - [67, 1334.99]
-  - - [2368, 1856, 1, 32]
-    - [60, 2901.0]
-  - - [5056, 4288, 1, 3328]
-    - [37, 10213.4]
-  - - [256, 32, 1, 32]
-    - [70, 24.4537]
-  - - [64, 256, 1, 3328]
-    - [16, 776.281]
-  - - [256, 6784, 1, 1]
-    - [83, 108.004]
-  - - [704, 5056, 1, 256]
-    - [37, 9097.57]
-  - - [1024, 3584, 1, 32]
-    - [60, 2861.61]
-  - - [256, 6784, 1, 32]
-    - [60, 2086.13]
-  - - [2944, 1408, 1, 32]
-    - [60, 2924.27]
-  - - [1024, 32, 1, 256]
-    - [70, 252.062]
-  - - [4288, 3584, 1, 1]
-    - [82, 228.421]
-  - - [1, 704, 1, 1]
-    - [82, 0.0637681]
-  - - [5056, 448, 1, 3328]
-    - [42, 9318.39]
-  - - [3584, 64, 1, 256]
-    - [6, 4421.71]
-  - - [64, 1856, 1, 32]
-    - [65, 239.968]
-  - - [64, 1856, 1, 3328]
-    - [14, 4670.52]
-  - - [5888, 5888, 1, 3328]
-    - [42, 10240.0]
-  - - [4288, 1856, 1, 256]
-    - [37, 9407.94]
-  - - [1856, 2944, 1, 256]
-    - [37, 9513.06]
-  - - [128, 448, 1, 1]
-    - [82, 4.81074]
-  - - [64, 128, 1, 32]
-    - [65, 16.0627]
-  - - [704, 1, 1, 1280]
-    - [92, 6.93169]
-  - - [5056, 5888, 1, 1280]
-    - [42, 10187.0]
-  - - [2944, 5888, 1, 1]
-    - [76, 239.954]
-  - - [1024, 1856, 1, 3328]
-    - [42, 8890.43]
-  - - [5888, 1024, 1, 32]
-    - [60, 3169.15]
-  - - [3584, 256, 1, 1280]
-    - [42, 7767.23]
-  - - [1024, 1, 1, 1]
-    - [77, 0.0920863]
-  - - [1408, 5056, 1, 1280]
-    - [39, 9937.32]
-  - - [3584, 128, 1, 1280]
-    - [24, 6944.21]
-  - - [5056, 6784, 1, 256]
-    - [19, 9857.17]
-  - - [64, 4288, 1, 256]
-    - [8, 4526.71]
-  - - [5888, 32, 1, 1280]
-    - [75, 1486.52]
-  - - [256, 128, 1, 32]
-    - [69, 71.2348]
-  - - [32, 1856, 1, 1280]
-    - [75, 655.812]
-  - - [2944, 5056, 1, 1]
-    - [76, 222.03]
-  - - [448, 128, 1, 1]
-    - [77, 4.74702]
-  - - [256, 704, 1, 32]
-    - [62, 335.3]
-  - - [1, 2368, 1, 1]
-    - [77, 0.205556]
-  - - [5888, 5888, 1, 1280]
-    - [43, 10157.0]
-  - - [256, 2944, 1, 1280]
-    - [42, 8192.0]
-  - - [2944, 256, 1, 3328]
-    - [42, 8265.86]
-  - - [5056, 2944, 1, 1280]
-    - [39, 10001.2]
-  - - [704, 1024, 1, 3328]
-    - [42, 8005.68]
-  - - [2368, 1856, 1, 1280]
-    - [42, 9758.55]
-  - - [1856, 128, 1, 256]
-    - [6, 4721.85]
-  - - [6784, 2944, 1, 1]
-    - [76, 251.918]
-  - - [2944, 1024, 1, 32]
-    - [60, 2679.69]
-  - - [2944, 1024, 1, 1280]
-    - [43, 9367.74]
-  - - [1408, 64, 1, 32]
-    - [68, 180.224]
-  - - [5056, 5056, 1, 1]
-    - [77, 247.513]
-  - - [2368, 4288, 1, 256]
-    - [37, 9601.88]
-  - - [448, 1856, 1, 1280]
-    - [42, 7129.59]
-  - - [256, 3584, 1, 1]
-    - [77, 73.9923]
-  - - [448, 2944, 1, 32]
-    - [70, 1844.63]
-  - - [448, 2944, 1, 1280]
-    - [42, 7924.37]
-  - - [2944, 6784, 1, 1280]
-    - [37, 10081.2]
-  - - [256, 6784, 1, 1280]
-    - [42, 9045.33]
-  - - [3584, 2368, 1, 32]
-    - [60, 3318.44]
-  - - [704, 32, 1, 32]
-    - [65, 46.6902]
-  - - [6784, 3584, 1, 3328]
-    - [42, 10257.0]
-  - - [128, 32, 1, 256]
-    - [70, 30.8405]
-  - - [128, 1408, 1, 1280]
-    - [25, 5339.97]
-  - - [6784, 3584, 1, 32]
-    - [60, 3688.11]
-  - - [128, 1856, 1, 3328]
-    - [15, 6310.87]
-  - - [2944, 2944, 1, 256]
-    - [43, 9475.52]
-  - - [1408, 1024, 1, 3328]
-    - [42, 8767.51]
-  - - [5056, 2368, 1, 1280]
-    - [19, 10069.5]
-  - - [448, 128, 1, 32]
-    - [65, 114.688]
-  - - [32, 5056, 1, 3328]
-    - [75, 1307.16]
-  - - [1024, 5056, 1, 1280]
-    - [43, 10010.6]
-  - - [2944, 1024, 1, 1]
-    - [84, 151.948]
-  - - [2368, 128, 1, 1280]
-    - [8, 6009.5]
-  - - [2368, 5888, 1, 3328]
-    - [19, 10066.1]
-  - - [448, 5056, 1, 256]
-    - [42, 8639.19]
-  - - [4288, 2368, 1, 1]
-    - [77, 222.285]
-  - - [1408, 3584, 1, 32]
-    - [60, 3039.92]
-  - - [2944, 4288, 1, 32]
-    - [66, 3449.15]
-  - - [5888, 1408, 1, 1280]
-    - [42, 9962.05]
-  - - [3584, 5056, 1, 1280]
-    - [43, 10113.0]
-  - - [2368, 448, 1, 1]
-    - [77, 79.8843]
-  - - [448, 704, 1, 1]
-    - [86, 28.9882]
-  - - [704, 128, 1, 32]
-    - [65, 184.845]
-  - - [3584, 2944, 1, 1]
-    - [76, 227.007]
-  - - [2944, 5888, 1, 256]
-    - [37, 9663.71]
-  - - [2944, 32, 1, 32]
-    - [65, 187.479]
-  - - [256, 4288, 1, 3328]
-    - [42, 7867.93]
-  - - [4288, 64, 1, 1]
-    - [86, 24.5029]
-  - - [1, 1408, 1, 1280]
-    - [97, 14.3673]
-  - - [6784, 1408, 1, 32]
-    - [60, 3445.22]
-  - - [1856, 704, 1, 32]
-    - [61, 1840.32]
-  - - [1024, 1856, 1, 1]
-    - [77, 118.784]
-  - - [704, 5056, 1, 3328]
-    - [42, 9811.94]
-  - - [1024, 3584, 1, 3328]
-    - [42, 10112.8]
-  - - [5888, 256, 1, 3328]
-    - [42, 9018.38]
-  - - [2368, 256, 1, 1280]
-    - [42, 6531.53]
-  - - [1856, 1408, 1, 1]
-    - [77, 139.003]
-  - - [2944, 448, 1, 32]
-    - [65, 1788.36]
-  - - [128, 448, 1, 256]
-    - [4, 1699.08]
-  - - [128, 1024, 1, 1]
-    - [82, 10.996]
-  - - [32, 32, 1, 256]
-    - [70, 7.7283]
-  - - [4288, 5056, 1, 1280]
-    - [42, 10163.2]
-  - - [1856, 1856, 1, 3328]
-    - [42, 9486.99]
-  - - [1024, 2368, 1, 256]
-    - [19, 8508.18]
-  - - [4288, 2368, 1, 3328]
-    - [43, 9898.66]
-  - - [256, 64, 1, 32]
-    - [70, 45.5111]
-  - - [1, 1024, 1, 1280]
-    - [97, 10.4824]
-  - - [64, 32, 1, 1280]
-    - [75, 22.5986]
-  - - [1024, 32, 1, 3328]
-    - [70, 388.251]
-  - - [5888, 3584, 1, 256]
-    - [39, 9755.6]
-  - - [1024, 5056, 1, 32]
-    - [60, 3068.06]
-  - - [704, 5888, 1, 3328]
-    - [42, 10051.8]
-  - - [1024, 1408, 1, 256]
-    - [42, 7846.49]
-  - - [3584, 2944, 1, 1280]
-    - [43, 9755.03]
-  - - [1, 5056, 1, 256]
-    - [97, 29.6322]
-  - - [256, 1024, 1, 1]
-    - [82, 23.9182]
-  - - [32, 32, 1, 3328]
-    - [75, 12.3366]
-  - - [5056, 128, 1, 32]
-    - [67, 1262.77]
-  - - [2368, 1, 1, 3328]
-    - [97, 26.1644]
-  - - [4288, 1856, 1, 1280]
-    - [42, 9868.74]
-  - - [3584, 5888, 1, 1]
-    - [81, 247.916]
-  - - [5888, 4288, 1, 256]
-    - [39, 9781.2]
-  - - [1024, 2944, 1, 1280]
-    - [42, 9494.98]
-  - - [6784, 1, 1, 1]
-    - [82, 0.695082]
-  - - [1408, 64, 1, 1280]
-    - [12, 3432.84]
-  - - [1, 256, 1, 1280]
-    - [92, 2.54252]
-  - - [2944, 3584, 1, 256]
-    - [37, 9503.0]
-  - - [1, 128, 1, 1280]
-    - [97, 1.30696]
-  - - [1024, 256, 1, 32]
-    - [70, 609.637]
-  - - [2368, 32, 1, 1280]
-    - [70, 829.854]
-  - - [5888, 1856, 1, 1]
-    - [76, 225.788]
-  - - [1408, 1408, 1, 3328]
-    - [42, 9261.15]
-  - - [448, 2368, 1, 1280]
-    - [42, 7490.65]
-  - - [6784, 2368, 1, 3328]
-    - [39, 10164.3]
-  - - [1, 64, 1, 256]
-    - [92, 0.449123]
-  - - [704, 128, 1, 1]
-    - [77, 7.61081]
-  - - [1408, 4288, 1, 32]
-    - [60, 3165.14]
-  - - [256, 64, 1, 1280]
-    - [16, 722.16]
-  - - [256, 448, 1, 256]
-    - [13, 3058.35]
-  - - [1856, 1024, 1, 1280]
-    - [42, 8740.64]
-  - - [4288, 3584, 1, 1280]
-    - [37, 10088.2]
-  - - [448, 1024, 1, 1280]
-    - [42, 6853.44]
-  - - [1024, 448, 1, 3328]
-    - [42, 7039.5]
-  - - [5056, 1856, 1, 1]
-    - [77, 202.94]
-  - - [5888, 2368, 1, 256]
-    - [43, 9709.87]
-  - - [1408, 1024, 1, 32]
-    - [60, 1948.37]
-  - - [32, 704, 1, 256]
-    - [75, 160.556]
-  - - [2944, 1, 1, 256]
-    - [92, 20.2163]
-  - - [32, 4288, 1, 256]
-    - [75, 817.675]
-  - - [5056, 1856, 1, 32]
-    - [60, 3384.65]
-  - - [5056, 1856, 1, 1280]
-    - [42, 10044.3]
-  - - [1, 64, 1, 1]
-    - [82, 0.0057971]
-  - - [1408, 5888, 1, 3328]
-    - [39, 10229.2]
-  - - [1408, 704, 1, 3328]
-    - [42, 8610.41]
-  - - [5056, 704, 1, 3328]
-    - [42, 9624.43]
-  - - [704, 64, 1, 1280]
-    - [12, 1932.7]
-  - - [1, 704, 1, 1280]
-    - [97, 7.20665]
-  - - [5888, 6784, 1, 1]
-    - [84, 262.101]
-  - - [5888, 4288, 1, 32]
-    - [60, 3661.75]
-  - - [1408, 3584, 1, 256]
-    - [39, 9307.25]
-  - - [64, 5056, 1, 1]
-    - [85, 30.6424]
-  - - [6784, 256, 1, 1]
-    - [78, 111.327]
-  - - [2944, 1, 1, 1]
-    - [77, 0.245333]
-  - - [256, 1856, 1, 3328]
-    - [42, 7293.6]
-  - - [4288, 128, 1, 1280]
-    - [6, 6818.19]
-  - - [6784, 256, 1, 1280]
-    - [42, 8903.3]
-  - - [128, 4288, 1, 256]
-    - [6, 6014.95]
-  - - [2368, 6784, 1, 1280]
-    - [19, 10062.7]
-  - - [128, 128, 1, 32]
-    - [75, 45.8294]
-  - - [128, 1408, 1, 32]
-    - [61, 344.926]
-  - - [6784, 128, 1, 32]
-    - [67, 1497.16]
-  - - [1408, 448, 1, 1]
-    - [79, 55.1385]
-  - - [2368, 1024, 1, 1]
-    - [82, 134.713]
-  - - [2368, 704, 1, 3328]
-    - [42, 8679.62]
-  - - [5888, 1, 1, 1280]
-    - [97, 41.4101]
-  - - [2944, 1856, 1, 32]
-    - [68, 2914.17]
-  - - [1024, 64, 1, 1]
-    - [79, 5.49799]
-  - - [1408, 32, 1, 1280]
-    - [75, 489.739]
-  - - [704, 1, 1, 256]
-    - [92, 5.03982]
-  - - [2368, 1408, 1, 256]
-    - [37, 9011.2]
-  - - [128, 3584, 1, 1]
-    - [82, 42.1647]
-  - - [4288, 1408, 1, 1]
-    - [77, 195.515]
-  - - [5888, 64, 1, 256]
-    - [26, 5531.48]
-  - - [64, 5056, 1, 1280]
-    - [8, 6329.27]
-  - - [1408, 2944, 1, 1]
-    - [76, 172.715]
-  - - [4288, 1408, 1, 32]
-    - [60, 3207.17]
-  - - [5888, 2944, 1, 256]
-    - [37, 9658.65]
-  - - [128, 64, 1, 1280]
-    - [3, 334.367]
-  - - [1408, 2944, 1, 32]
-    - [66, 2863.66]
-  - - [1, 3584, 1, 1280]
-    - [97, 35.1157]
-  - - [64, 64, 1, 32]
-    - [65, 8.03137]
-  - - [448, 1408, 1, 32]
-    - [68, 1224.82]
-  - - [128, 5056, 1, 256]
-    - [9, 6767.77]
-  - - [1, 1, 1, 1280]
-    - [97, 0.0102041]
-  - - [64, 704, 1, 256]
-    - [12, 1360.18]
-  - - [5888, 6784, 1, 256]
-    - [43, 9891.75]
-  - - [6784, 5888, 1, 1]
-    - [76, 264.601]
-  - - [1, 448, 1, 1280]
-    - [97, 4.58312]
-  - - [1024, 1024, 1, 1]
-    - [77, 79.4376]
-  - - [1856, 704, 1, 1]
-    - [86, 93.8667]
-  - - [6784, 5888, 1, 1280]
-    - [39, 10203.3]
-  - - [1024, 4288, 1, 32]
-    - [61, 2837.42]
-  - - [1856, 1, 1, 1280]
-    - [97, 19.0603]
-  - - [3584, 5888, 1, 256]
-    - [43, 9748.55]
-  - - [5056, 2368, 1, 1]
-    - [77, 228.834]
-  - - [256, 1408, 1, 1280]
-    - [42, 5399.97]
-  - - [64, 256, 1, 32]
-    - [65, 43.9839]
-  - - [64, 5888, 1, 3328]
-    - [8, 6684.95]
-  - - [6784, 64, 1, 3328]
-    - [24, 6774.84]
-  - - [5056, 448, 1, 1]
-    - [77, 131.081]
-  - - [2944, 448, 1, 3328]
-    - [42, 7922.99]
-  - - [2368, 1024, 1, 1280]
-    - [42, 8943.59]
-  - - [1856, 6784, 1, 256]
-    - [37, 9550.02]
-  - - [4288, 32, 1, 1280]
-    - [75, 1089.56]
-  - - [448, 1408, 1, 1280]
-    - [42, 6875.03]
-  - - [5056, 448, 1, 32]
-    - [63, 2253.82]
-  - - [3584, 2944, 1, 32]
-    - [60, 3511.25]
-  - - [2368, 128, 1, 1]
-    - [86, 29.1446]
-  - - [3584, 1856, 1, 32]
-    - [60, 3171.35]
-  - - [128, 128, 1, 3328]
-    - [16, 777.166]
-  - - [5056, 64, 1, 256]
-    - [8, 4954.4]
-  - - [64, 448, 1, 3328]
-    - [16, 1346.22]
-  - - [4288, 1408, 1, 1280]
-    - [43, 9637.83]
-  - - [32, 5056, 1, 256]
-    - [75, 1031.34]
-  - - [704, 128, 1, 256]
-    - [5, 2485.85]
-  - - [704, 5056, 1, 1]
-    - [89, 142.15]
-  - - [256, 1024, 1, 32]
-    - [75, 624.152]
-  - - [256, 1024, 1, 1280]
-    - [21, 5924.16]
-  - - [2368, 128, 1, 256]
-    - [8, 4801.65]
-  - - [2368, 1408, 1, 1280]
-    - [42, 9579.15]
-  - - [128, 256, 1, 32]
-    - [74, 71.2348]
-  - - [64, 6784, 1, 32]
-    - [70, 918.891]
-  - - [6784, 32, 1, 256]
-    - [75, 1364.8]
-  - - [256, 4288, 1, 1]
-    - [78, 84.1816]
-  - - [5888, 1408, 1, 1]
-    - [90, 190.494]
-  - - [1024, 4288, 1, 1280]
-    - [42, 9928.57]
-  - - [1856, 4288, 1, 1]
-    - [77, 190.213]
-  - - [128, 2944, 1, 256]
-    - [9, 5556.97]
-  - - [3584, 4288, 1, 256]
-    - [37, 9686.47]
-  - - [3584, 128, 1, 32]
-    - [70, 926.772]
-  - - [3584, 128, 1, 3328]
-    - [6, 7131.57]
-  - - [4288, 448, 1, 3328]
-    - [39, 8752.0]
-  - - [1856, 4288, 1, 32]
-    - [60, 3235.17]
-  - - [64, 256, 1, 1280]
-    - [16, 718.203]
-  - - [4288, 1024, 1, 1280]
-    - [37, 9710.37]
-  - - [1, 4288, 1, 256]
-    - [97, 25.3634]
-  - - [64, 2368, 1, 1]
-    - [82, 12.3817]
-  - - [4288, 6784, 1, 32]
-    - [60, 3826.35]
-  - - [256, 6784, 1, 3328]
-    - [42, 9173.04]
-  - - [128, 2944, 1, 1]
-    - [77, 35.6848]
-  - - [3584, 1408, 1, 256]
-    - [43, 9185.48]
-  - - [704, 3584, 1, 3328]
-    - [42, 9573.37]
-  - - [5056, 448, 1, 1280]
-    - [42, 9212.36]
-  - - [1408, 2944, 1, 1280]
-    - [43, 9916.63]
-  - - [5888, 704, 1, 1280]
-    - [43, 9777.73]
-  - - [64, 64, 1, 256]
-    - [3, 107.436]
-  - - [704, 1408, 1, 1280]
-    - [42, 8454.0]
-  - - [4288, 5888, 1, 256]
-    - [39, 9769.37]
-  - - [6784, 64, 1, 32]
-    - [68, 943.861]
-  - - [3584, 3584, 1, 3328]
-    - [42, 10217.9]
-  - - [2944, 6784, 1, 32]
-    - [60, 3715.74]
-  - - [448, 64, 1, 32]
-    - [65, 56.4965]
-  - - [5056, 256, 1, 1]
-    - [76, 93.5214]
-  - - [64, 6784, 1, 1280]
-    - [6, 6584.66]
-  - - [2944, 2368, 1, 3328]
-    - [37, 9938.31]
-  - - [1, 4288, 1, 1]
-    - [85, 0.432258]
-  - - [1408, 128, 1, 256]
-    - [8, 4061.39]
-  - - [1024, 1856, 1, 1280]
-    - [42, 8765.84]
-  - - [1024, 5888, 1, 256]
-    - [37, 9642.08]
-  - - [704, 1408, 1, 256]
-    - [42, 7516.45]
-  - - [6784, 2944, 1, 3328]
-    - [42, 10166.9]
-  - - [1408, 2368, 1, 256]
-    - [37, 9119.03]
-  - - [64, 128, 1, 1280]
-    - [3, 335.223]
-  - - [5888, 32, 1, 3328]
-    - [75, 1516.95]
-  - - [1408, 5056, 1, 256]
-    - [39, 9519.56]
-  - - [1024, 1408, 1, 32]
-    - [68, 1968.32]
-  - - [4288, 128, 1, 32]
-    - [67, 1143.47]
-  - - [6784, 704, 1, 1]
-    - [77, 179.817]
-  - - [448, 704, 1, 256]
-    - [42, 4086.05]
-  - - [704, 3584, 1, 32]
-    - [66, 2461.6]
-  - - [1856, 256, 1, 3328]
-    - [42, 7293.6]
-  - - [6784, 448, 1, 256]
-    - [43, 8914.34]
-  - - [4288, 4288, 1, 1]
-    - [77, 244.768]
-  - - [5056, 2944, 1, 1]
-    - [82, 237.02]
-  - - [64, 2368, 1, 3328]
-    - [5, 4758.16]
-  - - [256, 704, 1, 3328]
-    - [21, 4223.84]
-  - - [1, 2944, 1, 1]
-    - [82, 0.252055]
-  - - [1024, 1024, 1, 256]
-    - [42, 7895.16]
-  - - [3584, 1, 1, 1]
-    - [86, 0.367213]
-  - - [256, 2944, 1, 32]
-    - [68, 1382.87]
-  - - [6784, 4288, 1, 3328]
-    - [42, 10289.6]
-  - - [5056, 2944, 1, 3328]
-    - [42, 10199.3]
-  - - [704, 1024, 1, 1280]
-    - [42, 7835.83]
-  - - [256, 3584, 1, 1280]
-    - [42, 7829.37]
-  - - [2368, 1856, 1, 3328]
-    - [42, 9857.78]
-  - - [1856, 4288, 1, 1280]
-    - [37, 10024.1]
-  - - [1, 1024, 1, 256]
-    - [92, 7.20176]
-  - - [3584, 448, 1, 1]
-    - [82, 104.533]
-  - - [2944, 1024, 1, 3328]
-    - [42, 9460.59]
-  - - [32, 1408, 1, 3328]
-    - [75, 536.135]
-  - - [128, 1, 1, 3328]
-    - [97, 1.41316]
-  - - [5888, 5056, 1, 32]
-    - [60, 3744.62]
-  - - [704, 2944, 1, 1]
-    - [79, 122.783]
-  - - [3584, 448, 1, 1280]
-    - [42, 8244.58]
-  - - [2944, 6784, 1, 3328]
-    - [42, 10158.4]
-  - - [1856, 2368, 1, 1280]
-    - [42, 9904.24]
-  - - [6784, 1024, 1, 1280]
-    - [42, 9866.75]
-  - - [6784, 3584, 1, 1280]
-    - [42, 10186.5]
-  - - [1, 5056, 1, 3328]
-    - [97, 36.5156]
-  - - [448, 1856, 1, 1]
-    - [77, 67.0555]
-  - - [128, 2368, 1, 32]
-    - [70, 704.893]
-  - - [128, 1408, 1, 3328]
-    - [8, 5632.85]
-  - - [704, 1856, 1, 256]
-    - [42, 8230.7]
-  - - [448, 2368, 1, 1]
-    - [78, 80.3685]
-  - - [1408, 4288, 1, 256]
-    - [43, 9364.98]
-  - - [256, 5056, 1, 3328]
-    - [42, 9269.13]
-  - - [2368, 64, 1, 1280]
-    - [5, 4523.94]
-  - - [1856, 448, 1, 32]
-    - [67, 1465.18]
-  - - [32, 128, 1, 256]
-    - [70, 30.4111]
-  - - [448, 1024, 1, 1]
-    - [85, 40.96]
-  - - [128, 1024, 1, 1280]
-    - [14, 4821.04]
-  - - [704, 2944, 1, 256]
-    - [42, 8749.66]
-  - - [1408, 1408, 1, 256]
-    - [43, 8458.51]
-  - - [448, 6784, 1, 32]
-    - [60, 2677.74]
-  - - [1, 64, 1, 1280]
-    - [97, 0.653061]
-  - - [448, 2944, 1, 1]
-    - [76, 93.1435]
-  - - [4288, 448, 1, 32]
-    - [70, 2176.8]
-  - - [4288, 448, 1, 1280]
-    - [42, 8731.93]
-  - - [2944, 704, 1, 32]
-    - [61, 2210.75]
-  - - [5888, 448, 1, 1280]
-    - [42, 8900.28]
-  - - [448, 4288, 1, 1]
-    - [77, 119.467]
-  - - [3584, 5056, 1, 1]
-    - [81, 246.473]
-  - - [64, 5888, 1, 1]
-    - [85, 35.9573]
-  - - [1408, 3584, 1, 1280]
-    - [43, 9753.61]
-  - - [6784, 448, 1, 1280]
-    - [43, 9429.45]
-  - - [3584, 5056, 1, 3328]
-    - [42, 10129.8]
-  - - [2368, 2368, 1, 32]
-    - [60, 3123.91]
-  - - [64, 5888, 1, 32]
-    - [68, 846.813]
-  - - [1856, 448, 1, 256]
-    - [37, 6335.15]
-  - - [3584, 2368, 1, 1280]
-    - [42, 9894.38]
-  - - [128, 1024, 1, 256]
-    - [13, 3410.0]
-  - - [3584, 64, 1, 3328]
-    - [15, 6108.86]
-  - - [5888, 2944, 1, 32]
-    - [60, 3647.4]
-  - - [1856, 2944, 1, 32]
-    - [60, 3126.79]
-  - - [5056, 1408, 1, 1]
-    - [77, 202.701]
-  - - [5888, 1408, 1, 3328]
-    - [43, 10061.2]
-  - - [448, 4288, 1, 256]
-    - [42, 8174.57]
-  - - [6784, 1024, 1, 1]
-    - [81, 204.318]
-  - - [256, 448, 1, 1]
-    - [77, 9.36993]
-  - - [128, 5888, 1, 3328]
-    - [42, 8367.34]
-  - - [6784, 1024, 1, 32]
-    - [60, 3261.42]
-  - - [256, 448, 1, 32]
-    - [63, 229.376]
-  - - [6784, 3584, 1, 1]
-    - [76, 249.731]
-  - - [2944, 2368, 1, 32]
-    - [60, 3257.66]
-  - - [3584, 6784, 1, 3328]
-    - [19, 10139.6]
-  - - [5056, 1024, 1, 1]
-    - [77, 187.043]
-  - - [448, 128, 1, 1280]
-    - [12, 2446.68]
-  - - [64, 3584, 1, 32]
-    - [70, 527.301]
-  - - [64, 3584, 1, 1280]
-    - [6, 5752.38]
-  - - [6784, 1408, 1, 256]
-    - [37, 9510.26]
-  - - [5056, 1024, 1, 32]
-    - [60, 3100.21]
+    - [41, 9906.08]
   - - [256, 704, 1, 1280]
-    - [21, 4078.62]
-  - - [4288, 3584, 1, 256]
-    - [37, 9696.01]
-  - - [2368, 256, 1, 32]
-    - [70, 1224.66]
-  - - [2368, 256, 1, 3328]
-    - [42, 6699.85]
-  - - [448, 6784, 1, 1280]
-    - [42, 9593.16]
-  - - [1856, 5888, 1, 1]
-    - [82, 225.788]
-  - - [256, 5888, 1, 32]
-    - [66, 2016.49]
-  - - [3584, 1, 1, 3328]
-    - [97, 39.9931]
-  - - [4288, 32, 1, 256]
-    - [75, 888.849]
-  - - [256, 64, 1, 1]
-    - [79, 1.8963]
-  - - [4288, 5056, 1, 32]
-    - [60, 3723.51]
-  - - [4288, 5056, 1, 3328]
-    - [19, 10111.9]
-  - - [1856, 5888, 1, 32]
-    - [60, 3513.87]
-  - - [1856, 5888, 1, 1280]
-    - [42, 10050.6]
-  - - [256, 256, 1, 1280]
-    - [12, 2702.52]
-  - - [704, 2368, 1, 1280]
-    - [42, 8668.56]
-  - - [5056, 32, 1, 1280]
-    - [75, 1260.31]
-  - - [4288, 2368, 1, 1280]
-    - [43, 9834.36]
-  - - [2944, 5056, 1, 256]
-    - [37, 9706.86]
-  - - [32, 1856, 1, 256]
-    - [70, 443.017]
-  - - [64, 5888, 1, 1280]
-    - [8, 6469.22]
-  - - [1, 1856, 1, 1280]
-    - [97, 19.0115]
-  - - [2944, 4288, 1, 1]
-    - [76, 221.627]
-  - - [5056, 5888, 1, 32]
-    - [60, 3755.25]
-  - - [704, 1, 1, 3328]
-    - [97, 7.78273]
-  - - [448, 256, 1, 1280]
-    - [14, 4199.1]
-  - - [1408, 256, 1, 1]
-    - [91, 34.1333]
-  - - [2368, 5056, 1, 3328]
-    - [39, 9755.75]
-  - - [1024, 5056, 1, 3328]
-    - [42, 10114.9]
-  - - [704, 704, 1, 1280]
-    - [42, 7362.91]
-  - - [128, 32, 1, 3328]
-    - [75, 49.3608]
-  - - [1024, 6784, 1, 32]
-    - [60, 3125.68]
-  - - [3584, 2944, 1, 3328]
-    - [43, 9808.57]
-  - - [128, 1856, 1, 256]
-    - [6, 4663.91]
-  - - [32, 32, 1, 1280]
-    - [75, 11.1078]
-  - - [1408, 5888, 1, 1]
-    - [81, 214.998]
-  - - [1, 3584, 1, 256]
-    - [92, 23.5016]
-  - - [704, 4288, 1, 32]
-    - [60, 2695.31]
-  - - [1408, 5888, 1, 32]
-    - [60, 3408.14]
-  - - [6784, 1024, 1, 3328]
-    - [37, 9902.59]
-  - - [6784, 2368, 1, 1]
-    - [76, 234.04]
-  - - [1856, 1, 1, 3328]
-    - [97, 20.6498]
-  - - [5056, 1408, 1, 256]
-    - [19, 9363.06]
-  - - [1, 1, 1, 256]
-    - [92, 0.00694143]
-  - - [2944, 1408, 1, 256]
-    - [43, 9308.41]
-  - - [4288, 1, 1, 1]
-    - [79, 0.439344]
-  - - [2368, 2368, 1, 256]
-    - [19, 9273.26]
-  - - [1, 448, 1, 256]
-    - [92, 3.15771]
-  - - [1408, 6784, 1, 1]
-    - [76, 223.593]
-  - - [3584, 32, 1, 3328]
-    - [70, 1331.94]
-  - - [1856, 1, 1, 256]
-    - [92, 13.1108]
-  - - [6784, 6784, 1, 1280]
-    - [43, 10271.3]
-  - - [128, 128, 1, 1]
-    - [82, 1.93208]
-  - - [6784, 32, 1, 3328]
-    - [75, 1743.75]
-  - - [1408, 32, 1, 256]
-    - [70, 339.245]
-  - - [128, 3584, 1, 32]
-    - [68, 986.563]
-  - - [1856, 3584, 1, 256]
-    - [19, 9536.78]
+    - [21, 4055.67]
+  - - [128, 6784, 1, 3328]
+    - [25, 8287.11]
+  - - [5888, 1856, 1, 3328]
+    - [44, 10356.5]
+  - - [5888, 2944, 1, 3328]
+    - [44, 10362.5]
+  - - [1856, 4288, 1, 256]
+    - [40, 9603.07]
+  - - [5056, 5056, 1, 3328]
+    - [44, 10474.1]
+  - - [1408, 5888, 1, 1280]
+    - [46, 10182.3]
+  - - [1024, 3584, 1, 3328]
+    - [44, 10158.6]
+  - - [448, 3584, 1, 3328]
+    - [44, 8554.62]
+  - - [256, 4288, 1, 3328]
+    - [44, 7929.43]
+  - - [5888, 1408, 1, 1280]
+    - [46, 10183.9]
+  - - [704, 1856, 1, 3328]
+    - [44, 9428.57]
+  - - [1024, 2368, 1, 256]
+    - [46, 8555.09]
+  - - [5056, 6784, 1, 1280]
+    - [40, 10454.9]
+  - - [1408, 64, 1, 1280]
+    - [12, 3482.64]
+  - - [448, 1024, 1, 1280]
+    - [32, 7017.24]
+  - - [5056, 5056, 1, 1280]
+    - [44, 10399.7]
+  - - [4288, 6784, 1, 256]
+    - [41, 10079.9]
+  - - [6784, 448, 1, 256]
+    - [46, 9055.44]
+  - - [5056, 256, 1, 1280]
+    - [44, 9187.86]
+  - - [5888, 704, 1, 1280]
+    - [44, 9985.33]
+  - - [3584, 1024, 1, 256]
+    - [46, 9463.38]
+  - - [6784, 4288, 1, 3328]
+    - [44, 10521.3]
+  - - [1856, 2368, 1, 3328]
+    - [44, 10084.5]
+  - - [5888, 2944, 1, 1280]
+    - [40, 10272.9]
+  - - [5888, 1024, 1, 256]
+    - [40, 9675.93]
+  - - [448, 64, 1, 1280]
+    - [16, 1267.27]
   - - [1024, 704, 1, 256]
-    - [42, 6784.9]
-  - - [2368, 704, 1, 32]
-    - [63, 2039.23]
-  - - [256, 5888, 1, 1280]
-    - [42, 9025.92]
-  - - [448, 2368, 1, 32]
-    - [61, 1664.1]
-  - - [448, 2368, 1, 3328]
-    - [42, 7631.32]
-  - - [64, 1408, 1, 256]
-    - [13, 2464.6]
-  - - [5056, 32, 1, 32]
-    - [70, 404.48]
-  - - [1024, 704, 1, 3328]
-    - [42, 8016.38]
-  - - [32, 5888, 1, 3328]
-    - [75, 1508.78]
-  - - [256, 64, 1, 3328]
-    - [16, 775.397]
-  - - [32, 1408, 1, 1280]
-    - [75, 487.421]
-  - - [64, 32, 1, 256]
-    - [70, 15.384]
+    - [18, 6886.17]
+  - - [1408, 2944, 1, 256]
+    - [46, 9461.12]
+  - - [256, 1856, 1, 1280]
+    - [21, 7260.91]
+  - - [6784, 5056, 1, 3328]
+    - [44, 10529.9]
+  - - [5056, 5056, 1, 256]
+    - [19, 10065.5]
+  - - [256, 2944, 1, 3328]
+    - [44, 8471.35]
+  - - [64, 1024, 1, 1280]
+    - [34, 2766.69]
+  - - [1024, 3584, 1, 1280]
+    - [44, 10032.5]
+  - - [2368, 2944, 1, 1280]
+    - [44, 10114.5]
+  - - [128, 3584, 1, 1280]
+    - [2, 7154.03]
+  - - [6784, 6784, 1, 1280]
+    - [46, 10484.1]
+  - - [1024, 256, 1, 3328]
+    - [32, 6220.87]
+  - - [1408, 4288, 1, 1280]
+    - [44, 9838.09]
+  - - [3584, 4288, 1, 1280]
+    - [44, 10335.5]
+  - - [2368, 704, 1, 1280]
+    - [44, 8745.31]
+  - - [5056, 4288, 1, 3328]
+    - [44, 10473.3]
+  - - [3584, 2368, 1, 3328]
+    - [44, 10204.8]
+  - - [5888, 6784, 1, 1280]
+    - [40, 10431.2]
+  - - [64, 704, 1, 1280]
+    - [36, 1902.1]
+  - - [4288, 256, 1, 256]
+    - [44, 7082.12]
+  - - [6784, 448, 1, 1280]
+    - [44, 9642.63]
+  - - [2944, 5888, 1, 256]
+    - [40, 9864.8]
+  - - [256, 128, 1, 256]
+    - [16, 970.904]
+  - - [4288, 2944, 1, 256]
+    - [40, 9764.67]
+  - - [5888, 64, 1, 3328]
+    - [25, 7264.23]
+  - - [2944, 256, 1, 3328]
+    - [21, 8494.3]
+  - - [5056, 2368, 1, 1280]
+    - [40, 10288.5]
+  - - [448, 3584, 1, 1280]
+    - [44, 8434.07]
+  - - [6784, 5888, 1, 256]
+    - [41, 10103.7]
+  - - [64, 1024, 1, 3328]
+    - [34, 2973.06]
+  - - [704, 128, 1, 1280]
+    - [12, 3525.16]
+  - - [1408, 448, 1, 1280]
+    - [21, 7018.49]
+  - - [1024, 1408, 1, 256]
+    - [40, 7886.73]
+  - - [2368, 2368, 1, 3328]
+    - [44, 10020.6]
+  - - [5056, 704, 1, 3328]
+    - [44, 9847.2]
+  - - [1408, 1856, 1, 256]
+    - [46, 9199.55]
+  - - [1408, 256, 1, 1280]
+    - [21, 5615.55]
+  - - [5888, 1856, 1, 256]
+    - [46, 9920.59]
+  - - [704, 5888, 1, 256]
+    - [41, 9447.64]
+  - - [6784, 64, 1, 256]
+    - [26, 5717.54]
+  - - [3584, 704, 1, 3328]
+    - [44, 9619.89]
+  - - [1408, 1408, 1, 256]
+    - [47, 8538.2]
+  - - [1024, 64, 1, 1280]
+    - [9, 2781.37]
+  - - [448, 4288, 1, 256]
+    - [22, 8251.38]
+  - - [64, 3584, 1, 3328]
+    - [29, 6054.59]
+  - - [704, 2368, 1, 1280]
+    - [44, 8753.92]
+  - - [1856, 2368, 1, 1280]
+    - [44, 9984.42]
+  - - [2368, 128, 1, 3328]
+    - [24, 6190.07]
+  - - [1408, 1408, 1, 3328]
+    - [44, 9317.67]
+  - - [2944, 128, 1, 256]
+    - [7, 5582.7]
+  - - [448, 1408, 1, 256]
+    - [44, 6079.85]
+  - - [64, 5056, 1, 3328]
+    - [6, 6592.13]
+  - - [1408, 1024, 1, 1280]
+    - [44, 8698.61]
+  - - [704, 6784, 1, 256]
+    - [40, 9245.61]
+  - - [6784, 704, 1, 256]
+    - [40, 9228.9]
+  - - [256, 3584, 1, 3328]
+    - [44, 8072.81]
+  - - [5056, 704, 1, 256]
+    - [19, 9170.82]
+  - - [1408, 3584, 1, 256]
+    - [46, 9339.54]
+  - - [3584, 4288, 1, 3328]
+    - [44, 10417.8]
+  - - [5888, 1856, 1, 1280]
+    - [46, 10284.1]
+  - - [256, 1408, 1, 256]
+    - [44, 4669.77]
+  - - [5056, 64, 1, 1280]
+    - [24, 6313.83]
+  - - [2368, 128, 1, 256]
+    - [6, 4731.52]
+  - - [2368, 3584, 1, 1280]
+    - [44, 10118.5]
+  - - [1024, 256, 1, 256]
+    - [21, 4559.03]
+  - - [448, 448, 1, 256]
+    - [11, 4039.33]
+  - - [2944, 3584, 1, 3328]
+    - [44, 10241.4]
+  - - [256, 256, 1, 3328]
+    - [13, 2979.56]
+  - - [128, 1024, 1, 3328]
+    - [12, 5105.43]
+  - - [6784, 2944, 1, 256]
+    - [41, 9908.66]
+  - - [64, 1856, 1, 1280]
+    - [12, 4349.07]
+  - - [448, 256, 1, 256]
+    - [13, 3033.07]
+  - - [1856, 2368, 1, 256]
+    - [40, 9413.67]
+  - - [3584, 6784, 1, 3328]
+    - [44, 10494.6]
+  - - [256, 1024, 1, 256]
+    - [21, 4634.59]
+  - - [1024, 128, 1, 1280]
+    - [12, 4766.25]
+  - - [4288, 128, 1, 1280]
+    - [4, 6969.7]
+  - - [5056, 4288, 1, 1280]
+    - [44, 10401.0]
+  - - [5888, 64, 1, 256]
+    - [7, 5661.33]
+  - - [6784, 1856, 1, 3328]
+    - [44, 10256.5]
+  - - [1408, 5056, 1, 1280]
+    - [44, 9972.14]
+  - - [1856, 256, 1, 1280]
+    - [21, 7281.78]
+  - - [64, 5888, 1, 3328]
+    - [6, 6636.84]
+  - - [6784, 5888, 1, 3328]
+    - [44, 10508.3]
+  - - [448, 256, 1, 3328]
+    - [12, 4484.04]
+  - - [2368, 5056, 1, 1280]
+    - [44, 10294.6]
+  - - [1024, 704, 1, 1280]
+    - [21, 7982.24]
+  - - [256, 1408, 1, 3328]
+    - [21, 5791.69]
+  - - [6784, 128, 1, 3328]
+    - [25, 8277.61]
+  - - [1024, 5056, 1, 1280]
+    - [44, 10047.0]
+  - - [4288, 1024, 1, 256]
+    - [40, 9379.79]
+  - - [2368, 1408, 1, 256]
+    - [40, 9166.03]
+  - - [704, 704, 1, 3328]
+    - [21, 7851.36]
+  - - [5888, 448, 1, 1280]
+    - [44, 9092.04]
+  - - [3584, 256, 1, 3328]
+    - [21, 8139.96]
+  - - [704, 5888, 1, 3328]
+    - [44, 10094.2]
+  - - [1024, 6784, 1, 1280]
+    - [44, 10077.9]
+  - - [128, 3584, 1, 3328]
+    - [2, 7388.36]
+  - - [128, 704, 1, 1280]
+    - [12, 3491.02]
+  - - [3584, 2944, 1, 1280]
+    - [44, 10159.5]
+  - - [1856, 128, 1, 3328]
+    - [35, 6274.81]
+  - - [128, 2944, 1, 1280]
+    - [7, 6986.46]
+  - - [448, 1856, 1, 1280]
+    - [21, 7257.97]
+  - - [1408, 5056, 1, 3328]
+    - [44, 10056.2]
+  - - [1856, 1856, 1, 3328]
+    - [44, 9540.06]
+  - - [3584, 128, 1, 256]
+    - [26, 5991.86]
+  - - [448, 1408, 1, 3328]
+    - [21, 7181.35]
+  - - [2368, 2368, 1, 256]
+    - [19, 9444.08]
+  - - [4288, 4288, 1, 1280]
+    - [40, 10295.8]
+  - - [64, 448, 1, 1280]
+    - [15, 1270.78]
+  - - [5888, 1024, 1, 1280]
+    - [44, 10224.6]
+  - - [704, 1024, 1, 256]
+    - [44, 6886.17]
+  - - [704, 6784, 1, 3328]
+    - [44, 9846.33]
+  - - [5888, 5888, 1, 3328]
+    - [44, 10487.0]
+  - - [5056, 1024, 1, 1280]
+    - [44, 10055.6]
+  - - [448, 5888, 1, 3328]
+    - [44, 9194.28]
+  - - [1024, 2944, 1, 1280]
+    - [44, 9555.18]
+  - - [5056, 5888, 1, 1280]
+    - [41, 10439.1]
+  - - [448, 6784, 1, 256]
+    - [45, 9030.22]
+  - - [256, 3584, 1, 256]
+    - [44, 7057.72]
+  - - [256, 448, 1, 256]
+    - [37, 3058.35]
+  - - [3584, 5888, 1, 256]
+    - [40, 9964.35]
+  - - [2944, 3584, 1, 256]
+    - [40, 9705.15]
+  - - [1408, 704, 1, 256]
+    - [46, 7588.38]
+  - - [6784, 1024, 1, 3328]
+    - [44, 10169.2]
+  - - [6784, 2944, 1, 3328]
+    - [44, 10396.9]
+  - - [64, 64, 1, 3328]
+    - [12, 189.748]
+  - - [6784, 2368, 1, 1280]
+    - [46, 10298.6]
+  - - [4288, 3584, 1, 256]
+    - [40, 9895.03]
+  - - [4288, 5888, 1, 1280]
+    - [44, 10378.3]
+  - - [448, 2944, 1, 3328]
+    - [44, 8086.49]
+  - - [4288, 1856, 1, 1280]
+    - [44, 10082.9]
+  - - [1856, 2944, 1, 3328]
+    - [44, 10223.3]
+  - - [256, 6784, 1, 3328]
+    - [44, 9236.39]
+  - - [64, 5888, 1, 256]
+    - [20, 5407.45]
+  - - [5056, 1024, 1, 256]
+    - [41, 9582.13]
+  - - [704, 64, 1, 3328]
+    - [38, 2068.81]
+  - - [5056, 1856, 1, 3328]
+    - [44, 10358.6]
+  - - [448, 448, 1, 3328]
+    - [29, 5324.8]
+  - - [448, 2368, 1, 1280]
+    - [44, 7540.59]
+  - - [1408, 128, 1, 1280]
+    - [6, 5252.43]
+  - - [5056, 256, 1, 3328]
+    - [44, 9349.62]
+  - - [704, 704, 1, 256]
+    - [21, 6318.61]
+  - - [1024, 5888, 1, 1280]
+    - [44, 10225.7]
+  - - [64, 128, 1, 256]
+    - [3, 216.659]
+  - - [128, 1856, 1, 1280]
+    - [14, 5948.55]
+  - - [5056, 3584, 1, 256]
+    - [41, 9980.43]
+  - - [1856, 1024, 1, 1280]
+    - [44, 8821.8]
+  - - [1856, 1856, 1, 1280]
+    - [44, 9431.18]
+  - - [128, 4288, 1, 3328]
+    - [4, 7099.75]
   - - [1856, 1024, 1, 3328]
-    - [42, 8872.48]
-  - - [2368, 1, 1, 1]
-    - [82, 0.209929]
+    - [44, 8937.69]
+  - - [256, 2368, 1, 256]
+    - [44, 5896.25]
+  - - [1024, 448, 1, 3328]
+    - [21, 7261.84]
+  - - [1856, 704, 1, 1280]
+    - [44, 9254.53]
+  - - [6784, 1024, 1, 256]
+    - [40, 9590.11]
+  - - [5056, 5888, 1, 3328]
+    - [44, 10492.0]
+  - - [1856, 1024, 1, 256]
+    - [22, 8174.38]
+  - - [5056, 1408, 1, 3328]
+    - [44, 10060.3]
+  - - [1024, 1024, 1, 1280]
+    - [21, 9034.58]
+  - - [448, 5888, 1, 256]
+    - [40, 8526.3]
+  - - [1408, 6784, 1, 3328]
+    - [44, 10265.0]
+  - - [2944, 1408, 1, 3328]
+    - [44, 10091.2]
+  - - [2944, 4288, 1, 3328]
+    - [44, 10280.8]
+  - - [256, 2944, 1, 256]
+    - [44, 7199.18]
+  - - [5056, 2944, 1, 256]
+    - [40, 9919.12]
+  - - [2368, 1856, 1, 256]
+    - [40, 9407.41]
+  - - [128, 6784, 1, 1280]
+    - [7, 8139.21]
+  - - [1408, 3584, 1, 3328]
+    - [44, 9900.27]
+  - - [2368, 6784, 1, 256]
+    - [41, 9970.23]
+  - - [4288, 2368, 1, 3328]
+    - [44, 10360.5]
+  - - [704, 3584, 1, 1280]
+    - [44, 9501.11]
+  - - [1408, 5888, 1, 3328]
+    - [44, 10271.9]
+  - - [1856, 5056, 1, 256]
+    - [19, 9835.79]
+  - - [6784, 6784, 1, 256]
+    - [41, 10190.5]
+  - - [1408, 704, 1, 3328]
+    - [44, 8714.14]
+  - - [128, 5888, 1, 1280]
+    - [1, 8310.56]
+  - - [2368, 4288, 1, 1280]
+    - [44, 10279.3]
+  - - [3584, 1856, 1, 1280]
+    - [44, 10009.5]
+  - - [704, 1408, 1, 3328]
+    - [44, 8714.14]
+  - - [704, 64, 1, 1280]
+    - [15, 1897.09]
+  - - [3584, 448, 1, 256]
+    - [44, 7749.66]
+  - - [3584, 3584, 1, 1280]
+    - [44, 10378.3]
+  - - [256, 6784, 1, 256]
+    - [40, 8332.01]
+  - - [1856, 3584, 1, 3328]
+    - [44, 10106.3]
+  - - [128, 448, 1, 256]
+    - [34, 1683.49]
+  - - [3584, 3584, 1, 256]
+    - [40, 9923.77]
+  - - [6784, 4288, 1, 1280]
+    - [40, 10453.6]
+  - - [448, 704, 1, 1280]
+    - [21, 4932.82]
+  - - [3584, 5056, 1, 256]
+    - [46, 9970.14]
+  - - [6784, 128, 1, 256]
+    - [7, 7198.77]
+  - - [64, 1408, 1, 3328]
+    - [12, 3790.35]
+  - - [704, 448, 1, 256]
+    - [21, 4102.66]
+  - - [2944, 2368, 1, 1280]
+    - [44, 10110.8]
+  - - [448, 64, 1, 3328]
+    - [39, 1390.16]
+  - - [6784, 3584, 1, 256]
+    - [41, 10018.6]
+  - - [256, 1856, 1, 3328]
+    - [32, 7593.43]
+  - - [256, 704, 1, 256]
+    - [21, 3134.33]
+  - - [128, 1408, 1, 256]
+    - [6, 3819.32]
+  - - [64, 128, 1, 3328]
+    - [37, 379.921]
+  - - [1856, 1408, 1, 256]
+    - [41, 9159.25]
+  - - [2944, 2944, 1, 3328]
+    - [44, 10119.4]
+  - - [5056, 6784, 1, 256]
+    - [41, 10104.0]
+  - - [1408, 4288, 1, 3328]
+    - [44, 9919.46]
+  - - [6784, 256, 1, 1280]
+    - [44, 9104.63]
+  - - [1024, 704, 1, 3328]
+    - [21, 8113.99]
+  - - [2368, 704, 1, 3328]
+    - [44, 8870.59]
+  - - [128, 4288, 1, 256]
+    - [4, 6056.43]
+  - - [3584, 6784, 1, 256]
+    - [40, 10010.9]
+  - - [128, 128, 1, 3328]
+    - [15, 795.303]
+  - - [5056, 1856, 1, 256]
+    - [19, 9845.46]
+  - - [704, 4288, 1, 256]
+    - [19, 8952.74]
+  - - [256, 448, 1, 3328]
+    - [12, 4492.49]
+  - - [1408, 6784, 1, 1280]
+    - [44, 10169.7]
+  - - [64, 2368, 1, 1280]
+    - [12, 4609.95]
+  - - [64, 6784, 1, 3328]
+    - [2, 6899.07]
+  - - [2944, 256, 1, 1280]
+    - [44, 8276.34]
   - - [5056, 2368, 1, 3328]
-    - [42, 10144.0]
-  - - [128, 1, 1, 1280]
-    - [97, 1.28967]
-  - - [704, 4288, 1, 1280]
-    - [42, 9522.88]
+    - [44, 10374.6]
+  - - [2944, 4288, 1, 256]
+    - [40, 9759.95]
+  - - [1408, 3584, 1, 1280]
+    - [44, 9802.18]
+  - - [2368, 64, 1, 256]
+    - [12, 3439.48]
+  - - [256, 256, 1, 256]
+    - [13, 1872.46]
+  - - [704, 128, 1, 3328]
+    - [12, 3794.19]
+  - - [1856, 704, 1, 256]
+    - [18, 8279.6]
+  - - [2368, 6784, 1, 3328]
+    - [44, 10367.1]
+  - - [5056, 704, 1, 1280]
+    - [44, 9750.2]
+  - - [1856, 4288, 1, 3328]
+    - [44, 10171.9]
+  - - [1408, 5888, 1, 256]
+    - [41, 9792.93]
+  - - [704, 2944, 1, 1280]
+    - [44, 9589.73]
+  - - [4288, 64, 1, 1280]
+    - [27, 5441.03]
+  - - [704, 1856, 1, 256]
+    - [40, 8279.6]
+  - - [3584, 704, 1, 1280]
+    - [44, 9507.84]
+  - - [5888, 5056, 1, 256]
+    - [42, 10114.0]
+  - - [3584, 448, 1, 3328]
+    - [44, 8550.23]
+  - - [704, 2368, 1, 3328]
+    - [44, 8871.73]
+  - - [2944, 448, 1, 256]
+    - [44, 7289.32]
+  - - [448, 5056, 1, 3328]
+    - [44, 9533.37]
+  - - [2368, 128, 1, 1280]
+    - [6, 5957.82]
+  - - [4288, 448, 1, 256]
+    - [22, 8240.32]
+  - - [64, 6784, 1, 256]
+    - [2, 5741.17]
+  - - [64, 5056, 1, 1280]
+    - [6, 6329.27]
+  - - [5888, 2368, 1, 256]
+    - [46, 9892.9]
+  - - [704, 448, 1, 3328]
+    - [21, 5085.4]
+  - - [6784, 704, 1, 3328]
+    - [44, 9847.8]
+  - - [128, 64, 1, 1280]
+    - [28, 338.687]
+  - - [2368, 256, 1, 1280]
+    - [21, 6735.64]
+  - - [1408, 2944, 1, 3328]
+    - [44, 10087.1]
+  - - [64, 1024, 1, 256]
+    - [13, 1889.33]
+  - - [2368, 448, 1, 1280]
+    - [21, 7584.37]
+  - - [128, 3584, 1, 256]
+    - [2, 5943.35]
+  - - [1856, 448, 1, 3328]
+    - [21, 7376.83]
+  - - [128, 5056, 1, 256]
+    - [7, 6903.13]
+  - - [4288, 4288, 1, 256]
+    - [40, 9878.84]
+  - - [2368, 704, 1, 256]
+    - [40, 8022.0]
+  - - [3584, 2368, 1, 256]
+    - [40, 9644.24]
+  - - [5888, 5056, 1, 1280]
+    - [46, 10444.2]
+  - - [128, 1024, 1, 1280]
+    - [12, 4733.98]
+  - - [64, 704, 1, 256]
+    - [10, 1310.72]
+  - - [4288, 256, 1, 1280]
+    - [44, 7813.01]
+  - - [3584, 3584, 1, 3328]
+    - [44, 10460.7]
+  - - [128, 1024, 1, 256]
+    - [37, 3302.6]
+  - - [5888, 6784, 1, 256]
+    - [41, 10098.1]
+  - - [4288, 2944, 1, 3328]
+    - [44, 10283.8]
+  - - [1856, 64, 1, 256]
+    - [12, 3115.65]
+  - - [4288, 128, 1, 3328]
+    - [4, 7095.33]
+  - - [256, 5056, 1, 1280]
+    - [44, 9151.32]
+  - - [6784, 5888, 1, 1280]
+    - [44, 10437.8]
+  - - [704, 128, 1, 256]
+    - [13, 2363.59]
+  - - [5888, 4288, 1, 1280]
+    - [44, 10379.9]
+  - - [448, 256, 1, 1280]
+    - [12, 4218.41]
+  - - [448, 2368, 1, 3328]
+    - [44, 7672.47]
+  - - [1, 1, 1, 1280]
+    - [54, 0.00964436]
+  - - [256, 1408, 1, 1280]
+    - [21, 5632.0]
+  - - [1408, 1856, 1, 1280]
+    - [44, 9833.5]
+  - - [5888, 448, 1, 3328]
+    - [44, 9199.67]
+  - - [704, 5888, 1, 1280]
+    - [44, 9971.82]
+  - - [256, 64, 1, 3328]
+    - [38, 793.451]
+  - - [128, 2368, 1, 256]
+    - [6, 4801.65]
+  - - [6784, 64, 1, 3328]
+    - [26, 6997.97]
+  - - [5056, 2944, 1, 3328]
+    - [44, 10438.5]
+  - - [448, 128, 1, 256]
+    - [34, 1699.08]
+  - - [1856, 128, 1, 1280]
+    - [35, 5985.97]
+  - - [448, 4288, 1, 1280]
+    - [44, 8919.45]
+  - - [64, 3584, 1, 256]
+    - [11, 4475.63]
+  - - [128, 2944, 1, 3328]
+    - [25, 7250.81]
+  - - [3584, 704, 1, 256]
+    - [46, 8853.11]
+  - - [2944, 448, 1, 3328]
+    - [44, 8096.04]
+  - - [3584, 1408, 1, 3328]
+    - [44, 9900.27]
+  - - [2368, 1024, 1, 1280]
+    - [44, 9128.79]
+  - - [2944, 6784, 1, 1280]
+    - [44, 10317.5]
+  - - [1856, 6784, 1, 256]
+    - [40, 9744.04]
+  - - [4288, 448, 1, 3328]
+    - [44, 9035.02]
+  - - [6784, 704, 1, 1280]
+    - [44, 9748.07]
+  - - [5888, 1024, 1, 3328]
+    - [44, 10321.4]
+  - - [704, 6784, 1, 1280]
+    - [44, 9745.58]
+  - - [5888, 128, 1, 256]
+    - [21, 7220.73]
+  - - [5056, 1024, 1, 3328]
+    - [44, 10153.6]
+  - - [704, 5056, 1, 1280]
+    - [44, 9731.87]
+  - - [64, 704, 1, 3328]
+    - [15, 2068.8]
+  - - [2944, 1856, 1, 256]
+    - [40, 9575.58]
+  - - [5056, 64, 1, 256]
+    - [6, 5051.07]
+  - - [5888, 5056, 1, 3328]
+    - [46, 10498.2]
+  - - [128, 5056, 1, 3328]
+    - [7, 8281.22]
+  - - [3584, 6784, 1, 1280]
+    - [40, 10422.3]
+  - - [1856, 5888, 1, 256]
+    - [41, 9912.15]
+  - - [64, 448, 1, 3328]
+    - [39, 1395.05]
+  - - [4288, 4288, 1, 3328]
+    - [44, 10373.2]
+  - - [4288, 1408, 1, 1280]
+    - [44, 9836.09]
+  - - [64, 1856, 1, 256]
+    - [12, 3040.87]
+  - - [4288, 2368, 1, 256]
+    - [40, 9807.67]
+  - - [2944, 5056, 1, 1280]
+    - [40, 10356.5]
+  - - [256, 4288, 1, 1280]
+    - [44, 7809.54]
+  - - [6784, 2368, 1, 3328]
+    - [44, 10369.9]
+  - - [256, 1024, 1, 1280]
+    - [21, 5899.16]
+  - - [4288, 128, 1, 256]
+    - [4, 6014.95]
+  - - [4288, 1856, 1, 3328]
+    - [44, 10179.4]
+  - - [1856, 2944, 1, 1280]
+    - [44, 10117.5]
+  - - [3584, 64, 1, 1280]
+    - [14, 5761.41]
+  - - [4288, 6784, 1, 3328]
+    - [44, 10529.9]
+  - - [3584, 1024, 1, 1280]
+    - [44, 10037.7]
+  - - [1024, 4288, 1, 256]
+    - [40, 9373.53]
+  - - [5888, 3584, 1, 3328]
+    - [44, 10447.6]
+  - - [5056, 3584, 1, 3328]
+    - [44, 10371.9]
+  - - [1408, 128, 1, 3328]
+    - [6, 5541.26]
+  - - [2368, 1408, 1, 1280]
+    - [44, 9790.12]
+  - - [5056, 2944, 1, 1280]
+    - [40, 10358.8]
+  - - [3584, 256, 1, 256]
+    - [44, 7074.73]
+  - - [1024, 6784, 1, 256]
+    - [40, 9561.21]
+  - - [2944, 5056, 1, 3328]
+    - [44, 10442.9]
+  - - [3584, 2944, 1, 256]
+    - [40, 9719.12]
+  - - [448, 128, 1, 3328]
+    - [13, 2604.27]
+  - - [64, 2944, 1, 3328]
+    - [24, 5806.03]
+  - - [64, 4288, 1, 3328]
+    - [27, 5693.95]
+  - - [5056, 6784, 1, 3328]
+    - [44, 10526.2]
+  - - [128, 2944, 1, 256]
+    - [7, 5661.33]
+  - - [3584, 4288, 1, 256]
+    - [40, 9908.99]
+  - - [1856, 6784, 1, 3328]
+    - [44, 10257.1]
+  - - [3584, 128, 1, 3328]
+    - [26, 7354.19]
+  - - [128, 256, 1, 1280]
+    - [16, 1464.49]
+  - - [64, 448, 1, 256]
+    - [16, 873.813]
+  - - [64, 256, 1, 1280]
+    - [15, 728.178]
+  - - [5056, 1408, 1, 1280]
+    - [46, 9962.55]
+  - - [5888, 5888, 1, 256]
+    - [41, 10068.0]
+  - - [4288, 1024, 1, 1280]
+    - [44, 9977.95]
+  - - [5888, 128, 1, 3328]
+    - [1, 8494.3]
+  - - [448, 6784, 1, 3328]
+    - [44, 9751.06]
+  - - [2944, 1408, 1, 1280]
+    - [44, 9979.32]
+  - - [64, 128, 1, 1280]
+    - [12, 337.82]
+  - - [2944, 1856, 1, 3328]
+    - [44, 10220.6]
+  - - [448, 5056, 1, 256]
+    - [40, 8753.96]
+  - - [64, 64, 1, 256]
+    - [3, 109.227]
+  - - [3584, 5888, 1, 1280]
+    - [40, 10372.1]
+  - - [6784, 1856, 1, 1280]
+    - [40, 10176.2]
+  - - [5888, 256, 1, 3328]
+    - [44, 9232.18]
+  - - [1856, 5888, 1, 3328]
+    - [44, 10362.4]
+  - - [3584, 1408, 1, 256]
+    - [46, 9328.75]
+  - - [704, 3584, 1, 3328]
+    - [44, 9622.54]
+  - - [5056, 448, 1, 1280]
+    - [44, 9410.92]
+  - - [3584, 1856, 1, 3328]
+    - [44, 10106.3]
+  - - [1408, 704, 1, 1280]
+    - [21, 8549.71]
+  - - [2944, 1024, 1, 256]
+    - [46, 9015.79]
+  - - [448, 1408, 1, 1280]
+    - [21, 7028.23]
+  - - [2368, 4288, 1, 3328]
+    - [44, 10356.7]
+  - - [1024, 1408, 1, 1280]
+    - [44, 8701.9]
+  - - [256, 128, 1, 1280]
+    - [16, 1448.31]
+  - - [704, 1408, 1, 1280]
+    - [21, 8545.1]
+  - - [6784, 5056, 1, 256]
+    - [42, 10082.7]
+  - - [4288, 5888, 1, 256]
+    - [41, 9994.17]
+  - - [448, 2944, 1, 256]
+    - [40, 7340.03]
+  - - [2944, 6784, 1, 256]
+    - [40, 9896.38]
+  - - [2368, 2368, 1, 1280]
+    - [44, 9922.47]
+  - - [1856, 3584, 1, 1280]
+    - [44, 10013.2]
+  - - [64, 2944, 1, 256]
+    - [6, 3966.65]
+  - - [3584, 1408, 1, 1280]
+    - [44, 9800.98]
+  - - [5056, 3584, 1, 1280]
+    - [46, 10305.4]
+  - - [256, 5888, 1, 256]
+    - [46, 8245.21]
+  - - [128, 256, 1, 3328]
+    - [16, 1596.19]
+  - - [1856, 1408, 1, 3328]
+    - [44, 9965.29]
+  - - [1024, 4288, 1, 3328]
+    - [44, 10077.4]
+  - - [448, 2368, 1, 256]
+    - [44, 6858.11]
+  - - [64, 1408, 1, 1280]
+    - [12, 3533.86]
+  - - [64, 6784, 1, 1280]
+    - [26, 6810.6]
+  - - [2944, 2368, 1, 3328]
+    - [44, 10210.6]
+  - - [704, 4288, 1, 3328]
+    - [44, 9683.86]
+  - - [1024, 1856, 1, 1280]
+    - [44, 8821.8]
+  - - [6784, 1856, 1, 256]
+    - [40, 9739.33]
+  - - [128, 2368, 1, 3328]
+    - [6, 6202.25]
+  - - [1024, 5888, 1, 256]
+    - [40, 9651.76]
+  - - [64, 2944, 1, 1280]
+    - [24, 5441.62]
+  - - [5056, 64, 1, 3328]
+    - [24, 6595.34]
+  - - [1408, 2368, 1, 256]
+    - [40, 9142.47]
+  - - [2944, 704, 1, 3328]
+    - [44, 9743.39]
+  - - [256, 64, 1, 256]
+    - [15, 489.989]
+  - - [2944, 2944, 1, 1280]
+    - [46, 10039.4]
+  - - [6784, 256, 1, 3328]
+    - [44, 9241.11]
+  - - [1408, 5056, 1, 256]
+    - [46, 9571.56]
+  - - [5056, 128, 1, 3328]
+    - [25, 8263.43]
+  - - [128, 128, 1, 1280]
+    - [15, 728.178]
+  - - [448, 704, 1, 256]
+    - [44, 4119.41]
+  - - [1856, 256, 1, 3328]
+    - [32, 7495.53]
+  - - [2944, 128, 1, 3328]
+    - [25, 7230.72]
   - - [704, 256, 1, 256]
-    - [21, 3186.28]
-  - - [3136, 64, 128, 64]
-    - [106, 15223.8]
-  - - [3136, 256, 64, 64]
-    - [106, 18012.3]
-  - - [12544, 1024, 1, 256]
-    - [102, 20780.7]
-  - - [784, 128, 128, 512]
-    - [101, 19837.9]
-  - - [784, 512, 256, 128]
-    - [105, 18471.7]
-  - - [3136, 64, 64, 256]
-    - [103, 19306.8]
-  - - [12544, 256, 1, 1024]
-    - [107, 17648.9]
-  - - [3136, 256, 256, 64]
-    - [109, 18095.6]
-  - - [3136, 64, 128, 256]
-    - [100, 19910.0]
-  - - [784, 128, 64, 512]
-    - [101, 19325.0]
-  - - [3136, 64, 256, 64]
-    - [106, 15429.5]
-  - - [784, 512, 128, 128]
-    - [99, 19136.0]
-  - - [3136, 64, 64, 64]
-    - [108, 14680.1]
-  - - [784, 128, 256, 512]
-    - [101, 20166.4]
-  - - [3136, 64, 256, 256]
-    - [103, 20048.3]
-  - - [3136, 256, 128, 64]
-    - [98, 18309.2]
+    - [21, 3203.98]
+  - - [256, 448, 1, 1280]
+    - [12, 4208.79]
+  - - [704, 256, 1, 1280]
+    - [33, 4096.0]
+  - - [64, 2368, 1, 3328]
+    - [37, 4933.15]
+  - - [256, 704, 1, 3328]
+    - [32, 4286.63]
+  - - [1024, 1024, 1, 256]
+    - [21, 7951.29]
+  - - [1408, 4288, 1, 256]
+    - [46, 9410.62]
+  - - [5888, 2368, 1, 1280]
+    - [46, 10247.8]
+  - - [128, 256, 1, 256]
+    - [10, 953.251]
+  - - [256, 64, 1, 1280]
+    - [15, 726.161]
+  - - [2368, 5888, 1, 1280]
+    - [40, 10235.1]
+  - - [5888, 256, 1, 1280]
+    - [44, 9080.31]
+  - - [704, 1024, 1, 1280]
+    - [44, 7921.93]
+  - - [2368, 1856, 1, 3328]
+    - [44, 10095.1]
+  - - [2944, 704, 1, 256]
+    - [22, 8890.41]
+  - - [2368, 6784, 1, 1280]
+    - [41, 10293.7]
+  - - [2368, 1024, 1, 3328]
+    - [44, 9250.18]
+  - - [1856, 4288, 1, 1280]
+    - [44, 10084.5]
+  - - [704, 3584, 1, 256]
+    - [40, 8833.74]
+  - - [704, 2944, 1, 3328]
+    - [44, 9740.1]
+  - - [1856, 5056, 1, 3328]
+    - [44, 10359.4]
+  - - [3584, 5056, 1, 1280]
+    - [46, 10309.8]
+  - - [2944, 1024, 1, 3328]
+    - [44, 9672.21]
+  - - [256, 4288, 1, 256]
+    - [44, 7067.87]
+  - - [2368, 256, 1, 256]
+    - [44, 5914.22]
+  - - [1408, 6784, 1, 256]
+    - [40, 9703.51]
+  - - [6784, 1408, 1, 3328]
+    - [44, 10265.0]
+  - - [1024, 2368, 1, 1280]
+    - [44, 9141.7]
+  - - [704, 64, 1, 256]
+    - [12, 1322.74]
+  - - [256, 2368, 1, 3328]
+    - [21, 6916.7]
+  - - [6784, 2944, 1, 1280]
+    - [44, 10319.8]
+  - - [3584, 448, 1, 1280]
+    - [44, 8428.51]
+  - - [2944, 6784, 1, 3328]
+    - [44, 10398.6]
+  - - [448, 5056, 1, 1280]
+    - [44, 9408.48]
+  - - [4288, 5056, 1, 1280]
+    - [40, 10402.5]
+  - - [128, 448, 1, 1280]
+    - [34, 2420.85]
+  - - [4288, 704, 1, 256]
+    - [19, 8969.37]
+  - - [64, 64, 1, 1280]
+    - [34, 179.06]
+  - - [5888, 704, 1, 256]
+    - [46, 9467.87]
+  - - [256, 5888, 1, 3328]
+    - [44, 9233.54]
+  - - [6784, 4288, 1, 256]
+    - [42, 10061.3]
+  - - [5888, 256, 1, 256]
+    - [40, 8217.12]
+  - - [6784, 1024, 1, 1280]
+    - [44, 10077.9]
+  - - [704, 448, 1, 1280]
+    - [21, 4942.48]
+  - - [128, 64, 1, 3328]
+    - [12, 379.921]
+  - - [448, 64, 1, 256]
+    - [37, 873.813]
+  - - [2944, 704, 1, 1280]
+    - [44, 9598.05]
+  - - [6784, 3584, 1, 1280]
+    - [40, 10419.5]
+  - - [2944, 64, 1, 1280]
+    - [6, 5471.24]
+  - - [1408, 2944, 1, 1280]
+    - [44, 9985.33]
+  - - [256, 1856, 1, 256]
+    - [44, 6009.63]
+  - - [1408, 2368, 1, 3328]
+    - [44, 9907.19]
+  - - [128, 1408, 1, 3328]
+    - [6, 5561.81]
+  - - [2368, 2944, 1, 256]
+    - [40, 9615.71]
+  - - [64, 5056, 1, 256]
+    - [6, 4978.22]
+  - - [1408, 256, 1, 3328]
+    - [32, 5776.07]
+  - - [3584, 1856, 1, 256]
+    - [46, 9592.65]
+  - - [4288, 3584, 1, 1280]
+    - [40, 10336.8]
+  - - [2368, 448, 1, 256]
+    - [21, 6885.93]
+  - - [4288, 256, 1, 3328]
+    - [44, 7934.94]
+  - - [1408, 64, 1, 256]
+    - [13, 2402.99]
+  - - [4288, 2944, 1, 1280]
+    - [44, 10206.3]
+  - - [5056, 448, 1, 3328]
+    - [44, 9539.16]
+  - - [1024, 64, 1, 256]
+    - [13, 1889.33]
+  - - [64, 2368, 1, 256]
+    - [12, 3391.37]
+  - - [4288, 5056, 1, 3328]
+    - [44, 10478.7]
+  - - [2944, 256, 1, 256]
+    - [18, 7135.28]
+  - - [1024, 128, 1, 3328]
+    - [37, 5076.9]
+  - - [256, 5056, 1, 3328]
+    - [44, 9341.52]
+  - - [5056, 2368, 1, 256]
+    - [19, 9915.22]
+  - - [4288, 704, 1, 3328]
+    - [44, 9682.37]
+  - - [448, 3584, 1, 256]
+    - [40, 7749.66]
+  - - [2368, 64, 1, 1280]
+    - [12, 4609.95]
+  - - [1024, 1408, 1, 3328]
+    - [44, 8838.59]
+  - - [2944, 5888, 1, 1280]
+    - [40, 10277.5]
+  - - [5888, 3584, 1, 256]
+    - [41, 9952.6]
+  - - [1408, 1856, 1, 3328]
+    - [44, 9969.86]
+  - - [6784, 1408, 1, 1280]
+    - [44, 10179.2]
+  - - [704, 2944, 1, 256]
+    - [22, 8866.64]
+  - - [4288, 64, 1, 256]
+    - [5, 4435.26]
+  - - [2944, 5888, 1, 3328]
+    - [44, 10357.6]
+  - - [64, 4288, 1, 1280]
+    - [5, 5481.79]
+  - - [6784, 64, 1, 1280]
+    - [2, 6810.6]
+  - - [704, 1856, 1, 1280]
+    - [44, 9262.73]
+  - - [1408, 64, 1, 3328]
+    - [12, 3778.89]
+  - - [1408, 1408, 1, 1280]
+    - [44, 9204.72]
+  - - [448, 1024, 1, 3328]
+    - [32, 7272.91]
+  - - [448, 4288, 1, 3328]
+    - [44, 9034.0]
+  - - [704, 2368, 1, 256]
+    - [40, 8058.35]
+  - - [2944, 448, 1, 1280]
+    - [21, 7996.45]
+  - - [5888, 2368, 1, 3328]
+    - [44, 10315.2]
+  - - [4288, 5056, 1, 256]
+    - [40, 9985.11]
+  - - [4288, 448, 1, 1280]
+    - [44, 8909.11]
+  - - [5888, 704, 1, 3328]
+    - [44, 10088.9]
+  - - [4288, 3584, 1, 3328]
+    - [44, 10417.3]
+  - - [2944, 64, 1, 256]
+    - [6, 3966.65]
+  - - [1024, 6784, 1, 3328]
+    - [44, 10171.3]
+  - - [1408, 1024, 1, 256]
+    - [44, 7927.38]
+  - - [448, 1024, 1, 256]
+    - [44, 5872.03]
+  - - [6784, 6784, 1, 3328]
+    - [46, 10535.5]
+  - - [1024, 448, 1, 1280]
+    - [32, 7050.94]
+  - - [704, 5056, 1, 3328]
+    - [44, 9853.75]
+  - - [256, 2368, 1, 1280]
+    - [21, 6749.71]
+  - - [3584, 5056, 1, 3328]
+    - [46, 10366.7]
+  - - [2368, 2944, 1, 3328]
+    - [44, 10203.7]
+  - - [448, 448, 1, 1280]
+    - [29, 5057.11]
+  - - [2368, 3584, 1, 256]
+    - [40, 9657.96]
+  - - [1024, 256, 1, 1280]
+    - [44, 5890.88]
+  - - [128, 5056, 1, 1280]
+    - [7, 8089.6]
+  - - [3584, 2368, 1, 1280]
+    - [44, 10126.1]
+  - - [1856, 1856, 1, 256]
+    - [46, 8875.33]
+  - - [4288, 1408, 1, 3328]
+    - [44, 9923.77]
+  - - [3584, 64, 1, 3328]
+    - [29, 6066.14]
+  - - [1, 1, 1, 1]
+    - [52, 9.12409e-05]
+  - - [256, 1024, 1, 3328]
+    - [32, 6210.27]
+  - - [1856, 64, 1, 3328]
+    - [12, 4644.19]
+  - - [5888, 1408, 1, 3328]
+    - [44, 10274.9]
+  - - [256, 5056, 1, 256]
+    - [40, 8185.52]
+  - - [1856, 64, 1, 1280]
+    - [37, 4359.05]
+  - - [1408, 256, 1, 256]
+    - [44, 4669.77]
+  - - [2368, 5056, 1, 256]
+    - [19, 9912.65]
+  - - [128, 5888, 1, 3328]
+    - [44, 8471.35]
+  - - [1024, 5056, 1, 256]
+    - [46, 9576.59]
+  - - [2368, 1408, 1, 3328]
+    - [44, 9902.24]
+  - - [5888, 448, 1, 256]
+    - [40, 8526.3]
+  - - [6784, 5056, 1, 1280]
+    - [44, 10451.5]
+  - - [4288, 6784, 1, 1280]
+    - [40, 10455.5]
+  - - [2368, 448, 1, 3328]
+    - [44, 7671.13]
+  - - [1024, 128, 1, 256]
+    - [13, 3355.44]
+  - - [448, 128, 1, 1280]
+    - [13, 2433.7]
+  - - [1024, 64, 1, 3328]
+    - [34, 2976.31]
+  - - [64, 3584, 1, 1280]
+    - [29, 5752.38]
+  - - [6784, 1408, 1, 256]
+    - [40, 9706.59]
+  - - [5888, 4288, 1, 256]
+    - [40, 9969.51]
+  - - [5056, 5888, 1, 256]
+    - [41, 10134.4]
+  - - [2368, 1024, 1, 256]
+    - [40, 8526.88]
+  - - [1856, 6784, 1, 1280]
+    - [40, 10169.0]
+  - - [3584, 128, 1, 1280]
+    - [26, 7161.01]
+  - - [128, 64, 1, 256]
+    - [3, 216.648]
+  - - [1408, 448, 1, 256]
+    - [44, 6098.21]
+  - - [64, 256, 1, 3328]
+    - [15, 794.382]
+  - - [6784, 448, 1, 3328]
+    - [44, 9745.05]
+  - - [5056, 1856, 1, 1280]
+    - [44, 10275.3]
+  - - [1408, 1024, 1, 3328]
+    - [44, 8838.59]
+  - - [2368, 256, 1, 3328]
+    - [21, 6914.81]
+  - - [5888, 3584, 1, 1280]
+    - [40, 10370.5]
+  - - [5888, 128, 1, 1280]
+    - [21, 8304.84]
+  - - [1024, 2944, 1, 256]
+    - [46, 8965.52]
+  - - [448, 6784, 1, 1280]
+    - [44, 9633.09]
+  - - [256, 3584, 1, 1280]
+    - [21, 7965.31]
+  - - [704, 5056, 1, 256]
+    - [19, 9163.49]
+  - - [3584, 1024, 1, 3328]
+    - [44, 10156.5]
+  - - [2944, 1856, 1, 1280]
+    - [44, 10115.1]
+  - - [5056, 256, 1, 256]
+    - [18, 8234.34]
+  - - [128, 5888, 1, 256]
+    - [1, 7199.18]
+  - - [2368, 3584, 1, 3328]
+    - [44, 10205.7]
+  - - [3584, 5888, 1, 3328]
+    - [44, 10445.7]
+  - - [2944, 3584, 1, 1280]
+    - [44, 10163.2]
+  - - [1856, 5888, 1, 1280]
+    - [44, 10268.4]
+  - - [256, 256, 1, 1280]
+    - [34, 2744.96]
+  - - [4288, 1408, 1, 256]
+    - [41, 9392.35]
+  - - [3584, 64, 1, 256]
+    - [23, 4475.63]
+  - - [64, 1856, 1, 3328]
+    - [12, 4639.83]
+  - - [1408, 128, 1, 256]
+    - [24, 3844.78]
+  - - [4288, 2368, 1, 1280]
+    - [44, 10265.6]
+  - - [2944, 5056, 1, 256]
+    - [40, 9919.14]
+  - - [256, 128, 1, 3328]
+    - [16, 1596.19]
+  - - [6784, 2368, 1, 256]
+    - [42, 9949.0]
+  - - [1408, 448, 1, 3328]
+    - [21, 7197.11]
+  - - [4288, 1856, 1, 256]
+    - [40, 9613.93]
+  - - [1856, 2944, 1, 256]
+    - [40, 9570.37]
+  - - [64, 5888, 1, 1280]
+    - [20, 6669.59]
+  - - [1856, 1408, 1, 1280]
+    - [44, 9819.66]
+  - - [128, 704, 1, 256]
+    - [9, 2383.13]
+  - - [1024, 4288, 1, 1280]
+    - [44, 9972.28]
+  - - [2368, 5056, 1, 3328]
+    - [44, 10382.1]
+  - - [4288, 1024, 1, 3328]
+    - [44, 10081.8]
+  - - [1024, 5056, 1, 3328]
+    - [44, 10156.0]
+  - - [1024, 1856, 1, 3328]
+    - [44, 8935.67]
+  - - [704, 704, 1, 1280]
+    - [21, 7602.93]
+  - - [128, 2368, 1, 1280]
+    - [6, 5957.82]
+  - - [3584, 256, 1, 1280]
+    - [21, 7978.3]
+  - - [5888, 64, 1, 1280]
+    - [25, 6978.37]
+  - - [128, 704, 1, 3328]
+    - [37, 3778.89]
+  - - [3584, 2944, 1, 3328]
+    - [44, 10245.7]
+  - - [128, 1856, 1, 256]
+    - [23, 4552.2]
+  - - [64, 4288, 1, 256]
+    - [5, 4412.98]
+  - - [5888, 2944, 1, 256]
+    - [40, 9861.3]
+  - - [5056, 128, 1, 1280]
+    - [7, 8083.28]
+  - - [448, 1856, 1, 3328]
+    - [21, 7386.28]
+  - - [5056, 4288, 1, 256]
+    - [40, 9982.24]
+  - - [1024, 448, 1, 256]
+    - [21, 5848.63]
+  - - [1024, 3584, 1, 256]
+    - [46, 9417.84]
+  - - [2944, 128, 1, 1280]
+    - [25, 6994.56]
+  - - [64, 256, 1, 256]
+    - [9, 480.998]
+  - - [704, 256, 1, 3328]
+    - [33, 4255.02]
+  - - [5056, 1408, 1, 256]
+    - [41, 9567.54]
+  - - [5888, 5888, 1, 1280]
+    - [44, 10410.0]
+  - - [448, 5888, 1, 1280]
+    - [44, 9092.04]
+  - - [1, 1, 1, 256]
+    - [53, 0.00688172]
+  - - [4288, 704, 1, 1280]
+    - [44, 9571.96]
+  - - [2944, 1408, 1, 256]
+    - [42, 9420.84]
+  - - [256, 2944, 1, 1280]
+    - [44, 8299.16]
+  - - [2368, 5888, 1, 3328]
+    - [44, 10318.3]
+  - - [704, 1024, 1, 3328]
+    - [21, 8122.79]
+  - - [2368, 1856, 1, 1280]
+    - [44, 9980.17]
+  - - [1856, 448, 1, 1280]
+    - [21, 7261.93]
+  - - [128, 6784, 1, 256]
+    - [7, 7255.16]
+  - - [5888, 4288, 1, 3328]
+    - [44, 10453.1]
+  - - [1856, 128, 1, 256]
+    - [4, 4663.91]
+  - - [5056, 448, 1, 256]
+    - [40, 8732.87]
+  - - [1856, 5056, 1, 1280]
+    - [44, 10268.3]
+  - - [2944, 1024, 1, 1280]
+    - [44, 9558.98]
+  - - [2368, 4288, 1, 256]
+    - [40, 9804.71]
+  - - [1024, 2368, 1, 3328]
+    - [44, 9252.72]
+  - - [4288, 64, 1, 3328]
+    - [27, 5657.29]
+  - - [704, 1408, 1, 256]
+    - [44, 7606.58]
+  - - [4288, 5888, 1, 3328]
+    - [44, 10451.0]
+  - - [448, 2944, 1, 1280]
+    - [44, 7966.27]
+  - - [1024, 2944, 1, 3328]
+    - [44, 9671.47]
+  - - [256, 6784, 1, 1280]
+    - [44, 9101.64]
+  - - [1856, 3584, 1, 256]
+    - [41, 9588.33]
+  - - [128, 448, 1, 3328]
+    - [9, 2609.97]
+  - - [1856, 256, 1, 256]
+    - [21, 6033.47]
+  - - [5056, 128, 1, 256]
+    - [7, 6949.45]
+  - - [256, 5888, 1, 1280]
+    - [44, 9087.15]
+  - - [6784, 128, 1, 1280]
+    - [25, 8143.98]
+  - - [64, 1408, 1, 256]
+    - [12, 2443.72]
+  - - [2944, 2368, 1, 256]
+    - [40, 9611.57]
+  - - [1856, 448, 1, 256]
+    - [44, 6489.66]
+  - - [1024, 1856, 1, 256]
+    - [22, 8163.41]
+  - - [6784, 3584, 1, 3328]
+    - [44, 10489.3]
+  - - [2944, 64, 1, 3328]
+    - [6, 5797.42]
+  - - [1024, 5888, 1, 3328]
+    - [44, 10324.8]
+  - - [1408, 2368, 1, 1280]
+    - [44, 9795.52]
+  - - [128, 1408, 1, 1280]
+    - [6, 5242.88]
+  - - [128, 1856, 1, 3328]
+    - [35, 6290.81]
+  - - [2944, 2944, 1, 256]
+    - [41, 9660.36]
+  - - [6784, 256, 1, 256]
+    - [40, 8307.1]
+  - - [128, 4288, 1, 1280]
+    - [4, 6975.24]
+  - - [5888, 1408, 1, 256]
+    - [46, 9778.49]
+  - - [128, 128, 1, 256]
+    - [8, 494.611]
+  - - [448, 704, 1, 3328]
+    - [21, 5075.57]
+  - - [448, 1856, 1, 256]
+    - [40, 6442.52]
+  - - [1856, 704, 1, 3328]
+    - [44, 9430.19]
+  - - [5888, 6784, 1, 3328]
+    - [44, 10508.0]
+  - - [704, 4288, 1, 1280]
+    - [44, 9571.96]
   - - [4096, 7000, 1, 4096]
-    - [138, 17060.9]
+    - [83, 17060.9]
   - - [5124, 9124, 1, 1760]
-    - [137, 17597.3]
+    - [82, 17597.3]
   - - [1760, 32, 1, 1760]
-    - [116, 2065.07]
+    - [61, 2065.07]
   - - [1024, 1500, 1, 1536]
-    - [130, 14247.0]
+    - [75, 14247.0]
   - - [512, 24000, 1, 2048]
-    - [140, 15569.1]
+    - [85, 15569.1]
   - - [3072, 24000, 1, 1024]
-    - [138, 17692.8]
+    - [83, 17692.8]
   - - [1024, 3000, 1, 2560]
-    - [138, 16608.2]
+    - [83, 16608.2]
   - - [512, 3136, 1, 2048]
-    - [149, 12702.2]
+    - [94, 12702.2]
   - - [7680, 4, 1, 2560]
-    - [116, 1128.63]
+    - [61, 1128.63]
   - - [64, 193600, 1, 64]
-    - [137, 13431.3]
+    - [82, 13431.3]
   - - [8448, 1500, 1, 2816]
-    - [137, 16834.1]
-  - - [784, 512, 64, 128]
-    - [151, 14218.0]
+    - [82, 16834.1]
   - - [2560, 7000, 1, 2560]
-    - [137, 17276.5]
+    - [82, 17276.5]
   - - [3072, 16, 1, 1024]
-    - [111, 1695.81]
+    - [56, 1695.81]
   - - [512, 48000, 1, 2048]
-    - [140, 15995.8]
+    - [85, 15995.8]
   - - [1760, 64, 1, 1760]
-    - [132, 4157.85]
+    - [77, 4157.85]
   - - [1024, 16, 1, 512]
-    - [113, 440.578]
+    - [58, 440.578]
   - - [196, 256, 64, 1024]
-    - [150, 8949.31]
+    - [95, 8949.31]
   - - [512, 48000, 1, 1536]
-    - [138, 17684.6]
+    - [83, 17684.6]
   - - [2560, 32, 1, 2560]
-    - [116, 3037.59]
+    - [61, 3037.59]
   - - [4608, 1500, 1, 1536]
-    - [138, 16508.3]
+    - [83, 16508.3]
   - - [2048, 128, 1, 2048]
-    - [135, 8473.34]
+    - [80, 8473.34]
   - - [1024, 24000, 1, 2560]
-    - [137, 17746.8]
+    - [82, 17746.8]
   - - [4608, 3000, 1, 1536]
-    - [138, 16899.3]
+    - [83, 16899.3]
   - - [5124, 9124, 1, 2048]
-    - [138, 16332.6]
+    - [83, 16332.6]
   - - [2048, 16, 1, 2048]
-    - [115, 1217.5]
+    - [60, 1217.5]
   - - [1024, 700, 1, 512]
-    - [129, 9400.66]
+    - [74, 9400.66]
   - - [3072, 1, 1, 128]
-    - [111, 57.8259]
+    - [56, 57.8259]
   - - [5124, 700, 1, 2560]
-    - [138, 14715.1]
+    - [83, 14715.1]
   - - [8448, 16, 1, 2816]
-    - [112, 4678.38]
+    - [57, 4678.38]
   - - [6144, 6000, 1, 2560]
-    - [131, 16507.6]
+    - [76, 16507.6]
   - - [4608, 32, 1, 1536]
-    - [111, 5128.9]
+    - [56, 5128.9]
   - - [3072, 64, 1, 1024]
-    - [127, 6403.52]
+    - [72, 6403.52]
   - - [512, 16, 1, 512]
-    - [113, 220.289]
+    - [58, 220.289]
   - - [7680, 2, 1, 2560]
-    - [116, 566.267]
+    - [61, 566.267]
   - - [4224, 1, 1, 128]
-    - [111, 78.586]
+    - [56, 78.586]
   - - [7680, 1, 1, 2560]
-    - [116, 283.46]
+    - [61, 283.46]
   - - [128, 1500, 1, 1280]
-    - [111, 6536.17]
+    - [56, 6536.17]
   - - [1024, 1500, 1, 2816]
-    - [130, 14522.5]
+    - [75, 14522.5]
   - - [6144, 2, 1, 2560]
-    - [116, 450.419]
+    - [61, 450.419]
   - - [8448, 48000, 1, 2816]
-    - [138, 15518.5]
+    - [83, 15518.5]
   - - [512, 6000, 1, 2048]
-    - [142, 12121.3]
+    - [87, 12121.3]
   - - [4224, 1500, 1, 176]
-    - [123, 14023.3]
+    - [68, 14023.3]
   - - [1024, 6000, 1, 2816]
-    - [137, 17591.4]
+    - [82, 17591.4]
   - - [1024, 48000, 1, 1536]
-    - [138, 18080.3]
+    - [83, 18080.3]
   - - [1024, 48000, 1, 2560]
-    - [137, 18254.9]
+    - [82, 18254.9]
   - - [4096, 32, 1, 4096]
-    - [117, 4827.98]
+    - [62, 4827.98]
   - - [512, 16, 1, 500000]
-    - [113, 330.658]
+    - [58, 330.658]
   - - [2560, 128, 1, 2560]
-    - [132, 8673.08]
+    - [77, 8673.08]
   - - [4608, 24000, 1, 1536]
-    - [137, 18298.6]
+    - [82, 18298.6]
   - - [512, 2, 1, 500000]
-    - [113, 41.3314]
+    - [58, 41.3314]
   - - [7680, 48000, 1, 2560]
-    - [138, 15645.3]
+    - [83, 15645.3]
   - - [3072, 48000, 1, 1024]
-    - [138, 17986.4]
+    - [83, 17986.4]
   - - [1760, 16, 1, 1760]
-    - [111, 1035.99]
+    - [56, 1035.99]
   - - [1024, 1500, 1, 2048]
-    - [134, 11136.1]
+    - [79, 11136.1]
   - - [1024, 16, 1, 500000]
-    - [113, 661.008]
+    - [58, 661.008]
   - - [64, 193600, 1, 256]
-    - [143, 15677.8]
+    - [88, 15677.8]
   - - [1024, 3000, 1, 2048]
-    - [139, 12173.9]
+    - [84, 12173.9]
   - - [6144, 4, 1, 2560]
-    - [116, 904.985]
+    - [61, 904.985]
   - - [1024, 6000, 1, 2048]
-    - [140, 14556.8]
+    - [85, 14556.8]
   - - [512, 24000, 1, 2816]
-    - [137, 17783.8]
+    - [82, 17783.8]
   - - [6144, 48000, 1, 2560]
-    - [140, 14434.6]
+    - [85, 14434.6]
   - - [1760, 7000, 1, 1760]
-    - [124, 16687.6]
+    - [69, 16687.6]
   - - [8448, 3000, 1, 2816]
-    - [137, 17630.2]
+    - [82, 17630.2]
   - - [3072, 4, 1, 1024]
-    - [111, 423.953]
+    - [56, 423.953]
   - - [4608, 48000, 1, 1536]
-    - [137, 18437.1]
+    - [82, 18437.1]
   - - [2048, 32, 1, 2048]
-    - [136, 2407.06]
+    - [81, 2407.06]
   - - [7680, 1500, 1, 2560]
-    - [138, 16260.4]
+    - [83, 16260.4]
   - - [4096, 128, 1, 4096]
-    - [128, 11511.0]
+    - [73, 11511.0]
   - - [4608, 16, 1, 1536]
-    - [116, 2655.87]
+    - [61, 2655.87]
   - - [512, 3000, 1, 1536]
-    - [130, 14260.7]
+    - [75, 14260.7]
   - - [3072, 2, 1, 1024]
-    - [111, 214.872]
+    - [56, 214.872]
   - - [8448, 1, 1, 2816]
-    - [112, 289.834]
+    - [57, 289.834]
   - - [1024, 3000, 1, 2816]
-    - [137, 17002.3]
+    - [82, 17002.3]
   - - [128, 1, 1, 1408]
-    - [111, 4.75274]
+    - [56, 4.75274]
   - - [64, 1, 1, 1216]
-    - [113, 2.11939]
+    - [58, 2.11939]
   - - [1024, 2, 1, 512]
-    - [113, 55.0723]
+    - [58, 55.0723]
   - - [1024, 4, 1, 500000]
-    - [113, 165.084]
+    - [58, 165.084]
   - - [6144, 1, 1, 2560]
-    - [116, 226.768]
+    - [61, 226.768]
   - - [5124, 9124, 1, 2560]
-    - [138, 17113.5]
+    - [83, 17113.5]
   - - [512, 48000, 1, 2816]
-    - [137, 18060.4]
+    - [82, 18060.4]
   - - [512, 3000, 1, 2816]
-    - [130, 14530.3]
+    - [75, 14530.3]
   - - [1024, 24000, 1, 1536]
-    - [138, 17629.1]
+    - [83, 17629.1]
   - - [7680, 6000, 1, 2560]
-    - [137, 17726.0]
+    - [82, 17726.0]
   - - [1760, 128, 1, 1760]
-    - [135, 7497.97]
+    - [80, 7497.97]
   - - [512, 1500, 1, 2816]
-    - [129, 11273.4]
+    - [74, 11273.4]
   - - [512, 1, 1, 512]
-    - [118, 16.1419]
+    - [63, 16.1419]
   - - [512, 6000, 1, 2560]
-    - [138, 16656.0]
+    - [83, 16656.0]
   - - [512, 8, 1, 500000]
-    - [113, 165.328]
+    - [58, 165.328]
   - - [512, 24000, 1, 2560]
-    - [138, 17561.4]
+    - [83, 17561.4]
   - - [6144, 3000, 1, 2560]
-    - [140, 16106.6]
+    - [85, 16106.6]
   - - [1024, 24000, 1, 2816]
-    - [137, 18138.0]
+    - [82, 18138.0]
   - - [2048, 7000, 1, 2048]
-    - [140, 15826.5]
+    - [85, 15826.5]
   - - [7680, 3000, 1, 2560]
-    - [131, 16179.8]
+    - [76, 16179.8]
   - - [1024, 4, 1, 512]
-    - [113, 110.609]
+    - [58, 110.609]
   - - [5124, 700, 1, 2048]
-    - [140, 13074.5]
+    - [85, 13074.5]
   - - [5124, 9124, 1, 4096]
-    - [131, 15808.6]
+    - [76, 15808.6]
   - - [4096, 64, 1, 4096]
-    - [136, 8409.63]
+    - [81, 8409.63]
   - - [256, 193600, 1, 64]
-    - [120, 14460.0]
+    - [65, 14460.0]
   - - [7680, 32, 1, 2560]
-    - [119, 8501.97]
+    - [64, 8501.97]
   - - [2560, 64, 1, 2560]
-    - [127, 5877.67]
-  - - [3136, 2048, 1, 512]
-    - [152, 15303.1]
+    - [72, 5877.67]
   - - [3072, 128, 1, 1024]
-    - [132, 9514.49]
+    - [77, 9514.49]
   - - [8448, 6000, 1, 2816]
-    - [138, 17792.5]
+    - [83, 17792.5]
   - - [7680, 64, 1, 2560]
-    - [113, 11163.0]
+    - [58, 11163.0]
   - - [5124, 1500, 1, 2560]
-    - [138, 16136.5]
+    - [83, 16136.5]
   - - [1024, 1500, 1, 2560]
-    - [130, 14448.0]
+    - [75, 14448.0]
   - - [512, 4, 1, 512]
-    - [118, 64.251]
+    - [63, 64.251]
   - - [1024, 6000, 1, 2560]
-    - [138, 17205.6]
+    - [83, 17205.6]
   - - [3072, 32, 1, 1024]
-    - [136, 3364.41]
+    - [81, 3364.41]
   - - [6144, 32, 1, 2560]
-    - [127, 6883.43]
-  - - [3136, 512, 1, 2048]
-    - [150, 9484.12]
+    - [72, 6883.43]
   - - [196, 1024, 64, 256]
-    - [153, 12380.8]
+    - [98, 12380.8]
   - - [512, 50176, 1, 128]
-    - [145, 15888.7]
+    - [90, 15888.7]
   - - [4608, 1, 1, 1536]
-    - [116, 165.681]
+    - [61, 165.681]
   - - [1024, 32, 1, 512]
-    - [113, 907.858]
+    - [58, 907.858]
   - - [7680, 24000, 1, 2560]
-    - [138, 17224.8]
+    - [83, 17224.8]
   - - [8448, 4, 1, 2816]
-    - [116, 1155.96]
+    - [61, 1155.96]
   - - [512, 1, 1, 500000]
-    - [113, 20.6657]
+    - [58, 20.6657]
   - - [176, 1500, 1, 1408]
-    - [113, 6743.69]
+    - [58, 6743.69]
   - - [512, 3000, 1, 2560]
-    - [130, 14469.2]
+    - [75, 14469.2]
   - - [8448, 24000, 1, 2816]
-    - [138, 14526.0]
+    - [83, 14526.0]
   - - [4608, 2, 1, 1536]
-    - [116, 329.511]
+    - [61, 329.511]
   - - [512, 6000, 1, 1536]
-    - [138, 16415.9]
+    - [83, 16415.9]
   - - [7680, 128, 1, 2560]
-    - [121, 13827.4]
+    - [66, 13827.4]
   - - [3072, 6000, 1, 1024]
-    - [138, 16775.4]
+    - [83, 16775.4]
   - - [3072, 1500, 1, 128]
-    - [137, 12889.5]
+    - [82, 12889.5]
   - - [2048, 3136, 1, 512]
-    - [147, 15706.6]
+    - [92, 15706.6]
   - - [1024, 3000, 1, 1536]
-    - [138, 16365.8]
+    - [83, 16365.8]
   - - [512, 4, 1, 500000]
-    - [113, 82.6644]
+    - [58, 82.6644]
   - - [512, 6000, 1, 2816]
-    - [138, 16718.4]
+    - [83, 16718.4]
   - - [128, 50176, 1, 512]
-    - [144, 15938.0]
+    - [89, 15938.0]
   - - [256, 12544, 1, 1024]
-    - [148, 14000.1]
+    - [93, 14000.1]
   - - [1024, 12544, 1, 256]
-    - [146, 16382.7]
+    - [91, 16382.7]
   - - [512, 48000, 1, 2560]
-    - [138, 17747.2]
+    - [83, 17747.2]
   - - [2560, 16, 1, 2560]
-    - [111, 1534.8]
+    - [56, 1534.8]
   - - [2048, 64, 1, 2048]
-    - [136, 4719.33]
+    - [81, 4719.33]
   - - [512, 2, 1, 512]
-    - [118, 32.1255]
+    - [63, 32.1255]
   - - [1024, 1, 1, 512]
-    - [113, 27.5361]
+    - [58, 27.5361]
   - - [512, 1500, 1, 2560]
-    - [129, 11050.4]
+    - [74, 11050.4]
   - - [512, 24000, 1, 1536]
-    - [138, 17469.8]
+    - [83, 17469.8]
   - - [1024, 1, 1, 500000]
-    - [113, 41.1425]
+    - [58, 41.1425]
   - - [6144, 16, 1, 2560]
-    - [116, 3615.78]
+    - [61, 3615.78]
   - - [1024, 24000, 1, 2048]
-    - [140, 15988.1]
+    - [85, 15988.1]
   - - [4096, 16, 1, 4096]
-    - [117, 2507.81]
+    - [62, 2507.81]
   - - [512, 32, 1, 512]
-    - [113, 455.903]
+    - [58, 455.903]
   - - [5124, 1500, 1, 2048]
-    - [140, 14375.8]
+    - [85, 14375.8]
   - - [3072, 1500, 1, 1024]
-    - [130, 14683.2]
+    - [75, 14683.2]
   - - [1024, 2, 1, 500000]
-    - [113, 82.5046]
+    - [58, 82.5046]
   - - [1024, 8, 1, 500000]
-    - [113, 330.528]
+    - [58, 330.528]
   - - [7680, 16, 1, 2560]
-    - [116, 4514.54]
+    - [61, 4514.54]
   - - [6144, 1500, 1, 2560]
-    - [138, 16981.2]
+    - [83, 16981.2]
   - - [3072, 1, 1, 1024]
-    - [111, 107.143]
+    - [56, 107.143]
   - - [1024, 48000, 1, 2816]
-    - [137, 18584.6]
+    - [82, 18584.6]
   - - [8448, 2, 1, 2816]
-    - [116, 579.103]
+    - [61, 579.103]
   - - [4608, 4, 1, 1536]
-    - [116, 659.021]
+    - [61, 659.021]
   - - [1024, 6000, 1, 1536]
-    - [138, 17098.8]
+    - [83, 17098.8]
   - - [8448, 32, 1, 2816]
-    - [113, 7214.43]
+    - [58, 7214.43]
   - - [512, 3000, 1, 2048]
-    - [140, 11148.7]
+    - [85, 11148.7]
   - - [6144, 24000, 1, 2560]
-    - [140, 15954.4]
+    - [85, 15954.4]
   - - [4608, 6000, 1, 1536]
-    - [138, 17669.4]
+    - [83, 17669.4]
   - - [1024, 1024, 1, 1024]
-    - [140, 13068.9]
+    - [85, 13068.9]
   - - [512, 1500, 1, 2048]
-    - [140, 9265.22]
+    - [85, 9265.22]
   - - [512, 1500, 1, 1536]
-    - [129, 10818.5]
+    - [74, 10818.5]
   - - [128, 1, 1, 1024]
-    - [111, 4.64136]
+    - [56, 4.64136]
   - - [3072, 3000, 1, 1024]
-    - [140, 15741.2]
+    - [85, 15741.2]
   - - [1024, 48000, 1, 2048]
-    - [138, 16800.7]
+    - [83, 16800.7]
+  - - [3136, 64, 128, 64]
+    - [143, 15223.8]
+  - - [784, 512, 64, 128]
+    - [136, 18907.2]
+  - - [3136, 256, 64, 64]
+    - [143, 18012.3]
+  - - [12544, 1024, 1, 256]
+    - [139, 20780.7]
+  - - [784, 128, 128, 512]
+    - [138, 19837.9]
+  - - [784, 512, 256, 128]
+    - [142, 18471.7]
+  - - [3136, 64, 64, 256]
+    - [140, 19306.8]
+  - - [3136, 512, 1, 2048]
+    - [141, 15558.0]
+  - - [12544, 256, 1, 1024]
+    - [144, 17648.9]
+  - - [3136, 2048, 1, 512]
+    - [137, 19499.1]
+  - - [3136, 256, 256, 64]
+    - [146, 18095.6]
+  - - [3136, 64, 128, 256]
+    - [137, 19910.0]
+  - - [784, 128, 64, 512]
+    - [138, 19325.0]
+  - - [3136, 64, 256, 64]
+    - [143, 15429.5]
+  - - [784, 512, 128, 128]
+    - [136, 19136.0]
+  - - [3136, 64, 64, 64]
+    - [145, 14680.1]
+  - - [784, 128, 256, 512]
+    - [138, 20166.4]
+  - - [3136, 64, 256, 256]
+    - [140, 20048.3]
+  - - [3136, 256, 128, 64]
+    - [135, 18309.2]
 - null

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HBH.yaml
@@ -43,155 +43,7 @@
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 64
-    LSPA: 32
-    LSPB: 4
-    LVCA: 2
-    LVCB: 16
-    LVPA: 8
-    LVPB: 1
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 64
-    MacroTileA: 32
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 0
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x064x08_PGR1_PLR1_TT04_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id001 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id003 [8, 8, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -206,302 +58,6 @@
     ExpandPointerSwap: true
     FractionalLoad: 0
     GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 32
-    LSPA: 16
-    LSPB: 8
-    LVCA: 8
-    LVCB: 16
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 896
-    LdsNumElementsAlignedA: 128
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 128
-    LdsOffsetB_Blk: 640
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 16
-    MacroTile1: 32
-    MacroTileA: 16
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 1
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x032x08_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id005 [2, 2]
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id006 [8, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 64
-    LSPA: 32
-    LSPB: 8
-    LVCA: 8
-    LVCB: 32
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 64
-    MacroTileA: 32
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 2
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x064x08_PGR1_PLR1_TT02_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id004 [2, 4]
-    ThreadTile0: 2
-    ThreadTile1: 4
-    ThreadTileA: 2
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id002 [16, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
     GlobalLoadVectorWidthB: 4
     GlobalRead2A: true
     GlobalRead2B: true
@@ -520,19 +76,19 @@
     KernelLanguage: Assembly
     LSCA: 8
     LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
+    LSPA: 16
+    LSPB: 4
+    LVCA: 8
     LVCB: 32
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
+    LVPA: 16
+    LVPB: 1
+    LdsNumElements: 3200
+    LdsNumElementsAlignedA: 128
     LdsNumElementsAlignedB: 1024
     LdsOffsetA: 0
     LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
+    LdsOffsetB: 128
+    LdsOffsetB_Blk: 2176
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -546,9 +102,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 64
+    MacroTile0: 16
     MacroTile1: 128
-    MacroTileA: 64
+    MacroTileA: 16
     MacroTileB: 128
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -557,15 +113,20 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 4
     NumLoadsA: 1
-    NumLoadsB: 1
+    NumLoadsB: 2
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -609,33 +170,41 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 3
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id001
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x128x08_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 4
+    SubGroup1: 32
+    SubGroupA: 4
+    SubGroupB: 32
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
-    ThreadTile1: 8
+    ThreadTile1: 4
     ThreadTileA: 4
-    ThreadTileB: 8
+    ThreadTileB: 4
     UnrollMemFence: false
     UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id002
+    WorkGroup: [4, 32, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -649,38 +218,38 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
     GlobalReadCoalesceGroupA: true
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
+    GlobalReadVectorWidth: 2
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
     GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 8
-    LSCB: 64
-    LSPA: 32
-    LSPB: 4
-    LVCA: 2
-    LVCB: 16
+    LSCB: 16
+    LSPA: 16
+    LSPB: 8
+    LVCA: 4
+    LVCB: 8
     LVPA: 8
-    LVPB: 1
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
+    LVPB: 4
+    LdsNumElements: 819
+    LdsNumElementsAlignedA: 128
+    LdsNumElementsAlignedB: 128
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
+    LdsOffsetA_Blk: 256
+    LdsOffsetB: 128
+    LdsOffsetB_Blk: 384
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -694,10 +263,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 64
-    MacroTileA: 32
-    MacroTileB: 64
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -705,15 +274,20 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 2
     NumLoadsA: 1
-    NumLoadsB: 2
+    NumLoadsB: 1
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
+    NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -757,33 +331,41 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 4
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x064x08_PGR1_PLR1_TT04_08
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x016x08_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id001
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
     UnrollMemFence: false
     UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 2
     VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id003
-    WorkGroupMapping: -4
+    VectorWidth: 2
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: -1
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -810,7 +392,7 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 8
-    GuaranteeNoPartialA: false
+    GuaranteeNoPartialA: true
     GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
@@ -862,6 +444,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -905,13 +492,20 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 5
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT08_08
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
+    SuppressNoLoadLoop: true
     ThreadTile: [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
@@ -923,459 +517,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id003
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: -4
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 64
-    LSPA: 32
-    LSPB: 8
-    LVCA: 8
-    LVCB: 32
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 64
-    MacroTileA: 32
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 6
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x064x08_PGR1_PLR1_TT02_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 4
-    ThreadTileA: 2
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id002
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 7
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id001
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id002
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 16
-    LSPA: 8
-    LSPB: 8
-    LVCA: 8
-    LVCB: 8
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 8
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x016x16_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id003
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -1408,160 +559,12 @@
     KernelLanguage: Assembly
     LSCA: 16
     LSCB: 32
-    LSPA: 8
-    LSPB: 4
+    LSPA: 32
+    LSPB: 16
     LVCA: 8
     LVCB: 16
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 32
-    MacroTileA: 16
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 9
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x032x16_PGR1_PLR1_TT02_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 4
-    ThreadTileA: 2
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id003
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 32
-    LSPA: 16
-    LSPB: 8
-    LVCA: 4
-    LVCB: 8
-    LVPA: 4
-    LVPB: 2
+    LVPA: 16
+    LVPB: 8
     LdsNumElements: 2048
     LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
@@ -1593,748 +596,8 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 10
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id008 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id003
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 32
-    LSPA: 16
-    LSPB: 8
-    LVCA: 8
-    LVCB: 16
-    LVPA: 8
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 32
-    MacroTileA: 16
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
     NumElementsPerThread: 4
     NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 11
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x032x16_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id006
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 16
-    LSPB: 4
-    LVCA: 8
-    LVCB: 32
-    LVPA: 8
-    LVPB: 2
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 2304
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 64
-    MacroTileA: 16
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 4
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 12
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x064x16_PGR1_PLR1_TT02_04
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 4
-    ThreadTileA: 2
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id006
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 16
-    LSPB: 8
-    LVCA: 16
-    LVCB: 32
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 2304
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 64
-    MacroTileA: 16
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 13
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x064x16_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id007 [8, 32, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 128
-    LSPA: 16
-    LSPB: 4
-    LVCA: 16
-    LVCB: 64
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 6400
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 4352
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 128
-    MacroTileA: 16
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 14
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x128x16_PGR1_PLR1_TT02_04
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 4
-    ThreadTileA: 2
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id007
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 64
-    LSPB: 16
-    LVCA: 4
-    LVCB: 16
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
     NumLoadsA: 1
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
@@ -2342,6 +605,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -2385,458 +653,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 15
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x032x16_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id008
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id002
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 16
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id001
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id002
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 16
-    LSPB: 4
-    LVCA: 8
-    LVCB: 32
-    LVPA: 8
-    LVPB: 2
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 2304
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 64
-    MacroTileA: 16
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 4
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 17
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x064x16_PGR1_PLR1_TT02_04
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 4
-    ThreadTileA: 2
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id006
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 16
-    LSPB: 8
-    LVCA: 16
-    LVCB: 32
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 2304
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 16
-    MacroTile1: 64
-    MacroTileA: 16
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 18
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x064x16_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -2847,1199 +678,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id007
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 64
-    LSPB: 16
-    LVCA: 4
-    LVCB: 16
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 19
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id008
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id002
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 128
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 20
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id001
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id002
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 16
-    LSPA: 16
-    LSPB: 8
-    LVCA: 4
-    LVCB: 8
-    LVPA: 8
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 3
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 3
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 21
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x016x24_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id003
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
     AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 32
-    LSPA: 16
-    LSPB: 4
-    LVCA: 4
-    LVCB: 16
-    LVPA: 8
-    LVPB: 2
-    LdsNumElements: 3200
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 2432
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 16
-    MacroTile1: 32
-    MacroTileA: 16
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 8
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 3
-    NumLoadsB: 6
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 6
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 22
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x032x24_PGR1_PLR1_TT02_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id004
-    ThreadTile0: 2
-    ThreadTile1: 4
-    ThreadTileA: 2
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id003
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 32
-    LSPA: 32
-    LSPB: 8
-    LVCA: 2
-    LVCB: 8
-    LVPA: 8
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 3
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 3
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 23
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x032x24_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id008
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id003
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 16
-    LSPA: 16
-    LSPB: 8
-    LVCA: 4
-    LVCB: 8
-    LVPA: 8
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 16
-    MacroTile1: 16
-    MacroTileA: 16
-    MacroTileB: 16
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 3
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 3
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 24
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x016x24_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id003
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 32
-    LSPA: 32
-    LSPB: 8
-    LVCA: 2
-    LVCB: 8
-    LVPA: 8
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 3
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 3
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 25
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x032x24_PGR1_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id008
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id003
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 64
-    LSPA: 8
-    LSPB: 4
-    LVCA: 16
-    LVCB: 32
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 6400
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 4352
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 8
-    MacroTile1: 64
-    MacroTileA: 8
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 8
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 26
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT008x064x32_PGR1_PLR1_TT02_02
-    SubGroup0: 4
-    SubGroup1: 32
-    SubGroupA: 4
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id009 [4, 32, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
@@ -4118,6 +766,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 4
     NumThreads: 64
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -4161,14 +814,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 27
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 4
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x016x32_PGR1_PLR1_TT02_02
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 8
     SubGroup1: 8
     SubGroupA: 8
     SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
+    SuppressNoLoadLoop: true
+    ThreadTile: [2, 2]
     ThreadTile0: 2
     ThreadTile1: 2
     ThreadTileA: 2
@@ -4179,2219 +839,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id003
+    WorkGroup: [8, 8, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 32
-    LSPA: 8
-    LSPB: 8
-    LVCA: 16
-    LVCB: 16
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 16
-    MacroTile1: 32
-    MacroTileA: 16
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 28
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x032x32_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id006
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 64
-    LSPA: 16
-    LSPB: 8
-    LVCA: 16
-    LVCB: 32
-    LVPA: 8
-    LVPB: 4
-    LdsNumElements: 6656
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 4608
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 16
-    MacroTile1: 64
-    MacroTileA: 16
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 29
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x064x32_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id007
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 64
-    LSPA: 8
-    LSPB: 4
-    LVCA: 16
-    LVCB: 32
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 6400
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 4352
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 8
-    MacroTile1: 64
-    MacroTileA: 8
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 8
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 30
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT008x064x32_PGR1_PLR1_TT02_02
-    SubGroup0: 4
-    SubGroup1: 32
-    SubGroupA: 4
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id009
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 32
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 64
-    LSPA: 16
-    LSPB: 8
-    LVCA: 16
-    LVCB: 32
-    LVPA: 8
-    LVPB: 4
-    LdsNumElements: 6656
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 4608
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 32
-    MacroTile0: 16
-    MacroTile1: 64
-    MacroTileA: 16
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 1
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 31
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x064x32_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id007
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 32
-    LVCB: 32
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 12800
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 8704
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 8
-    MacroTile1: 64
-    MacroTileA: 8
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 16
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 32
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT008x064x64_PGR1_PLR1_TT02_02
-    SubGroup0: 4
-    SubGroup1: 32
-    SubGroupA: 4
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id009
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 13312
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 9216
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 16
-    MacroTile1: 64
-    MacroTileA: 16
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 8
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 33
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT016x064x64_PGR1_PLR1_TT02_02
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id007
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 64
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 32
-    LVCB: 32
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 12800
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 4096
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 8192
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 8704
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 64
-    MacroTile0: 8
-    MacroTile1: 64
-    MacroTileA: 8
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 4
-    NumGlobalWriteVectorsPerThread: 2
-    NumLoadsA: 2
-    NumLoadsB: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 16
-    NumThreads: 128
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 34
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT008x064x64_PGR1_PLR1_TT02_02
-    SubGroup0: 4
-    SubGroup1: 32
-    SubGroupA: 4
-    SubGroupB: 32
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id005
-    ThreadTile0: 2
-    ThreadTile1: 2
-    ThreadTileA: 2
-    ThreadTileB: 2
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id009
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 64
-    LSPA: 16
-    LSPB: 2
-    LVCA: 4
-    LVCB: 32
-    LVPA: 8
-    LVPB: 1
-    LdsNumElements: 1920
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 48
-    MacroTile1: 64
-    MacroTileA: 48
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 48
-    NumGlobalWriteVectorsPerThread: 24
-    NumLoadsA: 3
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 3
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 35
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT048x064x08_PGR1_PLR1_TT06_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id010 [6, 8]
-    ThreadTile0: 6
-    ThreadTile1: 8
-    ThreadTileA: 6
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id011 [8, 8, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 64
-    LSPA: 16
-    LSPB: 2
-    LVCA: 4
-    LVCB: 32
-    LVPA: 8
-    LVPB: 1
-    LdsNumElements: 1920
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 48
-    MacroTile1: 64
-    MacroTileA: 48
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 48
-    NumGlobalWriteVectorsPerThread: 24
-    NumLoadsA: 3
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 3
-    NumLoadsPerpendicularB: 4
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 36
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT048x064x08_PGR1_PLR1_TT06_08
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id010
-    ThreadTile0: 6
-    ThreadTile1: 8
-    ThreadTileA: 6
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id011
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 64
-    LSPB: 16
-    LVCA: 4
-    LVCB: 16
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 37
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id013 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: &id012 [16, 16, 1]
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 64
-    LSPB: 16
-    LVCA: 4
-    LVCB: 16
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 38
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT128x064x16_PGR1_PLR1_TT08_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: &id014 [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id012
-    WorkGroupMapping: -1
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 64
-    LSPB: 16
-    LVCA: 4
-    LVCB: 16
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 39
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id013
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id012
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 16
-    LSCB: 64
-    LSPA: 64
-    LSPB: 16
-    LVCA: 4
-    LVCB: 16
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 2048
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 2048
-    LdsOffsetB_Blk: 6144
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 40
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT128x064x16_PGR1_PLR1_TT08_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: true
-    ThreadTile: *id014
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id012
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 24
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: 0
-    GlobalLoadVectorWidthA: 4
-    GlobalLoadVectorWidthB: 4
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 4
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 4
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 8
-    LSCB: 32
-    LSPA: 32
-    LSPB: 8
-    LVCA: 2
-    LVCB: 8
-    LVPA: 8
-    LVPB: 2
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 768
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 24
-    MacroTile0: 32
-    MacroTile1: 32
-    MacroTileA: 32
-    MacroTileB: 32
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 4
-    NumLoadsA: 3
-    NumLoadsB: 3
-    NumLoadsCoalescedA: 3
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 3
-    NumThreads: 64
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 41
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT032x032x24_PGR0_PLR1_TT04_04
-    SubGroup0: 8
-    SubGroup1: 8
-    SubGroupA: 8
-    SubGroupB: 8
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id013
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: false
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 4
-    WorkGroup: *id011
-    WorkGroupMapping: -4
-    WorkGroupMappingType: B
+    _staggerStrideShift: 2
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
+    AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 4
-    LVCA: 4
-    LVCB: 64
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 42
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id017 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: &id015 [16, 16, 1]
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -6413,11 +870,11 @@
     GlobalReadCoalesceGroupB: true
     GlobalReadCoalesceVectorA: true
     GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
+    GlobalReadVectorWidth: 1
     GlobalSplitU: 1
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
+    GlobalWriteVectorWidth: 1
     GuaranteeNoPartialA: true
     GuaranteeNoPartialB: true
     InnerUnroll: 1
@@ -6458,7 +915,7 @@
     NonTemporalB: 0
     NonTemporalC: 0
     NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsA: 1
     NumLoadsB: 1
     NumLoadsCoalescedA: 1
@@ -6466,6 +923,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -6509,2354 +971,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 43
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 5
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id016 [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 64
-    LSPA: 64
-    LSPB: 4
-    LVCA: 4
-    LVCB: 64
-    LVPA: 64
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 44
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 128
-    LSPB: 4
-    LVCA: 2
-    LVCB: 64
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 45
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 4
-    LVCA: 4
-    LVCB: 64
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 46
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x04_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id017
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 64
-    LSPB: 4
-    LVCA: 4
-    LVCB: 64
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 47
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x08_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id017
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 64
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 48
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 64
-    LSPB: 4
-    LVCA: 4
-    LVCB: 64
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 49
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x08_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id017
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 64
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 50
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 64
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 51
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 64
-    LSPA: 64
-    LSPB: 8
-    LVCA: 4
-    LVCB: 32
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 52
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 128
-    LSPA: 32
-    LSPB: 4
-    LVCA: 8
-    LVCB: 64
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 53
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x16_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id017
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 64
-    LSPA: 32
-    LSPB: 8
-    LVCA: 8
-    LVCB: 32
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 54
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR1_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 128
-    LSPA: 32
-    LSPB: 4
-    LVCA: 8
-    LVCB: 64
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 7168
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 2048
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 4096
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 5120
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 55
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x16_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id017
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 2
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: false
-    GuaranteeNoPartialB: false
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 64
-    LSPA: 32
-    LSPB: 8
-    LVCA: 8
-    LVCB: 32
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 56
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id016
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: *id015
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 2
-    LVCA: 4
-    LVCB: 128
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 57
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT128x128x04_PGR0_PLR0_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id021 [8, 8]
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: &id018 [16, 16, 1]
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 2
-    LVCA: 4
-    LVCB: 128
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 58
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x04_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id019 [4, 8]
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 64
-    LSPA: 64
-    LSPB: 4
-    LVCA: 4
-    LVCB: 64
-    LVPA: 64
-    LVPB: 4
-    LdsNumElements: 819
-    LdsOffsetA: 0
-    LdsOffsetB: 256
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 1
-    NumLoadsB: 1
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 59
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x04_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: &id020 [4, 4]
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -8867,163 +996,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 5
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 2
-    LVCA: 4
-    LVCB: 128
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 60
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x04_PGR1_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -9102,6 +1084,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -9145,14 +1132,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 61
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 6
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x04_PGR1_PLR0_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -9163,15 +1157,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 5
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -9246,6 +1241,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 2
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -9289,14 +1289,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 62
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 7
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x04_PGR0_PLR1_TT04_08
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -9307,15 +1314,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 5
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -9390,6 +1398,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -9433,14 +1446,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 63
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 8
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x04_PGR0_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -9451,311 +1471,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 5
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 2
-    LVCA: 4
-    LVCB: 128
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 64
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT128x128x04_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id021
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 4
-    LSCB: 128
-    LSPA: 64
-    LSPB: 2
-    LVCA: 4
-    LVCB: 128
-    LVPA: 64
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 1
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 65
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x04_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -9834,6 +1559,11 @@
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -9877,14 +1607,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 66
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 9
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x04_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -9895,159 +1632,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 5
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 32
-    LSPB: 2
-    LVCA: 8
-    LVCB: 128
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 67
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x08_PGR0_PLR0_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -10122,6 +1716,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -10165,14 +1764,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 68
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 10
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR0_PLR0_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -10183,15 +1789,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -10270,6 +1877,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -10313,14 +1925,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 69
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 11
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR1_PLR0_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -10331,599 +1950,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 32
-    LSPB: 2
-    LVCA: 8
-    LVCB: 128
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 1536
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 70
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x08_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 64
-    LSPA: 32
-    LSPB: 4
-    LVCA: 8
-    LVCB: 64
-    LVPA: 32
-    LVPB: 4
-    LdsNumElements: 1024
-    LdsOffsetA: 0
-    LdsOffsetB: 512
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 2
-    NumLoadsB: 2
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 71
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 32
-    LSPB: 2
-    LVCA: 8
-    LVCB: 128
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 64
-    NumGlobalWriteVectorsPerThread: 64
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 72
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT128x128x08_PGR1_PLR1_TT08_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id021
-    ThreadTile0: 8
-    ThreadTile1: 8
-    ThreadTileA: 8
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 8
-    LSCB: 128
-    LSPA: 32
-    LSPB: 2
-    LVCA: 8
-    LVCB: 128
-    LVPA: 32
-    LVPB: 2
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 2
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 73
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x08_PGR1_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -11002,6 +2038,11 @@
     NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 2
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -11045,14 +2086,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 74
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 12
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x08_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -11063,447 +2111,16 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 4
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 1
     AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 0
     AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 64
-    LSPA: 16
-    LSPB: 4
-    LVCA: 16
-    LVCB: 64
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 75
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR0_PLR0_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 128
-    LSPA: 16
-    LSPB: 2
-    LVCA: 16
-    LVCB: 128
-    LVPA: 16
-    LVPB: 2
-    LdsNumElements: 3072
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 128
-    MacroTileA: 64
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 32
-    NumLoadsA: 4
-    NumLoadsB: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 8
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 76
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x128x16_PGR0_PLR1_TT04_08
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id019
-    ThreadTile0: 4
-    ThreadTile1: 8
-    ThreadTileA: 4
-    ThreadTileB: 8
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: false
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 16
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: false
-    FractionalLoad: false
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 1
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 1
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Source
-    LSCA: 16
-    LSCB: 64
-    LSPA: 16
-    LSPB: 4
-    LVCA: 16
-    LVCB: 64
-    LVPA: 16
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsOffsetA: 0
-    LdsOffsetB: 1024
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 16
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 2
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsA: 4
-    NumLoadsB: 4
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 4
-    NumLoadsPerpendicularB: 4
-    NumThreads: 256
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: false
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 4
-      DestDataType: 4
-      HighPrecisionAccumulate: true
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [3, 0, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 0
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: false
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: true
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    SolutionIndex: 77
-    SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR0_PLR1_TT04_04
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 0
-    Valid: true
-    VectorAtomicWidth: 2
-    VectorStore: true
-    VectorWidth: 1
-    WorkGroup: *id018
-    WorkGroupMapping: -8
-    WorkGroupMappingType: B
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 1
-    AssertFree1ElementMultiple: 1
-    AssertMinApproxSize: 0
-    AssertSummationElementMultiple: 1
-    AssignedDerivedParameters: true
+    AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: false
     BufferStore: true
@@ -11582,6 +2199,11 @@
     NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 4
     NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
@@ -11625,14 +2247,21 @@
       TransposeB: true
       UseBeta: true
       UseInitialStrides: false
-    SolutionIndex: 78
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 13
     SolutionNameMin: Cijk_Alik_Bjlk_HBH_MT064x064x16_PGR1_PLR1_TT04_04
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppresssNoLoadLoop: false
-    ThreadTile: *id020
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -11643,9 +2272,10 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id018
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
+    _staggerStrideShift: 3
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
     AssertFree1ElementMultiple: 1
@@ -11779,7 +2409,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: &id022 [4, 4]
+    ThreadTile: &id001 [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -11790,7 +2420,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id023 [8, 8, 1]
+    WorkGroup: &id002 [8, 8, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -11926,7 +2556,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -11937,7 +2567,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12073,7 +2703,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: &id024 [4, 8]
+    ThreadTile: &id003 [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -12084,7 +2714,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12220,7 +2850,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: &id028 [8, 8]
+    ThreadTile: &id007 [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -12231,7 +2861,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id026 [16, 16, 1]
+    WorkGroup: &id005 [16, 16, 1]
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12367,7 +2997,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -12378,7 +3008,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12514,7 +3144,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id003
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -12525,7 +3155,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12661,7 +3291,7 @@
     SubGroupA: 8
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -12672,7 +3302,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id025 [8, 16, 1]
+    WorkGroup: &id004 [8, 16, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12808,7 +3438,7 @@
     SubGroupA: 8
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id003
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -12819,7 +3449,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id025
+    WorkGroup: *id004
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -12955,7 +3585,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -12966,7 +3596,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id026
+    WorkGroup: *id005
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -13102,7 +3732,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id003
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -13113,7 +3743,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id026
+    WorkGroup: *id005
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -13249,7 +3879,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -13260,7 +3890,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -13396,7 +4026,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id003
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -13407,7 +4037,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -13543,7 +4173,7 @@
     SubGroupA: 8
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -13554,7 +4184,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id025
+    WorkGroup: *id004
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -13690,7 +4320,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -13701,7 +4331,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id026
+    WorkGroup: *id005
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -13837,7 +4467,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id024
+    ThreadTile: *id003
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -13848,7 +4478,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id026
+    WorkGroup: *id005
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -13984,7 +4614,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -13995,7 +4625,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -14131,7 +4761,7 @@
     SubGroupA: 8
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -14142,7 +4772,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id025
+    WorkGroup: *id004
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -14278,7 +4908,7 @@
     SubGroupA: 8
     SubGroupB: 32
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -14289,7 +4919,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: &id027 [8, 32, 1]
+    WorkGroup: &id006 [8, 32, 1]
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -14425,7 +5055,7 @@
     SubGroupA: 8
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -14436,7 +5066,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id025
+    WorkGroup: *id004
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -14572,7 +5202,7 @@
     SubGroupA: 8
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -14583,7 +5213,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id025
+    WorkGroup: *id004
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -14719,7 +5349,7 @@
     SubGroupA: 8
     SubGroupB: 32
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -14730,7 +5360,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id027
+    WorkGroup: *id006
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -14866,7 +5496,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id022
+    ThreadTile: *id001
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -14877,7 +5507,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 4
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -15013,7 +5643,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id028
+    ThreadTile: *id007
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -15024,7 +5654,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -15160,7 +5790,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id028
+    ThreadTile: *id007
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -15171,7 +5801,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -15307,7 +5937,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id028
+    ThreadTile: *id007
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -15318,7 +5948,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id026
+    WorkGroup: *id005
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -15454,7 +6084,7 @@
     SubGroupA: 8
     SubGroupB: 8
     SuppresssNoLoadLoop: true
-    ThreadTile: *id028
+    ThreadTile: *id007
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -15465,7 +6095,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id023
+    WorkGroup: *id002
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -15601,7 +6231,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id028
+    ThreadTile: *id007
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -15612,7 +6242,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id026
+    WorkGroup: *id005
     WorkGroupMapping: -4
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -15748,7 +6378,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: true
-    ThreadTile: *id028
+    ThreadTile: *id007
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -15759,7 +6389,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 8
-    WorkGroup: *id026
+    WorkGroup: *id005
     WorkGroupMapping: -1
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -15891,7 +6521,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id031 [4, 8]
+    ThreadTile: &id010 [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -15902,7 +6532,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: &id029 [16, 16, 1]
+    WorkGroup: &id008 [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16034,7 +6664,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id030 [4, 4]
+    ThreadTile: &id009 [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16045,7 +6675,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16181,7 +6811,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16192,7 +6822,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16324,7 +6954,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16335,7 +6965,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16471,7 +7101,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id031
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -16482,7 +7112,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16614,7 +7244,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id031
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -16625,7 +7255,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16757,7 +7387,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -16768,7 +7398,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -16904,7 +7534,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id031
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -16915,7 +7545,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17051,7 +7681,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17062,7 +7692,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17194,7 +7824,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17205,7 +7835,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17341,7 +7971,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17352,7 +7982,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17484,7 +8114,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17495,7 +8125,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17631,7 +8261,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17642,7 +8272,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17778,7 +8408,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id031
+    ThreadTile: *id010
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -17789,7 +8419,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -17925,7 +8555,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id030
+    ThreadTile: *id009
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -17936,7 +8566,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: *id029
+    WorkGroup: *id008
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18068,7 +8698,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id033 [4, 8]
+    ThreadTile: &id012 [4, 8]
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -18079,7 +8709,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: &id032 [16, 16, 1]
+    WorkGroup: &id011 [16, 16, 1]
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18211,7 +8841,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id034 [4, 4]
+    ThreadTile: &id013 [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -18222,7 +8852,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18358,7 +8988,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id033
+    ThreadTile: *id012
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -18369,7 +8999,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18505,7 +9135,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -18516,7 +9146,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18648,7 +9278,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: &id035 [8, 8]
+    ThreadTile: &id014 [8, 8]
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -18659,7 +9289,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18791,7 +9421,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id033
+    ThreadTile: *id012
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -18802,7 +9432,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -18934,7 +9564,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -18945,7 +9575,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19081,7 +9711,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id035
+    ThreadTile: *id014
     ThreadTile0: 8
     ThreadTile1: 8
     ThreadTileA: 8
@@ -19092,7 +9722,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19228,7 +9858,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id033
+    ThreadTile: *id012
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -19239,7 +9869,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19375,7 +10005,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -19386,7 +10016,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19518,7 +10148,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id033
+    ThreadTile: *id012
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -19529,7 +10159,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19661,7 +10291,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -19672,7 +10302,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19808,7 +10438,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id033
+    ThreadTile: *id012
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -19819,7 +10449,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -19955,7 +10585,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -19966,7 +10596,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20098,7 +10728,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id033
+    ThreadTile: *id012
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -20109,7 +10739,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20241,7 +10871,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -20252,7 +10882,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20388,7 +11018,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -20399,7 +11029,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20531,7 +11161,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id033
+    ThreadTile: *id012
     ThreadTile0: 4
     ThreadTile1: 8
     ThreadTileA: 4
@@ -20542,7 +11172,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20674,7 +11304,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -20685,7 +11315,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20821,7 +11451,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -20832,7 +11462,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -20964,7 +11594,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -20975,7 +11605,7 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
   - AggressivePerfMode: 1
@@ -21111,7 +11741,7 @@
     SubGroupA: 16
     SubGroupB: 16
     SuppresssNoLoadLoop: false
-    ThreadTile: *id034
+    ThreadTile: *id013
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
@@ -21122,2756 +11752,218 @@
     VectorAtomicWidth: 2
     VectorStore: true
     VectorWidth: 1
-    WorkGroup: *id032
+    WorkGroup: *id011
     WorkGroupMapping: -8
     WorkGroupMappingType: B
 - [2, 3, 0, 1]
-- - - [2368, 1024, 1, 1]
-    - [63, 134.117]
-  - - [128, 256, 1, 1280]
-    - [32, 1436.41]
-  - - [32, 5056, 1, 1280]
-    - [56, 1263.38]
-  - - [448, 1, 1, 256]
-    - [78, 3.05672]
-  - - [5056, 1408, 1, 3328]
-    - [3, 9839.64]
-  - - [2368, 64, 1, 1]
-    - [63, 12.3013]
-  - - [5056, 1856, 1, 3328]
-    - [15, 10122.4]
-  - - [704, 64, 1, 1]
-    - [72, 4.26667]
-  - - [448, 3584, 1, 3328]
-    - [15, 8495.84]
-  - - [2368, 32, 1, 256]
-    - [52, 554.881]
-  - - [5888, 256, 1, 256]
-    - [15, 8189.22]
-  - - [448, 3584, 1, 32]
-    - [51, 2032.45]
-  - - [1856, 256, 1, 1]
-    - [59, 42.4229]
-  - - [6784, 6784, 1, 1280]
-    - [16, 10275.6]
-  - - [448, 1, 1, 1]
-    - [59, 0.0411765]
-  - - [1408, 3584, 1, 3328]
-    - [15, 9863.04]
-  - - [448, 448, 1, 3328]
-    - [14, 5390.11]
-  - - [1024, 2368, 1, 3328]
-    - [15, 9199.54]
-  - - [1, 4288, 1, 1280]
-    - [78, 30.0516]
-  - - [6784, 64, 1, 32]
-    - [52, 959.505]
-  - - [256, 128, 1, 256]
-    - [11, 927.943]
-  - - [448, 3584, 1, 1]
-    - [62, 107.905]
-  - - [448, 64, 1, 1]
-    - [77, 2.32727]
-  - - [32, 1408, 1, 32]
-    - [51, 93.3803]
-  - - [64, 1024, 1, 1280]
-    - [29, 2774.01]
-  - - [1, 1408, 1, 3328]
-    - [78, 15.3252]
-  - - [32, 3584, 1, 1280]
-    - [56, 1300.5]
-  - - [1024, 1, 1, 3328]
-    - [78, 11.1807]
-  - - [32, 1024, 1, 3328]
-    - [56, 386.599]
-  - - [1408, 5056, 1, 1]
-    - [59, 204.095]
-  - - [1024, 64, 1, 1280]
-    - [29, 2766.69]
-  - - [64, 5056, 1, 3328]
-    - [18, 6644.17]
-  - - [5888, 4288, 1, 3328]
-    - [3, 10140.7]
-  - - [1, 2368, 1, 1280]
-    - [78, 24.0101]
-  - - [704, 1024, 1, 1]
-    - [58, 60.8865]
-  - - [2368, 1408, 1, 32]
-    - [42, 2683.42]
-  - - [256, 1856, 1, 1280]
-    - [15, 7084.97]
-  - - [1024, 2944, 1, 1]
-    - [58, 148.359]
-  - - [2944, 3584, 1, 3328]
-    - [19, 10009.7]
-  - - [2368, 2944, 1, 1280]
-    - [19, 9887.62]
-  - - [256, 1408, 1, 1]
-    - [74, 33.3748]
-  - - [1, 1024, 1, 3328]
-    - [78, 11.219]
-  - - [3584, 1408, 1, 32]
-    - [42, 3081.69]
-  - - [6784, 1856, 1, 32]
-    - [42, 3497.53]
-  - - [5056, 256, 1, 256]
-    - [15, 8121.32]
-  - - [1856, 2368, 1, 256]
-    - [15, 9407.38]
-  - - [2368, 1024, 1, 3328]
-    - [15, 9049.34]
-  - - [3584, 4288, 1, 32]
-    - [42, 3678.8]
-  - - [1024, 1024, 1, 1280]
-    - [15, 8938.31]
-  - - [32, 128, 1, 3328]
-    - [56, 48.6005]
-  - - [32, 2944, 1, 3328]
-    - [56, 1117.81]
-  - - [704, 1408, 1, 3328]
-    - [15, 8621.21]
-  - - [1408, 704, 1, 256]
-    - [15, 7606.58]
-  - - [704, 64, 1, 32]
-    - [51, 91.0222]
-  - - [5888, 1, 1, 3328]
-    - [78, 42.4581]
-  - - [5056, 4288, 1, 32]
-    - [42, 3519.5]
-  - - [6784, 128, 1, 3328]
-    - [2, 8208.01]
-  - - [2944, 1856, 1, 1]
-    - [63, 189.199]
-  - - [32, 448, 1, 3328]
-    - [56, 170.833]
-  - - [5056, 1, 1, 3328]
-    - [78, 36.4902]
-  - - [2368, 3584, 1, 1280]
-    - [36, 9749.46]
-  - - [4288, 5056, 1, 1]
-    - [59, 238.558]
-  - - [128, 4288, 1, 3328]
-    - [17, 7006.06]
-  - - [1408, 4288, 1, 1280]
-    - [15, 9803.13]
-  - - [1856, 704, 1, 1280]
-    - [15, 9185.41]
-  - - [448, 5888, 1, 256]
-    - [15, 8526.3]
-  - - [1, 5888, 1, 3328]
-    - [78, 42.436]
-  - - [1024, 128, 1, 32]
-    - [48, 267.494]
-  - - [32, 4288, 1, 1280]
-    - [56, 1058.05]
-  - - [1024, 5056, 1, 1]
-    - [62, 183.334]
-  - - [704, 3584, 1, 1280]
-    - [15, 9467.68]
-  - - [1856, 5056, 1, 256]
-    - [15, 9781.3]
-  - - [1408, 1024, 1, 1280]
-    - [15, 8656.16]
-  - - [5056, 5888, 1, 3328]
-    - [20, 10273.7]
-  - - [3584, 3584, 1, 1280]
-    - [15, 10162.2]
-  - - [2368, 3584, 1, 32]
-    - [42, 3411.82]
-  - - [5056, 5056, 1, 1]
-    - [59, 247.705]
-  - - [2368, 256, 1, 32]
-    - [51, 1218.51]
-  - - [1024, 6784, 1, 1280]
-    - [15, 10053.3]
-  - - [1024, 3584, 1, 1]
-    - [62, 159.844]
-  - - [256, 5056, 1, 1]
-    - [62, 92.9839]
-  - - [32, 5056, 1, 32]
-    - [52, 409.6]
-  - - [5888, 32, 1, 32]
-    - [50, 448.61]
-  - - [64, 128, 1, 3328]
-    - [26, 374.491]
-  - - [256, 5056, 1, 32]
-    - [43, 1835.94]
-  - - [5056, 64, 1, 32]
-    - [50, 765.879]
-  - - [128, 6784, 1, 32]
-    - [51, 1536.91]
-  - - [64, 128, 1, 1]
-    - [63, 0.691892]
-  - - [64, 2368, 1, 1280]
-    - [13, 4557.95]
-  - - [128, 704, 1, 32]
-    - [43, 182.969]
-  - - [64, 6784, 1, 3328]
-    - [17, 6769.76]
-  - - [2944, 256, 1, 1280]
-    - [15, 8103.91]
-  - - [2944, 4288, 1, 256]
-    - [15, 9615.9]
-  - - [1024, 1024, 1, 3328]
-    - [19, 9118.05]
-  - - [5056, 704, 1, 32]
-    - [42, 2593.39]
-  - - [1856, 4288, 1, 3328]
-    - [15, 10131.1]
-  - - [1, 1856, 1, 256]
-    - [78, 12.6098]
-  - - [6784, 4288, 1, 32]
-    - [42, 3751.1]
-  - - [4288, 1024, 1, 3328]
-    - [0, 9231.87]
-  - - [256, 128, 1, 1]
-    - [63, 2.78639]
-  - - [3584, 448, 1, 3328]
-    - [19, 8356.59]
-  - - [2944, 448, 1, 256]
-    - [15, 7239.31]
-  - - [3584, 2368, 1, 3328]
-    - [19, 9969.65]
-  - - [4288, 1856, 1, 1]
-    - [59, 208.995]
-  - - [1856, 2944, 1, 1]
-    - [59, 189.724]
-  - - [32, 4288, 1, 3328]
-    - [56, 1103.24]
-  - - [1, 3584, 1, 3328]
-    - [78, 39.4847]
-  - - [256, 32, 1, 3328]
-    - [56, 96.9523]
-  - - [1856, 2368, 1, 32]
-    - [42, 2925.13]
-  - - [4288, 1856, 1, 32]
-    - [42, 3336.91]
-  - - [5056, 64, 1, 3328]
-    - [13, 6683.76]
-  - - [6784, 1, 1, 1280]
-    - [74, 46.4459]
-  - - [32, 2368, 1, 256]
-    - [52, 549.849]
-  - - [1408, 64, 1, 1]
-    - [59, 7.66258]
-  - - [1, 1, 1, 3328]
-    - [78, 0.0109301]
-  - - [5056, 2368, 1, 256]
-    - [15, 9691.95]
-  - - [1408, 5888, 1, 256]
-    - [3, 9785.68]
-  - - [5056, 6784, 1, 1]
-    - [63, 255.055]
-  - - [32, 448, 1, 1280]
-    - [56, 154.151]
-  - - [32, 448, 1, 32]
-    - [46, 34.3377]
-  - - [256, 5056, 1, 1280]
-    - [19, 9095.03]
-  - - [704, 2368, 1, 1]
-    - [58, 109.102]
-  - - [64, 1024, 1, 32]
-    - [48, 131.072]
-  - - [1024, 256, 1, 256]
-    - [15, 4686.37]
-  - - [128, 1, 1, 1]
-    - [77, 0.0118519]
-  - - [128, 3584, 1, 256]
-    - [19, 5825.42]
-  - - [3584, 4288, 1, 1280]
-    - [16, 9982.57]
-  - - [1856, 128, 1, 32]
-    - [52, 562.291]
-  - - [1856, 128, 1, 1280]
-    - [14, 6033.47]
-  - - [128, 2944, 1, 3328]
-    - [14, 6951.76]
-  - - [1, 6784, 1, 3328]
-    - [78, 48.8429]
-  - - [2368, 4288, 1, 1]
-    - [63, 209.102]
-  - - [4288, 448, 1, 3328]
-    - [15, 8832.28]
-  - - [4288, 32, 1, 3328]
-    - [56, 1093.1]
-  - - [32, 2944, 1, 256]
-    - [52, 655.36]
-  - - [256, 1856, 1, 1]
-    - [68, 41.2444]
-  - - [704, 6784, 1, 1280]
-    - [15, 9739.35]
-  - - [3584, 6784, 1, 1]
-    - [70, 240.446]
-  - - [704, 5056, 1, 1280]
-    - [15, 9723.53]
-  - - [256, 3584, 1, 3328]
-    - [15, 7995.01]
-  - - [1024, 32, 1, 3328]
-    - [56, 386.928]
-  - - [3584, 6784, 1, 32]
-    - [42, 3802.01]
-  - - [3584, 6784, 1, 1280]
-    - [19, 10178.5]
-  - - [4288, 4288, 1, 3328]
-    - [3, 10027.1]
-  - - [3584, 64, 1, 1280]
-    - [22, 5779.55]
-  - - [64, 1856, 1, 256]
-    - [29, 3115.65]
-  - - [3584, 64, 1, 32]
-    - [48, 556.063]
-  - - [448, 1, 1, 1280]
-    - [78, 4.48842]
-  - - [256, 4288, 1, 1280]
-    - [15, 7750.95]
-  - - [1408, 3584, 1, 1]
-    - [58, 183.367]
-  - - [4288, 1856, 1, 3328]
-    - [19, 9940.68]
-  - - [1856, 2944, 1, 1280]
-    - [15, 10070.8]
-  - - [4288, 256, 1, 256]
-    - [15, 7025.46]
-  - - [128, 5888, 1, 32]
-    - [51, 1382.87]
-  - - [128, 5888, 1, 1280]
-    - [15, 8186.44]
-  - - [1408, 128, 1, 3328]
-    - [13, 5645.57]
-  - - [3584, 256, 1, 256]
-    - [15, 6957.38]
-  - - [32, 6784, 1, 3328]
-    - [56, 1726.41]
-  - - [64, 64, 1, 1280]
-    - [21, 167.609]
-  - - [32, 3584, 1, 256]
-    - [56, 926.772]
-  - - [704, 256, 1, 32]
-    - [51, 353.38]
-  - - [448, 128, 1, 3328]
-    - [29, 2595.77]
-  - - [64, 2944, 1, 3328]
-    - [13, 5924.49]
-  - - [64, 4288, 1, 3328]
-    - [13, 5685.44]
-  - - [5056, 1024, 1, 3328]
-    - [15, 9928.42]
-  - - [2368, 64, 1, 3328]
-    - [11, 4783.43]
-  - - [1856, 256, 1, 256]
-    - [15, 6033.47]
-  - - [3584, 704, 1, 1]
-    - [59, 136.533]
-  - - [256, 704, 1, 256]
-    - [10, 3314.46]
-  - - [448, 5056, 1, 1]
-    - [61, 129.879]
-  - - [5888, 5888, 1, 256]
-    - [3, 9911.48]
-  - - [3584, 704, 1, 32]
-    - [54, 2151.93]
-  - - [448, 6784, 1, 3328]
-    - [15, 9709.11]
-  - - [6784, 4288, 1, 1]
-    - [58, 252.867]
-  - - [5056, 704, 1, 1]
-    - [59, 160.046]
-  - - [1408, 2368, 1, 32]
-    - [46, 2599.72]
-  - - [448, 5056, 1, 32]
-    - [42, 2323.17]
-  - - [4288, 4288, 1, 1280]
-    - [19, 10062.3]
-  - - [6784, 1408, 1, 1]
-    - [62, 222.758]
-  - - [5888, 256, 1, 3328]
-    - [19, 9013.19]
-  - - [1856, 5888, 1, 3328]
-    - [3, 10337.4]
-  - - [1024, 704, 1, 1]
-    - [73, 54.9463]
-  - - [5056, 5888, 1, 1]
-    - [59, 252.115]
-  - - [2944, 1024, 1, 256]
-    - [3, 8874.79]
-  - - [448, 1408, 1, 3328]
-    - [15, 7016.21]
-  - - [5056, 32, 1, 3328]
-    - [56, 1293.84]
-  - - [2368, 4288, 1, 3328]
-    - [39, 9851.79]
-  - - [1024, 704, 1, 32]
-    - [48, 1310.72]
-  - - [448, 2944, 1, 256]
-    - [15, 7365.65]
-  - - [2944, 6784, 1, 256]
-    - [3, 9760.33]
-  - - [2368, 2368, 1, 1280]
-    - [15, 9737.22]
-  - - [5888, 128, 1, 3328]
-    - [19, 8367.34]
-  - - [256, 256, 1, 32]
-    - [48, 131.731]
-  - - [1024, 1, 1, 256]
-    - [74, 6.97191]
-  - - [3584, 3584, 1, 32]
-    - [42, 3578.01]
-  - - [2944, 448, 1, 1]
-    - [61, 93.6727]
-  - - [128, 32, 1, 32]
-    - [56, 9.47052]
-  - - [5056, 64, 1, 1280]
-    - [13, 6399.68]
-  - - [2944, 2944, 1, 1280]
-    - [3, 9858.81]
-  - - [1, 2368, 1, 256]
-    - [78, 16.0203]
-  - - [64, 6784, 1, 1]
-    - [66, 40.806]
-  - - [2944, 32, 1, 1280]
-    - [56, 998.23]
-  - - [64, 1408, 1, 3328]
-    - [26, 3775.08]
-  - - [256, 448, 1, 1280]
-    - [26, 4247.7]
-  - - [2368, 2944, 1, 1]
-    - [59, 202.657]
-  - - [6784, 4288, 1, 1280]
-    - [39, 10024.5]
-  - - [2944, 704, 1, 256]
-    - [15, 8738.13]
-  - - [5888, 1856, 1, 256]
-    - [15, 9670.89]
-  - - [704, 2944, 1, 3328]
-    - [15, 9682.11]
-  - - [5888, 256, 1, 1]
-    - [63, 104.097]
-  - - [704, 704, 1, 32]
-    - [52, 1037.94]
-  - - [256, 4288, 1, 256]
-    - [15, 7125.21]
-  - - [5056, 6784, 1, 32]
-    - [42, 3697.11]
-  - - [5056, 128, 1, 1]
-    - [75, 52.191]
-  - - [448, 5056, 1, 1280]
-    - [19, 9367.13]
-  - - [448, 448, 1, 256]
-    - [9, 3989.15]
-  - - [256, 5888, 1, 3328]
-    - [15, 9168.72]
-  - - [704, 448, 1, 1280]
-    - [15, 4711.74]
-  - - [448, 64, 1, 256]
-    - [28, 865.57]
-  - - [1024, 704, 1, 1280]
-    - [15, 7830.51]
-  - - [5888, 1024, 1, 1]
-    - [59, 195.757]
-  - - [5888, 448, 1, 32]
-    - [52, 2436.79]
-  - - [6784, 2944, 1, 256]
-    - [3, 9763.3]
-  - - [1024, 256, 1, 1]
-    - [63, 23.2397]
-  - - [5888, 256, 1, 32]
-    - [46, 1970.36]
-  - - [2368, 448, 1, 256]
-    - [15, 6816.8]
-  - - [4288, 256, 1, 3328]
-    - [15, 7772.84]
-  - - [4288, 2944, 1, 256]
-    - [15, 9627.34]
-  - - [704, 4288, 1, 3328]
-    - [15, 9639.24]
-  - - [448, 5888, 1, 3328]
-    - [15, 9160.49]
-  - - [128, 256, 1, 3328]
-    - [32, 1557.88]
-  - - [2368, 5056, 1, 32]
-    - [42, 3552.7]
-  - - [32, 128, 1, 1280]
-    - [56, 44.1318]
-  - - [1408, 4288, 1, 1]
-    - [60, 192.522]
-  - - [1408, 1856, 1, 3328]
-    - [15, 9907.15]
-  - - [4288, 64, 1, 256]
-    - [13, 4457.78]
-  - - [2944, 5888, 1, 3328]
-    - [19, 10119.8]
-  - - [128, 6784, 1, 3328]
-    - [6, 8163.49]
-  - - [448, 4288, 1, 3328]
-    - [15, 8987.25]
-  - - [704, 2368, 1, 256]
-    - [15, 8058.35]
-  - - [1, 64, 1, 3328]
-    - [78, 0.699711]
-  - - [4288, 128, 1, 1]
-    - [59, 49.3583]
-  - - [256, 2368, 1, 32]
-    - [48, 1182.84]
-  - - [4288, 3584, 1, 3328]
-    - [16, 10036.5]
-  - - [2368, 1024, 1, 1280]
-    - [15, 8960.12]
-  - - [1408, 1024, 1, 1]
-    - [70, 98.4831]
-  - - [1408, 1024, 1, 256]
-    - [15, 7941.02]
-  - - [5056, 3584, 1, 1]
-    - [63, 243.82]
-  - - [448, 1024, 1, 256]
-    - [19, 5734.4]
-  - - [6784, 6784, 1, 3328]
-    - [20, 10293.3]
-  - - [1408, 256, 1, 1280]
-    - [15, 5399.97]
-  - - [6784, 32, 1, 32]
-    - [50, 496.201]
-  - - [64, 1024, 1, 3328]
-    - [29, 2956.94]
-  - - [2368, 2944, 1, 3328]
-    - [19, 9967.34]
-  - - [448, 448, 1, 1280]
-    - [14, 5138.02]
-  - - [5056, 3584, 1, 32]
-    - [42, 3686.82]
-  - - [5056, 3584, 1, 1280]
-    - [3, 10119.7]
-  - - [1024, 256, 1, 1280]
-    - [23, 6000.38]
-  - - [1856, 1856, 1, 256]
-    - [15, 8904.0]
-  - - [32, 5888, 1, 256]
-    - [52, 1137.61]
-  - - [256, 1408, 1, 32]
-    - [51, 805.47]
-  - - [2944, 1, 1, 3328]
-    - [78, 32.3312]
-  - - [32, 704, 1, 3328]
-    - [56, 264.96]
-  - - [5888, 4288, 1, 1]
-    - [62, 250.275]
-  - - [1024, 128, 1, 256]
-    - [11, 3226.39]
-  - - [32, 1856, 1, 3328]
-    - [56, 701.109]
-  - - [5056, 704, 1, 256]
-    - [15, 9032.64]
-  - - [448, 256, 1, 256]
-    - [11, 3033.07]
-  - - [2368, 5056, 1, 256]
-    - [15, 9696.87]
-  - - [1024, 5056, 1, 256]
-    - [7, 9483.4]
-  - - [1024, 64, 1, 1]
-    - [59, 5.53514]
-  - - [5888, 448, 1, 256]
-    - [15, 8415.79]
-  - - [6784, 5056, 1, 1280]
-    - [37, 10064.1]
-  - - [704, 6784, 1, 32]
-    - [42, 3008.46]
-  - - [4288, 6784, 1, 1280]
-    - [15, 10237.9]
-  - - [64, 1, 1, 256]
-    - [74, 0.413737]
-  - - [1856, 64, 1, 1280]
-    - [26, 4369.07]
-  - - [128, 1408, 1, 1]
-    - [59, 14.349]
-  - - [1024, 64, 1, 32]
-    - [48, 134.433]
-  - - [1024, 64, 1, 3328]
-    - [29, 2979.56]
-  - - [704, 6784, 1, 3328]
-    - [15, 9819.55]
-  - - [5888, 4288, 1, 1280]
-    - [15, 10160.8]
-  - - [5888, 3584, 1, 1280]
-    - [16, 10071.0]
-  - - [32, 2368, 1, 1280]
-    - [56, 814.796]
-  - - [5888, 128, 1, 1280]
-    - [15, 8164.27]
-  - - [1024, 2944, 1, 256]
-    - [20, 8899.35]
-  - - [1, 2944, 1, 1280]
-    - [78, 29.2208]
-  - - [4288, 2368, 1, 32]
-    - [42, 3381.84]
-  - - [2944, 1856, 1, 1280]
-    - [15, 9905.39]
-  - - [3584, 1, 1, 1280]
-    - [78, 37.0918]
-  - - [256, 3584, 1, 32]
-    - [51, 1555.09]
-  - - [1024, 2368, 1, 1]
-    - [58, 132.36]
-  - - [2944, 3584, 1, 1280]
-    - [19, 9932.37]
-  - - [64, 1, 1, 1]
-    - [78, 0.00714286]
-  - - [1856, 4288, 1, 256]
-    - [15, 9621.19]
-  - - [256, 128, 1, 3328]
-    - [26, 1552.56]
-  - - [1, 1856, 1, 3328]
-    - [78, 20.3344]
-  - - [1408, 704, 1, 1]
-    - [61, 75.5512]
-  - - [2368, 2944, 1, 32]
-    - [42, 3280.65]
-  - - [128, 4288, 1, 32]
-    - [52, 1108.82]
-  - - [128, 704, 1, 1280]
-    - [26, 3533.8]
-  - - [64, 64, 1, 1]
-    - [59, 0.348299]
-  - - [1, 1408, 1, 1]
-    - [59, 0.128467]
-  - - [128, 2368, 1, 1280]
-    - [13, 6009.5]
-  - - [2944, 32, 1, 32]
-    - [44, 191.285]
-  - - [448, 1856, 1, 1]
-    - [60, 66.6256]
-  - - [4288, 704, 1, 256]
-    - [15, 8829.99]
-  - - [1856, 1024, 1, 256]
-    - [3, 8163.41]
-  - - [448, 1856, 1, 32]
-    - [51, 1478.2]
-  - - [448, 1856, 1, 3328]
-    - [15, 7256.12]
-  - - [448, 448, 1, 32]
-    - [51, 371.674]
-  - - [1024, 448, 1, 256]
-    - [19, 5779.55]
-  - - [6784, 1, 1, 256]
-    - [74, 38.8351]
-  - - [1024, 5056, 1, 32]
-    - [42, 3142.55]
-  - - [1024, 4288, 1, 1]
-    - [62, 166.828]
-  - - [704, 256, 1, 3328]
-    - [23, 4369.07]
-  - - [704, 1856, 1, 32]
-    - [43, 1859.96]
-  - - [1408, 5888, 1, 1280]
-    - [3, 10172.9]
-  - - [32, 704, 1, 1280]
-    - [56, 247.901]
-  - - [5056, 1856, 1, 256]
-    - [15, 9652.39]
-  - - [6784, 704, 1, 1280]
-    - [15, 9555.44]
-  - - [704, 1408, 1, 32]
-    - [50, 1605.23]
-  - - [5888, 1024, 1, 256]
-    - [15, 9532.51]
-  - - [64, 2944, 1, 1]
-    - [63, 14.4491]
-  - - [64, 2944, 1, 32]
-    - [51, 352.179]
-  - - [64, 2944, 1, 1280]
-    - [13, 5562.1]
-  - - [6784, 1856, 1, 3328]
-    - [15, 10026.8]
-  - - [64, 704, 1, 3328]
-    - [26, 2055.19]
-  - - [2368, 5888, 1, 1280]
-    - [7, 10052.0]
-  - - [1, 6784, 1, 256]
-    - [74, 38.8351]
-  - - [6784, 6784, 1, 32]
-    - [42, 3902.71]
-  - - [256, 1, 1, 1280]
-    - [78, 2.56803]
-  - - [5888, 128, 1, 32]
-    - [51, 1322.22]
-  - - [6784, 256, 1, 256]
-    - [15, 8270.02]
-  - - [2368, 3584, 1, 3328]
-    - [35, 9722.02]
-  - - [128, 4288, 1, 1280]
-    - [12, 6839.43]
-  - - [128, 128, 1, 256]
-    - [8, 480.998]
-  - - [5888, 1024, 1, 1280]
-    - [15, 10008.2]
-  - - [1856, 704, 1, 3328]
-    - [15, 9345.87]
-  - - [5888, 6784, 1, 3328]
-    - [37, 10100.5]
-  - - [6784, 1856, 1, 1]
-    - [70, 223.564]
-  - - [128, 32, 1, 1280]
-    - [56, 44.0726]
-  - - [2944, 2368, 1, 1280]
-    - [35, 9579.37]
-  - - [4288, 448, 1, 1]
-    - [61, 117.71]
-  - - [6784, 448, 1, 32]
-    - [44, 2532.69]
-  - - [6784, 448, 1, 3328]
-    - [40, 9283.49]
-  - - [1, 6784, 1, 1]
-    - [63, 0.737391]
-  - - [448, 3584, 1, 1280]
-    - [15, 8395.46]
-  - - [1408, 6784, 1, 1280]
-    - [15, 10142.7]
-  - - [5056, 5888, 1, 1280]
-    - [3, 10244.4]
-  - - [32, 2944, 1, 32]
-    - [51, 174.459]
-  - - [5888, 704, 1, 1]
-    - [63, 173.292]
-  - - [1, 256, 1, 256]
-    - [78, 1.73928]
-  - - [5056, 2944, 1, 32]
-    - [42, 3621.62]
-  - - [32, 6784, 1, 256]
-    - [56, 1330.81]
-  - - [64, 5056, 1, 256]
-    - [13, 5026.55]
-  - - [4288, 6784, 1, 1]
-    - [63, 251.294]
-  - - [448, 704, 1, 1280]
-    - [15, 4747.2]
-  - - [64, 2368, 1, 1]
-    - [63, 12.2219]
-  - - [1, 4288, 1, 3328]
-    - [78, 30.8137]
-  - - [5056, 4288, 1, 1]
-    - [63, 241.75]
-  - - [2368, 5888, 1, 32]
-    - [42, 3688.57]
-  - - [128, 3584, 1, 1280]
-    - [12, 6950.79]
-  - - [2944, 6784, 1, 1]
-    - [65, 243.325]
-  - - [1, 256, 1, 1]
-    - [63, 0.0233577]
-  - - [5888, 1024, 1, 3328]
-    - [15, 10085.2]
-  - - [6784, 5888, 1, 256]
-    - [3, 9954.15]
-  - - [704, 128, 1, 1280]
-    - [30, 3491.02]
-  - - [4288, 128, 1, 256]
-    - [12, 5835.1]
-  - - [32, 3584, 1, 3328]
-    - [56, 1356.17]
-  - - [6784, 64, 1, 256]
-    - [12, 5579.77]
-  - - [1024, 1, 1, 1280]
-    - [78, 10.4357]
-  - - [2368, 4288, 1, 32]
-    - [42, 3421.73]
-  - - [704, 3584, 1, 1]
-    - [63, 134.783]
-  - - [704, 1856, 1, 3328]
-    - [15, 9349.08]
-  - - [2944, 128, 1, 1280]
-    - [2, 6669.59]
-  - - [1, 2368, 1, 3328]
-    - [78, 25.7674]
-  - - [6784, 704, 1, 32]
-    - [42, 2939.04]
-  - - [4288, 1, 1, 1280]
-    - [78, 30.0122]
-  - - [704, 5888, 1, 256]
-    - [3, 9467.87]
-  - - [2944, 256, 1, 1]
-    - [62, 62.8053]
-  - - [64, 448, 1, 256]
-    - [26, 890.781]
-  - - [1408, 448, 1, 1280]
-    - [19, 6865.68]
-  - - [1408, 128, 1, 32]
-    - [51, 349.949]
-  - - [256, 1024, 1, 256]
-    - [15, 4609.13]
-  - - [3584, 5056, 1, 32]
-    - [42, 3651.53]
-  - - [1024, 32, 1, 1280]
-    - [56, 361.578]
-  - - [128, 2368, 1, 1]
-    - [74, 29.1446]
-  - - [6784, 1856, 1, 1280]
-    - [15, 9968.2]
-  - - [5056, 5056, 1, 3328]
-    - [3, 10064.3]
-  - - [128, 2944, 1, 1280]
-    - [14, 6699.24]
-  - - [128, 6784, 1, 1]
-    - [63, 71.4105]
-  - - [5888, 1408, 1, 256]
-    - [3, 9650.41]
-  - - [2368, 1024, 1, 32]
-    - [42, 2383.13]
-  - - [256, 256, 1, 3328]
-    - [29, 2979.56]
-  - - [64, 4288, 1, 1]
-    - [63, 25.7925]
-  - - [4288, 1024, 1, 256]
-    - [15, 9274.53]
-  - - [3584, 32, 1, 32]
-    - [50, 288.523]
-  - - [3584, 64, 1, 1]
-    - [61, 21.2385]
-  - - [704, 32, 1, 1280]
-    - [56, 243.217]
-  - - [32, 4288, 1, 32]
-    - [43, 280.033]
-  - - [64, 64, 1, 3328]
-    - [27, 188.697]
-  - - [64, 1408, 1, 1]
-    - [59, 7.76828]
-  - - [4288, 5888, 1, 1280]
-    - [19, 10134.8]
-  - - [704, 64, 1, 3328]
-    - [21, 2043.98]
-  - - [5056, 5888, 1, 256]
-    - [3, 9977.27]
-  - - [1408, 128, 1, 1280]
-    - [13, 5359.82]
-  - - [1024, 5888, 1, 1280]
-    - [15, 10183.6]
-  - - [64, 1024, 1, 1]
-    - [63, 5.53514]
-  - - [32, 32, 1, 32]
-    - [48, 2.0898]
-  - - [64, 128, 1, 256]
-    - [8, 234.057]
-  - - [5888, 5056, 1, 1280]
-    - [15, 10200.1]
-  - - [5888, 2944, 1, 1]
-    - [62, 235.264]
-  - - [64, 4288, 1, 1280]
-    - [13, 5481.79]
-  - - [704, 2944, 1, 1]
-    - [63, 124.554]
-  - - [1408, 4288, 1, 3328]
-    - [15, 9882.75]
-  - - [704, 2944, 1, 32]
-    - [42, 2341.89]
-  - - [1, 5888, 1, 1280]
-    - [78, 41.2107]
-  - - [2944, 4288, 1, 3328]
-    - [15, 10020.1]
-  - - [256, 2944, 1, 256]
-    - [15, 7156.45]
-  - - [704, 448, 1, 32]
-    - [52, 737.759]
-  - - [5056, 2944, 1, 256]
-    - [15, 9778.59]
-  - - [704, 1024, 1, 256]
-    - [15, 6886.17]
-  - - [2368, 1856, 1, 256]
-    - [15, 9270.95]
-  - - [64, 3584, 1, 1]
-    - [59, 16.6698]
-  - - [1024, 128, 1, 1280]
-    - [29, 4798.97]
-  - - [2368, 4288, 1, 1280]
-    - [15, 10065.3]
-  - - [3584, 448, 1, 256]
-    - [15, 7714.75]
-  - - [256, 6784, 1, 256]
-    - [15, 8319.54]
-  - - [1024, 32, 1, 32]
-    - [48, 72.0176]
-  - - [2944, 5888, 1, 1]
-    - [62, 239.158]
-  - - [128, 64, 1, 32]
-    - [51, 16.0627]
-  - - [64, 1, 1, 1280]
-    - [78, 0.6404]
-  - - [6784, 5888, 1, 3328]
-    - [15, 10263.3]
-  - - [256, 5888, 1, 1]
-    - [63, 103.525]
-  - - [6784, 3584, 1, 256]
-    - [3, 9872.38]
-  - - [1408, 1856, 1, 256]
-    - [15, 9109.3]
-  - - [128, 1408, 1, 256]
-    - [13, 3923.24]
-  - - [2944, 2944, 1, 32]
-    - [42, 3369.15]
-  - - [2944, 2944, 1, 3328]
-    - [15, 9894.96]
-  - - [1, 2944, 1, 256]
-    - [74, 18.9935]
-  - - [448, 32, 1, 1280]
-    - [56, 154.462]
-  - - [3584, 1, 1, 256]
-    - [78, 27.8369]
-  - - [704, 32, 1, 3328]
-    - [56, 266.846]
-  - - [256, 448, 1, 3328]
-    - [26, 4526.59]
-  - - [2368, 64, 1, 256]
-    - [13, 3321.69]
-  - - [64, 448, 1, 1280]
-    - [32, 1270.78]
-  - - [1408, 448, 1, 3328]
-    - [15, 7014.33]
-  - - [2368, 6784, 1, 3328]
-    - [16, 10140.7]
-  - - [256, 2368, 1, 1]
-    - [59, 52.2593]
-  - - [4288, 3584, 1, 32]
-    - [42, 3534.95]
-  - - [5888, 64, 1, 3328]
-    - [13, 6719.34]
-  - - [3584, 704, 1, 1280]
-    - [15, 9295.44]
-  - - [448, 5056, 1, 3328]
-    - [19, 9485.37]
-  - - [4288, 448, 1, 256]
-    - [15, 8152.89]
-  - - [5056, 256, 1, 1280]
-    - [15, 8965.1]
-  - - [704, 448, 1, 3328]
-    - [15, 4852.18]
-  - - [2944, 5888, 1, 32]
-    - [42, 3694.04]
-  - - [3584, 5056, 1, 256]
-    - [16, 9758.7]
-  - - [6784, 1, 1, 3328]
-    - [78, 48.6493]
-  - - [32, 2368, 1, 3328]
-    - [56, 889.721]
-  - - [64, 256, 1, 1]
-    - [66, 1.46286]
-  - - [1856, 448, 1, 3328]
-    - [19, 7251.55]
-  - - [3584, 2368, 1, 256]
-    - [15, 9512.48]
-  - - [128, 1024, 1, 1280]
-    - [26, 4832.15]
-  - - [4288, 256, 1, 32]
-    - [52, 1656.95]
-  - - [4288, 256, 1, 1280]
-    - [15, 7653.01]
-  - - [448, 5056, 1, 256]
-    - [15, 8722.36]
-  - - [128, 1856, 1, 1]
-    - [66, 22.8431]
-  - - [128, 1856, 1, 32]
-    - [52, 565.638]
-  - - [1408, 1856, 1, 1]
-    - [59, 140.8]
-  - - [128, 2944, 1, 1]
-    - [74, 35.9573]
-  - - [3584, 32, 1, 256]
-    - [54, 780.854]
-  - - [1408, 1408, 1, 1280]
-    - [15, 9148.95]
-  - - [3584, 256, 1, 1]
-    - [63, 73.9923]
-  - - [1408, 1856, 1, 1280]
-    - [15, 9778.28]
-  - - [448, 4288, 1, 1]
-    - [63, 120.667]
-  - - [3584, 4288, 1, 3328]
-    - [16, 10038.7]
-  - - [448, 128, 1, 256]
-    - [31, 1668.19]
-  - - [448, 4288, 1, 32]
-    - [42, 2208.07]
-  - - [448, 4288, 1, 1280]
-    - [15, 8878.22]
-  - - [64, 3584, 1, 256]
-    - [14, 4503.09]
-  - - [6784, 1408, 1, 1280]
-    - [15, 9971.27]
-  - - [1, 6784, 1, 1280]
-    - [78, 47.3576]
-  - - [5056, 1024, 1, 256]
-    - [3, 9461.74]
-  - - [2368, 448, 1, 32]
-    - [52, 1664.1]
-  - - [256, 1, 1, 256]
-    - [74, 1.74298]
-  - - [32, 2944, 1, 1280]
-    - [56, 994.936]
-  - - [5056, 1024, 1, 1]
-    - [59, 187.585]
-  - - [2368, 256, 1, 256]
-    - [15, 5896.25]
-  - - [1, 5056, 1, 1]
-    - [59, 0.540171]
-  - - [4288, 32, 1, 32]
-    - [52, 340.909]
-  - - [1856, 3584, 1, 32]
-    - [42, 3072.47]
-  - - [5056, 3584, 1, 3328]
-    - [3, 10167.0]
-  - - [4288, 5056, 1, 256]
-    - [15, 9828.07]
-  - - [1856, 5888, 1, 256]
-    - [3, 9917.76]
-  - - [256, 256, 1, 256]
-    - [31, 1855.89]
-  - - [2368, 3584, 1, 1]
-    - [63, 214.316]
-  - - [4288, 2368, 1, 256]
-    - [15, 9664.71]
-  - - [448, 1, 1, 3328]
-    - [78, 4.88514]
-  - - [1856, 256, 1, 1280]
-    - [15, 7084.97]
-  - - [1024, 6784, 1, 1]
-    - [62, 196.016]
-  - - [1408, 2944, 1, 3328]
-    - [15, 10047.7]
-  - - [32, 1856, 1, 32]
-    - [52, 119.984]
-  - - [256, 1, 1, 1]
-    - [61, 0.0235294]
-  - - [6784, 5056, 1, 3328]
-    - [35, 10135.0]
-  - - [6784, 5056, 1, 1]
-    - [58, 257.198]
-  - - [5888, 3584, 1, 32]
-    - [42, 3759.93]
-  - - [5888, 3584, 1, 3328]
-    - [7, 10110.4]
-  - - [1, 256, 1, 3328]
-    - [78, 2.78639]
-  - - [1024, 6784, 1, 256]
-    - [19, 9483.71]
-  - - [6784, 5888, 1, 32]
-    - [42, 3858.41]
-  - - [1408, 1, 1, 1280]
-    - [78, 14.349]
-  - - [2368, 6784, 1, 32]
-    - [42, 3697.24]
-  - - [6784, 64, 1, 1]
-    - [66, 42.4]
-  - - [2368, 32, 1, 32]
-    - [44, 159.528]
-  - - [3584, 1408, 1, 3328]
-    - [15, 9684.21]
-  - - [2944, 1408, 1, 1280]
-    - [3, 9760.47]
-  - - [1856, 64, 1, 1]
-    - [63, 9.9651]
-  - - [3584, 1024, 1, 1]
-    - [63, 164.427]
-  - - [256, 32, 1, 256]
-    - [52, 59.7139]
-  - - [2944, 1856, 1, 3328]
-    - [19, 9979.14]
-  - - [128, 1024, 1, 3328]
-    - [29, 5115.0]
-  - - [1408, 128, 1, 1]
-    - [59, 14.349]
-  - - [2944, 3584, 1, 32]
-    - [42, 3561.62]
-  - - [3584, 1024, 1, 32]
-    - [47, 2713.51]
-  - - [4288, 6784, 1, 3328]
-    - [3, 10232.6]
-  - - [256, 128, 1, 1280]
-    - [26, 1440.35]
-  - - [6784, 5056, 1, 256]
-    - [15, 9893.59]
-  - - [1408, 32, 1, 3328]
-    - [56, 535.676]
-  - - [1856, 3584, 1, 1280]
-    - [3, 9985.03]
-  - - [256, 5888, 1, 256]
-    - [15, 8259.33]
-  - - [5056, 32, 1, 256]
-    - [56, 1029.29]
-  - - [1024, 4288, 1, 3328]
-    - [19, 10034.7]
-  - - [448, 2368, 1, 256]
-    - [15, 6928.09]
-  - - [64, 1408, 1, 1280]
-    - [26, 3551.21]
-  - - [3584, 32, 1, 1280]
-    - [56, 1213.63]
-  - - [128, 2368, 1, 3328]
-    - [13, 6276.32]
-  - - [3584, 1024, 1, 256]
-    - [3, 9320.68]
-  - - [256, 64, 1, 256]
-    - [27, 485.452]
-  - - [2368, 448, 1, 3328]
-    - [15, 7514.38]
-  - - [3584, 2368, 1, 1]
-    - [58, 214.316]
-  - - [1, 1, 1, 1]
-    - [75, 8.56164e-05]
-  - - [1024, 1856, 1, 32]
-    - [42, 2209.93]
-  - - [32, 1024, 1, 32]
-    - [51, 65.21]
-  - - [4288, 1, 1, 256]
-    - [74, 25.2235]
-  - - [1856, 128, 1, 3328]
-    - [14, 6363.7]
-  - - [5888, 2368, 1, 1]
-    - [63, 233.001]
-  - - [5888, 128, 1, 1]
-    - [67, 64.526]
-  - - [704, 256, 1, 1280]
-    - [23, 4143.08]
-  - - [704, 4288, 1, 256]
-    - [3, 8977.7]
-  - - [5888, 2368, 1, 32]
-    - [42, 3563.65]
-  - - [5888, 2368, 1, 1280]
-    - [19, 10006.9]
-  - - [128, 256, 1, 256]
-    - [11, 944.663]
-  - - [2944, 5056, 1, 3328]
-    - [15, 10203.8]
-  - - [6784, 704, 1, 3328]
-    - [41, 9166.68]
-  - - [1856, 1856, 1, 32]
-    - [42, 2680.73]
-  - - [4288, 2944, 1, 32]
-    - [42, 3531.15]
-  - - [128, 448, 1, 1]
-    - [59, 4.90959]
-  - - [2944, 64, 1, 1]
-    - [59, 14.6286]
-  - - [704, 64, 1, 256]
-    - [11, 1322.74]
-  - - [256, 2368, 1, 3328]
-    - [15, 6742.85]
-  - - [704, 1, 1, 1]
-    - [64, 0.0765217]
-  - - [128, 448, 1, 1280]
-    - [31, 2427.26]
-  - - [5056, 5056, 1, 256]
-    - [15, 9833.14]
-  - - [6784, 6784, 1, 256]
-    - [16, 10018.5]
-  - - [256, 3584, 1, 1]
-    - [61, 73.5179]
-  - - [2368, 2944, 1, 256]
-    - [15, 9488.92]
-  - - [448, 32, 1, 32]
-    - [51, 40.6695]
-  - - [5888, 3584, 1, 1]
-    - [65, 245.836]
-  - - [5888, 128, 1, 256]
-    - [15, 7156.45]
-  - - [3584, 704, 1, 3328]
-    - [15, 9406.07]
-  - - [4288, 704, 1, 3328]
-    - [5, 9317.4]
-  - - [4288, 2944, 1, 1280]
-    - [19, 9972.93]
-  - - [448, 3584, 1, 256]
-    - [15, 7796.7]
-  - - [704, 32, 1, 256]
-    - [52, 166.489]
-  - - [6784, 256, 1, 32]
-    - [42, 2117.93]
-  - - [1856, 128, 1, 1]
-    - [66, 23.2]
-  - - [1856, 32, 1, 32]
-    - [51, 127.042]
-  - - [2368, 5056, 1, 1280]
-    - [15, 10084.3]
-  - - [704, 1856, 1, 1280]
-    - [15, 9201.58]
-  - - [448, 1024, 1, 3328]
-    - [15, 7031.72]
-  - - [32, 704, 1, 32]
-    - [46, 53.9593]
-  - - [3584, 448, 1, 1]
-    - [63, 103.992]
-  - - [6784, 1024, 1, 3328]
-    - [19, 9930.49]
-  - - [5888, 1856, 1, 32]
-    - [42, 3401.75]
-  - - [5888, 704, 1, 3328]
-    - [15, 9858.11]
-  - - [5056, 1, 1, 256]
-    - [74, 29.7408]
-  - - [448, 6784, 1, 256]
-    - [3, 9080.81]
-  - - [1024, 128, 1, 1]
-    - [59, 11.1456]
-  - - [128, 64, 1, 256]
-    - [11, 211.406]
-  - - [128, 5056, 1, 1]
-    - [59, 56.1778]
-  - - [1856, 128, 1, 256]
-    - [14, 4663.91]
-  - - [64, 704, 1, 1]
-    - [62, 3.91111]
-  - - [2944, 5888, 1, 256]
-    - [15, 9717.87]
-  - - [1408, 64, 1, 256]
-    - [29, 2423.18]
-  - - [128, 5056, 1, 32]
-    - [48, 1250.57]
-  - - [128, 5056, 1, 1280]
-    - [14, 7952.91]
-  - - [448, 32, 1, 3328]
-    - [56, 168.136]
-  - - [1856, 1408, 1, 32]
-    - [42, 2512.74]
-  - - [64, 704, 1, 32]
-    - [55, 96.3765]
-  - - [1, 5888, 1, 256]
-    - [74, 33.6457]
-  - - [64, 2368, 1, 32]
-    - [48, 292.854]
-  - - [5888, 64, 1, 32]
-    - [48, 837.404]
-  - - [2368, 256, 1, 1]
-    - [59, 52.6222]
-  - - [5888, 64, 1, 1280]
-    - [2, 6589.41]
-  - - [5056, 1, 1, 1]
-    - [68, 0.522314]
-  - - [5888, 2944, 1, 1280]
-    - [15, 10071.8]
-  - - [256, 1408, 1, 256]
-    - [15, 4650.94]
-  - - [448, 5888, 1, 1]
-    - [59, 140.31]
-  - - [2944, 128, 1, 32]
-    - [48, 871.288]
-  - - [3584, 1408, 1, 1]
-    - [59, 183.367]
-  - - [32, 6784, 1, 1280]
-    - [56, 1660.33]
-  - - [32, 6784, 1, 32]
-    - [52, 501.938]
-  - - [32, 1856, 1, 1280]
-    - [56, 635.633]
-  - - [448, 5888, 1, 32]
-    - [42, 2476.83]
-  - - [5056, 704, 1, 1280]
-    - [19, 9531.5]
-  - - [1856, 6784, 1, 1]
-    - [59, 231.114]
-  - - [5056, 64, 1, 1]
-    - [65, 27.8952]
-  - - [1, 5888, 1, 1]
-    - [59, 0.545185]
-  - - [2368, 1024, 1, 256]
-    - [16, 8425.04]
-  - - [1856, 6784, 1, 32]
-    - [42, 3559.32]
-  - - [1856, 6784, 1, 1280]
-    - [15, 9979.57]
-  - - [64, 3584, 1, 3328]
-    - [14, 6160.13]
-  - - [5888, 5056, 1, 3328]
-    - [0, 10240.3]
-  - - [1, 2944, 1, 3328]
-    - [78, 32.1445]
-  - - [1408, 6784, 1, 32]
-    - [42, 3492.46]
-  - - [32, 5888, 1, 1280]
-    - [56, 1430.1]
-  - - [448, 256, 1, 1]
-    - [59, 9.62148]
-  - - [3584, 5888, 1, 3328]
-    - [15, 10209.1]
-  - - [4288, 1408, 1, 256]
-    - [3, 9301.88]
-  - - [448, 64, 1, 1280]
-    - [32, 1263.78]
-  - - [128, 448, 1, 32]
-    - [43, 117.029]
-  - - [6784, 2368, 1, 256]
-    - [15, 9717.65]
-  - - [1408, 448, 1, 32]
-    - [50, 1242.92]
-  - - [1856, 1408, 1, 1280]
-    - [15, 9757.75]
-  - - [448, 256, 1, 3328]
-    - [26, 4522.29]
-  - - [1856, 2368, 1, 1]
-    - [59, 174.961]
-  - - [1408, 5056, 1, 3328]
-    - [15, 10024.8]
-  - - [128, 704, 1, 3328]
-    - [26, 3801.89]
-  - - [5056, 128, 1, 1280]
-    - [14, 7971.28]
-  - - [5056, 4288, 1, 256]
-    - [15, 9825.29]
-  - - [5056, 5056, 1, 32]
-    - [42, 3787.13]
-  - - [1856, 704, 1, 256]
-    - [15, 8345.7]
-  - - [5888, 32, 1, 1280]
-    - [56, 1450.75]
-  - - [64, 256, 1, 256]
-    - [27, 494.611]
-  - - [448, 5888, 1, 1280]
-    - [15, 9070.53]
-  - - [704, 704, 1, 3328]
-    - [15, 7591.17]
-  - - [128, 6784, 1, 256]
-    - [2, 7106.72]
-  - - [5056, 448, 1, 256]
-    - [15, 8608.41]
-  - - [4288, 5888, 1, 1]
-    - [63, 247.527]
-  - - [1856, 5056, 1, 1280]
-    - [15, 10220.8]
-  - - [704, 1856, 1, 1]
-    - [68, 93.8667]
-  - - [2368, 32, 1, 3328]
-    - [56, 893.504]
-  - - [3584, 1856, 1, 256]
-    - [15, 9385.4]
-  - - [256, 3584, 1, 256]
-    - [15, 7091.82]
-  - - [2944, 1408, 1, 1]
-    - [60, 138.913]
-  - - [4288, 5888, 1, 32]
-    - [42, 3708.81]
-  - - [4288, 5888, 1, 3328]
-    - [16, 10121.3]
-  - - [1, 1024, 1, 1]
-    - [59, 0.0920863]
-  - - [32, 64, 1, 32]
-    - [48, 4.07562]
-  - - [1408, 2368, 1, 1]
-    - [63, 157.271]
-  - - [2944, 2368, 1, 256]
-    - [15, 9476.83]
-  - - [1024, 1856, 1, 256]
-    - [19, 8119.81]
-  - - [2944, 64, 1, 3328]
-    - [13, 5915.55]
-  - - [1024, 5888, 1, 32]
-    - [45, 2999.66]
-  - - [1024, 5888, 1, 3328]
-    - [15, 10280.7]
-  - - [5056, 2368, 1, 32]
-    - [42, 3531.74]
-  - - [1408, 2368, 1, 1280]
-    - [15, 9759.65]
-  - - [256, 1, 1, 3328]
-    - [78, 2.78931]
-  - - [128, 1024, 1, 32]
-    - [48, 263.461]
-  - - [5056, 6784, 1, 3328]
-    - [7, 10237.5]
-  - - [448, 704, 1, 1]
-    - [61, 29.4209]
-  - - [448, 704, 1, 32]
-    - [52, 733.47]
-  - - [448, 704, 1, 3328]
-    - [15, 4845.02]
-  - - [1408, 2944, 1, 256]
-    - [3, 9467.87]
-  - - [3584, 4288, 1, 1]
-    - [58, 238.635]
-  - - [2368, 128, 1, 32]
-    - [52, 717.406]
-  - - [5056, 1408, 1, 1280]
-    - [3, 9787.87]
-  - - [2368, 128, 1, 3328]
-    - [13, 6276.32]
-  - - [704, 5056, 1, 32]
-    - [42, 2813.77]
-  - - [32, 2368, 1, 32]
-    - [48, 150.798]
-  - - [1408, 1, 1, 256]
-    - [78, 9.60682]
-  - - [256, 1856, 1, 32]
-    - [48, 974.638]
-  - - [448, 1408, 1, 1]
-    - [74, 55.5268]
-  - - [5056, 4288, 1, 1280]
-    - [15, 10188.0]
-  - - [1408, 256, 1, 256]
-    - [15, 4650.94]
-  - - [128, 256, 1, 1]
-    - [58, 3.35738]
-  - - [256, 4288, 1, 32]
-    - [54, 1688.81]
-  - - [1856, 2368, 1, 1280]
-    - [15, 9944.86]
-  - - [256, 256, 1, 1]
-    - [59, 5.57279]
-  - - [1408, 1, 1, 1]
-    - [59, 0.129412]
-  - - [448, 1408, 1, 256]
-    - [15, 6098.21]
-  - - [5888, 5888, 1, 1]
-    - [65, 254.466]
-  - - [128, 2944, 1, 32]
-    - [52, 842.083]
-  - - [32, 1024, 1, 1280]
-    - [56, 351.871]
-  - - [32, 256, 1, 32]
-    - [52, 24.0941]
-  - - [2944, 704, 1, 1280]
-    - [15, 9394.11]
-  - - [1024, 3584, 1, 1280]
-    - [15, 9994.94]
-  - - [704, 6784, 1, 256]
-    - [15, 9256.78]
-  - - [1856, 448, 1, 1]
-    - [63, 67.4909]
-  - - [128, 704, 1, 1]
-    - [63, 7.87692]
-  - - [5056, 256, 1, 32]
-    - [43, 1842.47]
-  - - [4288, 1, 1, 3328]
-    - [78, 30.9904]
-  - - [5056, 1024, 1, 1280]
-    - [3, 9854.55]
-  - - [704, 704, 1, 1]
-    - [66, 44.5698]
-  - - [1856, 448, 1, 1280]
-    - [19, 7133.41]
-  - - [3584, 6784, 1, 256]
-    - [16, 9843.66]
-  - - [64, 1856, 1, 1280]
-    - [26, 4379.13]
-  - - [1856, 1408, 1, 256]
-    - [16, 9149.23]
-  - - [4288, 4288, 1, 32]
-    - [42, 3646.39]
-  - - [128, 1, 1, 256]
-    - [78, 0.873348]
-  - - [32, 64, 1, 3328]
-    - [56, 24.2864]
-  - - [5888, 448, 1, 1]
-    - [59, 141.514]
-  - - [128, 5888, 1, 256]
-    - [15, 7199.18]
-  - - [3584, 256, 1, 3328]
-    - [15, 7895.76]
-  - - [5056, 5056, 1, 1280]
-    - [0, 10161.5]
-  - - [2368, 1, 1, 256]
-    - [74, 15.8196]
-  - - [6784, 1408, 1, 3328]
-    - [16, 9780.38]
-  - - [1408, 1408, 1, 1]
-    - [57, 115.798]
-  - - [32, 64, 1, 256]
-    - [52, 14.7272]
-  - - [2368, 1, 1, 1280]
-    - [78, 23.5475]
-  - - [32, 3584, 1, 32]
-    - [52, 290.349]
-  - - [2368, 5056, 1, 1]
-    - [63, 228.485]
-  - - [1, 3584, 1, 1]
-    - [71, 0.373333]
-  - - [256, 2944, 1, 3328]
-    - [15, 8367.34]
-  - - [1408, 64, 1, 3328]
-    - [26, 3778.89]
-  - - [1, 128, 1, 3328]
-    - [78, 1.402]
-  - - [32, 256, 1, 256]
-    - [56, 72.4155]
-  - - [5888, 1408, 1, 32]
-    - [42, 3457.9]
-  - - [704, 256, 1, 1]
-    - [63, 14.1686]
-  - - [1, 448, 1, 1]
-    - [73, 0.0523364]
-  - - [256, 6784, 1, 3328]
-    - [15, 9183.54]
-  - - [64, 5888, 1, 256]
-    - [14, 5359.39]
-  - - [1856, 1, 1, 1]
-    - [59, 0.170588]
-  - - [1024, 256, 1, 3328]
-    - [25, 6314.53]
-  - - [704, 704, 1, 256]
-    - [15, 6195.2]
-  - - [448, 1024, 1, 32]
-    - [56, 976.068]
-  - - [6784, 2368, 1, 1280]
-    - [15, 10075.7]
-  - - [128, 1856, 1, 1280]
-    - [14, 6091.49]
-  - - [256, 2368, 1, 256]
-    - [19, 5860.62]
-  - - [1024, 448, 1, 32]
-    - [50, 945.88]
-  - - [6784, 1024, 1, 256]
-    - [15, 9451.45]
-  - - [1408, 6784, 1, 3328]
-    - [15, 10225.9]
-  - - [2944, 1408, 1, 3328]
-    - [15, 9858.11]
-  - - [1856, 32, 1, 256]
-    - [56, 425.178]
-  - - [704, 2368, 1, 32]
-    - [42, 2039.23]
-  - - [448, 256, 1, 32]
-    - [48, 235.257]
-  - - [704, 6784, 1, 1]
-    - [59, 180.36]
-  - - [2368, 6784, 1, 256]
-    - [3, 9817.88]
-  - - [1856, 64, 1, 256]
-    - [11, 3065.39]
-  - - [1856, 3584, 1, 3328]
-    - [15, 10072.8]
-  - - [1, 704, 1, 3328]
-    - [78, 7.71101]
-  - - [5056, 1408, 1, 32]
-    - [42, 3303.41]
-  - - [64, 1, 1, 3328]
-    - [78, 0.700078]
-  - - [5056, 4288, 1, 3328]
-    - [40, 9975.14]
-  - - [4288, 2368, 1, 1]
-    - [59, 197.088]
-  - - [704, 448, 1, 256]
-    - [15, 4086.05]
-  - - [448, 64, 1, 3328]
-    - [26, 1344.71]
-  - - [2368, 256, 1, 1280]
-    - [15, 6566.91]
-  - - [2368, 448, 1, 1280]
-    - [15, 7399.23]
-  - - [6784, 2944, 1, 32]
-    - [42, 3757.68]
-  - - [64, 4288, 1, 32]
-    - [56, 630.878]
-  - - [3584, 1856, 1, 1]
-    - [63, 197.973]
-  - - [128, 448, 1, 3328]
-    - [29, 2612.83]
-  - - [5888, 2368, 1, 3328]
-    - [19, 10078.0]
-  - - [2368, 704, 1, 1280]
-    - [15, 8568.31]
-  - - [1024, 1408, 1, 1280]
-    - [15, 8630.26]
-  - - [4288, 64, 1, 1280]
-    - [13, 5474.95]
-  - - [2368, 6784, 1, 1]
-    - [63, 231.611]
-  - - [2944, 5056, 1, 32]
-    - [42, 3695.81]
-  - - [5056, 256, 1, 3328]
-    - [19, 9099.94]
-  - - [448, 448, 1, 1]
-    - [68, 14.7576]
-  - - [256, 2368, 1, 1280]
-    - [19, 6602.67]
-  - - [704, 2368, 1, 3328]
-    - [15, 8815.33]
-  - - [3584, 2944, 1, 256]
-    - [15, 9573.05]
-  - - [64, 6784, 1, 256]
-    - [15, 5579.77]
-  - - [3584, 1024, 1, 1280]
-    - [3, 9811.23]
-  - - [1408, 256, 1, 32]
-    - [48, 833.406]
-  - - [64, 1024, 1, 256]
-    - [29, 1906.5]
-  - - [1408, 32, 1, 32]
-    - [51, 96.3765]
-  - - [256, 32, 1, 1280]
-    - [56, 88.1453]
-  - - [4288, 2944, 1, 1]
-    - [59, 231.037]
-  - - [5056, 3584, 1, 256]
-    - [3, 9834.84]
-  - - [2368, 704, 1, 256]
-    - [15, 7950.27]
-  - - [1856, 1856, 1, 1280]
-    - [15, 9399.01]
-  - - [64, 32, 1, 32]
-    - [44, 4.13737]
-  - - [4288, 704, 1, 1]
-    - [59, 150.938]
-  - - [1856, 1024, 1, 1]
-    - [59, 118.784]
-  - - [4288, 2944, 1, 3328]
-    - [15, 10054.8]
-  - - [1024, 128, 1, 3328]
-    - [26, 5163.44]
-  - - [4288, 128, 1, 3328]
-    - [12, 7010.36]
-  - - [4288, 704, 1, 32]
-    - [52, 2526.15]
-  - - [1856, 1024, 1, 32]
-    - [52, 2165.86]
-  - - [1, 448, 1, 3328]
-    - [78, 4.9083]
-  - - [6784, 2368, 1, 32]
-    - [42, 3636.56]
-  - - [5888, 5056, 1, 1]
-    - [62, 256.282]
-  - - [128, 6784, 1, 1280]
-    - [14, 8007.86]
-  - - [704, 5888, 1, 1]
-    - [63, 172.141]
-  - - [6784, 6784, 1, 1]
-    - [65, 264.255]
-  - - [5888, 448, 1, 3328]
-    - [41, 8534.91]
-  - - [704, 5888, 1, 32]
-    - [42, 2950.29]
-  - - [704, 5888, 1, 1280]
-    - [4, 9935.95]
-  - - [1024, 6784, 1, 3328]
-    - [15, 10137.1]
-  - - [704, 2944, 1, 1280]
-    - [15, 9545.54]
-  - - [4288, 6784, 1, 256]
-    - [16, 9921.89]
-  - - [3584, 256, 1, 32]
-    - [51, 1575.11]
-  - - [1408, 1408, 1, 32]
-    - [42, 2265.67]
-  - - [1408, 1408, 1, 3328]
-    - [15, 9260.11]
-  - - [1024, 64, 1, 256]
-    - [8, 1839.61]
-  - - [4288, 64, 1, 32]
-    - [56, 596.591]
-  - - [5888, 6784, 1, 32]
-    - [42, 3905.57]
-  - - [1024, 2944, 1, 3328]
-    - [15, 9627.64]
-  - - [64, 704, 1, 1280]
-    - [21, 1897.09]
-  - - [2944, 1856, 1, 256]
-    - [15, 9436.05]
-  - - [128, 5056, 1, 3328]
-    - [14, 8165.66]
-  - - [704, 1408, 1, 1]
-    - [65, 76.484]
-  - - [6784, 5056, 1, 32]
-    - [42, 3817.46]
-  - - [1024, 448, 1, 3328]
-    - [19, 7036.9]
-  - - [5888, 1408, 1, 1]
-    - [58, 191.905]
-  - - [2944, 4288, 1, 1280]
-    - [15, 9992.67]
-  - - [64, 32, 1, 3328]
-    - [56, 24.328]
-  - - [1024, 4288, 1, 256]
-    - [19, 9323.77]
-  - - [128, 2368, 1, 256]
-    - [13, 4777.99]
-  - - [2368, 64, 1, 32]
-    - [48, 300.103]
-  - - [1408, 1, 1, 3328]
-    - [78, 15.5242]
-  - - [64, 1408, 1, 32]
-    - [48, 180.224]
-  - - [2368, 5888, 1, 1]
-    - [60, 228.419]
-  - - [448, 1856, 1, 256]
-    - [19, 6411.47]
-  - - [1856, 6784, 1, 3328]
-    - [19, 10025.3]
-  - - [3584, 128, 1, 256]
-    - [15, 5825.42]
-  - - [1024, 448, 1, 1280]
-    - [15, 6808.93]
-  - - [1024, 2368, 1, 32]
-    - [42, 2455.53]
-  - - [128, 5888, 1, 1]
-    - [62, 63.6541]
-  - - [64, 5056, 1, 1]
-    - [59, 30.1851]
-  - - [1856, 256, 1, 32]
-    - [48, 984.738]
-  - - [2368, 2368, 1, 3328]
-    - [3, 9784.35]
-  - - [64, 448, 1, 1]
-    - [76, 2.82205]
-  - - [3584, 5888, 1, 32]
-    - [42, 3753.24]
-  - - [3584, 5888, 1, 1280]
-    - [15, 10154.6]
-  - - [64, 5056, 1, 32]
-    - [52, 743.871]
-  - - [6784, 704, 1, 256]
-    - [15, 9113.29]
-  - - [1408, 704, 1, 32]
-    - [48, 1645.2]
-  - - [1408, 704, 1, 1280]
-    - [15, 8463.03]
-  - - [2368, 5888, 1, 256]
-    - [3, 9765.14]
-  - - [2944, 64, 1, 32]
-    - [43, 364.089]
-  - - [1, 1408, 1, 256]
-    - [74, 9.60682]
-  - - [64, 2944, 1, 256]
-    - [13, 4129.67]
-  - - [5888, 5888, 1, 32]
-    - [42, 3734.83]
-  - - [1856, 1408, 1, 3328]
-    - [15, 9900.83]
-  - - [1024, 1024, 1, 32]
-    - [46, 1671.04]
-  - - [6784, 704, 1, 1]
-    - [63, 180.36]
-  - - [2944, 5056, 1, 1280]
-    - [19, 10124.0]
-  - - [6784, 2944, 1, 1280]
-    - [20, 9987.28]
-  - - [6784, 256, 1, 3328]
-    - [19, 9018.45]
-  - - [5056, 128, 1, 3328]
-    - [14, 8175.58]
-  - - [128, 128, 1, 1280]
-    - [27, 697.191]
-  - - [5888, 64, 1, 1]
-    - [61, 37.6832]
-  - - [1408, 5056, 1, 32]
-    - [42, 3377.86]
-  - - [2944, 128, 1, 3328]
-    - [14, 6942.52]
-  - - [5888, 1856, 1, 1280]
-    - [15, 10065.0]
-  - - [256, 64, 1, 1280]
-    - [21, 708.497]
-  - - [5888, 256, 1, 1280]
-    - [15, 8876.41]
-  - - [1856, 5056, 1, 1]
-    - [63, 216.021]
-  - - [3584, 1856, 1, 1280]
-    - [40, 9648.3]
-  - - [704, 3584, 1, 256]
-    - [3, 8882.33]
-  - - [1856, 5056, 1, 32]
-    - [42, 3427.92]
-  - - [1856, 5056, 1, 3328]
-    - [15, 10308.7]
-  - - [1024, 2944, 1, 32]
-    - [49, 2544.01]
-  - - [1408, 6784, 1, 256]
-    - [15, 9709.65]
-  - - [1024, 2368, 1, 1280]
-    - [15, 9092.4]
-  - - [1856, 3584, 1, 1]
-    - [59, 200.359]
-  - - [2944, 5888, 1, 1280]
-    - [19, 10050.7]
-  - - [1, 1856, 1, 1]
-    - [61, 0.164539]
-  - - [3584, 3584, 1, 256]
-    - [15, 9761.14]
-  - - [1856, 2368, 1, 3328]
-    - [15, 10044.1]
-  - - [5888, 704, 1, 256]
-    - [15, 9275.86]
-  - - [64, 448, 1, 32]
-    - [44, 69.0892]
-  - - [6784, 4288, 1, 256]
-    - [15, 9889.22]
-  - - [128, 64, 1, 3328]
-    - [26, 374.903]
-  - - [1, 5056, 1, 1280]
-    - [78, 35.0958]
-  - - [32, 64, 1, 1280]
-    - [56, 22.0511]
-  - - [1408, 2368, 1, 3328]
-    - [15, 9859.98]
-  - - [1024, 3584, 1, 256]
-    - [20, 9395.24]
-  - - [2944, 128, 1, 256]
-    - [2, 5481.19]
-  - - [6784, 128, 1, 1]
-    - [59, 72.8483]
-  - - [1408, 256, 1, 3328]
-    - [19, 5533.08]
-  - - [2368, 1408, 1, 1]
-    - [63, 156.68]
-  - - [448, 32, 1, 256]
-    - [52, 105.46]
-  - - [5056, 6784, 1, 1280]
-    - [7, 10195.4]
-  - - [64, 2368, 1, 256]
-    - [13, 3439.48]
-  - - [2944, 256, 1, 256]
-    - [15, 7072.51]
-  - - [1, 128, 1, 256]
-    - [78, 0.871489]
-  - - [32, 256, 1, 1280]
-    - [56, 94.0258]
-  - - [5888, 1, 1, 256]
-    - [74, 34.1329]
-  - - [1856, 32, 1, 1280]
-    - [56, 642.51]
-  - - [6784, 128, 1, 256]
-    - [2, 7161.67]
-  - - [6784, 64, 1, 1280]
-    - [12, 6590.91]
-  - - [4288, 1024, 1, 32]
-    - [42, 2956.84]
-  - - [2944, 448, 1, 1280]
-    - [15, 7839.0]
-  - - [6784, 32, 1, 1280]
-    - [56, 1643.83]
-  - - [2944, 64, 1, 1280]
-    - [13, 5562.1]
-  - - [704, 448, 1, 1]
-    - [61, 30.5612]
-  - - [32, 128, 1, 32]
-    - [48, 8.192]
-  - - [1, 128, 1, 1]
-    - [63, 0.0114286]
-  - - [32, 4288, 1, 256]
-    - [56, 820.731]
-  - - [5888, 1, 1, 1]
-    - [59, 0.618487]
-  - - [5888, 1856, 1, 3328]
-    - [0, 10030.4]
-  - - [2368, 3584, 1, 256]
-    - [15, 9502.49]
-  - - [4288, 1408, 1, 3328]
-    - [19, 9692.05]
-  - - [1856, 32, 1, 3328]
-    - [56, 701.308]
-  - - [2944, 32, 1, 256]
-    - [52, 628.053]
-  - - [128, 64, 1, 1]
-    - [74, 0.716084]
-  - - [256, 1024, 1, 3328]
-    - [25, 6310.87]
-  - - [32, 448, 1, 256]
-    - [52, 103.556]
-  - - [1856, 64, 1, 32]
-    - [48, 241.186]
-  - - [1856, 64, 1, 3328]
-    - [26, 4701.63]
-  - - [256, 5056, 1, 256]
-    - [15, 8234.34]
-  - - [5888, 2944, 1, 3328]
-    - [3, 10009.1]
-  - - [2368, 1408, 1, 3328]
-    - [15, 9686.45]
-  - - [5888, 704, 1, 32]
-    - [42, 2824.64]
-  - - [2944, 704, 1, 1]
-    - [59, 125.763]
-  - - [6784, 1856, 1, 256]
-    - [15, 9602.35]
-  - - [1, 704, 1, 256]
-    - [78, 4.83433]
-  - - [1856, 1856, 1, 1]
-    - [59, 160.669]
-  - - [5888, 32, 1, 256]
-    - [56, 1179.9]
-  - - [2368, 1856, 1, 1]
-    - [59, 175.519]
-  - - [128, 704, 1, 256]
-    - [13, 2383.13]
-  - - [256, 1408, 1, 3328]
-    - [15, 5541.26]
-  - - [2944, 128, 1, 1]
-    - [63, 35.6848]
-  - - [32, 256, 1, 3328]
-    - [56, 97.3678]
-  - - [2944, 704, 1, 3328]
-    - [15, 9503.87]
-  - - [2368, 1856, 1, 32]
-    - [42, 2939.8]
-  - - [3584, 128, 1, 1280]
-    - [12, 6931.1]
-  - - [1024, 5056, 1, 3328]
-    - [19, 10114.9]
-  - - [256, 32, 1, 32]
-    - [54, 23.7449]
-  - - [64, 256, 1, 3328]
-    - [21, 765.814]
-  - - [256, 6784, 1, 1]
-    - [62, 112.481]
-  - - [1024, 3584, 1, 32]
-    - [42, 2906.94]
-  - - [256, 6784, 1, 32]
-    - [42, 2086.13]
-  - - [2944, 1408, 1, 32]
-    - [42, 2939.82]
-  - - [1024, 32, 1, 256]
-    - [52, 244.994]
-  - - [4288, 3584, 1, 1]
-    - [59, 236.871]
-  - - [1, 704, 1, 1]
-    - [76, 0.0752137]
-  - - [5056, 448, 1, 3328]
-    - [15, 9322.08]
-  - - [3584, 64, 1, 256]
-    - [12, 4369.07]
-  - - [64, 1856, 1, 32]
-    - [48, 237.568]
-  - - [64, 1856, 1, 3328]
-    - [26, 4692.7]
-  - - [5888, 5888, 1, 3328]
-    - [7, 10200.8]
-  - - [6784, 3584, 1, 32]
-    - [42, 3756.49]
-  - - [4288, 1856, 1, 256]
-    - [15, 9488.56]
-  - - [1856, 2944, 1, 256]
-    - [15, 9559.87]
-  - - [4288, 256, 1, 1]
-    - [63, 80.7153]
-  - - [64, 128, 1, 32]
-    - [48, 16.0627]
-  - - [704, 1, 1, 1280]
-    - [78, 7.04878]
-  - - [1024, 2368, 1, 256]
-    - [19, 8434.14]
-  - - [6784, 1024, 1, 1]
-    - [60, 201.942]
-  - - [1024, 1856, 1, 3328]
-    - [15, 8878.45]
-  - - [5888, 1024, 1, 32]
-    - [42, 3207.08]
-  - - [3584, 256, 1, 1280]
-    - [15, 7767.23]
-  - - [1024, 1, 1, 1]
-    - [59, 0.0941176]
-  - - [1408, 5056, 1, 1280]
-    - [3, 9949.47]
-  - - [5056, 6784, 1, 256]
-    - [3, 9945.59]
-  - - [256, 1856, 1, 256]
-    - [15, 5939.2]
-  - - [256, 704, 1, 1]
-    - [59, 13.9925]
-  - - [256, 128, 1, 32]
-    - [42, 66.534]
-  - - [1408, 1856, 1, 32]
-    - [52, 2436.59]
-  - - [2944, 5056, 1, 1]
-    - [60, 237.626]
-  - - [448, 128, 1, 1]
-    - [59, 4.87619]
-  - - [256, 704, 1, 32]
-    - [48, 346.585]
-  - - [256, 704, 1, 1280]
-    - [23, 4119.41]
-  - - [1, 2368, 1, 1]
-    - [59, 0.209929]
-  - - [5888, 5888, 1, 1280]
-    - [7, 10164.3]
-  - - [256, 2944, 1, 1280]
-    - [19, 8192.0]
-  - - [2944, 256, 1, 3328]
-    - [15, 8257.16]
-  - - [5056, 2944, 1, 1280]
-    - [3, 10006.2]
-  - - [704, 1024, 1, 3328]
-    - [15, 8012.1]
-  - - [2368, 1856, 1, 1280]
-    - [15, 9776.19]
-  - - [448, 2944, 1, 1]
-    - [60, 95.2971]
-  - - [6784, 2944, 1, 1]
-    - [60, 235.965]
-  - - [2944, 1024, 1, 32]
-    - [42, 2638.65]
-  - - [2944, 1024, 1, 1280]
-    - [15, 9371.37]
-  - - [1408, 64, 1, 32]
-    - [48, 185.798]
-  - - [2368, 4288, 1, 256]
-    - [15, 9656.09]
-  - - [448, 1856, 1, 1280]
-    - [15, 7133.41]
-  - - [2368, 448, 1, 1]
-    - [58, 73.6711]
-  - - [448, 2944, 1, 32]
-    - [50, 1838.2]
-  - - [448, 2944, 1, 1280]
-    - [15, 7942.26]
-  - - [2944, 6784, 1, 1280]
-    - [7, 10005.1]
-  - - [256, 6784, 1, 1280]
-    - [15, 9057.13]
-  - - [5056, 128, 1, 256]
-    - [14, 6767.77]
-  - - [3584, 2368, 1, 32]
-    - [42, 3279.97]
-  - - [704, 32, 1, 32]
-    - [51, 47.4274]
-  - - [6784, 3584, 1, 3328]
-    - [16, 10169.8]
-  - - [128, 32, 1, 256]
-    - [52, 30.0624]
-  - - [128, 1408, 1, 1280]
-    - [13, 5379.82]
-  - - [64, 32, 1, 1280]
-    - [56, 22.0809]
-  - - [128, 1856, 1, 3328]
-    - [14, 6359.61]
-  - - [2944, 2944, 1, 256]
-    - [3, 9537.43]
-  - - [5056, 2368, 1, 1280]
-    - [19, 10062.1]
-  - - [448, 128, 1, 32]
-    - [46, 127.431]
-  - - [32, 5056, 1, 3328]
-    - [56, 1294.09]
-  - - [448, 2944, 1, 3328]
-    - [15, 8035.55]
-  - - [2944, 1024, 1, 1]
-    - [59, 115.948]
-  - - [256, 4288, 1, 1]
-    - [65, 83.6683]
-  - - [2368, 128, 1, 1280]
-    - [13, 6024.43]
-  - - [3584, 704, 1, 256]
-    - [15, 8719.26]
-  - - [2368, 5888, 1, 3328]
-    - [3, 10114.4]
-  - - [1408, 3584, 1, 32]
-    - [42, 3067.64]
-  - - [2944, 4288, 1, 32]
-    - [42, 3548.52]
-  - - [5888, 1408, 1, 1280]
-    - [16, 9995.83]
-  - - [3584, 5056, 1, 1280]
-    - [7, 10101.4]
-  - - [5888, 6784, 1, 1280]
-    - [15, 10215.2]
-  - - [64, 1856, 1, 1]
-    - [59, 9.89867]
-  - - [704, 128, 1, 32]
-    - [48, 183.902]
-  - - [128, 3584, 1, 3328]
-    - [13, 7152.95]
-  - - [256, 4288, 1, 3328]
-    - [15, 7866.58]
-  - - [1, 1408, 1, 1280]
-    - [78, 14.1153]
-  - - [6784, 1408, 1, 32]
-    - [42, 3402.27]
-  - - [1856, 704, 1, 32]
-    - [43, 1821.08]
-  - - [128, 4288, 1, 1]
-    - [59, 48.6582]
-  - - [704, 5056, 1, 3328]
-    - [15, 9816.49]
-  - - [1024, 3584, 1, 3328]
-    - [19, 10104.7]
-  - - [3584, 1024, 1, 3328]
-    - [16, 9899.01]
-  - - [1856, 1408, 1, 1]
-    - [63, 142.024]
-  - - [2944, 448, 1, 32]
-    - [52, 1864.19]
-  - - [128, 448, 1, 256]
-    - [13, 1638.4]
-  - - [128, 1024, 1, 1]
-    - [59, 11.2219]
-  - - [32, 32, 1, 256]
-    - [52, 7.4984]
-  - - [4288, 5056, 1, 1280]
-    - [16, 10093.7]
-  - - [1856, 1856, 1, 3328]
-    - [15, 9496.42]
-  - - [3584, 1856, 1, 3328]
-    - [19, 9872.24]
-  - - [4288, 2368, 1, 3328]
-    - [16, 9892.16]
-  - - [256, 64, 1, 32]
-    - [54, 44.5823]
-  - - [1, 1024, 1, 1280]
-    - [78, 10.4224]
-  - - [32, 1408, 1, 256]
-    - [52, 332.21]
-  - - [448, 6784, 1, 32]
-    - [46, 2592.1]
-  - - [5888, 3584, 1, 256]
-    - [3, 9809.45]
-  - - [32, 1024, 1, 256]
-    - [52, 222.628]
-  - - [5888, 448, 1, 1280]
-    - [15, 8920.97]
-  - - [704, 5888, 1, 3328]
-    - [15, 10049.4]
-  - - [1024, 1408, 1, 256]
-    - [15, 7846.4]
-  - - [3584, 2944, 1, 1280]
-    - [19, 9940.56]
-  - - [1, 5056, 1, 256]
-    - [74, 29.6866]
-  - - [256, 1024, 1, 1]
-    - [59, 23.5741]
-  - - [32, 32, 1, 3328]
-    - [56, 12.1744]
-  - - [5056, 128, 1, 32]
-    - [56, 1238.6]
-  - - [2368, 1, 1, 3328]
-    - [78, 25.8893]
-  - - [4288, 1856, 1, 1280]
-    - [19, 9864.91]
-  - - [3584, 5888, 1, 1]
-    - [60, 244.923]
-  - - [5888, 4288, 1, 256]
-    - [15, 9815.66]
-  - - [1024, 2944, 1, 1280]
-    - [15, 9504.33]
-  - - [6784, 1, 1, 1]
-    - [74, 0.712605]
-  - - [1408, 64, 1, 1280]
-    - [26, 3551.21]
-  - - [1, 256, 1, 1280]
-    - [78, 2.5632]
-  - - [2944, 3584, 1, 256]
-    - [15, 9578.48]
-  - - [1, 128, 1, 1280]
-    - [78, 1.30197]
-  - - [1024, 256, 1, 32]
-    - [48, 602.63]
-  - - [5888, 1, 1, 1280]
-    - [78, 41.1389]
-  - - [2368, 32, 1, 1280]
-    - [56, 829.286]
-  - - [6784, 448, 1, 1]
-    - [63, 148.982]
-  - - [6784, 128, 1, 1280]
-    - [2, 8101.24]
-  - - [448, 2368, 1, 1280]
-    - [15, 7500.58]
-  - - [6784, 2368, 1, 3328]
-    - [39, 9882.33]
-  - - [1, 64, 1, 256]
-    - [74, 0.435745]
-  - - [704, 128, 1, 1]
-    - [59, 7.93239]
-  - - [1408, 4288, 1, 32]
-    - [42, 3202.92]
-  - - [32, 1408, 1, 3328]
-    - [56, 531.876]
-  - - [256, 448, 1, 256]
-    - [11, 3008.21]
-  - - [1856, 1024, 1, 1280]
-    - [15, 8778.49]
-  - - [1024, 448, 1, 1]
-    - [63, 39.2767]
-  - - [4288, 3584, 1, 1280]
-    - [15, 10124.4]
-  - - [448, 1024, 1, 1280]
-    - [15, 6847.04]
-  - - [5056, 1856, 1, 1]
-    - [59, 218.028]
-  - - [5888, 2368, 1, 256]
-    - [15, 9663.6]
-  - - [1408, 1024, 1, 32]
-    - [42, 1961.62]
-  - - [32, 704, 1, 256]
-    - [52, 166.489]
-  - - [2944, 1, 1, 256]
-    - [78, 19.2654]
-  - - [704, 1024, 1, 32]
-    - [50, 1322.74]
-  - - [5056, 1856, 1, 32]
-    - [42, 3393.83]
-  - - [5056, 1856, 1, 1280]
-    - [15, 10059.8]
-  - - [1, 64, 1, 1]
-    - [63, 0.0057971]
-  - - [1408, 5888, 1, 3328]
-    - [3, 10237.1]
-  - - [1408, 704, 1, 3328]
-    - [19, 8621.21]
-  - - [5056, 704, 1, 3328]
-    - [15, 9628.18]
-  - - [704, 64, 1, 1280]
-    - [21, 1897.09]
-  - - [1, 704, 1, 1280]
-    - [78, 6.98326]
-  - - [1408, 256, 1, 1]
-    - [66, 34.3939]
-  - - [5888, 4288, 1, 32]
-    - [42, 3554.77]
-  - - [1408, 3584, 1, 256]
-    - [16, 9350.36]
-  - - [1408, 6784, 1, 1]
-    - [62, 222.343]
-  - - [2944, 1, 1, 1]
-    - [59, 0.243709]
-  - - [256, 1856, 1, 3328]
-    - [15, 7282.85]
-  - - [4288, 128, 1, 1280]
-    - [12, 6855.44]
-  - - [128, 128, 1, 1]
-    - [69, 1.91402]
-  - - [6784, 256, 1, 1280]
-    - [15, 8903.32]
-  - - [128, 4288, 1, 256]
-    - [12, 5854.55]
-  - - [2368, 6784, 1, 1280]
-    - [3, 10115.8]
-  - - [128, 128, 1, 32]
-    - [52, 45.8294]
-  - - [128, 128, 1, 3328]
-    - [21, 765.814]
-  - - [128, 1408, 1, 32]
-    - [51, 351.657]
-  - - [6784, 128, 1, 32]
-    - [51, 1536.91]
-  - - [1408, 448, 1, 1]
-    - [61, 54.3779]
-  - - [2368, 704, 1, 3328]
-    - [15, 8677.45]
-  - - [704, 128, 1, 3328]
-    - [26, 3801.89]
-  - - [2944, 1856, 1, 32]
-    - [52, 2929.77]
-  - - [5888, 1856, 1, 1]
-    - [58, 201.181]
-  - - [1408, 32, 1, 1280]
-    - [56, 487.751]
-  - - [704, 1, 1, 256]
-    - [74, 4.79319]
-  - - [1856, 2944, 1, 3328]
-    - [15, 10177.1]
-  - - [3584, 2944, 1, 1]
-    - [62, 199.835]
-  - - [5888, 64, 1, 256]
-    - [2, 5456.39]
-  - - [64, 5056, 1, 1280]
-    - [13, 6407.6]
-  - - [1408, 2944, 1, 1]
-    - [59, 171.005]
-  - - [4288, 1408, 1, 32]
-    - [42, 3220.0]
-  - - [5888, 2944, 1, 256]
-    - [15, 9719.57]
-  - - [128, 64, 1, 1280]
-    - [8, 335.223]
-  - - [1408, 2944, 1, 32]
-    - [42, 2934.62]
-  - - [1, 3584, 1, 1280]
-    - [78, 37.4797]
-  - - [64, 64, 1, 32]
-    - [48, 8.03137]
-  - - [448, 1408, 1, 32]
-    - [50, 1236.83]
-  - - [128, 5056, 1, 256]
-    - [2, 6767.77]
-  - - [1, 1, 1, 1280]
-    - [78, 0.0101458]
-  - - [64, 704, 1, 256]
-    - [11, 1334.99]
-  - - [3584, 1408, 1, 1280]
-    - [16, 9615.37]
-  - - [5888, 6784, 1, 256]
-    - [3, 9947.18]
-  - - [6784, 5888, 1, 1]
-    - [65, 260.46]
-  - - [64, 4288, 1, 256]
-    - [1, 4503.5]
-  - - [1, 448, 1, 1280]
-    - [78, 4.56561]
-  - - [1024, 1024, 1, 1]
-    - [63, 73.636]
-  - - [6784, 5888, 1, 1280]
-    - [7, 10192.3]
-  - - [1024, 4288, 1, 32]
-    - [42, 2946.92]
-  - - [1856, 1, 1, 1280]
-    - [78, 17.4887]
-  - - [3584, 5888, 1, 256]
-    - [15, 9789.54]
-  - - [5056, 2368, 1, 1]
-    - [63, 229.185]
-  - - [256, 1408, 1, 1280]
-    - [15, 5399.97]
-  - - [64, 256, 1, 32]
-    - [48, 32.1255]
-  - - [64, 5888, 1, 3328]
-    - [14, 6930.24]
-  - - [6784, 64, 1, 3328]
-    - [12, 6790.12]
-  - - [5056, 448, 1, 1]
-    - [59, 128.116]
-  - - [2944, 448, 1, 3328]
-    - [15, 7918.41]
-  - - [1856, 6784, 1, 256]
-    - [15, 9616.12]
-  - - [4288, 32, 1, 1280]
-    - [56, 1053.48]
-  - - [448, 1408, 1, 1280]
-    - [15, 6879.72]
-  - - [5056, 448, 1, 32]
-    - [50, 2248.23]
-  - - [3584, 2944, 1, 32]
-    - [42, 3540.7]
-  - - [2368, 128, 1, 1]
-    - [61, 28.4872]
-  - - [128, 3584, 1, 32]
-    - [52, 970.904]
-  - - [3584, 1856, 1, 32]
-    - [42, 3233.0]
-  - - [4288, 64, 1, 3328]
-    - [13, 5682.61]
-  - - [5056, 64, 1, 256]
-    - [13, 5026.55]
-  - - [1024, 1856, 1, 1]
-    - [61, 113.669]
-  - - [64, 448, 1, 3328]
-    - [34, 1360.04]
-  - - [4288, 1408, 1, 1280]
-    - [3, 9639.75]
-  - - [32, 5056, 1, 256]
-    - [56, 1019.16]
-  - - [704, 128, 1, 256]
-    - [11, 2423.18]
-  - - [704, 5056, 1, 1]
-    - [63, 160.046]
-  - - [256, 1024, 1, 32]
-    - [52, 602.63]
-  - - [256, 1024, 1, 1280]
-    - [25, 6009.03]
-  - - [2368, 128, 1, 256]
-    - [13, 4825.54]
-  - - [2368, 1408, 1, 1280]
-    - [15, 9596.38]
-  - - [128, 256, 1, 32]
-    - [53, 67.5629]
-  - - [64, 6784, 1, 32]
-    - [51, 914.055]
-  - - [6784, 32, 1, 256]
-    - [56, 1346.28]
-  - - [5056, 2944, 1, 1]
-    - [63, 222.295]
-  - - [3584, 128, 1, 1]
-    - [61, 41.8569]
-  - - [1024, 4288, 1, 1280]
-    - [15, 9938.41]
-  - - [1856, 4288, 1, 1]
-    - [63, 193.921]
-  - - [128, 2944, 1, 256]
-    - [2, 5506.22]
-  - - [3584, 4288, 1, 256]
-    - [15, 9740.18]
-  - - [3584, 128, 1, 32]
-    - [50, 986.563]
-  - - [3584, 128, 1, 3328]
-    - [18, 7147.6]
-  - - [704, 5056, 1, 256]
-    - [15, 9178.21]
-  - - [1856, 4288, 1, 32]
-    - [42, 3379.42]
-  - - [5056, 1, 1, 1280]
-    - [78, 35.5431]
-  - - [64, 256, 1, 1280]
-    - [21, 714.289]
-  - - [4288, 1024, 1, 1280]
-    - [19, 9745.39]
-  - - [1, 4288, 1, 256]
-    - [74, 25.0391]
-  - - [2944, 3584, 1, 1]
-    - [58, 207.051]
-  - - [4288, 6784, 1, 32]
-    - [42, 3838.97]
-  - - [4288, 4288, 1, 256]
-    - [15, 9734.97]
-  - - [3584, 3584, 1, 1]
-    - [58, 232.364]
-  - - [3584, 1408, 1, 256]
-    - [3, 9201.18]
-  - - [704, 3584, 1, 3328]
-    - [15, 9579.49]
-  - - [5056, 448, 1, 1280]
-    - [15, 9210.0]
-  - - [1408, 2944, 1, 1280]
-    - [15, 9941.9]
-  - - [5888, 704, 1, 1280]
-    - [38, 9567.57]
-  - - [64, 64, 1, 256]
-    - [33, 121.363]
-  - - [704, 1408, 1, 1280]
-    - [15, 8454.0]
-  - - [4288, 5888, 1, 256]
-    - [3, 9835.97]
-  - - [3584, 3584, 1, 3328]
-    - [3, 10049.7]
-  - - [2944, 6784, 1, 32]
-    - [42, 3743.6]
-  - - [448, 64, 1, 32]
-    - [51, 74.9595]
-  - - [5056, 256, 1, 1]
-    - [62, 91.4079]
-  - - [64, 6784, 1, 1280]
-    - [13, 6572.2]
-  - - [2944, 2368, 1, 3328]
-    - [15, 9974.19]
-  - - [1, 4288, 1, 1]
-    - [66, 0.391241]
-  - - [1408, 128, 1, 256]
-    - [13, 3950.11]
-  - - [1024, 1856, 1, 1280]
-    - [19, 8760.79]
-  - - [1024, 5888, 1, 256]
-    - [15, 9598.9]
-  - - [704, 1408, 1, 256]
-    - [15, 7606.58]
-  - - [6784, 2944, 1, 3328]
-    - [7, 10051.4]
-  - - [1408, 2368, 1, 256]
-    - [15, 9173.91]
-  - - [1024, 1408, 1, 1]
-    - [61, 96.8946]
-  - - [64, 128, 1, 1280]
-    - [8, 336.946]
-  - - [5888, 32, 1, 3328]
-    - [56, 1500.69]
-  - - [1408, 5056, 1, 256]
-    - [3, 9567.54]
-  - - [1024, 1408, 1, 32]
-    - [42, 1948.37]
-  - - [4288, 1024, 1, 1]
-    - [59, 173.143]
-  - - [448, 704, 1, 256]
-    - [15, 4136.29]
-  - - [704, 3584, 1, 32]
-    - [42, 2455.61]
-  - - [1856, 256, 1, 3328]
-    - [15, 7298.99]
-  - - [6784, 448, 1, 256]
-    - [15, 8906.17]
-  - - [4288, 4288, 1, 1]
-    - [63, 243.729]
-  - - [256, 2944, 1, 1]
-    - [62, 62.8053]
-  - - [64, 2368, 1, 3328]
-    - [13, 4783.43]
-  - - [256, 704, 1, 3328]
-    - [25, 4366.52]
-  - - [1, 2944, 1, 1]
-    - [59, 0.221687]
-  - - [1024, 1024, 1, 256]
-    - [19, 7913.78]
-  - - [4288, 704, 1, 1280]
-    - [15, 9376.81]
-  - - [3584, 1, 1, 1]
-    - [61, 0.376471]
-  - - [256, 2944, 1, 32]
-    - [52, 1376.56]
-  - - [6784, 4288, 1, 3328]
-    - [19, 10278.1]
-  - - [5056, 2944, 1, 3328]
-    - [37, 9954.81]
-  - - [704, 1024, 1, 1280]
-    - [15, 7814.59]
-  - - [256, 3584, 1, 1280]
-    - [15, 7854.5]
-  - - [2368, 1856, 1, 3328]
-    - [15, 9863.1]
-  - - [1856, 4288, 1, 1280]
-    - [15, 10045.5]
-  - - [1, 1024, 1, 256]
-    - [78, 7.03176]
-  - - [2944, 1024, 1, 3328]
-    - [3, 9409.48]
-  - - [2944, 256, 1, 32]
-    - [50, 1389.24]
-  - - [128, 1, 1, 3328]
-    - [78, 1.39905]
-  - - [5888, 5056, 1, 32]
-    - [42, 3837.54]
-  - - [4288, 1408, 1, 1]
-    - [63, 192.522]
-  - - [3584, 448, 1, 32]
-    - [46, 1861.6]
-  - - [3584, 448, 1, 1280]
-    - [15, 8260.49]
-  - - [2944, 6784, 1, 3328]
-    - [3, 10068.6]
-  - - [1024, 1408, 1, 3328]
-    - [15, 8770.08]
-  - - [6784, 1024, 1, 1280]
-    - [35, 9580.97]
-  - - [6784, 3584, 1, 1280]
-    - [15, 10205.7]
-  - - [1, 5056, 1, 3328]
-    - [78, 36.108]
-  - - [4288, 64, 1, 1]
-    - [59, 27.011]
-  - - [128, 2368, 1, 32]
-    - [52, 713.186]
-  - - [128, 1408, 1, 3328]
-    - [13, 5658.35]
-  - - [2944, 32, 1, 3328]
-    - [56, 1118.77]
-  - - [704, 1856, 1, 256]
-    - [15, 8263.23]
-  - - [2944, 2944, 1, 1]
-    - [62, 216.678]
-  - - [1408, 4288, 1, 256]
-    - [3, 9401.47]
-  - - [5888, 5056, 1, 256]
-    - [15, 9857.51]
-  - - [256, 5056, 1, 3328]
-    - [15, 9262.75]
-  - - [2368, 64, 1, 1280]
-    - [13, 4549.4]
-  - - [1856, 448, 1, 32]
-    - [48, 1465.18]
-  - - [1408, 448, 1, 256]
-    - [15, 6098.21]
-  - - [32, 128, 1, 256]
-    - [52, 29.8569]
-  - - [448, 1024, 1, 1]
-    - [61, 41.2547]
-  - - [448, 6784, 1, 1]
-    - [63, 152.572]
-  - - [704, 2944, 1, 256]
-    - [3, 8866.64]
-  - - [1408, 1408, 1, 256]
-    - [15, 8515.28]
+- - - [64, 448, 1, 3328]
+    - [0, .inf]
   - - [1, 64, 1, 1280]
-    - [78, 0.6396]
-  - - [2944, 2368, 1, 1]
-    - [59, 203.129]
-  - - [4288, 448, 1, 32]
-    - [54, 2152.41]
-  - - [4288, 448, 1, 1280]
-    - [15, 8744.33]
-  - - [2944, 704, 1, 32]
-    - [52, 2216.66]
-  - - [1024, 704, 1, 256]
-    - [19, 6865.68]
-  - - [6784, 256, 1, 1]
-    - [58, 112.481]
-  - - [3584, 5056, 1, 1]
-    - [62, 229.725]
-  - - [2368, 2368, 1, 1]
-    - [59, 189.44]
-  - - [64, 5888, 1, 1]
-    - [74, 35.1522]
-  - - [1408, 3584, 1, 1280]
-    - [15, 9773.68]
-  - - [6784, 448, 1, 1280]
-    - [15, 9434.93]
-  - - [3584, 5056, 1, 3328]
-    - [3, 10155.3]
-  - - [2368, 2368, 1, 32]
-    - [42, 3093.75]
-  - - [64, 5888, 1, 32]
-    - [56, 842.083]
-  - - [1856, 448, 1, 256]
-    - [15, 6426.96]
-  - - [3584, 2368, 1, 1280]
-    - [15, 9917.5]
-  - - [128, 1024, 1, 256]
-    - [26, 3251.4]
-  - - [3584, 64, 1, 3328]
-    - [22, 6054.59]
-  - - [5888, 2944, 1, 32]
-    - [42, 3678.36]
-  - - [2944, 1, 1, 1280]
-    - [78, 29.0944]
-  - - [1856, 2944, 1, 32]
-    - [42, 3082.69]
-  - - [5056, 1408, 1, 1]
-    - [59, 202.701]
-  - - [5888, 1408, 1, 3328]
-    - [15, 10044.7]
-  - - [448, 4288, 1, 256]
-    - [15, 8284.74]
-  - - [256, 448, 1, 1]
-    - [59, 9.75238]
-  - - [128, 5888, 1, 3328]
-    - [15, 8383.0]
-  - - [6784, 1024, 1, 32]
-    - [42, 3269.09]
-  - - [256, 448, 1, 32]
-    - [51, 235.257]
-  - - [6784, 3584, 1, 1]
-    - [62, 249.731]
-  - - [2944, 2368, 1, 32]
-    - [42, 3269.12]
-  - - [3584, 6784, 1, 3328]
-    - [19, 10247.7]
-  - - [448, 128, 1, 1280]
-    - [31, 2433.7]
-  - - [64, 3584, 1, 32]
-    - [56, 527.301]
+    - [13, 0.637212]
+  - - [1, 2944, 1, 3328]
+    - [13, 31.1472]
+  - - [64, 128, 1, 256]
+    - [0, .inf]
+  - - [128, 64, 1, 1280]
+    - [1, .inf]
+  - - [1, 2368, 1, 1280]
+    - [13, 23.5475]
+  - - [1, 128, 1, 1]
+    - [5, 0.0126984]
+  - - [64, 1408, 1, 3328]
+    - [0, .inf]
+  - - [64, 1024, 1, 3328]
+    - [0, .inf]
+  - - [1, 64, 1, 3328]
+    - [13, 0.684247]
+  - - [64, 448, 1, 1280]
+    - [0, .inf]
+  - - [1, 256, 1, 1280]
+    - [13, 2.67364]
+  - - [64, 64, 1, 1280]
+    - [4, 168.476]
+  - - [64, 5056, 1, 256]
+    - [0, .inf]
+  - - [1, 1, 1, 3328]
+    - [13, 0.010513]
+  - - [1, 1408, 1, 1280]
+    - [11, 13.7871]
+  - - [1, 2368, 1, 3328]
+    - [13, 25.0979]
+  - - [1, 64, 1, 1]
+    - [5, 0.0064]
+  - - [1, 128, 1, 1280]
+    - [13, 1.2808]
+  - - [64, 1856, 1, 256]
+    - [0, .inf]
+  - - [64, 1024, 1, 1280]
+    - [0, .inf]
+  - - [64, 256, 1, 1280]
+    - [0, .inf]
+  - - [1, 1024, 1, 256]
+    - [9, 7.298]
+  - - [1, 704, 1, 3328]
+    - [13, 7.52478]
+  - - [64, 2368, 1, 3328]
+    - [0, .inf]
   - - [64, 3584, 1, 1280]
-    - [14, 5872.03]
-  - - [6784, 1408, 1, 256]
-    - [15, 9575.81]
-  - - [5056, 1024, 1, 32]
-    - [42, 3068.06]
-  - - [1024, 5056, 1, 1280]
-    - [15, 10014.2]
-  - - [4288, 3584, 1, 256]
-    - [15, 9747.9]
-  - - [1408, 1024, 1, 3328]
-    - [15, 8779.06]
-  - - [2368, 256, 1, 3328]
-    - [15, 6687.42]
-  - - [448, 6784, 1, 1280]
-    - [15, 9596.94]
-  - - [1856, 5888, 1, 1]
-    - [63, 226.162]
-  - - [256, 5888, 1, 32]
-    - [42, 1983.33]
-  - - [3584, 1, 1, 3328]
-    - [78, 39.8861]
-  - - [4288, 32, 1, 256]
-    - [56, 883.483]
-  - - [256, 64, 1, 1]
-    - [66, 1.3932]
-  - - [4288, 5056, 1, 32]
-    - [42, 3768.82]
-  - - [4288, 5056, 1, 3328]
-    - [15, 10238.7]
-  - - [1856, 5888, 1, 32]
-    - [42, 3497.0]
-  - - [1856, 5888, 1, 1280]
-    - [3, 10278.0]
-  - - [256, 256, 1, 1280]
-    - [29, 2788.77]
-  - - [704, 2368, 1, 1280]
-    - [15, 8696.82]
-  - - [5056, 32, 1, 1280]
-    - [56, 1258.47]
-  - - [4288, 2368, 1, 1280]
-    - [15, 10061.5]
-  - - [2944, 5056, 1, 256]
-    - [15, 9766.56]
-  - - [4288, 128, 1, 32]
-    - [43, 1030.73]
-  - - [64, 5888, 1, 1280]
-    - [14, 6729.14]
-  - - [1, 1856, 1, 1280]
-    - [78, 18.9147]
-  - - [2944, 4288, 1, 1]
-    - [58, 233.085]
-  - - [5056, 5888, 1, 32]
-    - [42, 3788.7]
-  - - [704, 4288, 1, 1]
-    - [59, 147.4]
-  - - [704, 1, 1, 3328]
-    - [78, 7.71101]
-  - - [448, 256, 1, 1280]
-    - [26, 4277.41]
-  - - [5888, 6784, 1, 1]
-    - [62, 259.918]
-  - - [2368, 5056, 1, 3328]
-    - [15, 10145.4]
-  - - [704, 704, 1, 1280]
-    - [19, 7390.36]
-  - - [128, 32, 1, 3328]
-    - [56, 48.8934]
-  - - [1024, 6784, 1, 32]
-    - [42, 3296.24]
-  - - [2368, 1408, 1, 256]
-    - [15, 9064.79]
-  - - [3584, 2944, 1, 3328]
-    - [15, 10017.9]
-  - - [128, 1856, 1, 256]
-    - [12, 4663.91]
-  - - [32, 32, 1, 1280]
-    - [56, 11.2682]
-  - - [1408, 5888, 1, 1]
-    - [62, 215.444]
-  - - [1, 3584, 1, 256]
-    - [78, 28.1098]
-  - - [704, 4288, 1, 32]
-    - [42, 2636.46]
-  - - [1408, 5888, 1, 32]
-    - [42, 3309.5]
-  - - [32, 1856, 1, 256]
-    - [52, 403.513]
-  - - [6784, 2368, 1, 1]
-    - [62, 241.062]
-  - - [1856, 1, 1, 3328]
-    - [78, 20.4529]
-  - - [5056, 1408, 1, 256]
-    - [3, 9460.26]
+    - [0, .inf]
+  - - [1, 256, 1, 1]
+    - [12, 0.0326531]
+  - - [1, 3584, 1, 1280]
+    - [13, 36.7121]
+  - - [128, 64, 1, 256]
+    - [0, .inf]
+  - - [64, 128, 1, 3328]
+    - [0, .inf]
+  - - [64, 256, 1, 3328]
+    - [0, .inf]
   - - [1, 1, 1, 256]
-    - [74, 0.0067086]
-  - - [2944, 1408, 1, 256]
-    - [3, 9328.05]
-  - - [4288, 1, 1, 1]
-    - [61, 0.432258]
-  - - [2368, 2368, 1, 256]
-    - [3, 9345.71]
+    - [11, 0.00711111]
+  - - [1, 2944, 1, 1]
+    - [9, 0.248649]
+  - - [1, 1408, 1, 3328]
+    - [13, 14.9535]
+  - - [64, 2944, 1, 256]
+    - [0, .inf]
+  - - [64, 1408, 1, 1280]
+    - [0, .inf]
+  - - [64, 2368, 1, 1280]
+    - [0, .inf]
+  - - [64, 3584, 1, 3328]
+    - [0, .inf]
+  - - [1, 704, 1, 1]
+    - [10, 0.06875]
+  - - [64, 6784, 1, 3328]
+    - [0, .inf]
+  - - [1, 704, 1, 1280]
+    - [13, 7.00498]
+  - - [1, 2944, 1, 256]
+    - [9, 20.087]
+  - - [64, 1856, 1, 3328]
+    - [0, .inf]
+  - - [64, 448, 1, 256]
+    - [0, .inf]
+  - - [1, 448, 1, 1280]
+    - [13, 4.41651]
+  - - [64, 5056, 1, 3328]
+    - [0, .inf]
+  - - [64, 128, 1, 1280]
+    - [0, .inf]
+  - - [1, 5056, 1, 256]
+    - [11, 30.1289]
+  - - [1, 1856, 1, 256]
+    - [6, 13.169]
+  - - [1, 1856, 1, 1280]
+    - [11, 17.9976]
+  - - [1, 1, 1, 1]
+    - [13, 9.25926e-05]
+  - - [256, 64, 1, 256]
+    - [1, .inf]
+  - - [1, 4288, 1, 1280]
+    - [6, 29.5469]
+  - - [1, 1408, 1, 1]
+    - [5, 0.1375]
+  - - [64, 6784, 1, 1280]
+    - [0, .inf]
+  - - [64, 1856, 1, 1280]
+    - [0, .inf]
+  - - [64, 6784, 1, 256]
+    - [0, .inf]
+  - - [64, 5056, 1, 1280]
+    - [0, .inf]
+  - - [1, 448, 1, 3328]
+    - [13, 4.79837]
+  - - [64, 4288, 1, 256]
+    - [0, .inf]
+  - - [1, 1408, 1, 256]
+    - [9, 9.81612]
+  - - [1, 2368, 1, 256]
+    - [9, 16.2959]
+  - - [1, 4288, 1, 1]
+    - [9, 0.41875]
+  - - [1, 128, 1, 256]
+    - [9, 0.910222]
+  - - [64, 5888, 1, 3328]
+    - [0, .inf]
+  - - [1, 1024, 1, 3328]
+    - [13, 10.9451]
+  - - [1, 1856, 1, 3328]
+    - [13, 19.9097]
+  - - [64, 1024, 1, 256]
+    - [0, .inf]
+  - - [64, 256, 1, 256]
+    - [0, .inf]
+  - - [1, 4288, 1, 3328]
+    - [11, 31.1202]
+  - - [1, 1024, 1, 1280]
+    - [13, 10.1324]
+  - - [1, 2368, 1, 1]
+    - [5, 0.209938]
+  - - [1, 3584, 1, 3328]
+    - [13, 38.6256]
+  - - [1, 1, 1, 1280]
+    - [13, 0.00988875]
+  - - [64, 704, 1, 256]
+    - [0, .inf]
+  - - [64, 2944, 1, 3328]
+    - [0, .inf]
+  - - [64, 64, 1, 256]
+    - [3, 123.653]
+  - - [1, 5056, 1, 1]
+    - [5, 0.522314]
+  - - [128, 64, 1, 3328]
+    - [1, .inf]
   - - [1, 448, 1, 256]
-    - [78, 3.05021]
-  - - [1856, 704, 1, 1]
-    - [66, 92.8]
-  - - [3584, 32, 1, 3328]
-    - [56, 1355.4]
-  - - [128, 3584, 1, 1]
-    - [61, 42.477]
-  - - [1856, 1, 1, 256]
-    - [78, 12.6098]
-  - - [32, 5888, 1, 32]
-    - [54, 430.665]
-  - - [1024, 5888, 1, 1]
-    - [62, 189.363]
-  - - [6784, 32, 1, 3328]
-    - [56, 1731.71]
-  - - [2368, 704, 1, 1]
-    - [63, 109.676]
-  - - [1408, 32, 1, 256]
-    - [52, 332.21]
-  - - [448, 2368, 1, 1]
-    - [62, 79.8843]
-  - - [1856, 3584, 1, 256]
-    - [3, 9596.98]
-  - - [2944, 64, 1, 256]
-    - [13, 3940.73]
-  - - [2368, 704, 1, 32]
-    - [54, 2026.84]
-  - - [256, 5888, 1, 1280]
-    - [15, 9039.45]
-  - - [448, 2368, 1, 32]
-    - [48, 1638.4]
-  - - [448, 2368, 1, 3328]
-    - [19, 7607.64]
+    - [9, 3.13698]
+  - - [1, 3584, 1, 256]
+    - [13, 27.5692]
+  - - [64, 4288, 1, 1280]
+    - [0, .inf]
+  - - [1, 1024, 1, 1]
+    - [11, 0.0914286]
+  - - [64, 2944, 1, 1280]
+    - [0, .inf]
+  - - [64, 5888, 1, 1280]
+    - [0, .inf]
+  - - [64, 704, 1, 3328]
+    - [0, .inf]
+  - - [1, 256, 1, 256]
+    - [12, 1.95981]
   - - [64, 1408, 1, 256]
-    - [11, 2485.85]
-  - - [5056, 32, 1, 32]
-    - [56, 387.526]
-  - - [1024, 704, 1, 3328]
-    - [15, 8007.82]
-  - - [32, 5888, 1, 3328]
-    - [56, 1511.69]
-  - - [256, 64, 1, 3328]
-    - [24, 765.814]
-  - - [32, 1408, 1, 1280]
-    - [56, 495.121]
-  - - [64, 32, 1, 256]
-    - [52, 14.9285]
-  - - [1856, 1024, 1, 3328]
-    - [15, 8884.44]
-  - - [2368, 1, 1, 1]
-    - [59, 0.208451]
-  - - [5056, 2368, 1, 3328]
-    - [15, 10142.1]
-  - - [128, 1, 1, 1280]
-    - [78, 1.3028]
-  - - [704, 4288, 1, 1280]
-    - [15, 9526.63]
-  - - [704, 256, 1, 256]
-    - [10, 3295.52]
+    - [0, .inf]
+  - - [64, 2368, 1, 256]
+    - [0, .inf]
+  - - [64, 3584, 1, 256]
+    - [0, .inf]
+  - - [1, 5056, 1, 1280]
+    - [11, 35.5901]
+  - - [1, 3584, 1, 1]
+    - [8, 0.315493]
+  - - [1, 704, 1, 256]
+    - [11, 5.03982]
+  - - [1, 128, 1, 3328]
+    - [13, 1.35182]
+  - - [1, 2944, 1, 1280]
+    - [11, 28.4446]
+  - - [64, 4288, 1, 3328]
+    - [0, .inf]
+  - - [64, 64, 1, 3328]
+    - [2, .inf]
+  - - [1, 448, 1, 1]
+    - [7, 0.0495575]
+  - - [1, 64, 1, 256]
+    - [6, 0.453097]
+  - - [64, 5888, 1, 256]
+    - [0, .inf]
+  - - [64, 704, 1, 1280]
+    - [0, .inf]
+  - - [1, 1856, 1, 1]
+    - [6, 0.170588]
+  - - [1, 256, 1, 3328]
+    - [13, 2.78567]
+  - - [1, 4288, 1, 256]
+    - [11, 25.5048]
   - - [1024, 1024, 1, 1024]
-    - [106, 12905.6]
+    - [41, 12905.6]
 - null


### PR DESCRIPTION

This is a fix which updates the vega20 HBH logic files which, by removing the VectorWidth=2 assertions from the Source configurations prevents the faulty kernel selection which is what we have been seeing in these 96 failures.

note as of this submission I have only verified that this fix works for one of the failing test cases.   
-  
-  
-  
