### PR TITLE
Fix TRSV compilation

### DIFF
--- a/library/src/blas2/rocblas_trsv.cpp
+++ b/library/src/blas2/rocblas_trsv.cpp
@@ -179,10 +179,14 @@ rocblas_status rocblas_trsv(rocblas_handle handle,
     // Calling TRSM for now
     rocblas_status status;
 
-    // alpha is a constant value of 1.0 either on host or device depending on pointer mode
     static constexpr T alpha_h{1};
-    static const __device__ T alpha_d{1};
-    const T* alpha = pointer_mode == rocblas_pointer_mode_device ? &alpha_d : &alpha_h;
+    const T* alpha = &alpha_h;
+    if(pointer_mode == rocblas_pointer_mode_device)
+    {
+        T* alpha_d = (T*)handle->get_trsv_alpha();
+        RETURN_IF_HIP_ERROR(hipMemcpy(alpha_d, &alpha_h, sizeof(T), hipMemcpyHostToDevice));
+        alpha = alpha_d;
+    }
 
     if(incx == 1)
     {

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -22,6 +22,7 @@ _rocblas_handle::_rocblas_handle()
 
     // allocate trsv temp buffers
     THROW_IF_HIP_ERROR(hipMalloc(&trsv_x, WORKBUF_TRSV_X_SZ));
+    THROW_IF_HIP_ERROR(hipMalloc(&trsv_alpha, WORKBUF_TRSV_ALPHA_SZ));
 }
 
 /*******************************************************************************
@@ -37,6 +38,8 @@ _rocblas_handle::~_rocblas_handle()
         hipFree(trsm_invA_C);
     if(trsv_x)
         hipFree(trsv_x);
+    if(trsv_alpha)
+        hipFree(trsv_alpha);
 }
 
 /*******************************************************************************

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -54,6 +54,7 @@ struct _rocblas_handle
 
     // trsv get pointers
     void* get_trsv_x() const { return trsv_x; }
+    void* get_trsv_alpha() const { return trsv_alpha; }
 
     rocblas_int device;
     hipDeviceProp_t device_properties;
@@ -70,7 +71,8 @@ struct _rocblas_handle
     void* trsm_invA_C = nullptr;
 
     // space allocated for trsv
-    void* trsv_x = nullptr;
+    void* trsv_x     = nullptr;
+    void* trsv_alpha = nullptr;
 
     // default logging_mode is no logging
     static rocblas_layer_mode layer_mode;
@@ -101,4 +103,5 @@ constexpr size_t WORKBUF_TRSM_Y_SZ      = 32000 * 128 * sizeof(double);
 constexpr size_t WORKBUF_TRSM_INVA_SZ   = 128 * 128 * 10 * sizeof(double);
 constexpr size_t WORKBUF_TRSM_INVA_C_SZ = 128 * 128 * 10 * sizeof(double) / 2;
 constexpr size_t WORKBUF_TRSV_X_SZ      = 131072 * sizeof(double);
+constexpr size_t WORKBUF_TRSV_ALPHA_SZ  = sizeof(double);
 #endif


### PR DESCRIPTION
resolves #473

Summary of proposed changes:
Copy from host to device memory instead of relying on dynamic initialization of `__device__` variables.

(Might be using some undocumented extension of `__device__` function-level `static` variables, but seems to work.)
