### PR TITLE
Fix compilation of IAMAX, IAMIN

### DIFF
--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -27,9 +27,21 @@ struct index_value_t
     // important: index must come first, so that index_value_t* can be cast to rocblas_int*
     rocblas_int index;
     T value;
-    __forceinline__ __host__ __device__ index_value_t() : index(-1) {}
 };
 
+// Specialization of default_value for index_value_t<T>
+template <typename T>
+struct default_value<index_value_t<T>>
+{
+    __forceinline__ __host__ __device__ constexpr auto operator()() const
+    {
+        index_value_t<T> x;
+        x.index = -1;
+        return x;
+    }
+};
+
+// Fetch absolute value
 template <typename To>
 struct rocblas_fetch_amax_amin
 {


### PR DESCRIPTION
resolves #457 ___

Summary of proposed changes:
Instead of using `T{}` to generate default values for a class, use variable templates specialized for classes. This avoids needing to define non-trivial default constructors, which are not allowed in `__shared__` variables. No further initialization of `__shared__` variables is required, because the original code did not depend on it.

