### PR TITLE
TRSM Optimization: Custom Trtri Kernel

### DIFF
--- a/library/src/blas3/trtri_device.h
+++ b/library/src/blas3/trtri_device.h
@@ -165,4 +165,212 @@ __device__ void trtri_device(rocblas_fill uplo,
     }
 }
 
+template <typename T, rocblas_int IB>
+__device__ void custom_trtri_device(rocblas_fill uplo,
+                                    rocblas_diagonal diag,
+                                    rocblas_int n,
+                                    const T* A,
+                                    rocblas_int lda,
+                                    T* invA,
+                                    rocblas_int ldinvA)
+{
+
+    // quick return
+    if(n <= 0)
+        return;
+
+    int tx = hipThreadIdx_x;
+
+    __shared__ T diag1[IB * IB];
+    __shared__ T diag2[IB * IB];
+    __shared__ T sA[IB * IB];
+    __shared__ T temp[IB * IB];
+
+    T* diagP       = tx < n ? diag1 : (tx < 2 * n ? diag2 : sA);
+    int Aoffset    = tx < n ? 0 : n * lda + n;
+    int AInvoffset = tx < n ? 0 : n * ldinvA + n;
+    int index      = tx < n ? tx : (tx < 2 * n ? tx - n : tx - 2 * n);
+    int r          = tx % n;
+    int c          = tx / n;
+
+    // read matrix A into shared memory, only need to read lower part
+    // its inverse will overwrite the shared memory
+
+    if(tx < 2 * n)
+    {
+        if(uplo == rocblas_fill_lower)
+        {
+            for(int i = 0; i < n; i++)
+            {
+                diagP[index + i * n] = i <= index ? A[Aoffset + index + i * lda] : 0.0f;
+            }
+        }
+        else
+        { // transpose A in sA if upper
+            for(int i = n - 1; i >= 0; i--)
+            {
+                diagP[(n - 1 - index) + (n - 1 - i) * n] =
+                    i >= index ? A[Aoffset + index + i * lda] : 0.0f;
+            }
+        }
+    }
+    else if(tx < n * 3)
+    {
+        if(uplo == rocblas_fill_lower)
+        {
+            for(int i = 0; i < n; i++)
+            {
+                diagP[index + i * n] = A[n + index + i * lda];
+            }
+        }
+        else
+        { // transpose A in diag1 if upper
+            for(int i = n - 1; i >= 0; i--)
+            {
+                diagP[index + i * n] = A[n * lda + index + i * lda];
+            }
+        }
+    }
+
+    __syncthreads(); // if IB < 64, this synch can be avoided - IB = 16 here
+
+    // invert the diagonal element
+    if(tx < 2 * n)
+    {
+        // compute only diagonal element
+        if(diag == rocblas_diagonal_unit)
+        {
+            diagP[index + index * n] = 1.0;
+        }
+        else
+        { // inverse the diagonal
+            if(diagP[index + index * n] == 0.0)
+            {                                   // notice this does not apply for complex
+                diagP[index + index * n] = 1.0; // means the matrix is singular
+            }
+            else
+            {
+                diagP[index + index * n] = 1.0 / diagP[index + index * n];
+            }
+        }
+    }
+
+    __syncthreads(); // if IB < 64, this synch can be avoided on AMD Fiji
+
+    // solve the inverse of A column by column, each inverse(A)' column will overwrite diag1'column
+    // which store A
+    // this operation is safe
+    if(tx < 2 * n)
+    {
+        for(int col = 0; col < n; col++)
+        {
+
+            T reg = 0;
+            // use the diagonal one to update current column
+            if(index > col)
+            {
+                reg += diagP[index + col * n] * diagP[col + col * n];
+            }
+
+            // __syncthreads(); // if IB < 64, this synch can be avoided on AMD Fiji
+
+            // in each column, it solves step, each step solve an inverse(A)[step][col]
+            for(int step = col + 1; step < n; step++)
+            {
+
+                // only tx == step solve off-diagonal
+                if(index == step)
+                {
+                    // solve the step row, off-diagonal elements, notice diag1[tx][tx] is already
+                    // inversed,
+                    // so multiply
+                    diagP[index + col * n] = (0 - reg) * diagP[index + index * n];
+                }
+
+                // __syncthreads(); // if IB < 64, this synch can be avoided on AMD Fiji
+
+                // tx > step  update with (tx = step)'s result
+                if(index > step)
+                {
+                    reg += diagP[index + step * n] * diagP[step + col * n];
+                }
+                // __syncthreads(); // if IB < 64, this synch can be avoided on AMD Fiji
+            }
+            // __syncthreads();
+        }
+    }
+
+    __syncthreads();
+
+    if(uplo == rocblas_fill_lower)
+    {
+        if(tx < n * n)
+        {
+            T sum = 0.0f;
+            for(int k = c; k < IB; k++)
+            {
+                sum += sA[r + k * IB] * diag1[k + c * IB];
+            }
+            temp[r + c * IB] = sum;
+        }
+    }
+    else
+    {
+        if(tx < n * n)
+        {
+            T sum = 0.0f;
+            for(int k = 0; k < c + 1; k++)
+            {
+                sum += sA[r + k * IB] * diag2[(IB - 1 - k) + (IB - 1 - c) * IB];
+            }
+            temp[r + c * IB] = sum;
+        }
+    }
+
+    __syncthreads();
+
+    if(uplo == rocblas_fill_lower)
+    {
+        if(tx < n * n)
+        {
+            T sum = 0.0f;
+            for(int k = 0; k < r + 1; k++)
+            {
+                sum += -1.0f * diag2[r + k * n] * temp[k + c * n];
+            }
+            invA[n + r + c * ldinvA] = sum;
+        }
+    }
+    else
+    {
+        if(tx < n * n)
+        {
+            T sum = 0.0f;
+            for(int k = r; k < IB; k++)
+            {
+                sum += -1.0f * diag1[(n - 1 - r) + (n - 1 - k) * n] * temp[k + c * n];
+            }
+            invA[n * ldinvA + r + c * ldinvA] = sum;
+        }
+    }
+
+    if(tx < 2 * n)
+    {
+        if(uplo == rocblas_fill_lower)
+        {
+            for(int i = 0; i <= index; i++)
+            {
+                invA[AInvoffset + index + i * ldinvA] = diagP[index + i * n];
+            }
+        }
+        else
+        { // transpose back to A from sA if upper
+            for(int i = n - 1; i >= index; i--)
+            {
+                invA[AInvoffset + index + i * ldinvA] = diagP[(n - 1 - index) + (n - 1 - i) * n];
+            }
+        }
+    }
+}
+
 #endif // _TRTRI_DEVICE_H_

--- a/library/src/blas3/trtri_trsm.hpp
+++ b/library/src/blas3/trtri_trsm.hpp
@@ -35,14 +35,14 @@ trtri_trsm_kernel(rocblas_fill uplo, rocblas_diagonal diag, const T* A, rocblas_
 
     // each hip thread Block compute a inverse of a IB * IB diagonal block of A
 
-    trtri_device<T, IB>(uplo,
-                        diag,
-                        IB,
-                        A + hipBlockIdx_x * (IB * lda + IB),
-                        lda,
-                        invA + (hipBlockIdx_x / IBD) * (NB * NB) +
-                            (hipBlockIdx_x % IBD) * (IB * NB + IB),
-                        NB);
+    custom_trtri_device<T, IB>(uplo,
+                               diag,
+                               IB,
+                               A + 2 * hipBlockIdx_x * (IB * lda + IB),
+                               lda,
+                               invA + (2 * hipBlockIdx_x / IBD) * (NB * NB) +
+                                   ((2 * hipBlockIdx_x) % IBD) * (IB * NB + IB),
+                               NB);
 }
 
 // compute square block of invA
@@ -208,8 +208,8 @@ rocblas_status rocblas_trtri_trsm_template(rocblas_handle handle,
     {
         constexpr rocblas_int IBD = 8;
         constexpr rocblas_int IB  = NB / IBD;
-        dim3 grid(blocks * IBD);
-        dim3 threads(IB);
+        dim3 grid(blocks * IBD / 2);
+        dim3 threads(IB * IB);
 
         /*
            Algorithm:
@@ -256,27 +256,6 @@ rocblas_status rocblas_trtri_trsm_template(rocblas_handle handle,
         rocblas_int stride_A     = NB * lda + NB;
         rocblas_int stride_invA  = NB * NB;
         rocblas_int stride_C     = JB * JB;
-
-        for(int i = 0; i < blocks; i++)
-            trtri_strided_gemm_block<T>(
-                handle,
-                IB,
-                (const T*)(A + ((uplo == rocblas_fill_lower) ? IB + i * stride_A
-                                                             : IB * lda + i * stride_A)),
-                lda,
-                2 * IB * lda + 2 * IB,
-                (const T*)(invA + ((uplo == rocblas_fill_lower) ? 0 + i * stride_invA
-                                                                : IB * NB + IB + i * stride_invA)),
-                (const T*)(invA + ((uplo == rocblas_fill_lower) ? IB * NB + IB + i * stride_invA
-                                                                : 0 + i * stride_invA)),
-                (T*)(invA + ((uplo == rocblas_fill_lower) ? IB + i * stride_invA
-                                                          : IB * NB + i * stride_invA)),
-                NB,
-                2 * IB * NB + 2 * IB,
-                (T*)C_tmp,
-                IB,
-                IB * IB,
-                NB / JB * 2);
 
         trtri_strided_gemm_block<T>(
             handle,


### PR DESCRIPTION
contributes towards #172044

- New custom trtri kernel used for TRSM runs 256 threads in a block to work on two 16x16 diagonal tiles at the same time.
- After completing the inverses the results are used within the kernel to preform 2 gemms. This was previously done outside of the kernel.
