### PR TITLE
Adding important trsm test sizes

### DIFF
--- a/clients/gtest/trsm_gtest.yaml
+++ b/clients/gtest/trsm_gtest.yaml
@@ -20,6 +20,41 @@ Definitions:
 
   - &alpha_range [ 1.0, -5.0 ]
 
+  - &testset1_matrix_size_range
+    - { M:   128, N:    2048, lda:   128, ldb:   128 }
+    - { M:   128, N:   16848, lda:   128, ldb:   128 }
+    - { M:   128, N:   29696, lda:   128, ldb:   128 }
+    - { M:   128, N:   44544, lda:   128, ldb:   128 }
+    - { M:   128, N:   53632, lda:   128, ldb:   128 }
+    - { M:   256, N:    2048, lda:   256, ldb:   256 }
+    - { M:   256, N:   14848, lda:   256, ldb:   256 }
+    - { M:   256, N:   29696, lda:   256, ldb:   256 }
+    - { M:   256, N:   44544, lda:   256, ldb:   256 }
+    - { M:   256, N:   53504, lda:   256, ldb:   256 }
+    - { M:   384, N:    2048, lda:   384, ldb:   384 }
+    - { M:   384, N:   14976, lda:   384, ldb:   384 }
+    - { M:   384, N:   29952, lda:   384, ldb:   384 }
+    - { M:   384, N:   44928, lda:   384, ldb:   384 }
+    - { M:   384, N:   53376, lda:   384, ldb:   384 }
+
+  - &testset2_matrix_size_range
+    - { M:   2048,  N: 128,  lda:  2048, ldb:    2048 }
+    - { M:  16848,  N: 128,  lda: 16848, ldb:   16848 }
+    - { M:  29696,  N: 128,  lda: 29696, ldb:   29696 }
+    - { M:  44544,  N: 128,  lda: 44544, ldb:   44544 }
+    - { M:  53632,  N: 128,  lda: 53632, ldb:   53632 }
+    - { M:   2048,  N: 256,  lda:  2048, ldb:    2048 }
+    - { M:  14848,  N: 256,  lda: 14848, ldb:   14848 }
+    - { M:  29696,  N: 256,  lda: 29696, ldb:   29696 }
+    - { M:  44544,  N: 256,  lda: 44544, ldb:   44544 }
+    - { M:  53504,  N: 256,  lda: 53504, ldb:   53504 }
+    - { M:   2048,  N: 384,  lda:  2048, ldb:    2048 }
+    - { M:  14976,  N: 384,  lda: 14976, ldb:   14976 }
+    - { M:  29952,  N: 384,  lda: 29952, ldb:   29952 }
+    - { M:  44928,  N: 384,  lda: 44928, ldb:   44928 }
+    - { M:  53376,  N: 384,  lda: 53376, ldb:   53376 }
+
+
 Tests:
 - name: trsm_small
   category: quick
@@ -42,6 +77,28 @@ Tests:
   diag: [N, U]
   matrix_size: *medium_matrix_size_range
   alpha: *alpha_range
+
+- name: trsm_testset1
+  category: nightly
+  function: testing_trsm
+  precision: *double_precision
+  side: [L]
+  uplo: [L]
+  transA: [N]
+  diag: [U]
+  matrix_size: *testset1_matrix_size_range
+  alpha: [ 1 ]
+
+- name: trsm_testset2
+  category: nightly
+  function: testing_trsm
+  precision: *double_precision
+  side: [R]
+  uplo: [L]
+  transA: [T]
+  diag: [U]
+  matrix_size: *testset2_matrix_size_range
+  alpha: [ 1 ]
 
 - name: trsm_large
   category: nightly


### PR DESCRIPTION
Contributes towards #172044

Summary of proposed changes:
- Adding some important sizes to the trsm nightly tests.
- These tests add approximately 2 min for a vega20.
- In the largest case there will be 0.154 GB of device memory and 0.77 Gb of host memory being used for matrix allocations.

