### PR TITLE
initial implementation of --data and --yaml options

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -31,6 +31,7 @@ set( rocblas_benchmark_common
       ../common/utility.cpp
       ../common/cblas_interface.cpp
       ../common/norm.cpp
+      ../common/rocblas_parse_data.cpp
     )
 
 add_executable( rocblas-bench client.cpp ${rocblas_benchmark_common} )

--- a/clients/common/rocblas_parse_data.cpp
+++ b/clients/common/rocblas_parse_data.cpp
@@ -1,0 +1,94 @@
+#include <string>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include "utility.hpp"
+#include "rocblas_data.hpp"
+#include "rocblas_parse_data.hpp"
+
+// Parse YAML data
+static std::string rocblas_parse_yaml(const std::string& yaml)
+{
+    char temp[] = "/tmp/rocblas-XXXXXX";
+    int fd      = mkostemp(temp, O_CLOEXEC);
+    if(fd == -1)
+    {
+        perror("Cannot open temporary file");
+        exit(1);
+    }
+    int saved_stdout = fcntl(1, F_DUPFD_CLOEXEC, 0);
+    dup2(fd, 1);
+    std::string cmd = rocblas_exepath() + "rocblas_gentest.py " + yaml;
+    std::cerr << cmd << std::endl;
+    int status = system(cmd.c_str());
+    dup2(saved_stdout, 1);
+    close(saved_stdout);
+    if(status == -1 || !WIFEXITED(status) || WEXITSTATUS(status))
+        exit(1);
+    return temp;
+}
+
+// Parse --data and --yaml command-line arguments
+bool rocblas_parse_data(int& argc, char** argv, const std::string& default_file)
+{
+    std::string filename;
+    char** argv_p = argv + 1;
+    bool help = false, yaml = false;
+
+    // Scan, process and remove any --yaml or --data options
+    for(int i = 1; argv[i]; ++i)
+    {
+        if(!strcmp(argv[i], "--data") || (yaml |= !strcmp(argv[i], "--yaml")))
+        {
+            if(filename != "")
+            {
+                std::cerr << "Only one of the --yaml and --data options may be specified"
+                          << std::endl;
+                exit(1);
+            }
+
+            if(!argv[i + 1] || !argv[i + 1][0])
+            {
+                std::cerr << "The " << argv[i] << " option requires an argument" << std::endl;
+                exit(1);
+            }
+            filename = argv[++i];
+        }
+        else
+        {
+            *argv_p++ = argv[i];
+            if(!help && (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")))
+            {
+                help = true;
+                std::cout << "\n"
+                          << argv[0] << " [ --data <path> | --yaml <path> ] <options> ...\n"
+                          << std::endl;
+            }
+        }
+    }
+
+    // argc and argv contain remaining options and non-option arguments
+    *argv_p = nullptr;
+    argc    = argv_p - argv;
+
+    if(filename == "-")
+        filename = "/dev/stdin";
+    else if(filename == "")
+        filename = default_file;
+
+    if(yaml)
+        filename = rocblas_parse_yaml(filename);
+
+    if(filename != "")
+    {
+        RocBLAS_TestData::set_filename(filename);
+        return true;
+    }
+
+    return false;
+}

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -65,6 +65,7 @@ set( rocblas_benchmark_common
       ../common/utility.cpp
       ../common/cblas_interface.cpp
       ../common/norm.cpp
+      ../common/rocblas_parse_data.cpp
     )
 
 add_executable( rocblas-test ${rocblas_test_source} ${rocblas_benchmark_common} )

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -6,12 +6,7 @@
 #include "utility.hpp"
 #include "rocblas_data.hpp"
 #include "test_cleanup.hpp"
-
-#define GTEST_DATA "rocblas_gtest.data"
-
-/* =====================================================================
-      Main function:
-=================================================================== */
+#include "rocblas_parse_data.hpp"
 
 using namespace testing;
 
@@ -150,11 +145,12 @@ class ConfigurableEventListener : public TestEventListener
     }
 };
 
+/* =====================================================================
+      Main function:
+=================================================================== */
+
 int main(int argc, char** argv)
 {
-    // Set data file path
-    RocBLAS_TestData::set_filename(rocblas_exepath() + GTEST_DATA);
-
     // Print Version
     char blas_version[100];
     rocblas_get_version_string(blas_version, sizeof(blas_version));
@@ -175,6 +171,10 @@ int main(int argc, char** argv)
     {
         set_device(device_id);
     }
+
+    // Set data file path
+    static constexpr char GTEST_DATA[] = "rocblas_gtest.data";
+    rocblas_parse_data(argc, argv, rocblas_exepath() + GTEST_DATA);
 
     testing::InitGoogleTest(&argc, argv);
 

--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -36,7 +36,6 @@ constexpr double sum_error_tolerance<rocblas_half> = 1 / 900.0;
 #define NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, err, NEAR_ASSERT) \
     do                                                            \
     {                                                             \
-        _Pragma("unroll")                                         \
         for(size_t k = 0; k < batch_count; k++)                   \
             for(size_t j = 0; j < N; j++)                         \
                 for(size_t i = 0; i < M; i++)                     \

--- a/clients/include/rocblas_data.hpp
+++ b/clients/include/rocblas_data.hpp
@@ -25,7 +25,7 @@ class RocBLAS_TestData
     static std::string& filename()
     {
         static std::string filename =
-            "(Uninitialized data. RocBLAS_TestData<...>::init needs to be called first.)";
+            "(Uninitialized data. RocBLAS_TestData::set_filename needs to be called first.)";
         return filename;
     }
 

--- a/clients/include/rocblas_parse_data.hpp
+++ b/clients/include/rocblas_parse_data.hpp
@@ -1,0 +1,9 @@
+#ifndef _ROCBLAS_PARSE_DATA_H
+#define _ROCBLAS_PARSE_DATA_H
+
+#include <string>
+
+// Parse --data and --yaml command-line arguments
+bool rocblas_parse_data(int& argc, char** argv, const std::string& default_file = "");
+
+#endif

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -134,10 +134,6 @@ void testing_trtri(const Arguments& arg)
             cblas_gflops  = trtri_gflop_count<T>(N) / cpu_time_used * 1e6;
         }
 
-#ifndef NDEBUG
-        rocblas_print_matrix(hB, hA, N, N, lda);
-#endif
-
         if(arg.unit_check)
         {
             T rel_error = std::numeric_limits<T>::epsilon() * 1000;

--- a/clients/include/unit.hpp
+++ b/clients/include/unit.hpp
@@ -22,7 +22,6 @@
 #define UNIT_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, UNIT_ASSERT_EQ) \
     do                                                                          \
     {                                                                           \
-        _Pragma("unroll")                                                       \
         for(size_t k = 0; k < batch_count; k++)                                 \
             for(size_t j = 0; j < N; j++)                                       \
                 for(size_t i = 0; i < M; i++)                                   \


### PR DESCRIPTION
`--data` and `--yaml` options for rocblas-test and rocblas-bench allow binary or YAML input data. More work is required to make free-form YAML parse correctly. This implements the command-line interface.
