### PR TITLE
env variable GTEST_LISTENER for NO_PASS_LINE_IN_LOG

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -213,7 +213,7 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
           sh """#!/usr/bin/env bash
                 set -x
                 cd ${paths.project_build_prefix}/build/release/clients/staging
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
+                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTNER=NO_PASS_LINE_IN_LOG ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
             """
           junit "${paths.project_build_prefix}/build/release/clients/staging/*.xml"
         }
@@ -223,7 +223,7 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
                 set -x
                 cd ${paths.project_build_prefix}/build/release/clients/staging
                 LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./example-sscal${build_type_postfix}
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin*
+                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTNER=NO_PASS_LINE_IN_LOG ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin*
             """
           junit "${paths.project_build_prefix}/build/release/clients/staging/*.xml"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -213,7 +213,7 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
           sh """#!/usr/bin/env bash
                 set -x
                 cd ${paths.project_build_prefix}/build/release/clients/staging
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTNER=NO_PASS_LINE_IN_LOG ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
+                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
             """
           junit "${paths.project_build_prefix}/build/release/clients/staging/*.xml"
         }
@@ -223,7 +223,7 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
                 set -x
                 cd ${paths.project_build_prefix}/build/release/clients/staging
                 LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./example-sscal${build_type_postfix}
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTNER=NO_PASS_LINE_IN_LOG ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin*
+                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin*
             """
           junit "${paths.project_build_prefix}/build/release/clients/staging/*.xml"
         }

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
     // [  PASSED  ] 149 tests.
     //
     ConfigurableEventListener* listener = new ConfigurableEventListener(default_printer);
-    char* gtest_listener(std::getenv("GTEST_LISTNER"));
+    char* gtest_listener(std::getenv("GTEST_LISTENER"));
     if(gtest_listener == NULL || strcmp(gtest_listener, "NO_PASS_LINE_IN_LOG") != 0)
     {
         listener->showEnvironment    = true;

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -197,11 +197,23 @@ int main(int argc, char** argv)
     // [  PASSED  ] 149 tests.
     //
     ConfigurableEventListener* listener = new ConfigurableEventListener(default_printer);
-    listener->showEnvironment           = false;
-    listener->showTestCases             = false;
-    listener->showTestNames             = false;
-    listener->showSuccesses             = false;
-    listener->showInlineFailures        = false;
+    char* gtest_listener(std::getenv("GTEST_LISTNER"));
+    if(gtest_listener == NULL || strcmp(gtest_listener, "NO_PASS_LINE_IN_LOG") != 0)
+    {
+        listener->showEnvironment    = true;
+        listener->showTestCases      = true;
+        listener->showTestNames      = true;
+        listener->showSuccesses      = true;
+        listener->showInlineFailures = true;
+    }
+    else
+    {
+        listener->showEnvironment    = true;
+        listener->showTestCases      = true;
+        listener->showTestNames      = false;
+        listener->showSuccesses      = false;
+        listener->showInlineFailures = false;
+    }
     listeners.Append(listener);
 
     return RUN_ALL_TESTS();


### PR DESCRIPTION
- Jenkinsfile sets environment variable GTEST_LISTNER to "NO_PASS_LINE_IN_LOG" to omit pass line from log. This reduces the size of the log file. 
- If envirnoment variable GTEST_LISTNER is not set to "NO_PASS_LINE_IN_LOG" then gtest will output pass and fail lines.