### PR TITLE
DGEMM NT tuning & re-tuning

### DIFF
--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
@@ -1,4 +1,4 @@
-- {MinimumRequiredVersion: 4.7.2}
+- {MinimumRequiredVersion: 4.8.1}
 - vega20
 - gfx906
 - [Device 66a0, Device 66a1, Device 66a7]
@@ -13,6 +13,9 @@
   Index01A: 0
   Index01B: 1
   Index1: 1
+  IndexAssignmentLDA: 5
+  IndexAssignmentLDB: 6
+  IndexAssignmentLDC: 4
   IndexAssignmentsA: [0, 3, 2]
   IndexAssignmentsB: [1, 3, 2]
   IndexUnroll: 3
@@ -145,6 +148,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -175,8 +181,8 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_
-    StaggerU: 32
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR1_TT04_04_WG16_16_01
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -306,6 +312,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -336,8 +345,8 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 1
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x04_
-    StaggerU: 32
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x04_PLR1_TT04_04_WG16_16_01
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -361,10 +370,10 @@
     WorkGroupMappingType: B
     _staggerStrideShift: 3
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -392,25 +401,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
+    LSCA: 64
+    LSCB: 32
     LSPA: 4
     LSPB: 4
-    LVCA: 48
-    LVCB: 32
+    LVCA: 32
+    LVCB: 16
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 256
+    LdsNumElements: 896
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 128
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -424,10 +433,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -435,13 +444,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -465,6 +474,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -495,37 +507,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 2
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK00_PLR1_TT06_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x04_PLR1_TT04_04_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 6
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -553,25 +565,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 96
-    LSCB: 64
-    LSPA: 4
+    LSCB: 32
+    LSPA: 2
     LSPB: 4
     LVCA: 48
-    LVCB: 32
-    LVPA: 2
+    LVCB: 16
+    LVPA: 1
     LVPB: 2
-    LdsNumElements: 1664
+    LdsNumElements: 1024
     LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 256
+    LdsNumElementsAlignedB: 128
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
+    LdsOffsetA_Blk: 512
     LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetB_Blk: 896
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -586,9 +598,9 @@
     LoopTail: true
     LoopUnroll: 4
     MacroTile0: 96
-    MacroTile1: 64
+    MacroTile1: 32
     MacroTileA: 96
-    MacroTileB: 64
+    MacroTileB: 32
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -600,9 +612,9 @@
     NumGlobalWriteVectorsPerThread: 12
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularA: 2
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -613,7 +625,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -626,6 +638,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -656,37 +671,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 3
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK00_PLR0_TT06_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x032x04_PLR1_TT06_04_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
     ThreadTile: [6, 4]
     ThreadTile0: 6
     ThreadTile1: 4
     ThreadTileA: 6
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -714,25 +729,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
+    LSCA: 64
+    LSCB: 48
     LSPA: 4
     LSPB: 4
-    LVCA: 48
-    LVCB: 32
+    LVCA: 32
+    LVCB: 24
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 256
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -746,10 +761,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -763,7 +778,7 @@
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -772,9 +787,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -787,6 +802,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -817,37 +835,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 4
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK02_PLR1_TT06_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PLR0_TT04_06_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -875,25 +893,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 96
+    LSCB: 48
     LSPA: 4
     LSPB: 4
     LVCA: 32
-    LVCB: 48
+    LVCB: 24
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1664
+    LdsNumElements: 960
     LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 384
+    LdsNumElementsAlignedB: 192
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
+    LdsOffsetA_Blk: 512
     LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -908,9 +926,9 @@
     LoopTail: true
     LoopUnroll: 4
     MacroTile0: 64
-    MacroTile1: 96
+    MacroTile1: 48
     MacroTileA: 64
-    MacroTileB: 96
+    MacroTileB: 48
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -924,7 +942,7 @@
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -935,7 +953,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -948,6 +966,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -978,37 +999,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 5
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x04_PK00_PLR1_TT04_06_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PLR0_TT04_06_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
     ThreadTile: [4, 6]
     ThreadTile0: 4
     ThreadTile1: 6
     ThreadTileA: 4
     ThreadTileB: 6
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -1036,25 +1057,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
+    LSCA: 64
+    LSCB: 128
     LSPA: 4
     LSPB: 4
-    LVCA: 48
-    LVCB: 48
+    LVCA: 32
+    LVCB: 64
     LVPA: 2
     LVPB: 2
     LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
     LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -1068,10 +1089,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -1079,8 +1100,8 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
@@ -1094,9 +1115,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -1109,6 +1130,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -1139,7 +1163,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 6
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK02_PLR0_TT06_06_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x128x04_PLR1_TT04_08_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -1147,14 +1171,14 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
@@ -1166,10 +1190,10 @@
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -1197,25 +1221,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
+    LSCA: 64
+    LSCB: 128
     LSPA: 4
     LSPB: 4
-    LVCA: 64
-    LVCB: 32
+    LVCA: 32
+    LVCB: 64
     LVPA: 2
     LVPB: 2
     LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
     LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -1229,10 +1253,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -1255,7 +1279,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 0
+    PersistentKernel: 4
     PrefetchGlobalRead: true
     PrefetchLocalRead: true
     ProblemType:
@@ -1270,6 +1294,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -1300,7 +1327,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 7
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK00_PLR1_TT08_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x128x04_PLR1_TT04_08_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -1308,14 +1335,14 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
@@ -1327,10 +1354,10 @@
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -1358,25 +1385,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
+    LSCA: 64
+    LSCB: 48
     LSPA: 4
     LSPB: 4
-    LVCA: 64
-    LVCB: 32
+    LVCA: 32
+    LVCB: 24
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -1390,10 +1417,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -1401,13 +1428,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -1416,9 +1443,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -1431,6 +1458,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -1461,37 +1491,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 8
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK02_PLR1_TT08_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PLR0_TT04_06_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -1519,25 +1549,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
+    LSCA: 64
+    LSCB: 48
     LSPA: 4
     LSPB: 4
-    LVCA: 48
-    LVCB: 32
+    LVCA: 32
+    LVCB: 24
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 256
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -1551,10 +1581,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -1568,7 +1598,7 @@
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -1579,7 +1609,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -1592,6 +1622,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -1622,37 +1655,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 9
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK00_PLR1_TT06_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PLR0_TT04_06_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -1680,25 +1713,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
+    LSCA: 64
     LSCB: 64
     LSPA: 4
     LSPB: 4
-    LVCA: 48
+    LVCA: 32
     LVCB: 32
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 384
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
     LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -1712,9 +1745,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 96
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -1723,13 +1756,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -1740,7 +1773,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -1753,6 +1786,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -1783,37 +1819,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 10
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK00_PLR0_TT06_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x04_PLR1_TT04_08_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -1841,25 +1877,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
+    LSCA: 64
     LSCB: 64
     LSPA: 4
     LSPB: 4
-    LVCA: 48
+    LVCA: 32
     LVCB: 32
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 384
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
     LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -1873,9 +1909,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 96
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -1884,13 +1920,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -1899,7 +1935,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 4
     PrefetchGlobalRead: true
     PrefetchLocalRead: true
     ProblemType:
@@ -1914,6 +1950,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -1944,37 +1983,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 11
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK02_PLR1_TT06_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x04_PLR1_TT04_08_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -2002,25 +2041,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
+    LSCA: 64
+    LSCB: 64
     LSPA: 4
     LSPB: 4
-    LVCA: 48
-    LVCB: 48
+    LVCA: 32
+    LVCB: 32
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -2034,10 +2073,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -2045,13 +2084,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -2062,7 +2101,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -2075,6 +2114,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -2105,37 +2147,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 12
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK00_PLR0_TT06_06_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x04_PLR1_TT04_08_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -2163,25 +2205,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
+    LSCA: 48
+    LSCB: 64
     LSPA: 4
     LSPB: 4
-    LVCA: 48
-    LVCB: 48
+    LVCA: 24
+    LVCB: 32
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 192
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 192
+    LdsOffsetB_Blk: 704
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -2195,10 +2237,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
+    MacroTile0: 48
+    MacroTile1: 64
+    MacroTileA: 48
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -2206,13 +2248,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -2221,7 +2263,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
     PrefetchLocalRead: false
     ProblemType:
@@ -2236,6 +2278,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -2266,37 +2311,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 13
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK02_PLR0_TT06_06_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT048x064x04_PLR0_TT06_04_WG08_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
-    SubGroup0: 16
+    SubGroup0: 8
     SubGroup1: 16
-    SubGroupA: 16
+    SubGroupA: 8
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
     ThreadTile0: 6
-    ThreadTile1: 6
+    ThreadTile1: 4
     ThreadTileA: 6
-    ThreadTileB: 6
+    ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [8, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -2324,25 +2369,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
+    LSCA: 48
     LSCB: 64
     LSPA: 4
     LSPB: 4
-    LVCA: 64
+    LVCA: 24
     LVCB: 32
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 192
     LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 192
+    LdsOffsetB_Blk: 704
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -2356,9 +2401,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 128
+    MacroTile0: 48
     MacroTile1: 64
-    MacroTileA: 128
+    MacroTileA: 48
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -2367,13 +2412,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -2384,7 +2429,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -2397,6 +2442,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -2427,37 +2475,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 14
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK00_PLR1_TT08_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT048x064x04_PLR0_TT06_04_WG08_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
-    SubGroup0: 16
+    SubGroup0: 8
     SubGroup1: 16
-    SubGroupA: 16
+    SubGroupA: 8
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
     ThreadTile1: 4
-    ThreadTileA: 8
+    ThreadTileA: 6
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [8, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -2485,25 +2533,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
+    LSCA: 64
     LSCB: 64
     LSPA: 4
     LSPB: 4
-    LVCA: 64
+    LVCA: 32
     LVCB: 32
     LVPA: 2
     LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
     LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -2517,9 +2565,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 128
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 128
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -2534,7 +2582,7 @@
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -2543,7 +2591,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 4
     PrefetchGlobalRead: true
     PrefetchLocalRead: true
     ProblemType:
@@ -2558,6 +2606,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -2588,44 +2639,44 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 15
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK02_PLR1_TT08_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x04_PLR1_TT08_04_WG08_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
-    SubGroup0: 16
+    SubGroup0: 8
     SubGroup1: 16
-    SubGroupA: 16
+    SubGroupA: 8
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
+    SuppressNoLoadLoop: false
     ThreadTile: [8, 4]
     ThreadTile0: 8
     ThreadTile1: 4
     ThreadTileA: 8
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [8, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 8
+    DepthU: 4
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -2646,25 +2697,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 96
     LSCB: 64
-    LSPA: 5
-    LSPB: 8
+    LSPA: 4
+    LSPB: 4
     LVCA: 48
     LVCB: 32
-    LVPA: 3
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 512
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -2677,7 +2728,7 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
+    LoopUnroll: 4
     MacroTile0: 96
     MacroTile1: 64
     MacroTileA: 96
@@ -2693,7 +2744,7 @@
     NumGlobalWriteVectorsPerThread: 12
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
@@ -2706,7 +2757,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -2719,6 +2770,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -2749,7 +2803,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 16
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK00_PLR1_TT06_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PLR0_TT06_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -2757,36 +2811,36 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
+    SuppressNoLoadLoop: true
     ThreadTile: [6, 4]
     ThreadTile0: 6
     ThreadTile1: 4
     ThreadTileA: 6
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 8
+    DepthU: 4
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -2807,25 +2861,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 96
-    LSCB: 64
-    LSPA: 5
-    LSPB: 8
+    LSCB: 96
+    LSPA: 4
+    LSPB: 4
     LVCA: 48
-    LVCB: 32
-    LVPA: 3
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 512
+    LVCB: 48
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 384
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -2838,11 +2892,11 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
+    LoopUnroll: 4
     MacroTile0: 96
-    MacroTile1: 64
+    MacroTile1: 96
     MacroTileA: 96
-    MacroTileB: 64
+    MacroTileB: 96
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -2850,11 +2904,11 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 36
+    NumGlobalWriteVectorsPerThread: 18
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
@@ -2867,7 +2921,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 2
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -2880,6 +2934,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -2910,7 +2967,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 17
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK02_PLR1_TT06_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PLR0_TT06_06_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -2918,36 +2975,36 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 6]
     ThreadTile0: 6
-    ThreadTile1: 4
+    ThreadTile1: 6
     ThreadTileA: 6
-    ThreadTileB: 4
+    ThreadTileB: 6
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 8
+    DepthU: 4
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -2968,25 +3025,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 96
-    LSPA: 8
-    LSPB: 5
+    LSCB: 128
+    LSPA: 4
+    LSPB: 4
     LVCA: 32
-    LVCB: 48
-    LVPA: 4
-    LVPB: 3
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 768
+    LVCB: 64
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -2999,11 +3056,11 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 8
+    LoopUnroll: 4
     MacroTile0: 64
-    MacroTile1: 96
+    MacroTile1: 128
     MacroTileA: 64
-    MacroTileB: 96
+    MacroTileB: 128
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -3011,12 +3068,12 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
+    NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
     PackFreeDims: 1
@@ -3026,7 +3083,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 0
+    PersistentKernel: 4
     PrefetchGlobalRead: true
     PrefetchLocalRead: true
     ProblemType:
@@ -3041,6 +3098,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -3071,7 +3131,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 18
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x08_PK00_PLR1_TT04_06_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x128x04_PLR1_TT04_08_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -3079,29 +3139,29 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 6]
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 8]
     ThreadTile0: 4
-    ThreadTile1: 6
+    ThreadTile1: 8
     ThreadTileA: 4
-    ThreadTileB: 6
+    ThreadTileB: 8
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
+    WorkGroupMapping: 8
     WorkGroupMappingType: B
-    _staggerStrideShift: 2
+    _staggerStrideShift: 3
     fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 3
+    fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -3129,25 +3189,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 96
-    LSPA: 8
-    LSPB: 5
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
     LVCA: 32
-    LVCB: 48
-    LVPA: 4
-    LVPB: 3
-    LdsNumElements: 3328
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 1792
     LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 768
+    LdsNumElementsAlignedB: 256
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
+    LdsOffsetA_Blk: 1024
     LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -3162,9 +3222,9 @@
     LoopTail: true
     LoopUnroll: 8
     MacroTile0: 64
-    MacroTile1: 96
+    MacroTile1: 32
     MacroTileA: 64
-    MacroTileB: 96
+    MacroTileB: 32
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -3172,13 +3232,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -3187,7 +3247,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
     PrefetchLocalRead: true
     ProblemType:
@@ -3202,6 +3262,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -3232,37 +3295,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 19
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x08_PK02_PLR1_TT04_06_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x08_PLR1_TT04_04_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 6]
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
     ThreadTile0: 4
-    ThreadTile1: 6
+    ThreadTile1: 4
     ThreadTileA: 4
-    ThreadTileB: 6
+    ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 2
     fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 3
+    fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -3290,21 +3353,21 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 96
-    LSCB: 96
-    LSPA: 5
+    LSCB: 48
+    LSPA: 2
     LSPB: 5
     LVCA: 48
-    LVCB: 48
-    LVPA: 3
+    LVCB: 24
+    LVPA: 1
     LVPB: 3
-    LdsNumElements: 3584
+    LdsNumElements: 3200
     LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 768
+    LdsNumElementsAlignedB: 384
     LdsOffsetA: 0
     LdsOffsetA_Blk: 2048
     LdsOffsetB: 768
@@ -3323,9 +3386,9 @@
     LoopTail: true
     LoopUnroll: 8
     MacroTile0: 96
-    MacroTile1: 96
+    MacroTile1: 48
     MacroTileA: 96
-    MacroTileB: 96
+    MacroTileB: 48
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -3337,9 +3400,9 @@
     NumGlobalWriteVectorsPerThread: 18
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 4
     NumLoadsPerpendicularB: 2
-    NumThreads: 256
+    NumThreads: 128
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -3348,9 +3411,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -3363,6 +3426,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -3393,37 +3459,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 20
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x08_PK02_PLR0_TT06_06_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x048x08_PLR1_TT06_06_WG16_08_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
     ThreadTile: [6, 6]
     ThreadTile0: 6
     ThreadTile1: 6
     ThreadTileA: 6
     ThreadTileB: 6
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [16, 8, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
+    fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 3
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -3451,25 +3517,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
+    LSCA: 64
     LSCB: 64
-    LSPA: 4
+    LSPA: 8
     LSPB: 8
-    LVCA: 64
+    LVCA: 32
     LVCB: 32
-    LVPA: 2
+    LVPA: 4
     LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -3483,9 +3549,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 128
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 128
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -3494,11 +3560,11 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
@@ -3524,6 +3590,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -3554,7 +3623,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 21
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x08_PK00_PLR1_TT08_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR1_TT04_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -3562,14 +3631,14 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 8
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
@@ -3581,10 +3650,10 @@
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -3612,25 +3681,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
+    LSCA: 64
     LSCB: 64
-    LSPA: 4
+    LSPA: 8
     LSPB: 8
-    LVCA: 64
+    LVCA: 32
     LVCB: 32
-    LVPA: 2
+    LVPA: 4
     LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -3644,9 +3713,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 128
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 128
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -3655,11 +3724,11 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
@@ -3670,7 +3739,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
     PrefetchLocalRead: false
     ProblemType:
@@ -3685,6 +3754,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -3715,7 +3787,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 22
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x08_PK02_PLR0_TT08_04_WG16_16_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR0_TT04_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -3723,14 +3795,14 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 8
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
@@ -3742,10 +3814,10 @@
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -3773,25 +3845,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 128
+    LSCA: 64
+    LSCB: 64
     LSPA: 8
     LSPB: 8
-    LVCA: 64
-    LVCB: 64
+    LVCA: 32
+    LVCB: 32
     LVPA: 4
     LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -3805,10 +3877,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -3816,13 +3888,13 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
-    NumThreads: 512
+    NumThreads: 256
     PackBatchDims: 0
     PackFreeDims: 1
     PackGranularity: 2
@@ -3831,9 +3903,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 4
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -3846,6 +3918,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -3876,37 +3951,37 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 23
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x128x08_PK02_PLR1_TT08_04_WG16_32_01_WGM01
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR0_TT04_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 32
+    SubGroup1: 16
     SubGroupA: 16
-    SubGroupB: 32
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 8
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 32, 1]
+    WorkGroup: [16, 16, 1]
     WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 2
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -3934,25 +4009,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
+    LSCA: 64
     LSCB: 64
-    LSPA: 5
+    LSPA: 8
     LSPB: 8
-    LVCA: 48
+    LVCA: 32
     LVCB: 32
-    LVPA: 3
+    LVPA: 4
     LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -3966,9 +4041,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 96
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 96
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -3977,11 +4052,11 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
@@ -4007,6 +4082,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -4037,7 +4115,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 24
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK00_PLR1_TT06_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR1_TT04_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -4045,29 +4123,29 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 6
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
+    WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
+    fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -4095,25 +4173,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
+    LSCA: 64
     LSCB: 64
-    LSPA: 5
+    LSPA: 8
     LSPB: 8
-    LVCA: 48
+    LVCA: 32
     LVCB: 32
-    LVPA: 3
+    LVPA: 4
     LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4127,9 +4205,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 96
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 96
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -4138,11 +4216,11 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
@@ -4153,9 +4231,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -4168,6 +4246,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -4198,7 +4279,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 25
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK02_PLR1_TT06_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR0_TT04_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -4206,29 +4287,29 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 6
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
+    WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
+    fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -4256,25 +4337,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 96
+    LSCB: 64
     LSPA: 8
-    LSPB: 5
+    LSPB: 8
     LVCA: 32
-    LVCB: 48
+    LVCB: 32
     LVPA: 4
-    LVPB: 3
-    LdsNumElements: 3328
+    LVPB: 4
+    LdsNumElements: 2048
     LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 768
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
+    LdsOffsetA_Blk: 1024
     LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4289,9 +4370,9 @@
     LoopTail: true
     LoopUnroll: 8
     MacroTile0: 64
-    MacroTile1: 96
+    MacroTile1: 64
     MacroTileA: 64
-    MacroTileB: 96
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -4299,12 +4380,12 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
+    NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
     PackFreeDims: 1
@@ -4314,9 +4395,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 4
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -4329,6 +4410,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -4359,7 +4443,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 26
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x08_PK02_PLR1_TT04_06_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR0_TT04_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -4367,29 +4451,29 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 6]
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
     ThreadTile0: 4
-    ThreadTile1: 6
+    ThreadTile1: 4
     ThreadTileA: 4
-    ThreadTileB: 6
+    ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
+    WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 2
     fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 3
+    fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -4417,25 +4501,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 96
+    LSCA: 64
     LSCB: 96
-    LSPA: 5
+    LSPA: 8
     LSPB: 5
-    LVCA: 48
+    LVCA: 32
     LVCB: 48
-    LVPA: 3
+    LVPA: 4
     LVPB: 3
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 768
+    LdsNumElements: 3328
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 768
     LdsOffsetA: 0
     LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 2560
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4449,9 +4533,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 96
+    MacroTile0: 64
     MacroTile1: 96
-    MacroTileA: 96
+    MacroTileA: 64
     MacroTileB: 96
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -4460,11 +4544,11 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 2
     NumThreads: 256
     PackBatchDims: 0
@@ -4475,9 +4559,9 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: false
+    PrefetchLocalRead: true
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -4490,6 +4574,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -4520,7 +4607,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 27
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x08_PK02_PLR0_TT06_06_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x08_PLR1_TT04_06_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -4528,29 +4615,29 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
     ThreadTile1: 6
-    ThreadTileA: 6
+    ThreadTileA: 4
     ThreadTileB: 6
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
+    WorkGroupMapping: 1
     WorkGroupMappingType: B
     _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
+    fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 3
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
@@ -4578,25 +4665,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 128
+    LSCA: 64
     LSCB: 64
-    LSPA: 4
+    LSPA: 8
     LSPB: 8
-    LVCA: 64
+    LVCA: 32
     LVCB: 32
-    LVPA: 2
+    LVPA: 4
     LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
     LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4610,9 +4697,9 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 8
-    MacroTile0: 128
+    MacroTile0: 64
     MacroTile1: 64
-    MacroTileA: 128
+    MacroTileA: 64
     MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
@@ -4621,11 +4708,11 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularA: 1
     NumLoadsPerpendicularB: 1
     NumThreads: 256
     PackBatchDims: 0
@@ -4636,7 +4723,7 @@
     PerformanceSyncLocation: -1
     PerformanceWaitCount: -1
     PerformanceWaitLocation: -1
-    PersistentKernel: 2
+    PersistentKernel: 0
     PrefetchGlobalRead: true
     PrefetchLocalRead: false
     ProblemType:
@@ -4651,6 +4738,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -4681,7 +4771,7 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 28
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x08_PK02_PLR0_TT08_04_WG16_16_01_WGM08
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR0_TT04_04_WG16_16_01
     StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
@@ -4689,14 +4779,14 @@
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
     ThreadTile1: 4
-    ThreadTileA: 8
+    ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
@@ -4708,17 +4798,17 @@
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
     AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
+    AssertSummationElementMultiple: 1
     AssignedDerivedParameters: false
     AssignedProblemIndependentDerivedParameters: true
     BufferLoad: true
     BufferStore: true
     CheckDimOverflow: 0
     CheckTensorDimAsserts: false
-    DepthU: 4
+    DepthU: 8
     DirectToLds: false
     DirectToLdsA: false
     DirectToLdsB: false
@@ -4726,7 +4816,7 @@
     EdgeType: ShiftPtr
     ExpandPointerSwap: true
     FractionalLoad: true
-    GlobalLoadVectorWidthA: 1
+    GlobalLoadVectorWidthA: 2
     GlobalLoadVectorWidthB: 2
     GlobalRead2A: true
     GlobalRead2B: true
@@ -4739,25 +4829,25 @@
     GlobalSplitUSummationAssignmentRoundRobin: true
     GlobalSplitUWorkGroupMappingRoundRobin: false
     GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
     InnerUnroll: 1
     KernelLanguage: Assembly
     LSCA: 64
-    LSCB: 96
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 48
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
     LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 384
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
     LdsOffsetA: 0
     LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -4770,11 +4860,11 @@
     LocalWriteUseSgprB: false
     LoopDoWhile: false
     LoopTail: true
-    LoopUnroll: 4
+    LoopUnroll: 8
     MacroTile0: 64
-    MacroTile1: 96
+    MacroTile1: 64
     MacroTileA: 64
-    MacroTileB: 96
+    MacroTileB: 64
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -4782,8 +4872,8 @@
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
@@ -4799,7 +4889,7 @@
     PerformanceWaitLocation: -1
     PersistentKernel: 0
     PrefetchGlobalRead: true
-    PrefetchLocalRead: true
+    PrefetchLocalRead: false
     ProblemType:
       AssignedDerivedParameters: true
       Batched: true
@@ -4812,6 +4902,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -4842,5174 +4935,22 @@
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
     SolutionIndex: 29
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x04_PK00_PLR1_TT04_06_WG16_16_01_WGM01
-    StaggerU: 32
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR0_TT04_04_WG16_16_01
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
     SubGroup1: 16
     SubGroupA: 16
     SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 6]
-    ThreadTile0: 4
-    ThreadTile1: 6
-    ThreadTileA: 4
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 1
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 96
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 48
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 64
-    MacroTile1: 96
-    MacroTileA: 64
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 3
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 30
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x04_PK03_PLR0_TT04_06_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 6]
-    ThreadTile0: 4
-    ThreadTile1: 6
-    ThreadTileA: 4
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 4
-    LSPB: 4
-    LVCA: 48
-    LVCB: 48
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 31
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK00_PLR0_TT06_06_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 4
-    LSPB: 4
-    LVCA: 48
-    LVCB: 48
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 32
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK02_PLR0_TT06_06_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 33
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK00_PLR1_TT08_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 34
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK02_PLR1_TT08_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 35
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK04_PLR1_TT08_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 48
-    LVCB: 64
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 3
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 36
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK03_PLR0_TT06_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 4
-    LSPB: 4
-    LVCA: 48
-    LVCB: 48
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 37
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK00_PLR0_TT06_06_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 4
-    LSPB: 4
-    LVCA: 48
-    LVCB: 48
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 38
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK02_PLR0_TT06_06_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 4
-    LSPB: 4
-    LVCA: 48
-    LVCB: 48
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 384
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 39
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x04_PK04_PLR0_TT06_06_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 40
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK00_PLR1_TT08_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 41
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK02_PLR1_TT08_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 1
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 64
-    LVCB: 64
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 42
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x04_PK04_PLR1_TT08_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 43
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR1_TT04_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
+    SuppressNoLoadLoop: false
     ThreadTile: [4, 4]
     ThreadTile0: 4
     ThreadTile1: 4
     ThreadTileA: 4
     ThreadTileB: 4
     UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 44
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK04_PLR0_TT04_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
-    LSPA: 5
-    LSPB: 8
-    LVCA: 48
-    LVCB: 32
-    LVPA: 3
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 45
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK00_PLR1_TT06_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
-    LSPA: 5
-    LSPB: 8
-    LVCA: 48
-    LVCB: 32
-    LVPA: 3
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 46
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK02_PLR1_TT06_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 96
-    LSPA: 8
-    LSPB: 5
-    LVCA: 32
-    LVCB: 48
-    LVPA: 4
-    LVPB: 3
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 96
-    MacroTileA: 64
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 47
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x08_PK02_PLR1_TT04_06_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 6]
-    ThreadTile0: 4
-    ThreadTile1: 6
-    ThreadTileA: 4
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 3
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 5
-    LSPB: 5
-    LVCA: 48
-    LVCB: 48
-    LVPA: 3
-    LVPB: 3
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 48
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x08_PK02_PLR0_TT06_06_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
-    fractionalPerpOverhangB: 3
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 8
-    LVCA: 64
-    LVCB: 32
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 49
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x08_PK02_PLR0_TT08_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 8
-    LVCA: 64
-    LVCB: 32
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 50
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x08_PK04_PLR0_TT08_04_WG16_16_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 128
-    LSPA: 8
-    LSPB: 8
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 512
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 51
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x128x08_PK02_PLR1_TT08_04_WG16_32_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 32
-    SubGroupA: 16
-    SubGroupB: 32
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 32, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 128
-    LSPA: 8
-    LSPB: 8
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 512
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 3
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 52
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x128x08_PK03_PLR1_TT08_04_WG16_32_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 32
-    SubGroupA: 16
-    SubGroupB: 32
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 32, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 128
-    LSPA: 8
-    LSPB: 8
-    LVCA: 64
-    LVCB: 64
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 4096
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 1024
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 128
-    MacroTileA: 128
-    MacroTileB: 128
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 512
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 53
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x128x08_PK04_PLR1_TT08_04_WG16_32_01_WGM01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 32
-    SubGroupA: 16
-    SubGroupB: 32
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 32, 1]
-    WorkGroupMapping: 1
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 64
-    LSPA: 8
-    LSPB: 8
-    LVCA: 32
-    LVCB: 32
-    LVPA: 4
-    LVPB: 4
-    LdsNumElements: 2048
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 1536
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 64
-    MacroTileA: 64
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 54
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR1_TT04_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
-    LSPA: 5
-    LSPB: 8
-    LVCA: 48
-    LVCB: 32
-    LVPA: 3
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 55
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK02_PLR1_TT06_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
-    LSPA: 5
-    LSPB: 8
-    LVCA: 48
-    LVCB: 32
-    LVPA: 3
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 56
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK04_PLR1_TT06_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 64
-    LSCB: 96
-    LSPA: 8
-    LSPB: 5
-    LVCA: 32
-    LVCB: 48
-    LVPA: 4
-    LVPB: 3
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 512
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 512
-    LdsOffsetB_Blk: 2560
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 64
-    MacroTile1: 96
-    MacroTileA: 64
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 57
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x08_PK02_PLR1_TT04_06_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [4, 6]
-    ThreadTile0: 4
-    ThreadTile1: 6
-    ThreadTileA: 4
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 3
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 5
-    LSPB: 5
-    LVCA: 48
-    LVCB: 48
-    LVPA: 3
-    LVPB: 3
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 58
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x08_PK02_PLR0_TT06_06_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
-    fractionalPerpOverhangB: 3
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 96
-    LSPA: 5
-    LSPB: 5
-    LVCA: 48
-    LVCB: 48
-    LVPA: 3
-    LVPB: 3
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 768
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 96
-    MacroTileA: 96
-    MacroTileB: 96
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 36
-    NumGlobalWriteVectorsPerThread: 18
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 2
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 59
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x096x08_PK04_PLR0_TT06_06_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [6, 6]
-    ThreadTile0: 6
-    ThreadTile1: 6
-    ThreadTileA: 6
-    ThreadTileB: 6
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
-    fractionalPerpOverhangB: 3
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 8
-    LVCA: 64
-    LVCB: 32
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 2
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 60
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x08_PK02_PLR0_TT08_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: true
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 128
-    LSCB: 64
-    LSPA: 4
-    LSPB: 8
-    LVCA: 64
-    LVCB: 32
-    LVPA: 2
-    LVPB: 4
-    LdsNumElements: 3584
-    LdsNumElementsAlignedA: 1024
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 1024
-    LdsOffsetB_Blk: 3072
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 128
-    MacroTile1: 64
-    MacroTileA: 128
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 32
-    NumGlobalWriteVectorsPerThread: 16
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 4
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 61
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x064x08_PK04_PLR0_TT08_04_WG16_16_01_WGM08
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: 0
-    ThreadTile: [8, 4]
-    ThreadTile0: 8
-    ThreadTile1: 4
-    ThreadTileA: 8
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
+    UseSgprForGRO: false
     Valid: true
     VectorAtomicWidth: 1
     VectorStore: true
@@ -10125,6 +5066,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -10154,9 +5098,9 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 62
+    SolutionIndex: 30
     SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x04_PLR0_TT04_04_WG16_08_01
-    StaggerU: 32
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -10286,6 +5230,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -10315,9 +5262,9 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 63
+    SolutionIndex: 31
     SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x032x04_PLR1_TT06_04_WG16_08_01
-    StaggerU: 32
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -10378,21 +5325,21 @@
     GuaranteeNoPartialB: true
     InnerUnroll: 1
     KernelLanguage: Assembly
-    LSCA: 48
-    LSCB: 64
+    LSCA: 64
+    LSCB: 48
     LSPA: 4
     LSPB: 4
-    LVCA: 24
-    LVCB: 32
+    LVCA: 32
+    LVCB: 24
     LVPA: 2
     LVPB: 2
     LdsNumElements: 960
-    LdsNumElementsAlignedA: 192
-    LdsNumElementsAlignedB: 256
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
     LdsOffsetA: 0
     LdsOffsetA_Blk: 512
-    LdsOffsetB: 192
-    LdsOffsetB_Blk: 704
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
     LdsPadA: 0
     LdsPadB: 0
     LocalDotLayout: 1
@@ -10406,10 +5353,10 @@
     LoopDoWhile: false
     LoopTail: true
     LoopUnroll: 4
-    MacroTile0: 48
-    MacroTile1: 64
-    MacroTileA: 48
-    MacroTileB: 64
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
     MacroTileShapeMax: 64
     MacroTileShapeMin: 1
     MaxOccupancy: 40
@@ -10447,6 +5394,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -10476,336 +5426,342 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 64
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT048x064x04_PLR1_TT06_04_WG08_16_01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppressNoLoadLoop: true
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 48
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 24
-    LVCB: 32
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 960
-    LdsNumElementsAlignedA: 192
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 512
-    LdsOffsetB: 192
-    LdsOffsetB_Blk: 704
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 48
-    MacroTile1: 64
-    MacroTileA: 48
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 128
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: false
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 65
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT048x064x04_PLR0_TT06_04_WG08_16_01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppressNoLoadLoop: true
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 3
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 4
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
-    LSPA: 4
-    LSPB: 4
-    LVCA: 48
-    LVCB: 32
-    LVPA: 2
-    LVPB: 2
-    LdsNumElements: 1664
-    LdsNumElementsAlignedA: 384
-    LdsNumElementsAlignedB: 256
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 384
-    LdsOffsetB_Blk: 1408
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 4
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 66
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PLR1_TT06_04_WG16_16_01
-    StaggerU: 32
+    SolutionIndex: 32
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PLR1_TT04_06_WG16_08_01
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
-    SubGroup1: 16
+    SubGroup1: 8
     SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 2
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 32
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 896
+    LdsNumElementsAlignedA: 128
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 128
+    LdsOffsetB_Blk: 640
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 32
+    MacroTile1: 64
+    MacroTileA: 32
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 33
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT032x064x04_PLR0_TT04_04_WG08_16_01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 16
+    SubGroupA: 8
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: 1
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 2
+    AssertFree1ElementMultiple: 2
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 2
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: 1
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 48
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 24
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 192
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 192
+    LdsOffsetB_Blk: 704
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 48
+    MacroTile1: 64
+    MacroTileA: 48
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 34
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT048x064x04_PLR0_TT06_04_WG08_16_01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 16
+    SubGroupA: 8
     SubGroupB: 16
     SuppressNoLoadLoop: true
     ThreadTile: [6, 4]
@@ -10819,7 +5775,7 @@
     VectorAtomicWidth: 1
     VectorStore: true
     VectorWidth: 2
-    WorkGroup: [16, 16, 1]
+    WorkGroup: [8, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 3
@@ -10930,6 +5886,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -10959,9 +5918,9 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 67
+    SolutionIndex: 35
     SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PLR0_TT06_04_WG16_16_01
-    StaggerU: 32
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -11091,6 +6050,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -11120,9 +6082,9 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 68
+    SolutionIndex: 36
     SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x08_PLR1_TT04_04_WG16_08_01
-    StaggerU: 32
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -11142,167 +6104,6 @@
     VectorStore: true
     VectorWidth: 2
     WorkGroup: [16, 8, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 32
-    LSCB: 64
-    LSPA: 8
-    LSPB: 4
-    LVCA: 16
-    LVCB: 32
-    LVPA: 4
-    LVPB: 2
-    LdsNumElements: 1792
-    LdsNumElementsAlignedA: 256
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 1024
-    LdsOffsetB: 256
-    LdsOffsetB_Blk: 1280
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 32
-    MacroTile1: 64
-    MacroTileA: 32
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 16
-    NumGlobalWriteVectorsPerThread: 8
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 2
-    NumThreads: 128
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 69
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT032x064x08_PLR1_TT04_04_WG08_16_01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 8
-    SubGroup1: 16
-    SubGroupA: 8
-    SubGroupB: 16
-    SuppressNoLoadLoop: true
-    ThreadTile: [4, 4]
-    ThreadTile0: 4
-    ThreadTile1: 4
-    ThreadTileA: 4
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [8, 16, 1]
     WorkGroupMapping: 8
     WorkGroupMappingType: B
     _staggerStrideShift: 2
@@ -11413,6 +6214,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -11442,9 +6246,9 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 70
+    SolutionIndex: 37
     SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR1_TT04_04_WG16_16_01
-    StaggerU: 32
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -11574,6 +6378,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -11603,9 +6410,9 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 71
+    SolutionIndex: 38
     SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PLR0_TT04_04_WG16_16_01
-    StaggerU: 32
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -11629,167 +6436,6 @@
     WorkGroupMappingType: B
     _staggerStrideShift: 2
     fractionalPerpOverhangA: 0
-    fractionalPerpOverhangB: 0
-  - AggressivePerfMode: 1
-    AssertFree0ElementMultiple: 2
-    AssertFree1ElementMultiple: 2
-    AssertMinApproxSize: 1
-    AssertSummationElementMultiple: 2
-    AssignedDerivedParameters: false
-    AssignedProblemIndependentDerivedParameters: true
-    BufferLoad: true
-    BufferStore: true
-    CheckDimOverflow: 0
-    CheckTensorDimAsserts: false
-    DepthU: 8
-    DirectToLds: false
-    DirectToLdsA: false
-    DirectToLdsB: false
-    DisableKernelPieces: 0
-    EdgeType: ShiftPtr
-    ExpandPointerSwap: true
-    FractionalLoad: 1
-    GlobalLoadVectorWidthA: 2
-    GlobalLoadVectorWidthB: 2
-    GlobalRead2A: true
-    GlobalRead2B: true
-    GlobalReadCoalesceGroupA: true
-    GlobalReadCoalesceGroupB: true
-    GlobalReadCoalesceVectorA: true
-    GlobalReadCoalesceVectorB: true
-    GlobalReadVectorWidth: 2
-    GlobalSplitU: 1
-    GlobalSplitUSummationAssignmentRoundRobin: true
-    GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
-    GuaranteeNoPartialA: true
-    GuaranteeNoPartialB: true
-    InnerUnroll: 1
-    KernelLanguage: Assembly
-    LSCA: 96
-    LSCB: 64
-    LSPA: 5
-    LSPB: 8
-    LVCA: 48
-    LVCB: 32
-    LVPA: 3
-    LVPB: 4
-    LdsNumElements: 3328
-    LdsNumElementsAlignedA: 768
-    LdsNumElementsAlignedB: 512
-    LdsOffsetA: 0
-    LdsOffsetA_Blk: 2048
-    LdsOffsetB: 768
-    LdsOffsetB_Blk: 2816
-    LdsPadA: 0
-    LdsPadB: 0
-    LocalDotLayout: 1
-    LocalRead2A: true
-    LocalRead2B: true
-    LocalSplitU: 1
-    LocalWrite2A: true
-    LocalWrite2B: true
-    LocalWriteUseSgprA: false
-    LocalWriteUseSgprB: false
-    LoopDoWhile: false
-    LoopTail: true
-    LoopUnroll: 8
-    MacroTile0: 96
-    MacroTile1: 64
-    MacroTileA: 96
-    MacroTileB: 64
-    MacroTileShapeMax: 64
-    MacroTileShapeMin: 1
-    MaxOccupancy: 40
-    MinGlobalWriteVectorWidth: 1
-    NonTemporalA: 0
-    NonTemporalB: 0
-    NonTemporalC: 0
-    NumElementsPerThread: 24
-    NumGlobalWriteVectorsPerThread: 12
-    NumLoadsCoalescedA: 1
-    NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 2
-    NumLoadsPerpendicularB: 1
-    NumThreads: 256
-    PackBatchDims: 0
-    PackFreeDims: 1
-    PackGranularity: 2
-    PackedC0Indices: [I]
-    PackedC1Indices: [J]
-    PerformanceSyncLocation: -1
-    PerformanceWaitCount: -1
-    PerformanceWaitLocation: -1
-    PersistentKernel: 0
-    PrefetchGlobalRead: true
-    PrefetchLocalRead: true
-    ProblemType:
-      AssignedDerivedParameters: true
-      Batched: true
-      ComplexConjugateA: false
-      ComplexConjugateB: false
-      DataType: 1
-      DestDataType: 1
-      HighPrecisionAccumulate: false
-      Index0: 0
-      Index01A: 0
-      Index01B: 1
-      Index1: 1
-      IndexAssignmentsA: [0, 3, 2]
-      IndexAssignmentsB: [1, 3, 2]
-      IndexUnroll: 3
-      IndexUnrollA: 1
-      IndexUnrollB: 1
-      IndicesBatch: [2]
-      IndicesFree: [0, 1]
-      IndicesSummation: [3]
-      NumIndicesBatch: 1
-      NumIndicesC: 3
-      NumIndicesFree: 2
-      NumIndicesSummation: 1
-      OperationType: GEMM
-      SilentHighPrecisionAccumulate: false
-      TLUA: true
-      TLUB: true
-      Tensor0: 0
-      Tensor1: 1
-      TileA: 0
-      TileB: 1
-      TotalIndices: 4
-      TransposeA: false
-      TransposeB: true
-      UseBeta: true
-      UseInitialStrides: false
-    ReplacementKernel: false
-    ScheduleGlobalRead: 1
-    ScheduleIterAlg: 1
-    ScheduleLocalWrite: 1
-    SolutionIndex: 72
-    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PLR1_TT06_04_WG16_16_01
-    StaggerU: 32
-    StaggerUMapping: 0
-    StaggerUStride: 256
-    SubGroup0: 16
-    SubGroup1: 16
-    SubGroupA: 16
-    SubGroupB: 16
-    SuppressNoLoadLoop: true
-    ThreadTile: [6, 4]
-    ThreadTile0: 6
-    ThreadTile1: 4
-    ThreadTileA: 6
-    ThreadTileB: 4
-    UnrollMemFence: false
-    UseSgprForGRO: 1
-    Valid: true
-    VectorAtomicWidth: 1
-    VectorStore: true
-    VectorWidth: 2
-    WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 8
-    WorkGroupMappingType: B
-    _staggerStrideShift: 2
-    fractionalPerpOverhangA: 3
     fractionalPerpOverhangB: 0
   - AggressivePerfMode: 1
     AssertFree0ElementMultiple: 2
@@ -11896,6 +6542,9 @@
       Index01A: 0
       Index01B: 1
       Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
       IndexAssignmentsA: [0, 3, 2]
       IndexAssignmentsB: [1, 3, 2]
       IndexUnroll: 3
@@ -11925,9 +6574,9 @@
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 1
     ScheduleLocalWrite: 1
-    SolutionIndex: 73
+    SolutionIndex: 39
     SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x12_PLR1_TT04_04_WG16_08_01
-    StaggerU: 32
+    StaggerU: 0
     StaggerUMapping: 0
     StaggerUStride: 256
     SubGroup0: 16
@@ -11952,1983 +6601,8419 @@
     _staggerStrideShift: 1
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 4
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 896
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 40
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x04_PK00_PLR1_SNLL1_TT04_04_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 896
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 41
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x04_PK00_PLR0_SNLL1_TT04_04_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 896
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 42
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x04_PK00_PLR0_SNLL0_TT04_04_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 32
+    LSPA: 2
+    LSPB: 4
+    LVCA: 48
+    LVCB: 16
+    LVPA: 1
+    LVPB: 2
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 896
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 96
+    MacroTile1: 32
+    MacroTileA: 96
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 43
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x032x04_PK00_PLR1_SNLL0_TT06_04_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 44
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PK00_PLR0_SNLL1_TT04_06_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 45
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PK00_PLR0_SNLL0_TT04_06_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 32
+    LSPA: 2
+    LSPB: 4
+    LVCA: 48
+    LVCB: 16
+    LVPA: 1
+    LVPB: 2
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 896
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 96
+    MacroTile1: 32
+    MacroTileA: 96
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 4
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 46
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x032x04_PK04_PLR1_SNLL1_TT06_04_WG16_08_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 47
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PK00_PLR0_SNLL1_TT04_06_WG16_08_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 48
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x048x04_PK00_PLR0_SNLL0_TT04_06_WG16_08_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 48
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 24
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 192
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 192
+    LdsOffsetB_Blk: 704
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 48
+    MacroTile1: 64
+    MacroTileA: 48
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 49
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT048x064x04_PK00_PLR0_SNLL1_TT06_04_WG08_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 16
+    SubGroupA: 8
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 48
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 24
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 192
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 192
+    LdsOffsetB_Blk: 704
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 48
+    MacroTile1: 64
+    MacroTileA: 48
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 50
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT048x064x04_PK00_PLR0_SNLL0_TT06_04_WG08_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 16
+    SubGroupA: 8
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 48
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 96
+    MacroTile1: 64
+    MacroTileA: 96
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 51
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK00_PLR0_SNLL1_TT06_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 48
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 96
+    MacroTile1: 64
+    MacroTileA: 96
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 52
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x04_PK00_PLR0_SNLL0_TT06_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 96
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 48
+    LVPA: 2
+    LVPB: 2
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 96
+    MacroTileA: 64
+    MacroTileB: 96
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 53
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x096x04_PK00_PLR0_SNLL0_TT04_06_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 54
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x08_PK00_PLR1_SNLL1_TT04_04_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 55
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x032x08_PK00_PLR1_SNLL0_TT04_04_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 32
+    LSPA: 2
+    LSPB: 8
+    LVCA: 48
+    LVCB: 16
+    LVPA: 1
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 1792
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 96
+    MacroTile1: 32
+    MacroTileA: 96
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 4
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 56
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x032x08_PK04_PLR1_SNLL0_TT06_04_WG16_08_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 57
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR1_SNLL1_TT04_04_WG16_16_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 4
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 58
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK04_PLR0_SNLL1_TT04_04_WG16_16_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 59
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR1_SNLL0_TT04_04_WG16_16_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 60
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR0_SNLL0_TT04_04_WG16_16_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 4
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 61
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK04_PLR0_SNLL0_TT04_04_WG16_16_01_WGM01
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 48
+    LSPA: 2
+    LSPB: 5
+    LVCA: 48
+    LVCB: 24
+    LVPA: 1
+    LVPB: 3
+    LdsNumElements: 3200
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 96
+    MacroTile1: 48
+    MacroTileA: 96
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 36
+    NumGlobalWriteVectorsPerThread: 18
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 62
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x048x08_PK00_PLR1_SNLL1_TT06_06_WG16_08_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 6]
+    ThreadTile0: 6
+    ThreadTile1: 6
+    ThreadTileA: 6
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 63
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR1_SNLL1_TT04_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 64
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR0_SNLL1_TT04_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 4
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 65
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK04_PLR0_SNLL1_TT04_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 66
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR1_SNLL0_TT04_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 67
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK00_PLR0_SNLL0_TT04_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 4
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 68
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT064x064x08_PK04_PLR0_SNLL0_TT04_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 64
+    LSPA: 5
+    LSPB: 8
+    LVCA: 48
+    LVCB: 32
+    LVPA: 3
+    LVPB: 4
+    LdsNumElements: 3328
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 96
+    MacroTile1: 64
+    MacroTileA: 96
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 2
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 69
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK02_PLR1_SNLL1_TT06_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 3
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 64
+    LSPA: 5
+    LSPB: 8
+    LVCA: 48
+    LVCB: 32
+    LVPA: 3
+    LVPB: 4
+    LdsNumElements: 3328
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 2816
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 96
+    MacroTile1: 64
+    MacroTileA: 96
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 4
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentLDA: 5
+      IndexAssignmentLDB: 6
+      IndexAssignmentLDC: 4
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 70
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT096x064x08_PK04_PLR1_SNLL1_TT06_04_WG16_16_01_WGM08
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 3
+    fractionalPerpOverhangB: 0
 - [2, 3, 0, 1]
-- - - [1, 64, 1, 64]
-    - [1, 0.441379]
-  - - [64, 1, 1, 64]
-    - [1, 0.453097]
-  - - [1, 1, 1, 64]
-    - [1, 0.00650406]
-  - - [64, 64, 1, 64]
-    - [0, 27.7695]
-  - - [16640, 16640, 1, 256]
-    - [8, 4903.31]
-  - - [25728, 25728, 1, 384]
-    - [6, 5016.52]
-  - - [2688, 2688, 1, 384]
-    - [8, 4840.43]
-  - - [16896, 16896, 1, 256]
-    - [22, 4853.08]
-  - - [21120, 21120, 1, 384]
-    - [6, 5016.38]
-  - - [32640, 32640, 1, 384]
-    - [6, 5012.65]
-  - - [19200, 19200, 1, 256]
-    - [8, 4907.46]
-  - - [17408, 17408, 1, 256]
-    - [22, 4853.05]
-  - - [8704, 8704, 1, 256]
-    - [22, 4856.39]
-  - - [33408, 33408, 1, 384]
-    - [6, 5022.01]
-  - - [1280, 1280, 1, 256]
-    - [3, 3803.33]
-  - - [4992, 4992, 1, 384]
-    - [8, 4915.61]
-  - - [9984, 9984, 1, 256]
-    - [15, 4897.39]
-  - - [5760, 5760, 1, 5760]
-    - [8, 5072.73]
-  - - [28800, 28800, 1, 384]
-    - [6, 5012.78]
-  - - [33792, 33792, 1, 256]
-    - [28, 4854.69]
-  - - [23424, 23424, 1, 384]
-    - [6, 5013.73]
-  - - [9728, 9728, 1, 256]
-    - [22, 4850.62]
-  - - [4608, 4608, 1, 50000]
-    - [12, 5157.37]
-  - - [8192, 8192, 1, 256]
-    - [22, 4828.63]
-  - - [31744, 31744, 1, 256]
-    - [22, 4860.56]
-  - - [38656, 38656, 1, 256]
-    - [6, 4910.42]
-  - - [23296, 23296, 1, 256]
-    - [8, 4915.15]
-  - - [6528, 6528, 1, 384]
-    - [17, 4934.29]
-  - - [7680, 7680, 1, 384]
-    - [8, 4945.12]
-  - - [5376, 5376, 1, 384]
-    - [13, 4938.65]
-  - - [15104, 15104, 1, 256]
-    - [8, 4904.1]
-  - - [42240, 42240, 1, 256]
-    - [8, 4904.59]
-  - - [14848, 14848, 1, 256]
-    - [22, 4849.06]
-  - - [25344, 25344, 1, 384]
-    - [6, 4988.02]
-  - - [36480, 36480, 1, 384]
-    - [13, 5014.1]
-  - - [31488, 31488, 1, 384]
-    - [6, 4999.03]
-  - - [21504, 21504, 1, 256]
-    - [22, 4850.98]
-  - - [20736, 20736, 1, 256]
-    - [6, 4915.41]
-  - - [38400, 38400, 1, 384]
-    - [14, 4940.95]
-  - - [42240, 42240, 1, 384]
-    - [6, 4983.05]
-  - - [22656, 22656, 1, 384]
-    - [6, 5026.84]
-  - - [5632, 5632, 1, 256]
-    - [8, 4834.71]
-  - - [26880, 26880, 1, 256]
-    - [8, 4913.06]
-  - - [7424, 7424, 1, 256]
-    - [15, 4852.55]
-  - - [14592, 14592, 1, 384]
-    - [13, 5001.81]
-  - - [11264, 11264, 1, 256]
-    - [8, 4849.46]
-  - - [25088, 25088, 1, 256]
-    - [14, 4852.2]
-  - - [384, 384, 1, 384]
-    - [24, 1266.18]
-  - - [29952, 29952, 1, 256]
-    - [8, 4916.93]
-  - - [36352, 36352, 1, 256]
-    - [13, 4852.23]
-  - - [25600, 25600, 1, 256]
-    - [28, 4846.18]
-  - - [21248, 21248, 1, 256]
-    - [8, 4913.93]
-  - - [20352, 20352, 1, 384]
-    - [6, 5033.85]
-  - - [42624, 42624, 1, 384]
-    - [6, 5012.04]
-  - - [35712, 35712, 1, 384]
-    - [6, 5017.48]
-  - - [35072, 35072, 1, 256]
-    - [6, 4911.87]
-  - - [16896, 16896, 1, 384]
-    - [28, 4932.54]
-  - - [19584, 19584, 1, 384]
-    - [6, 5033.22]
-  - - [16128, 16128, 1, 256]
-    - [8, 4905.84]
-  - - [33536, 33536, 1, 256]
-    - [8, 4905.61]
-  - - [35584, 35584, 1, 256]
-    - [8, 4918.18]
-  - - [3840, 3840, 1, 384]
-    - [27, 4840.09]
-  - - [20224, 20224, 1, 256]
-    - [8, 4915.84]
-  - - [4608, 4608, 1, 4608]
-    - [13, 5147.56]
-  - - [7680, 7680, 1, 256]
-    - [15, 4855.33]
-  - - [38784, 38784, 1, 384]
-    - [6, 5006.2]
-  - - [23040, 23040, 1, 256]
-    - [28, 4853.39]
-  - - [18432, 18432, 1, 384]
-    - [14, 4934.81]
-  - - [27904, 27904, 1, 256]
-    - [8, 4913.68]
-  - - [4352, 4352, 1, 256]
-    - [25, 4753.74]
-  - - [768, 768, 1, 384]
-    - [5, 3547.81]
-  - - [37376, 37376, 1, 256]
-    - [14, 4856.57]
-  - - [4096, 4096, 1, 256]
-    - [8, 4815.21]
-  - - [36096, 36096, 1, 384]
-    - [6, 4993.86]
-  - - [24320, 24320, 1, 256]
-    - [8, 4918.51]
-  - - [40960, 40960, 1, 256]
-    - [23, 4777.73]
-  - - [40704, 40704, 1, 384]
-    - [8, 4989.05]
-  - - [41728, 41728, 1, 256]
-    - [8, 4904.59]
-  - - [24832, 24832, 1, 256]
-    - [8, 4918.17]
-  - - [44544, 44544, 1, 384]
-    - [15, 4950.44]
-  - - [13440, 13440, 1, 384]
-    - [13, 5009.56]
-  - - [9472, 9472, 1, 256]
-    - [8, 4868.5]
-  - - [6144, 6144, 1, 256]
-    - [22, 4838.13]
-  - - [9984, 9984, 1, 384]
-    - [13, 4989.34]
-  - - [29184, 29184, 1, 384]
-    - [15, 4958.4]
-  - - [39680, 39680, 1, 256]
-    - [8, 4910.54]
-  - - [41984, 41984, 1, 256]
-    - [28, 4861.21]
-  - - [31488, 31488, 1, 256]
-    - [8, 4909.99]
-  - - [34304, 34304, 1, 256]
-    - [8, 4850.55]
-  - - [12800, 12800, 1, 256]
-    - [8, 4851.74]
-  - - [26496, 26496, 1, 384]
-    - [6, 5004.72]
-  - - [29440, 29440, 1, 256]
-    - [8, 4920.11]
-  - - [30720, 30720, 1, 256]
-    - [28, 4860.34]
-  - - [17280, 17280, 1, 384]
-    - [6, 5017.53]
-  - - [1792, 1792, 1, 256]
-    - [6, 4235.8]
-  - - [23040, 23040, 1, 384]
-    - [14, 4946.25]
-  - - [3584, 3584, 1, 256]
-    - [8, 4707.31]
-  - - [31872, 31872, 1, 384]
-    - [6, 5016.1]
-  - - [29184, 29184, 1, 256]
-    - [28, 4867.7]
-  - - [32768, 32768, 1, 256]
-    - [23, 4798.29]
-  - - [16128, 16128, 1, 384]
-    - [13, 5008.8]
-  - - [256, 256, 1, 256]
-    - [16, 560.736]
-  - - [32256, 32256, 1, 384]
-    - [15, 4962.76]
-  - - [44160, 44160, 1, 384]
-    - [6, 5017.74]
-  - - [768, 768, 1, 256]
-    - [5, 3410.0]
-  - - [37632, 37632, 1, 256]
-    - [14, 4907.84]
-  - - [2560, 2560, 1, 256]
-    - [10, 4527.05]
-  - - [17664, 17664, 1, 384]
-    - [6, 5001.81]
-  - - [8448, 8448, 1, 256]
-    - [6, 4895.82]
-  - - [28416, 28416, 1, 384]
-    - [6, 5004.58]
-  - - [44544, 44544, 1, 256]
-    - [15, 4867.77]
-  - - [1024, 1024, 1, 256]
-    - [7, 4462.03]
-  - - [41216, 41216, 1, 256]
-    - [8, 4911.73]
-  - - [13824, 13824, 1, 384]
-    - [13, 4939.05]
-  - - [37888, 37888, 1, 256]
-    - [28, 4853.24]
-  - - [9216, 9216, 1, 256]
-    - [8, 4853.45]
-  - - [26880, 26880, 1, 384]
-    - [6, 4988.04]
-  - - [27264, 27264, 1, 384]
-    - [6, 5017.13]
-  - - [43264, 43264, 1, 256]
-    - [14, 4904.52]
-  - - [1536, 1536, 1, 256]
-    - [26, 4508.67]
-  - - [4864, 4864, 1, 256]
-    - [17, 4773.32]
-  - - [43008, 43008, 1, 256]
-    - [28, 4851.85]
-  - - [29696, 29696, 1, 256]
-    - [22, 4860.24]
-  - - [41472, 41472, 1, 256]
-    - [14, 4848.78]
-  - - [11776, 11776, 1, 256]
-    - [8, 4855.22]
-  - - [18048, 18048, 1, 384]
-    - [6, 5010.58]
-  - - [1536, 1536, 1, 384]
-    - [26, 4676.7]
-  - - [13568, 13568, 1, 256]
-    - [8, 4899.12]
-  - - [6912, 6912, 1, 256]
-    - [13, 4881.77]
-  - - [6400, 6400, 1, 256]
-    - [8, 4869.22]
-  - - [4608, 4608, 1, 384]
-    - [8, 4872.79]
-  - - [14080, 14080, 1, 256]
-    - [8, 4904.7]
-  - - [23552, 23552, 1, 256]
-    - [22, 4849.97]
-  - - [8448, 8448, 1, 384]
-    - [13, 4979.11]
-  - - [11136, 11136, 1, 384]
-    - [6, 5007.22]
-  - - [18688, 18688, 1, 256]
-    - [8, 4911.71]
-  - - [32000, 32000, 1, 256]
-    - [8, 4916.61]
-  - - [32256, 32256, 1, 256]
-    - [28, 4857.14]
-  - - [38400, 38400, 1, 256]
-    - [28, 4852.33]
-  - - [30720, 30720, 1, 384]
-    - [28, 4953.54]
-  - - [36608, 36608, 1, 256]
-    - [8, 4921.13]
-  - - [30208, 30208, 1, 256]
-    - [22, 4856.2]
-  - - [34944, 34944, 1, 384]
-    - [6, 5020.1]
-  - - [23808, 23808, 1, 384]
-    - [8, 4984.21]
-  - - [44288, 44288, 1, 256]
-    - [8, 4904.12]
-  - - [28416, 28416, 1, 256]
-    - [8, 4911.98]
-  - - [15872, 15872, 1, 256]
-    - [14, 4853.96]
-  - - [40704, 40704, 1, 256]
-    - [8, 4909.88]
-  - - [8064, 8064, 1, 384]
-    - [8, 4974.66]
-  - - [33024, 33024, 1, 256]
-    - [8, 4915.48]
-  - - [26112, 26112, 1, 384]
-    - [14, 4934.09]
-  - - [13824, 13824, 1, 256]
-    - [15, 4865.79]
-  - - [18816, 18816, 1, 384]
-    - [6, 5023.71]
-  - - [26624, 26624, 1, 256]
-    - [23, 4837.65]
-  - - [34560, 34560, 1, 384]
-    - [6, 4998.14]
-  - - [27392, 27392, 1, 256]
-    - [8, 4923.16]
-  - - [7936, 7936, 1, 256]
-    - [8, 4870.97]
-  - - [4608, 4608, 1, 256]
-    - [8, 4789.11]
-  - - [44800, 44800, 1, 256]
-    - [6, 4909.99]
-  - - [12672, 12672, 1, 384]
-    - [6, 5010.51]
-  - - [2816, 2816, 1, 256]
-    - [8, 4546.37]
-  - - [18432, 18432, 1, 256]
-    - [14, 4846.48]
-  - - [19712, 19712, 1, 256]
-    - [8, 4912.13]
-  - - [39936, 39936, 1, 384]
-    - [28, 4941.2]
-  - - [1152, 1152, 1, 384]
-    - [4, 4039.39]
-  - - [24960, 24960, 1, 384]
-    - [6, 5017.19]
-  - - [21888, 21888, 1, 384]
-    - [13, 5009.98]
-  - - [8960, 8960, 1, 256]
-    - [15, 4873.26]
-  - - [22272, 22272, 1, 256]
-    - [8, 4914.71]
-  - - [35328, 35328, 1, 384]
-    - [14, 4952.59]
-  - - [10240, 10240, 1, 256]
-    - [8, 4840.51]
-  - - [21504, 21504, 1, 384]
-    - [14, 4932.21]
-  - - [24576, 24576, 1, 256]
-    - [23, 4827.89]
-  - - [34816, 34816, 1, 256]
-    - [28, 4866.3]
-  - - [7744, 7744, 1, 7744]
-    - [8, 5064.38]
-  - - [19456, 19456, 1, 256]
-    - [28, 4857.05]
-  - - [9216, 9216, 1, 384]
-    - [8, 4944.62]
-  - - [27648, 27648, 1, 384]
-    - [14, 4933.21]
-  - - [13056, 13056, 1, 384]
-    - [13, 4983.14]
-  - - [6656, 6656, 1, 256]
-    - [8, 4847.09]
-  - - [37632, 37632, 1, 384]
-    - [6, 4986.31]
-  - - [39168, 39168, 1, 384]
-    - [8, 4981.74]
-  - - [11904, 11904, 1, 384]
-    - [6, 4998.99]
-  - - [35840, 35840, 1, 256]
-    - [14, 4843.33]
-  - - [3840, 3840, 1, 256]
-    - [25, 4741.84]
-  - - [43776, 43776, 1, 256]
-    - [6, 4914.59]
-  - - [10368, 10368, 1, 384]
-    - [6, 5003.23]
-  - - [17664, 17664, 1, 256]
-    - [6, 4918.42]
-  - - [43520, 43520, 1, 256]
-    - [14, 4844.37]
-  - - [13312, 13312, 1, 256]
-    - [8, 4847.29]
-  - - [11520, 11520, 1, 256]
-    - [13, 4899.95]
-  - - [14976, 14976, 1, 384]
-    - [13, 5011.77]
-  - - [26112, 26112, 1, 256]
-    - [28, 4864.9]
-  - - [18176, 18176, 1, 256]
-    - [8, 4914.7]
-  - - [34048, 34048, 1, 256]
-    - [6, 4924.59]
-  - - [15360, 15360, 1, 384]
-    - [15, 4956.41]
-  - - [36096, 36096, 1, 256]
-    - [8, 4909.97]
-  - - [19968, 19968, 1, 256]
-    - [15, 4873.17]
-  - - [39936, 39936, 1, 256]
-    - [28, 4856.67]
-  - - [30336, 30336, 1, 384]
-    - [6, 5017.56]
-  - - [15744, 15744, 1, 384]
-    - [6, 5012.74]
-  - - [41856, 41856, 1, 384]
-    - [6, 5004.35]
-  - - [10496, 10496, 1, 256]
-    - [8, 4897.7]
-  - - [31232, 31232, 1, 256]
-    - [22, 4855.06]
-  - - [22784, 22784, 1, 256]
-    - [8, 4915.67]
-  - - [33024, 33024, 1, 384]
-    - [8, 4999.77]
-  - - [14208, 14208, 1, 384]
-    - [6, 5009.13]
-  - - [34176, 34176, 1, 384]
-    - [6, 5010.18]
-  - - [14592, 14592, 1, 256]
-    - [8, 4906.5]
-  - - [43008, 43008, 1, 384]
-    - [28, 4936.39]
-  - - [27648, 27648, 1, 256]
-    - [28, 4855.17]
-  - - [7296, 7296, 1, 384]
-    - [8, 4951.49]
-  - - [13056, 13056, 1, 256]
-    - [6, 4908.74]
-  - - [19200, 19200, 1, 384]
-    - [6, 4984.54]
-  - - [512, 512, 1, 256]
-    - [19, 2041.02]
-  - - [14336, 14336, 1, 256]
-    - [8, 4847.66]
-  - - [20992, 20992, 1, 256]
-    - [14, 4852.32]
-  - - [39168, 39168, 1, 256]
-    - [8, 4909.31]
-  - - [11520, 11520, 1, 384]
-    - [13, 4988.88]
-  - - [28032, 28032, 1, 384]
-    - [13, 5008.51]
-  - - [24192, 24192, 1, 384]
-    - [6, 5013.54]
-  - - [12032, 12032, 1, 256]
-    - [8, 4893.35]
-  - - [41088, 41088, 1, 384]
-    - [6, 5017.2]
-  - - [38016, 38016, 1, 384]
-    - [6, 5016.9]
-  - - [2304, 2304, 1, 384]
-    - [25, 4667.17]
-  - - [22528, 22528, 1, 256]
-    - [22, 4846.22]
-  - - [22272, 22272, 1, 384]
-    - [6, 5013.3]
-  - - [5376, 5376, 1, 256]
-    - [13, 4843.39]
-  - - [8832, 8832, 1, 384]
-    - [8, 4985.89]
-  - - [37248, 37248, 1, 384]
-    - [8, 5005.62]
-  - - [15616, 15616, 1, 256]
-    - [8, 4909.19]
-  - - [28928, 28928, 1, 256]
-    - [8, 4917.14]
-  - - [24576, 24576, 1, 384]
-    - [23, 4899.1]
-  - - [12288, 12288, 1, 384]
-    - [28, 4930.6]
-  - - [23808, 23808, 1, 256]
-    - [8, 4911.44]
-  - - [24064, 24064, 1, 256]
-    - [14, 4846.83]
-  - - [40320, 40320, 1, 384]
-    - [6, 5003.65]
-  - - [43776, 43776, 1, 384]
-    - [6, 5004.33]
-  - - [9600, 9600, 1, 384]
-    - [6, 4987.33]
-  - - [30464, 30464, 1, 256]
-    - [8, 4908.55]
-  - - [20480, 20480, 1, 256]
-    - [28, 4878.89]
-  - - [39424, 39424, 1, 256]
-    - [28, 4856.22]
-  - - [4224, 4224, 1, 384]
-    - [17, 4866.61]
-  - - [29568, 29568, 1, 384]
-    - [6, 5010.07]
-  - - [40192, 40192, 1, 256]
-    - [6, 4913.05]
-  - - [7168, 7168, 1, 256]
-    - [8, 4858.3]
-  - - [10752, 10752, 1, 384]
-    - [15, 4956.18]
-  - - [44032, 44032, 1, 256]
-    - [14, 4848.91]
-  - - [31104, 31104, 1, 384]
-    - [6, 5012.72]
-  - - [33792, 33792, 1, 384]
-    - [14, 4951.73]
-  - - [32512, 32512, 1, 256]
-    - [8, 4913.63]
-  - - [27136, 27136, 1, 256]
-    - [14, 4849.27]
-  - - [15360, 15360, 1, 256]
-    - [8, 4850.96]
-  - - [21760, 21760, 1, 256]
-    - [8, 4911.98]
-  - - [22016, 22016, 1, 256]
-    - [22, 4854.31]
-  - - [19968, 19968, 1, 384]
-    - [14, 4945.94]
-  - - [35328, 35328, 1, 256]
-    - [14, 4850.45]
-  - - [2304, 2304, 1, 256]
-    - [19, 4532.27]
-  - - [29952, 29952, 1, 384]
-    - [8, 4988.27]
-  - - [5120, 5120, 1, 256]
-    - [8, 4853.54]
-  - - [16512, 16512, 1, 384]
-    - [6, 5016.05]
-  - - [39552, 39552, 1, 384]
-    - [13, 5010.95]
-  - - [12544, 12544, 1, 256]
-    - [8, 4906.97]
-  - - [38912, 38912, 1, 256]
-    - [22, 4844.07]
-  - - [40448, 40448, 1, 256]
-    - [28, 4854.24]
-  - - [38144, 38144, 1, 256]
-    - [8, 4910.85]
-  - - [25344, 25344, 1, 256]
-    - [8, 4916.02]
-  - - [12288, 12288, 1, 256]
-    - [22, 4846.72]
-  - - [37120, 37120, 1, 256]
-    - [6, 4909.43]
-  - - [43392, 43392, 1, 384]
-    - [13, 5004.76]
-  - - [42496, 42496, 1, 256]
-    - [14, 4853.14]
-  - - [34560, 34560, 1, 256]
-    - [8, 4919.49]
-  - - [25856, 25856, 1, 256]
-    - [8, 4914.76]
-  - - [28160, 28160, 1, 256]
-    - [28, 4857.66]
-  - - [36864, 36864, 1, 256]
-    - [28, 4847.28]
-  - - [5888, 5888, 1, 256]
-    - [8, 4838.71]
-  - - [20736, 20736, 1, 384]
-    - [8, 4993.28]
-  - - [17152, 17152, 1, 256]
-    - [8, 4900.1]
-  - - [18944, 18944, 1, 256]
-    - [22, 4847.98]
-  - - [6144, 6144, 1, 384]
-    - [8, 4939.52]
-  - - [30976, 30976, 1, 256]
-    - [8, 4914.66]
-  - - [41472, 41472, 1, 384]
-    - [14, 4941.82]
-  - - [11008, 11008, 1, 256]
-    - [8, 4882.14]
-  - - [26368, 26368, 1, 256]
-    - [8, 4918.3]
-  - - [3456, 3456, 1, 384]
-    - [15, 4840.31]
-  - - [10752, 10752, 1, 256]
-    - [8, 4852.69]
-  - - [28672, 28672, 1, 256]
-    - [22, 4840.71]
-  - - [36864, 36864, 1, 384]
-    - [28, 4918.86]
-  - - [44928, 44928, 1, 384]
-    - [20, 5003.55]
-  - - [1920, 1920, 1, 384]
-    - [25, 4546.44]
-  - - [3328, 3328, 1, 256]
-    - [22, 4636.87]
-  - - [42752, 42752, 1, 256]
-    - [8, 4907.31]
-  - - [17920, 17920, 1, 256]
-    - [14, 4864.38]
-  - - [33280, 33280, 1, 256]
-    - [28, 4856.54]
-  - - [6912, 6912, 1, 384]
-    - [13, 4968.4]
-  - - [5760, 5760, 1, 384]
-    - [17, 4924.78]
-  - - [16384, 16384, 1, 256]
-    - [23, 4795.62]
-  - - [33408, 2048, 1, 384]
-    - [41, 4985.35]
-  - - [39680, 2048, 1, 256]
-    - [41, 4882.65]
-  - - [36352, 3072, 1, 256]
-    - [61, 4867.18]
-  - - [11776, 3072, 1, 256]
-    - [60, 4819.64]
-  - - [4608, 2048, 1, 384]
-    - [34, 4888.16]
-  - - [9472, 3072, 1, 256]
-    - [42, 4838.21]
-  - - [11520, 2048, 1, 384]
-    - [41, 4923.97]
-  - - [2048, 2048, 1, 256]
-    - [34, 4642.62]
-  - - [1792, 2048, 1, 256]
-    - [54, 4530.02]
-  - - [34304, 3072, 1, 256]
-    - [60, 4877.11]
-  - - [17408, 2048, 1, 256]
-    - [42, 4805.41]
-  - - [5632, 2048, 1, 256]
-    - [49, 4769.96]
-  - - [6528, 2048, 1, 384]
-    - [55, 4870.26]
-  - - [38912, 3072, 1, 256]
-    - [40, 4834.03]
-  - - [9216, 2048, 1, 256]
-    - [60, 4786.09]
-  - - [30720, 2048, 1, 384]
-    - [60, 4931.79]
-  - - [20224, 3072, 1, 256]
-    - [42, 4914.97]
-  - - [20992, 2048, 1, 256]
-    - [42, 4869.08]
-  - - [2560, 3072, 1, 256]
-    - [34, 4659.92]
-  - - [7424, 3072, 1, 256]
-    - [41, 4826.15]
-  - - [24576, 2048, 1, 256]
-    - [53, 4751.01]
-  - - [25344, 3072, 1, 256]
-    - [41, 4899.89]
-  - - [26496, 2048, 1, 384]
-    - [42, 4963.45]
-  - - [9984, 3072, 1, 384]
-    - [39, 4954.25]
-  - - [14848, 3072, 1, 256]
-    - [42, 4881.68]
-  - - [12544, 3072, 1, 256]
-    - [41, 4853.88]
-  - - [43008, 3072, 1, 256]
-    - [58, 4842.7]
-  - - [42752, 2048, 1, 256]
-    - [42, 4912.9]
-  - - [42752, 3072, 1, 256]
-    - [39, 4908.32]
-  - - [3840, 2048, 1, 384]
-    - [56, 4820.43]
-  - - [3840, 3072, 1, 256]
-    - [58, 4754.56]
-  - - [30336, 2048, 1, 384]
-    - [42, 4980.93]
-  - - [39936, 2048, 1, 256]
-    - [41, 4872.25]
-  - - [7680, 3072, 1, 384]
-    - [34, 4883.94]
-  - - [30976, 2048, 1, 256]
-    - [42, 4896.99]
-  - - [19456, 3072, 1, 256]
-    - [42, 4866.68]
-  - - [23296, 3072, 1, 256]
-    - [41, 4905.58]
-  - - [1536, 2048, 1, 256]
-    - [34, 4658.19]
-  - - [20992, 3072, 1, 256]
-    - [42, 4895.62]
-  - - [28800, 3072, 1, 384]
-    - [38, 5022.49]
-  - - [42240, 2048, 1, 256]
-    - [42, 4906.59]
-  - - [7296, 3072, 1, 384]
-    - [38, 4965.35]
-  - - [32512, 3072, 1, 256]
-    - [42, 4911.58]
-  - - [27136, 3072, 1, 256]
-    - [61, 4832.58]
-  - - [16896, 2048, 1, 256]
-    - [42, 4822.1]
-  - - [20736, 2048, 1, 256]
-    - [42, 4872.56]
-  - - [14592, 3072, 1, 384]
-    - [39, 4970.56]
+- - - [12032, 2048, 1, 256]
+    - [14, 4711.57]
   - - [39936, 3072, 1, 384]
-    - [42, 4950.48]
-  - - [4096, 2048, 1, 256]
-    - [34, 4715.19]
-  - - [37888, 3072, 1, 256]
-    - [40, 4852.3]
-  - - [35712, 2048, 1, 384]
-    - [42, 4980.2]
-  - - [4864, 3072, 1, 256]
-    - [57, 4730.19]
-  - - [25088, 3072, 1, 256]
-    - [60, 4896.08]
-  - - [10752, 3072, 1, 256]
-    - [41, 4819.07]
-  - - [36480, 2048, 1, 384]
-    - [42, 4998.0]
-  - - [24960, 2048, 1, 384]
-    - [42, 4972.64]
-  - - [25600, 3072, 1, 256]
-    - [42, 4889.62]
-  - - [15616, 2048, 1, 256]
-    - [41, 4854.21]
-  - - [34560, 2048, 1, 256]
-    - [42, 4927.94]
-  - - [22528, 3072, 1, 256]
-    - [60, 4851.09]
-  - - [41728, 2048, 1, 256]
-    - [42, 4916.34]
-  - - [22272, 3072, 1, 256]
-    - [42, 4905.52]
-  - - [6144, 2048, 1, 256]
-    - [34, 4772.19]
-  - - [39552, 2048, 1, 384]
-    - [42, 5013.54]
-  - - [16128, 2048, 1, 384]
-    - [41, 4974.35]
-  - - [24192, 2048, 1, 384]
-    - [42, 4967.1]
-  - - [44544, 2048, 1, 384]
-    - [60, 4956.58]
-  - - [11904, 3072, 1, 384]
-    - [58, 4990.96]
-  - - [34944, 3072, 1, 384]
-    - [39, 5013.32]
-  - - [26880, 2048, 1, 256]
-    - [42, 4896.9]
-  - - [10240, 2048, 1, 256]
-    - [41, 4804.82]
-  - - [9984, 3072, 1, 256]
-    - [42, 4861.29]
-  - - [9984, 2048, 1, 256]
-    - [41, 4818.92]
-  - - [34560, 3072, 1, 384]
-    - [42, 5007.68]
-  - - [41472, 3072, 1, 256]
-    - [42, 4892.59]
-  - - [13824, 2048, 1, 256]
-    - [60, 4814.52]
-  - - [30976, 3072, 1, 256]
-    - [42, 4899.55]
-  - - [21760, 2048, 1, 256]
-    - [42, 4873.02]
-  - - [43264, 3072, 1, 256]
-    - [42, 4895.27]
-  - - [31872, 3072, 1, 384]
-    - [42, 5013.26]
-  - - [6144, 2048, 1, 384]
-    - [41, 4907.42]
-  - - [33408, 3072, 1, 384]
-    - [58, 4995.08]
-  - - [36864, 3072, 1, 256]
-    - [61, 4813.33]
-  - - [28416, 3072, 1, 256]
-    - [42, 4908.17]
-  - - [29184, 2048, 1, 256]
-    - [42, 4855.07]
-  - - [21888, 3072, 1, 384]
-    - [59, 4979.94]
-  - - [26112, 2048, 1, 384]
-    - [60, 4943.37]
-  - - [15616, 3072, 1, 256]
-    - [42, 4871.77]
-  - - [40192, 3072, 1, 256]
-    - [42, 4910.08]
-  - - [13440, 3072, 1, 384]
-    - [39, 4991.03]
-  - - [35072, 2048, 1, 256]
-    - [42, 4904.32]
-  - - [21504, 3072, 1, 256]
-    - [60, 4835.99]
-  - - [22656, 2048, 1, 384]
-    - [41, 4965.07]
-  - - [768, 3072, 1, 256]
-    - [38, 4586.74]
-  - - [8832, 2048, 1, 384]
-    - [56, 4899.26]
-  - - [26112, 3072, 1, 384]
-    - [42, 4976.1]
-  - - [9984, 2048, 1, 384]
-    - [41, 4912.26]
-  - - [33024, 2048, 1, 384]
-    - [41, 4995.88]
-  - - [41472, 2048, 1, 384]
-    - [60, 4936.64]
-  - - [36096, 2048, 1, 256]
-    - [42, 4904.21]
-  - - [25728, 3072, 1, 384]
-    - [42, 5014.05]
-  - - [28032, 3072, 1, 384]
-    - [39, 4997.91]
-  - - [38144, 3072, 1, 256]
-    - [39, 4888.68]
-  - - [42496, 2048, 1, 256]
-    - [42, 4881.98]
-  - - [33792, 3072, 1, 384]
-    - [42, 4969.28]
-  - - [44160, 2048, 1, 384]
-    - [42, 4993.37]
-  - - [18176, 3072, 1, 256]
-    - [42, 4903.54]
-  - - [43520, 2048, 1, 256]
-    - [42, 4874.82]
-  - - [9216, 3072, 1, 256]
-    - [42, 4833.65]
-  - - [36864, 2048, 1, 384]
-    - [61, 4918.48]
-  - - [6400, 2048, 1, 256]
-    - [60, 4727.58]
-  - - [19968, 2048, 1, 256]
-    - [42, 4840.75]
-  - - [2560, 2048, 1, 256]
-    - [35, 4680.5]
-  - - [37888, 2048, 1, 256]
-    - [42, 4886.85]
-  - - [44288, 3072, 1, 256]
-    - [39, 4916.65]
-  - - [27648, 3072, 1, 256]
-    - [42, 4838.64]
-  - - [43392, 3072, 1, 384]
-    - [39, 5005.98]
-  - - [39552, 3072, 1, 384]
-    - [39, 5017.52]
-  - - [14336, 3072, 1, 256]
-    - [42, 4806.66]
-  - - [33280, 3072, 1, 256]
-    - [61, 4857.48]
-  - - [31488, 3072, 1, 256]
-    - [41, 4911.43]
-  - - [28928, 2048, 1, 256]
-    - [41, 4873.79]
-  - - [22784, 3072, 1, 256]
-    - [39, 4900.69]
-  - - [9728, 2048, 1, 256]
-    - [42, 4805.06]
-  - - [17664, 2048, 1, 256]
-    - [42, 4851.05]
-  - - [40960, 3072, 1, 256]
-    - [52, 4804.02]
-  - - [7936, 3072, 1, 256]
-    - [42, 4798.22]
-  - - [4352, 3072, 1, 256]
-    - [42, 4725.46]
-  - - [43776, 3072, 1, 384]
-    - [42, 5013.2]
-  - - [25088, 2048, 1, 256]
-    - [42, 4848.77]
-  - - [17152, 2048, 1, 256]
-    - [60, 4855.3]
-  - - [3840, 2048, 1, 256]
-    - [36, 4691.63]
-  - - [39936, 3072, 1, 256]
-    - [42, 4845.06]
-  - - [11520, 3072, 1, 256]
-    - [42, 4846.22]
-  - - [37120, 2048, 1, 256]
-    - [42, 4910.04]
-  - - [17408, 3072, 1, 256]
-    - [38, 4838.15]
-  - - [9216, 2048, 1, 384]
-    - [42, 4915.34]
-  - - [13056, 3072, 1, 256]
-    - [42, 4856.71]
-  - - [36864, 3072, 1, 384]
-    - [60, 4935.38]
-  - - [37632, 2048, 1, 384]
-    - [42, 4987.0]
-  - - [24832, 3072, 1, 256]
-    - [42, 4877.25]
-  - - [3584, 3072, 1, 256]
-    - [34, 4718.08]
-  - - [7680, 2048, 1, 256]
-    - [60, 4795.1]
-  - - [384, 2048, 1, 384]
-    - [45, 4677.66]
-  - - [28800, 2048, 1, 384]
-    - [41, 4975.9]
-  - - [10368, 2048, 1, 384]
-    - [56, 4912.96]
-  - - [30720, 3072, 1, 256]
-    - [42, 4867.13]
-  - - [3328, 3072, 1, 256]
-    - [30, 4735.91]
-  - - [30464, 3072, 1, 256]
-    - [42, 4909.21]
-  - - [37376, 2048, 1, 256]
-    - [61, 4833.27]
-  - - [25344, 3072, 1, 384]
-    - [39, 4957.89]
-  - - [23040, 2048, 1, 256]
-    - [61, 4835.64]
-  - - [27136, 2048, 1, 256]
-    - [41, 4866.56]
-  - - [36096, 3072, 1, 256]
-    - [42, 4900.92]
-  - - [2304, 2048, 1, 256]
-    - [56, 4599.31]
-  - - [7168, 3072, 1, 256]
-    - [41, 4823.85]
-  - - [43008, 3072, 1, 384]
-    - [42, 4964.4]
-  - - [1920, 3072, 1, 384]
-    - [48, 4864.96]
-  - - [35712, 3072, 1, 384]
-    - [39, 5008.0]
-  - - [27264, 2048, 1, 384]
-    - [42, 4996.39]
-  - - [35328, 2048, 1, 384]
-    - [42, 4968.44]
-  - - [44160, 3072, 1, 384]
-    - [38, 4992.9]
-  - - [29952, 2048, 1, 256]
-    - [60, 4898.59]
-  - - [20480, 3072, 1, 256]
-    - [61, 4822.61]
-  - - [28928, 3072, 1, 256]
-    - [39, 4896.13]
-  - - [21248, 2048, 1, 256]
-    - [41, 4879.24]
-  - - [39168, 2048, 1, 256]
-    - [42, 4899.36]
-  - - [22016, 3072, 1, 256]
-    - [61, 4856.37]
-  - - [38784, 2048, 1, 384]
-    - [42, 4978.14]
-  - - [4608, 2048, 1, 256]
-    - [34, 4747.91]
-  - - [1536, 2048, 1, 384]
-    - [34, 4814.13]
-  - - [33536, 3072, 1, 256]
-    - [39, 4904.9]
-  - - [24832, 2048, 1, 256]
-    - [41, 4872.14]
-  - - [34176, 3072, 1, 384]
-    - [39, 5003.84]
-  - - [42240, 2048, 1, 384]
-    - [42, 4977.64]
-  - - [30208, 3072, 1, 256]
-    - [42, 4843.97]
-  - - [8192, 2048, 1, 256]
-    - [49, 4734.95]
-  - - [39168, 3072, 1, 384]
-    - [39, 5004.2]
-  - - [31488, 2048, 1, 256]
-    - [42, 4907.73]
-  - - [28160, 3072, 1, 256]
-    - [60, 4879.39]
-  - - [8960, 3072, 1, 256]
-    - [42, 4800.68]
-  - - [5376, 3072, 1, 384]
-    - [38, 4913.69]
-  - - [3584, 2048, 1, 256]
-    - [34, 4743.64]
-  - - [16896, 2048, 1, 384]
-    - [42, 4955.69]
-  - - [12672, 2048, 1, 384]
-    - [41, 4917.93]
-  - - [34944, 2048, 1, 384]
-    - [41, 4997.26]
-  - - [1152, 3072, 1, 384]
-    - [58, 4812.85]
-  - - [26368, 3072, 1, 256]
-    - [42, 4915.77]
-  - - [256, 2048, 1, 256]
-    - [43, 4023.31]
-  - - [36864, 2048, 1, 256]
-    - [51, 4798.83]
-  - - [18944, 2048, 1, 256]
-    - [60, 4824.98]
-  - - [768, 2048, 1, 384]
-    - [55, 4679.11]
-  - - [14592, 2048, 1, 256]
-    - [41, 4842.04]
-  - - [8448, 3072, 1, 384]
-    - [39, 4940.85]
-  - - [19584, 2048, 1, 384]
-    - [41, 4962.72]
-  - - [35072, 3072, 1, 256]
-    - [39, 4905.94]
-  - - [14208, 3072, 1, 384]
-    - [38, 4987.82]
-  - - [22272, 3072, 1, 384]
-    - [42, 4978.7]
-  - - [39424, 3072, 1, 256]
-    - [60, 4861.08]
-  - - [41216, 2048, 1, 256]
-    - [42, 4907.68]
-  - - [25856, 2048, 1, 256]
-    - [42, 4888.72]
-  - - [26880, 2048, 1, 384]
-    - [41, 4972.7]
-  - - [16384, 3072, 1, 256]
-    - [52, 4709.27]
-  - - [28032, 2048, 1, 384]
-    - [42, 4981.04]
-  - - [38144, 2048, 1, 256]
-    - [42, 4893.58]
-  - - [16128, 3072, 1, 256]
-    - [42, 4909.58]
-  - - [19200, 3072, 1, 384]
-    - [39, 4965.03]
-  - - [512, 2048, 1, 256]
-    - [33, 4525.23]
-  - - [13824, 2048, 1, 384]
-    - [42, 4939.42]
-  - - [4352, 2048, 1, 256]
-    - [36, 4676.78]
-  - - [23296, 2048, 1, 256]
-    - [41, 4864.83]
-  - - [19968, 3072, 1, 256]
-    - [42, 4879.41]
-  - - [4224, 3072, 1, 384]
-    - [32, 4925.9]
-  - - [44288, 2048, 1, 256]
-    - [42, 4908.16]
-  - - [41472, 2048, 1, 256]
-    - [42, 4874.48]
-  - - [4992, 2048, 1, 384]
-    - [56, 4868.16]
-  - - [31744, 2048, 1, 256]
-    - [42, 4845.53]
-  - - [13568, 3072, 1, 256]
-    - [42, 4884.7]
-  - - [40704, 3072, 1, 256]
-    - [42, 4910.39]
-  - - [28416, 3072, 1, 384]
-    - [42, 4988.86]
-  - - [3072, 2048, 1, 256]
-    - [34, 4696.22]
-  - - [36480, 3072, 1, 384]
-    - [59, 4989.66]
-  - - [29184, 2048, 1, 384]
-    - [60, 4925.63]
-  - - [23808, 2048, 1, 256]
-    - [60, 4895.93]
-  - - [6144, 3072, 1, 256]
-    - [34, 4795.97]
-  - - [21504, 3072, 1, 384]
-    - [41, 4965.98]
-  - - [40448, 2048, 1, 256]
-    - [61, 4842.98]
-  - - [5888, 3072, 1, 256]
-    - [41, 4762.93]
-  - - [768, 3072, 1, 384]
-    - [38, 4759.26]
-  - - [31232, 2048, 1, 256]
-    - [42, 4853.57]
-  - - [10496, 2048, 1, 256]
-    - [42, 4777.69]
-  - - [36096, 2048, 1, 384]
-    - [42, 4965.66]
-  - - [10368, 3072, 1, 384]
-    - [39, 4985.49]
-  - - [18432, 3072, 1, 384]
-    - [42, 4953.96]
-  - - [8064, 2048, 1, 384]
-    - [56, 4889.59]
-  - - [2816, 3072, 1, 256]
-    - [47, 4649.39]
-  - - [2688, 2048, 1, 384]
-    - [55, 4825.01]
-  - - [6912, 3072, 1, 256]
-    - [38, 4809.28]
-  - - [41216, 3072, 1, 256]
-    - [42, 4893.75]
-  - - [5376, 2048, 1, 256]
-    - [55, 4729.79]
-  - - [15360, 3072, 1, 256]
-    - [61, 4840.68]
-  - - [37632, 2048, 1, 256]
-    - [41, 4904.41]
-  - - [28672, 3072, 1, 256]
-    - [61, 4838.84]
-  - - [27648, 3072, 1, 384]
-    - [42, 4962.14]
-  - - [34304, 2048, 1, 256]
-    - [42, 4850.75]
-  - - [12032, 3072, 1, 256]
-    - [42, 4878.42]
-  - - [31488, 3072, 1, 384]
-    - [41, 4997.1]
-  - - [12800, 2048, 1, 256]
-    - [61, 4805.17]
-  - - [18816, 3072, 1, 384]
-    - [38, 5003.58]
-  - - [43776, 2048, 1, 256]
-    - [42, 4896.34]
-  - - [17664, 2048, 1, 384]
-    - [41, 4958.51]
-  - - [5120, 3072, 1, 256]
-    - [49, 4792.59]
-  - - [5376, 3072, 1, 256]
-    - [59, 4777.9]
-  - - [40320, 3072, 1, 384]
-    - [39, 4995.87]
-  - - [42496, 3072, 1, 256]
-    - [41, 4884.44]
-  - - [24576, 2048, 1, 384]
-    - [52, 4853.25]
-  - - [11776, 2048, 1, 256]
-    - [61, 4781.92]
-  - - [19712, 2048, 1, 256]
-    - [42, 4874.07]
-  - - [11520, 3072, 1, 384]
-    - [59, 4953.91]
-  - - [23552, 2048, 1, 256]
-    - [42, 4829.8]
-  - - [12288, 2048, 1, 384]
-    - [61, 4888.26]
-  - - [512, 3072, 1, 256]
-    - [57, 4415.06]
-  - - [1792, 3072, 1, 256]
-    - [47, 4642.54]
-  - - [13056, 3072, 1, 384]
-    - [39, 4949.9]
-  - - [21120, 3072, 1, 384]
-    - [38, 5003.34]
-  - - [11136, 3072, 1, 384]
-    - [39, 4985.65]
-  - - [10496, 3072, 1, 256]
-    - [42, 4833.47]
-  - - [32640, 2048, 1, 384]
-    - [42, 4979.21]
-  - - [11264, 3072, 1, 256]
-    - [42, 4844.89]
-  - - [30720, 3072, 1, 384]
-    - [42, 4933.81]
-  - - [15104, 3072, 1, 256]
-    - [42, 4880.15]
-  - - [33024, 3072, 1, 256]
-    - [39, 4880.7]
-  - - [14976, 2048, 1, 384]
-    - [42, 4932.09]
-  - - [23040, 2048, 1, 384]
-    - [40, 4929.54]
-  - - [14208, 2048, 1, 384]
-    - [41, 4938.06]
-  - - [1280, 2048, 1, 256]
-    - [44, 4491.91]
-  - - [37248, 2048, 1, 384]
-    - [42, 4973.59]
-  - - [2304, 2048, 1, 384]
-    - [56, 4778.84]
-  - - [24576, 3072, 1, 256]
-    - [52, 4784.24]
-  - - [9600, 3072, 1, 384]
-    - [59, 4963.2]
-  - - [25344, 2048, 1, 256]
-    - [41, 4890.25]
-  - - [18176, 2048, 1, 256]
-    - [41, 4871.32]
-  - - [8704, 2048, 1, 256]
-    - [41, 4833.71]
-  - - [35584, 2048, 1, 256]
-    - [42, 4908.93]
-  - - [12544, 2048, 1, 256]
-    - [60, 4827.7]
-  - - [29952, 3072, 1, 256]
-    - [42, 4899.38]
-  - - [29952, 2048, 1, 384]
-    - [41, 4970.47]
-  - - [44032, 2048, 1, 256]
-    - [61, 4833.36]
-  - - [1024, 3072, 1, 256]
-    - [34, 4646.37]
-  - - [44800, 2048, 1, 256]
-    - [42, 4921.25]
-  - - [3840, 3072, 1, 384]
-    - [38, 4887.42]
-  - - [6912, 2048, 1, 256]
-    - [56, 4747.04]
-  - - [7680, 2048, 1, 384]
-    - [34, 4895.77]
-  - - [35328, 3072, 1, 256]
-    - [60, 4873.38]
-  - - [29568, 3072, 1, 384]
-    - [58, 4993.89]
-  - - [29696, 2048, 1, 256]
-    - [42, 4841.02]
-  - - [12288, 2048, 1, 256]
-    - [61, 4770.5]
-  - - [38656, 3072, 1, 256]
-    - [42, 4915.05]
-  - - [39424, 2048, 1, 256]
-    - [61, 4848.1]
-  - - [32000, 2048, 1, 256]
-    - [41, 4916.32]
-  - - [19456, 2048, 1, 256]
-    - [60, 4824.06]
-  - - [34816, 3072, 1, 256]
-    - [40, 4834.33]
-  - - [14080, 3072, 1, 256]
-    - [42, 4883.22]
-  - - [34176, 2048, 1, 384]
-    - [42, 4978.98]
-  - - [40704, 2048, 1, 384]
-    - [42, 4980.92]
-  - - [44544, 3072, 1, 256]
-    - [60, 4884.37]
-  - - [3456, 2048, 1, 384]
-    - [56, 4845.46]
-  - - [7296, 2048, 1, 384]
-    - [56, 4890.41]
-  - - [11008, 3072, 1, 256]
-    - [41, 4832.03]
-  - - [18688, 2048, 1, 256]
-    - [60, 4885.47]
-  - - [16896, 3072, 1, 256]
-    - [61, 4843.47]
-  - - [40704, 2048, 1, 256]
-    - [42, 4925.01]
-  - - [13568, 2048, 1, 256]
-    - [41, 4833.5]
-  - - [14592, 2048, 1, 384]
-    - [41, 4936.27]
-  - - [4096, 3072, 1, 256]
-    - [34, 4773.61]
-  - - [33024, 2048, 1, 256]
-    - [41, 4876.89]
-  - - [4864, 2048, 1, 256]
-    - [34, 4680.88]
-  - - [40448, 3072, 1, 256]
-    - [61, 4852.67]
-  - - [5760, 2048, 1, 384]
-    - [56, 4869.35]
-  - - [26112, 2048, 1, 256]
-    - [42, 4848.78]
-  - - [35840, 2048, 1, 256]
-    - [42, 4863.32]
-  - - [8448, 2048, 1, 256]
-    - [41, 4792.46]
-  - - [42624, 2048, 1, 384]
-    - [42, 4994.99]
-  - - [13312, 3072, 1, 256]
-    - [61, 4839.23]
-  - - [32256, 2048, 1, 384]
-    - [60, 4926.25]
-  - - [24320, 2048, 1, 256]
-    - [42, 4900.2]
-  - - [16128, 3072, 1, 384]
-    - [39, 4976.67]
-  - - [6912, 3072, 1, 384]
-    - [39, 4929.71]
-  - - [24192, 3072, 1, 384]
-    - [39, 4979.43]
-  - - [30208, 2048, 1, 256]
-    - [41, 4868.23]
-  - - [41088, 2048, 1, 384]
-    - [42, 5001.33]
-  - - [27904, 2048, 1, 256]
-    - [41, 4872.62]
-  - - [10240, 3072, 1, 256]
-    - [42, 4805.86]
-  - - [2304, 3072, 1, 256]
-    - [59, 4692.7]
-  - - [37632, 3072, 1, 256]
-    - [42, 4904.82]
-  - - [19200, 2048, 1, 256]
-    - [41, 4910.7]
-  - - [11904, 2048, 1, 384]
-    - [56, 4914.38]
-  - - [44928, 2048, 1, 384]
-    - [42, 4993.26]
-  - - [3072, 3072, 1, 384]
-    - [41, 4881.05]
-  - - [21760, 3072, 1, 256]
-    - [42, 4891.55]
-  - - [23808, 2048, 1, 384]
-    - [42, 4981.49]
-  - - [43776, 3072, 1, 256]
-    - [41, 4906.24]
-  - - [39168, 2048, 1, 384]
-    - [41, 5006.38]
-  - - [6144, 3072, 1, 384]
-    - [61, 4916.14]
-  - - [23552, 3072, 1, 256]
-    - [42, 4891.33]
-  - - [32640, 3072, 1, 384]
-    - [38, 5001.35]
-  - - [39680, 3072, 1, 256]
-    - [42, 4907.05]
-  - - [29184, 3072, 1, 256]
-    - [42, 4886.25]
-  - - [9472, 2048, 1, 256]
-    - [41, 4784.45]
-  - - [21504, 2048, 1, 256]
-    - [42, 4831.21]
-  - - [15360, 3072, 1, 384]
-    - [42, 4919.64]
-  - - [38400, 2048, 1, 384]
-    - [42, 4972.9]
-  - - [768, 2048, 1, 256]
-    - [55, 4501.94]
-  - - [18048, 2048, 1, 384]
-    - [42, 4950.66]
-  - - [42240, 3072, 1, 256]
-    - [42, 4907.69]
-  - - [5632, 3072, 1, 256]
-    - [34, 4790.8]
-  - - [41472, 3072, 1, 384]
-    - [41, 4973.9]
-  - - [6528, 3072, 1, 384]
-    - [39, 4952.77]
-  - - [5376, 2048, 1, 384]
-    - [56, 4858.5]
-  - - [25728, 2048, 1, 384]
-    - [41, 4967.49]
-  - - [33792, 2048, 1, 384]
-    - [42, 4955.06]
-  - - [41856, 3072, 1, 384]
-    - [39, 4999.2]
-  - - [41984, 2048, 1, 256]
-    - [60, 4860.22]
-  - - [20224, 2048, 1, 256]
-    - [41, 4880.16]
-  - - [6656, 2048, 1, 256]
-    - [49, 4795.87]
-  - - [16512, 3072, 1, 384]
-    - [39, 4981.74]
-  - - [7424, 2048, 1, 256]
-    - [41, 4743.26]
-  - - [37248, 3072, 1, 384]
-    - [38, 4996.73]
-  - - [27648, 2048, 1, 256]
-    - [60, 4826.64]
-  - - [31104, 2048, 1, 384]
-    - [42, 4980.18]
-  - - [9600, 2048, 1, 384]
-    - [56, 4908.05]
-  - - [32768, 3072, 1, 256]
-    - [51, 4720.34]
-  - - [14848, 2048, 1, 256]
-    - [42, 4852.3]
-  - - [8448, 3072, 1, 256]
-    - [41, 4834.8]
-  - - [35584, 3072, 1, 256]
-    - [41, 4916.63]
-  - - [17664, 3072, 1, 256]
-    - [38, 4875.05]
-  - - [43008, 2048, 1, 256]
-    - [61, 4848.79]
-  - - [44032, 3072, 1, 256]
-    - [60, 4859.81]
-  - - [34816, 2048, 1, 256]
-    - [60, 4857.23]
-  - - [29568, 2048, 1, 384]
-    - [41, 4963.68]
-  - - [43776, 2048, 1, 384]
-    - [42, 5000.02]
-  - - [43264, 2048, 1, 256]
-    - [41, 4885.97]
-  - - [42624, 3072, 1, 384]
-    - [38, 4993.51]
-  - - [16640, 2048, 1, 256]
-    - [60, 4835.05]
-  - - [3328, 2048, 1, 256]
-    - [34, 4603.79]
-  - - [38656, 2048, 1, 256]
-    - [42, 4910.86]
-  - - [12288, 3072, 1, 256]
-    - [60, 4780.7]
-  - - [34048, 3072, 1, 256]
-    - [42, 4916.51]
-  - - [13056, 2048, 1, 256]
-    - [60, 4832.49]
-  - - [1536, 3072, 1, 256]
-    - [37, 4573.53]
-  - - [32256, 2048, 1, 256]
-    - [42, 4845.69]
-  - - [33792, 2048, 1, 256]
-    - [61, 4840.54]
-  - - [32768, 2048, 1, 256]
-    - [52, 4694.99]
-  - - [24576, 3072, 1, 384]
-    - [53, 4866.27]
+    - [14, 4998.05]
   - - [29696, 3072, 1, 256]
-    - [61, 4841.36]
-  - - [32512, 2048, 1, 256]
-    - [60, 4882.64]
-  - - [30336, 3072, 1, 384]
-    - [38, 5001.27]
-  - - [25344, 2048, 1, 384]
-    - [42, 4981.2]
-  - - [19968, 2048, 1, 384]
-    - [42, 4962.24]
-  - - [23040, 3072, 1, 256]
-    - [41, 4906.8]
-  - - [18688, 3072, 1, 256]
-    - [40, 4843.55]
-  - - [20736, 3072, 1, 256]
-    - [42, 4888.98]
-  - - [35328, 3072, 1, 384]
-    - [42, 4951.51]
+    - [9, 4810.75]
+  - - [38144, 38144, 1, 256]
+    - [14, 4943.8]
   - - [19584, 3072, 1, 384]
-    - [39, 5008.69]
-  - - [7168, 2048, 1, 256]
-    - [34, 4780.82]
-  - - [27392, 2048, 1, 256]
-    - [42, 4879.76]
-  - - [256, 3072, 1, 256]
-    - [29, 4391.97]
-  - - [10752, 2048, 1, 256]
-    - [49, 4780.33]
-  - - [41728, 3072, 1, 256]
-    - [42, 4912.56]
-  - - [15872, 2048, 1, 256]
-    - [42, 4835.39]
-  - - [29440, 2048, 1, 256]
-    - [41, 4895.11]
-  - - [24960, 3072, 1, 384]
-    - [42, 4991.1]
-  - - [35840, 3072, 1, 256]
-    - [42, 4875.62]
-  - - [33024, 3072, 1, 384]
-    - [39, 4972.02]
-  - - [22528, 2048, 1, 256]
-    - [60, 4833.2]
-  - - [38784, 3072, 1, 384]
-    - [38, 4995.56]
-  - - [32256, 3072, 1, 384]
-    - [39, 4967.81]
-  - - [44928, 3072, 1, 384]
-    - [39, 4995.6]
-  - - [4608, 3072, 1, 256]
-    - [34, 4760.25]
-  - - [44544, 3072, 1, 384]
-    - [42, 4978.39]
-  - - [26880, 3072, 1, 256]
-    - [42, 4880.89]
-  - - [42240, 3072, 1, 384]
-    - [42, 4990.79]
-  - - [8192, 3072, 1, 256]
-    - [50, 4778.28]
-  - - [8960, 2048, 1, 256]
-    - [41, 4785.3]
-  - - [34560, 2048, 1, 384]
-    - [41, 5009.57]
-  - - [13824, 3072, 1, 256]
-    - [42, 4860.71]
-  - - [16896, 3072, 1, 384]
-    - [41, 4996.13]
-  - - [14336, 2048, 1, 256]
-    - [61, 4789.96]
-  - - [40960, 2048, 1, 256]
-    - [53, 4776.14]
-  - - [11008, 2048, 1, 256]
-    - [41, 4853.81]
-  - - [1152, 2048, 1, 384]
-    - [46, 4740.33]
-  - - [2048, 3072, 1, 256]
-    - [49, 4702.8]
-  - - [37376, 3072, 1, 256]
-    - [61, 4857.96]
-  - - [28416, 2048, 1, 256]
-    - [42, 4887.92]
-  - - [15744, 2048, 1, 384]
-    - [42, 4942.84]
-  - - [18944, 3072, 1, 256]
-    - [41, 4898.79]
-  - - [16640, 3072, 1, 256]
-    - [58, 4868.76]
-  - - [43392, 2048, 1, 384]
-    - [42, 4991.71]
-  - - [8448, 2048, 1, 384]
-    - [55, 4882.7]
-  - - [43520, 3072, 1, 256]
-    - [60, 4895.13]
-  - - [16512, 2048, 1, 384]
-    - [41, 4928.72]
-  - - [17280, 3072, 1, 384]
-    - [39, 4998.76]
-  - - [17920, 3072, 1, 256]
-    - [60, 4834.08]
-  - - [25856, 3072, 1, 256]
-    - [39, 4889.96]
-  - - [18432, 2048, 1, 256]
-    - [42, 4828.18]
-  - - [11136, 2048, 1, 384]
-    - [42, 4915.87]
-  - - [19200, 2048, 1, 384]
-    - [41, 4957.95]
-  - - [22016, 2048, 1, 256]
-    - [42, 4854.05]
-  - - [41856, 2048, 1, 384]
-    - [42, 4971.3]
-  - - [38016, 2048, 1, 384]
-    - [41, 5009.16]
-  - - [38400, 2048, 1, 256]
-    - [42, 4888.38]
-  - - [6400, 3072, 1, 256]
-    - [42, 4796.61]
-  - - [25600, 2048, 1, 256]
-    - [42, 4862.41]
-  - - [44800, 3072, 1, 256]
-    - [42, 4919.41]
-  - - [36608, 3072, 1, 256]
-    - [42, 4908.37]
+    - [9, 4990.5]
   - - [31104, 3072, 1, 384]
-    - [38, 4991.71]
-  - - [9728, 3072, 1, 256]
-    - [60, 4833.23]
-  - - [44544, 2048, 1, 256]
-    - [42, 4869.26]
-  - - [29184, 3072, 1, 384]
-    - [41, 5000.28]
-  - - [23808, 3072, 1, 256]
-    - [42, 4899.01]
-  - - [26624, 3072, 1, 256]
-    - [42, 4842.55]
-  - - [13440, 2048, 1, 384]
-    - [55, 4912.65]
-  - - [21504, 2048, 1, 384]
-    - [42, 4953.27]
-  - - [7936, 2048, 1, 256]
-    - [34, 4742.58]
-  - - [2304, 3072, 1, 384]
-    - [58, 4844.42]
-  - - [41984, 3072, 1, 256]
-    - [60, 4856.25]
-  - - [31232, 3072, 1, 256]
-    - [61, 4845.01]
-  - - [11520, 2048, 1, 256]
-    - [60, 4824.13]
-  - - [36096, 3072, 1, 384]
-    - [38, 4987.1]
-  - - [15360, 2048, 1, 256]
-    - [60, 4787.8]
-  - - [9216, 3072, 1, 384]
-    - [42, 4953.01]
-  - - [38400, 3072, 1, 384]
-    - [42, 4966.25]
-  - - [2816, 2048, 1, 256]
-    - [54, 4573.16]
-  - - [41088, 3072, 1, 384]
-    - [38, 5001.39]
-  - - [37632, 3072, 1, 384]
-    - [42, 4991.48]
-  - - [7680, 3072, 1, 256]
-    - [34, 4799.44]
-  - - [20736, 2048, 1, 384]
-    - [41, 4975.5]
-  - - [384, 3072, 1, 384]
-    - [31, 4738.33]
-  - - [30720, 2048, 1, 256]
-    - [42, 4870.15]
-  - - [32256, 3072, 1, 256]
-    - [40, 4834.06]
-  - - [27648, 2048, 1, 384]
-    - [41, 4963.55]
-  - - [30464, 2048, 1, 256]
-    - [42, 4910.33]
-  - - [31488, 2048, 1, 384]
-    - [42, 4996.33]
-  - - [17920, 2048, 1, 256]
-    - [61, 4794.58]
-  - - [19968, 3072, 1, 384]
-    - [42, 4947.88]
-  - - [18816, 2048, 1, 384]
-    - [42, 4960.49]
-  - - [17664, 3072, 1, 384]
-    - [39, 4977.48]
-  - - [5120, 2048, 1, 256]
-    - [34, 4754.11]
-  - - [43008, 2048, 1, 384]
-    - [61, 4945.08]
-  - - [1920, 2048, 1, 384]
-    - [55, 4786.82]
-  - - [36352, 2048, 1, 256]
-    - [42, 4875.66]
-  - - [27904, 3072, 1, 256]
-    - [42, 4904.23]
-  - - [4608, 3072, 1, 384]
-    - [41, 4877.63]
-  - - [27264, 3072, 1, 384]
-    - [39, 4992.86]
-  - - [18432, 3072, 1, 256]
-    - [42, 4805.26]
-  - - [19712, 3072, 1, 256]
-    - [38, 4891.94]
-  - - [29440, 3072, 1, 256]
-    - [42, 4905.09]
-  - - [39168, 3072, 1, 256]
-    - [39, 4885.96]
-  - - [17152, 3072, 1, 256]
-    - [60, 4854.71]
-  - - [12288, 3072, 1, 384]
-    - [61, 4927.84]
-  - - [10752, 3072, 1, 384]
-    - [42, 4935.87]
-  - - [20352, 3072, 1, 384]
-    - [59, 4990.45]
-  - - [13056, 2048, 1, 384]
-    - [41, 4923.32]
-  - - [20480, 2048, 1, 256]
-    - [61, 4819.84]
-  - - [21120, 2048, 1, 384]
-    - [42, 4969.33]
-  - - [1536, 3072, 1, 384]
-    - [37, 4770.28]
-  - - [11264, 2048, 1, 256]
-    - [42, 4827.2]
-  - - [33536, 2048, 1, 256]
-    - [41, 4884.91]
-  - - [15104, 2048, 1, 256]
-    - [61, 4850.58]
-  - - [33792, 3072, 1, 256]
-    - [61, 4854.37]
-  - - [8832, 3072, 1, 384]
-    - [38, 4958.35]
-  - - [23040, 3072, 1, 384]
-    - [42, 4978.59]
-  - - [12672, 3072, 1, 384]
-    - [39, 4972.17]
-  - - [24064, 3072, 1, 256]
-    - [60, 4847.08]
-  - - [20736, 3072, 1, 384]
-    - [39, 4971.92]
-  - - [26624, 2048, 1, 256]
-    - [60, 4825.85]
-  - - [1280, 3072, 1, 256]
-    - [47, 4592.31]
-  - - [26368, 2048, 1, 256]
-    - [42, 4907.86]
-  - - [8704, 3072, 1, 256]
-    - [42, 4814.27]
-  - - [10752, 2048, 1, 384]
-    - [61, 4921.5]
-  - - [14592, 3072, 1, 256]
-    - [42, 4873.79]
-  - - [29952, 3072, 1, 384]
-    - [42, 4979.02]
-  - - [1024, 2048, 1, 256]
-    - [33, 4609.14]
-  - - [23424, 3072, 1, 384]
-    - [39, 5008.36]
-  - - [12800, 3072, 1, 256]
-    - [42, 4848.26]
-  - - [22272, 2048, 1, 384]
-    - [42, 4964.25]
-  - - [21248, 3072, 1, 256]
-    - [39, 4889.15]
-  - - [32000, 3072, 1, 256]
-    - [42, 4922.09]
-  - - [26880, 3072, 1, 384]
-    - [42, 4980.46]
-  - - [28160, 2048, 1, 256]
-    - [61, 4827.42]
-  - - [16384, 2048, 1, 256]
-    - [53, 4666.02]
-  - - [16128, 2048, 1, 256]
-    - [42, 4878.35]
-  - - [40704, 3072, 1, 384]
-    - [42, 4994.14]
-  - - [15360, 2048, 1, 384]
-    - [42, 4922.34]
-  - - [27392, 3072, 1, 256]
-    - [42, 4892.13]
-  - - [6656, 3072, 1, 256]
-    - [34, 4791.75]
-  - - [13824, 3072, 1, 384]
-    - [41, 4935.2]
-  - - [3456, 3072, 1, 384]
-    - [38, 4914.5]
-  - - [3072, 3072, 1, 256]
-    - [49, 4754.63]
-  - - [38400, 3072, 1, 256]
-    - [61, 4848.92]
-  - - [4224, 2048, 1, 384]
-    - [56, 4868.82]
-  - - [4992, 3072, 1, 384]
-    - [58, 4949.08]
-  - - [38912, 2048, 1, 256]
-    - [41, 4855.98]
-  - - [17280, 2048, 1, 384]
-    - [41, 4946.99]
-  - - [28416, 2048, 1, 384]
-    - [42, 4984.54]
-  - - [15872, 3072, 1, 256]
-    - [41, 4827.39]
-  - - [22272, 2048, 1, 256]
-    - [41, 4913.8]
-  - - [40192, 2048, 1, 256]
-    - [42, 4901.25]
-  - - [22784, 2048, 1, 256]
-    - [42, 4883.41]
-  - - [39936, 2048, 1, 384]
-    - [42, 4934.52]
-  - - [22656, 3072, 1, 384]
-    - [39, 5006.36]
-  - - [3072, 2048, 1, 384]
-    - [34, 4844.25]
-  - - [33280, 2048, 1, 256]
-    - [42, 4860.32]
-  - - [5888, 2048, 1, 256]
-    - [34, 4708.97]
-  - - [6912, 2048, 1, 384]
-    - [56, 4869.94]
-  - - [5760, 3072, 1, 384]
-    - [59, 4948.29]
-  - - [40320, 2048, 1, 384]
-    - [42, 4984.41]
-  - - [34048, 2048, 1, 256]
-    - [42, 4909.46]
-  - - [34560, 3072, 1, 256]
-    - [42, 4912.44]
-  - - [35328, 2048, 1, 256]
-    - [42, 4847.75]
-  - - [13312, 2048, 1, 256]
-    - [41, 4843.53]
-  - - [18432, 2048, 1, 384]
-    - [42, 4927.04]
-  - - [24320, 3072, 1, 256]
-    - [42, 4897.99]
-  - - [18048, 3072, 1, 384]
-    - [39, 4998.39]
-  - - [26496, 3072, 1, 384]
-    - [38, 4997.67]
-  - - [2688, 3072, 1, 384]
-    - [48, 4886.73]
-  - - [21888, 2048, 1, 384]
-    - [42, 4972.98]
-  - - [20352, 2048, 1, 384]
-    - [42, 4967.75]
-  - - [31744, 3072, 1, 256]
-    - [41, 4873.91]
-  - - [28672, 2048, 1, 256]
-    - [61, 4804.9]
-  - - [8064, 3072, 1, 384]
-    - [38, 4968.92]
-  - - [19200, 3072, 1, 256]
-    - [41, 4894.82]
-  - - [12032, 2048, 1, 256]
-    - [60, 4813.69]
-  - - [37120, 3072, 1, 256]
-    - [42, 4904.31]
-  - - [14080, 2048, 1, 256]
-    - [41, 4835.58]
-  - - [14976, 3072, 1, 384]
-    - [39, 4980.95]
-  - - [24064, 2048, 1, 256]
-    - [60, 4844.75]
-  - - [23424, 2048, 1, 384]
-    - [42, 4969.63]
-  - - [36608, 2048, 1, 256]
-    - [42, 4920.62]
-  - - [38016, 3072, 1, 384]
-    - [42, 5015.21]
-  - - [15744, 3072, 1, 384]
-    - [39, 4999.14]
-  - - [23808, 3072, 1, 384]
-    - [39, 4990.46]
-  - - [26112, 3072, 1, 256]
-    - [42, 4873.08]
-  - - [31872, 2048, 1, 384]
-    - [41, 4988.5]
-  - - [2688, 128, 1, 128]
-    - [70, 2525.24]
-  - - [35968, 128, 1, 256]
-    - [65, 4522.65]
-  - - [39808, 128, 1, 128]
-    - [70, 4356.23]
+    - [14, 5000.76]
   - - [29568, 128, 1, 384]
-    - [72, 4566.77]
-  - - [43648, 128, 1, 256]
-    - [70, 4485.83]
-  - - [7808, 128, 1, 384]
-    - [70, 4108.99]
-  - - [11648, 128, 1, 256]
-    - [72, 4267.47]
-  - - [37248, 128, 1, 384]
-    - [70, 4477.64]
-  - - [15488, 128, 1, 384]
-    - [70, 4339.19]
-  - - [19328, 128, 1, 256]
-    - [70, 4279.33]
-  - - [5248, 128, 1, 128]
-    - [63, 3369.28]
-  - - [38528, 128, 1, 256]
-    - [70, 4559.04]
-  - - [23168, 128, 1, 384]
-    - [72, 4462.91]
-  - - [27008, 128, 1, 256]
-    - [65, 4478.75]
-  - - [42368, 128, 1, 384]
-    - [65, 4721.74]
-  - - [12928, 128, 1, 128]
-    - [70, 3815.06]
-  - - [30848, 128, 1, 384]
-    - [65, 4422.08]
-  - - [14208, 128, 1, 256]
-    - [70, 4375.64]
-  - - [20608, 128, 1, 128]
-    - [70, 4054.3]
-  - - [18048, 128, 1, 384]
-    - [72, 4607.81]
-  - - [21888, 128, 1, 256]
-    - [70, 4413.16]
-  - - [6528, 128, 1, 384]
-    - [62, 3646.18]
-  - - [25728, 128, 1, 384]
-    - [70, 4481.8]
-  - - [29568, 128, 1, 128]
-    - [70, 4264.46]
-  - - [21888, 128, 1, 128]
-    - [70, 4209.08]
-  - - [29568, 128, 1, 256]
-    - [70, 4414.46]
-  - - [7808, 128, 1, 256]
-    - [70, 3975.35]
-  - - [33408, 128, 1, 384]
-    - [67, 4688.42]
-  - - [37248, 128, 1, 256]
-    - [70, 4437.7]
-  - - [1408, 128, 1, 384]
-    - [70, 2112.53]
-  - - [19328, 128, 1, 128]
-    - [70, 4097.7]
-  - - [30848, 128, 1, 128]
-    - [70, 4232.95]
-  - - [21888, 128, 1, 384]
-    - [70, 4486.41]
-  - - [23168, 128, 1, 256]
-    - [65, 4379.15]
-  - - [27008, 128, 1, 128]
-    - [70, 4204.67]
-  - - [16768, 128, 1, 384]
-    - [72, 4304.27]
+    - [37, 4500.02]
   - - [30848, 128, 1, 256]
-    - [70, 4357.02]
-  - - [14208, 128, 1, 128]
-    - [70, 4081.06]
-  - - [3968, 128, 1, 128]
-    - [70, 3480.28]
-  - - [44928, 128, 1, 384]
-    - [65, 4692.53]
-  - - [18048, 128, 1, 256]
-    - [65, 4446.6]
-  - - [2688, 128, 1, 384]
-    - [68, 3021.97]
-  - - [11648, 128, 1, 384]
-    - [72, 4450.59]
-  - - [6528, 128, 1, 256]
-    - [62, 3534.53]
-  - - [25728, 128, 1, 256]
-    - [70, 4411.13]
-  - - [10368, 128, 1, 384]
-    - [72, 4026.61]
-  - - [128, 128, 1, 128]
-    - [69, 157.444]
-  - - [33408, 128, 1, 256]
-    - [65, 4574.28]
-  - - [37248, 128, 1, 128]
-    - [70, 4294.06]
-  - - [1408, 128, 1, 256]
-    - [70, 1975.06]
-  - - [28288, 128, 1, 128]
-    - [70, 4328.27]
-  - - [41088, 128, 1, 256]
-    - [65, 4512.59]
-  - - [34688, 128, 1, 128]
-    - [70, 4379.85]
-  - - [5248, 128, 1, 384]
-    - [72, 4017.91]
-  - - [16768, 128, 1, 256]
-    - [64, 4152.47]
-  - - [9088, 128, 1, 256]
-    - [65, 4358.85]
-  - - [35968, 128, 1, 128]
-    - [71, 4298.95]
-  - - [12928, 128, 1, 384]
-    - [70, 4096.44]
-  - - [34688, 128, 1, 384]
-    - [70, 4630.61]
-  - - [43648, 128, 1, 128]
-    - [70, 4352.06]
-  - - [41088, 128, 1, 128]
-    - [70, 4319.73]
-  - - [20608, 128, 1, 384]
-    - [70, 4243.87]
-  - - [44928, 128, 1, 256]
-    - [70, 4602.94]
-  - - [2688, 128, 1, 256]
-    - [68, 2889.8]
-  - - [6528, 128, 1, 128]
-    - [62, 3272.81]
-  - - [38528, 128, 1, 128]
-    - [70, 4384.86]
-  - - [10368, 128, 1, 256]
-    - [66, 3878.31]
-  - - [24448, 128, 1, 384]
-    - [72, 4673.58]
-  - - [1408, 128, 1, 128]
-    - [70, 1652.48]
-  - - [32128, 128, 1, 384]
-    - [70, 4555.62]
-  - - [5248, 128, 1, 256]
-    - [72, 3852.3]
-  - - [9088, 128, 1, 128]
-    - [65, 3877.55]
-  - - [39808, 128, 1, 384]
-    - [70, 4539.36]
-  - - [9088, 128, 1, 384]
-    - [65, 4543.27]
-  - - [12928, 128, 1, 256]
-    - [70, 4031.46]
-  - - [16768, 128, 1, 128]
-    - [70, 3940.45]
-  - - [10368, 128, 1, 128]
-    - [70, 3562.7]
-  - - [7808, 128, 1, 128]
-    - [71, 3642.55]
-  - - [20608, 128, 1, 256]
-    - [70, 4200.57]
-  - - [44928, 128, 1, 128]
-    - [70, 4431.14]
-  - - [25728, 128, 1, 128]
-    - [70, 4227.11]
-  - - [15488, 128, 1, 128]
-    - [70, 4025.32]
-  - - [23168, 128, 1, 128]
-    - [70, 4149.37]
-  - - [128, 128, 1, 384]
-    - [73, 199.349]
-  - - [41088, 128, 1, 384]
-    - [65, 4608.35]
-  - - [24448, 128, 1, 256]
-    - [67, 4526.06]
-  - - [3968, 128, 1, 256]
-    - [70, 3998.26]
-  - - [28288, 128, 1, 384]
-    - [70, 4571.93]
-  - - [32128, 128, 1, 256]
-    - [70, 4499.03]
-  - - [18048, 128, 1, 128]
-    - [70, 4174.17]
-  - - [35968, 128, 1, 384]
-    - [67, 4654.82]
-  - - [39808, 128, 1, 256]
-    - [70, 4488.75]
-  - - [3968, 128, 1, 384]
-    - [70, 4178.13]
-  - - [43648, 128, 1, 384]
-    - [67, 4561.17]
-  - - [33408, 128, 1, 128]
-    - [70, 4290.97]
-  - - [34688, 128, 1, 256]
-    - [70, 4569.3]
-  - - [19328, 128, 1, 384]
-    - [70, 4344.3]
+    - [37, 4373.61]
+  - - [24832, 3072, 1, 256]
+    - [9, 4818.23]
+  - - [8832, 3072, 1, 384]
+    - [14, 4941.59]
+  - - [25728, 128, 1, 384]
+    - [37, 4474.18]
+  - - [32256, 32256, 1, 256]
+    - [14, 4916.49]
+  - - [1024, 1024, 1, 256]
+    - [7, 3970.95]
+  - - [7680, 7680, 1, 256]
+    - [9, 4862.77]
   - - [11648, 128, 1, 128]
-    - [70, 3888.36]
-  - - [38528, 128, 1, 384]
-    - [70, 4611.21]
-  - - [42368, 128, 1, 256]
-    - [65, 4611.12]
-  - - [27008, 128, 1, 384]
-    - [67, 4599.79]
-  - - [128, 128, 1, 256]
-    - [68, 186.912]
-  - - [24448, 128, 1, 128]
-    - [70, 4320.07]
+    - [38, 3500.38]
+  - - [40704, 3072, 1, 256]
+    - [9, 4838.76]
+  - - [34048, 3072, 1, 256]
+    - [9, 4836.08]
+  - - [18688, 3072, 1, 256]
+    - [9, 4814.4]
+  - - [40192, 3072, 1, 256]
+    - [9, 4833.22]
+  - - [41984, 41984, 1, 256]
+    - [12, 4914.14]
+  - - [41728, 2048, 1, 256]
+    - [14, 4806.67]
+  - - [36864, 3072, 1, 256]
+    - [9, 4812.49]
+  - - [40448, 40448, 1, 256]
+    - [14, 4917.55]
+  - - [25728, 128, 1, 256]
+    - [37, 4361.84]
+  - - [35328, 3072, 1, 256]
+    - [9, 4807.32]
+  - - [64, 64, 1, 64]
+    - [0, 27.1934]
+  - - [15104, 15104, 1, 256]
+    - [9, 4937.66]
+  - - [17280, 17280, 1, 384]
+    - [9, 5028.89]
+  - - [14848, 2048, 1, 256]
+    - [14, 4715.9]
+  - - [39936, 3072, 1, 256]
+    - [9, 4814.83]
+  - - [1152, 1152, 1, 384]
+    - [3, 3855.99]
+  - - [34688, 128, 1, 384]
+    - [37, 4631.6]
+  - - [27392, 27392, 1, 256]
+    - [8, 4944.53]
+  - - [41472, 3072, 1, 384]
+    - [9, 5006.69]
+  - - [32768, 3072, 1, 256]
+    - [9, 4812.54]
+  - - [6528, 128, 1, 256]
+    - [33, 3504.42]
+  - - [43008, 2048, 1, 256]
+    - [14, 4799.37]
+  - - [35328, 35328, 1, 256]
+    - [9, 4913.01]
+  - - [13824, 2048, 1, 256]
+    - [14, 4723.63]
+  - - [18432, 18432, 1, 384]
+    - [14, 5016.36]
+  - - [21248, 3072, 1, 256]
+    - [9, 4824.77]
+  - - [31232, 31232, 1, 256]
+    - [14, 4912.53]
+  - - [7808, 128, 1, 256]
+    - [37, 3823.26]
+  - - [3328, 3072, 1, 256]
+    - [29, 4590.7]
+  - - [4608, 2048, 1, 256]
+    - [29, 4567.65]
+  - - [37632, 3072, 1, 384]
+    - [14, 4998.34]
+  - - [38400, 38400, 1, 384]
+    - [12, 5031.62]
+  - - [38400, 3072, 1, 384]
+    - [9, 4996.32]
+  - - [9984, 3072, 1, 384]
+    - [8, 4945.0]
+  - - [16128, 16128, 1, 256]
+    - [9, 4943.0]
+  - - [9472, 9472, 1, 256]
+    - [9, 4905.43]
+  - - [34560, 2048, 1, 256]
+    - [14, 4796.58]
+  - - [21888, 21888, 1, 384]
+    - [12, 5036.49]
+  - - [36608, 2048, 1, 256]
+    - [14, 4807.32]
+  - - [37248, 128, 1, 128]
+    - [37, 4144.74]
+  - - [11520, 3072, 1, 256]
+    - [8, 4774.99]
+  - - [38656, 38656, 1, 256]
+    - [9, 4955.08]
+  - - [30720, 3072, 1, 256]
+    - [9, 4806.08]
+  - - [20224, 20224, 1, 256]
+    - [9, 4937.41]
+  - - [44288, 3072, 1, 256]
+    - [9, 4838.05]
+  - - [22272, 3072, 1, 384]
+    - [14, 4985.56]
+  - - [44032, 3072, 1, 256]
+    - [9, 4823.24]
+  - - [36608, 3072, 1, 256]
+    - [9, 4833.63]
+  - - [8960, 8960, 1, 256]
+    - [9, 4907.66]
+  - - [41984, 2048, 1, 256]
+    - [13, 4793.41]
+  - - [29952, 29952, 1, 384]
+    - [12, 5037.48]
+  - - [17280, 3072, 1, 384]
+    - [14, 4983.99]
+  - - [29952, 2048, 1, 256]
+    - [14, 4798.82]
+  - - [36864, 36864, 1, 384]
+    - [12, 5032.98]
+  - - [5120, 3072, 1, 256]
+    - [9, 4646.35]
+  - - [33408, 33408, 1, 384]
+    - [12, 5043.49]
+  - - [20608, 128, 1, 384]
+    - [37, 4271.06]
+  - - [23424, 23424, 1, 384]
+    - [12, 5031.57]
+  - - [42496, 2048, 1, 256]
+    - [14, 4792.83]
+  - - [11264, 3072, 1, 256]
+    - [9, 4755.3]
+  - - [4864, 4864, 1, 256]
+    - [9, 4801.16]
+  - - [25728, 128, 1, 128]
+    - [37, 3991.74]
+  - - [21504, 21504, 1, 384]
+    - [9, 5021.86]
+  - - [17152, 3072, 1, 256]
+    - [9, 4817.87]
+  - - [14208, 3072, 1, 384]
+    - [14, 4966.35]
+  - - [25600, 25600, 1, 256]
+    - [14, 4903.23]
+  - - [40960, 40960, 1, 256]
+    - [10, 4912.97]
+  - - [19200, 19200, 1, 384]
+    - [9, 5039.59]
+  - - [11520, 3072, 1, 384]
+    - [14, 4953.32]
+  - - [64, 1, 1, 64]
+    - [1, 0.433898]
+  - - [24576, 3072, 1, 384]
+    - [14, 4989.13]
+  - - [25088, 25088, 1, 256]
+    - [14, 4917.16]
+  - - [41728, 41728, 1, 256]
+    - [9, 4950.97]
+  - - [35840, 35840, 1, 256]
+    - [12, 4913.98]
+  - - [19200, 2048, 1, 256]
+    - [14, 4775.39]
+  - - [7424, 2048, 1, 256]
+    - [29, 4661.01]
+  - - [34560, 34560, 1, 256]
+    - [9, 4938.35]
+  - - [26368, 26368, 1, 256]
+    - [9, 4930.11]
+  - - [40704, 3072, 1, 384]
+    - [14, 5000.43]
+  - - [18432, 2048, 1, 256]
+    - [14, 4751.16]
+  - - [5888, 5888, 1, 256]
+    - [9, 4847.58]
+  - - [1536, 2048, 1, 256]
+    - [25, 4331.47]
+  - - [17408, 2048, 1, 256]
+    - [14, 4740.8]
+  - - [28032, 28032, 1, 384]
+    - [8, 5039.79]
+  - - [42496, 42496, 1, 256]
+    - [14, 4913.66]
+  - - [28160, 3072, 1, 256]
+    - [9, 4798.22]
+  - - [15104, 2048, 1, 256]
+    - [14, 4731.85]
+  - - [28672, 2048, 1, 256]
+    - [14, 4774.79]
+  - - [27008, 128, 1, 256]
+    - [37, 4323.82]
+  - - [28416, 3072, 1, 256]
+    - [9, 4830.67]
+  - - [42752, 2048, 1, 256]
+    - [14, 4807.31]
+  - - [38400, 38400, 1, 256]
+    - [14, 4915.12]
+  - - [28032, 3072, 1, 384]
+    - [14, 4993.07]
+  - - [11008, 11008, 1, 256]
+    - [9, 4903.83]
+  - - [20736, 3072, 1, 384]
+    - [9, 4992.93]
+  - - [2816, 3072, 1, 256]
+    - [29, 4596.5]
+  - - [43520, 3072, 1, 256]
+    - [9, 4817.56]
+  - - [19328, 128, 1, 128]
+    - [37, 3802.47]
+  - - [20224, 3072, 1, 256]
+    - [9, 4828.18]
+  - - [15616, 2048, 1, 256]
+    - [14, 4738.56]
+  - - [17152, 2048, 1, 256]
+    - [14, 4743.72]
+  - - [32000, 32000, 1, 256]
+    - [14, 4933.59]
+  - - [34176, 3072, 1, 384]
+    - [14, 4998.19]
+  - - [512, 512, 1, 256]
+    - [21, 2633.79]
+  - - [14592, 3072, 1, 256]
+    - [9, 4805.45]
+  - - [42496, 3072, 1, 256]
+    - [9, 4817.12]
+  - - [37248, 37248, 1, 384]
+    - [12, 5048.12]
+  - - [10496, 10496, 1, 256]
+    - [9, 4921.39]
+  - - [3328, 3328, 1, 256]
+    - [9, 4642.33]
+  - - [14336, 3072, 1, 256]
+    - [9, 4769.96]
+  - - [16640, 16640, 1, 256]
+    - [9, 4936.05]
+  - - [2048, 2048, 1, 256]
+    - [22, 4397.71]
+  - - [24960, 24960, 1, 384]
+    - [9, 5038.33]
+  - - [1536, 1536, 1, 384]
+    - [4, 4666.1]
+  - - [18688, 18688, 1, 256]
+    - [9, 4946.22]
+  - - [22272, 22272, 1, 384]
+    - [12, 5031.77]
+  - - [7296, 3072, 1, 384]
+    - [13, 4916.88]
+  - - [14080, 3072, 1, 256]
+    - [9, 4793.49]
   - - [15488, 128, 1, 256]
-    - [70, 4256.22]
-  - - [14208, 128, 1, 384]
-    - [70, 4472.03]
-  - - [28288, 128, 1, 256]
-    - [70, 4516.39]
-  - - [42368, 128, 1, 128]
-    - [70, 4394.51]
+    - [37, 4149.04]
+  - - [28416, 28416, 1, 384]
+    - [10, 5039.67]
+  - - [3840, 3840, 1, 256]
+    - [8, 4748.27]
+  - - [19968, 19968, 1, 384]
+    - [9, 5016.45]
+  - - [43776, 43776, 1, 256]
+    - [9, 4949.83]
+  - - [39168, 3072, 1, 256]
+    - [9, 4839.64]
+  - - [18944, 3072, 1, 256]
+    - [9, 4790.47]
+  - - [4096, 2048, 1, 256]
+    - [29, 4571.45]
+  - - [35072, 35072, 1, 256]
+    - [12, 4936.95]
+  - - [20736, 20736, 1, 256]
+    - [9, 4947.98]
+  - - [28416, 2048, 1, 256]
+    - [14, 4794.41]
+  - - [1280, 2048, 1, 256]
+    - [26, 4362.26]
+  - - [7168, 7168, 1, 256]
+    - [14, 4838.49]
+  - - [33280, 3072, 1, 256]
+    - [9, 4803.45]
+  - - [18432, 18432, 1, 256]
+    - [14, 4913.01]
+  - - [20480, 2048, 1, 256]
+    - [14, 4756.2]
+  - - [19200, 3072, 1, 384]
+    - [9, 4989.35]
+  - - [38016, 38016, 1, 384]
+    - [12, 5038.34]
+  - - [14848, 3072, 1, 256]
+    - [9, 4772.1]
+  - - [35328, 35328, 1, 384]
+    - [12, 5030.83]
+  - - [3072, 3072, 1, 256]
+    - [29, 4587.43]
+  - - [38784, 38784, 1, 384]
+    - [12, 5052.56]
+  - - [11264, 2048, 1, 256]
+    - [14, 4695.61]
+  - - [26112, 26112, 1, 384]
+    - [10, 5023.99]
+  - - [43648, 128, 1, 128]
+    - [38, 4199.72]
+  - - [27264, 27264, 1, 384]
+    - [9, 5038.76]
+  - - [44928, 44928, 1, 384]
+    - [12, 5044.23]
+  - - [26368, 2048, 1, 256]
+    - [14, 4785.13]
+  - - [39936, 2048, 1, 256]
+    - [14, 4796.43]
+  - - [41088, 128, 1, 384]
+    - [34, 4559.64]
+  - - [42368, 128, 1, 256]
+    - [37, 4531.65]
+  - - [23296, 3072, 1, 256]
+    - [9, 4825.46]
+  - - [22784, 2048, 1, 256]
+    - [14, 4772.04]
+  - - [3072, 3072, 1, 384]
+    - [16, 4787.42]
+  - - [3456, 3072, 1, 384]
+    - [16, 4812.85]
+  - - [9216, 9216, 1, 384]
+    - [14, 4982.57]
+  - - [29440, 3072, 1, 256]
+    - [9, 4835.29]
+  - - [14336, 2048, 1, 256]
+    - [14, 4721.58]
+  - - [16640, 2048, 1, 256]
+    - [14, 4750.06]
+  - - [38528, 128, 1, 128]
+    - [38, 4208.28]
+  - - [14592, 3072, 1, 384]
+    - [9, 4977.28]
+  - - [10752, 10752, 1, 256]
+    - [9, 4887.21]
+  - - [31488, 3072, 1, 384]
+    - [9, 5004.03]
+  - - [9088, 128, 1, 384]
+    - [34, 4442.06]
+  - - [512, 2048, 1, 256]
+    - [6, 3952.23]
+  - - [18176, 3072, 1, 256]
+    - [8, 4810.78]
+  - - [17152, 17152, 1, 256]
+    - [9, 4931.31]
+  - - [44928, 128, 1, 384]
+    - [34, 4690.53]
+  - - [33536, 2048, 1, 256]
+    - [14, 4788.74]
+  - - [768, 768, 1, 256]
+    - [2, 3273.96]
+  - - [18048, 128, 1, 128]
+    - [37, 3789.06]
+  - - [7808, 128, 1, 384]
+    - [37, 4053.43]
+  - - [29184, 29184, 1, 256]
+    - [14, 4921.28]
+  - - [13312, 3072, 1, 256]
+    - [9, 4769.21]
+  - - [11776, 11776, 1, 256]
+    - [14, 4885.04]
+  - - [23552, 2048, 1, 256]
+    - [14, 4765.96]
+  - - [37376, 2048, 1, 256]
+    - [14, 4784.45]
+  - - [1, 64, 1, 64]
+    - [1, 0.433898]
+  - - [37888, 3072, 1, 256]
+    - [9, 4818.51]
+  - - [18432, 3072, 1, 384]
+    - [14, 4976.94]
+  - - [27136, 27136, 1, 256]
+    - [12, 4903.82]
+  - - [27392, 2048, 1, 256]
+    - [14, 4786.14]
+  - - [30848, 128, 1, 128]
+    - [37, 4062.81]
+  - - [33408, 128, 1, 256]
+    - [37, 4422.73]
+  - - [33792, 33792, 1, 384]
+    - [12, 5023.83]
+  - - [42240, 3072, 1, 256]
+    - [9, 4849.47]
+  - - [4224, 4224, 1, 384]
+    - [14, 4889.8]
+  - - [18048, 3072, 1, 384]
+    - [9, 4981.35]
+  - - [34816, 3072, 1, 256]
+    - [9, 4809.62]
+  - - [32256, 2048, 1, 256]
+    - [14, 4783.24]
+  - - [43520, 43520, 1, 256]
+    - [12, 4915.38]
+  - - [14592, 14592, 1, 384]
+    - [9, 5010.72]
+  - - [41472, 41472, 1, 256]
+    - [10, 4912.51]
+  - - [2048, 2048, 1, 256]
+    - [25, 4466.49]
+  - - [14080, 14080, 1, 256]
+    - [9, 4923.92]
+  - - [43008, 3072, 1, 384]
+    - [9, 4999.67]
+  - - [15872, 3072, 1, 256]
+    - [9, 4776.61]
+  - - [34688, 128, 1, 256]
+    - [37, 4509.11]
+  - - [16896, 16896, 1, 256]
+    - [14, 4908.48]
+  - - [17664, 3072, 1, 384]
+    - [9, 4979.04]
+  - - [16384, 2048, 1, 256]
+    - [29, 4727.74]
+  - - [15744, 15744, 1, 384]
+    - [9, 5029.34]
+  - - [28416, 28416, 1, 256]
+    - [9, 4935.51]
+  - - [32512, 3072, 1, 256]
+    - [9, 4837.79]
+  - - [21504, 3072, 1, 384]
+    - [9, 4983.41]
+  - - [7936, 2048, 1, 256]
+    - [29, 4662.22]
+  - - [29952, 3072, 1, 256]
+    - [9, 4834.1]
+  - - [24448, 128, 1, 128]
+    - [37, 3997.57]
+  - - [23808, 23808, 1, 256]
+    - [9, 4947.2]
+  - - [22784, 3072, 1, 256]
+    - [9, 4821.4]
+  - - [1280, 1280, 1, 256]
+    - [24, 3885.05]
+  - - [40320, 3072, 1, 384]
+    - [8, 5010.68]
+  - - [20736, 2048, 1, 256]
+    - [14, 4781.01]
+  - - [27648, 27648, 1, 256]
+    - [14, 4917.33]
+  - - [4864, 3072, 1, 256]
+    - [9, 4651.72]
+  - - [14592, 2048, 1, 256]
+    - [14, 4744.61]
+  - - [1152, 3072, 1, 384]
+    - [14, 4728.45]
+  - - [17920, 3072, 1, 256]
+    - [9, 4793.1]
+  - - [21888, 128, 1, 256]
+    - [37, 4327.94]
+  - - [21760, 3072, 1, 256]
+    - [9, 4826.86]
+  - - [2688, 128, 1, 384]
+    - [37, 2844.97]
+  - - [34816, 34816, 1, 256]
+    - [14, 4915.79]
+  - - [43776, 43776, 1, 384]
+    - [12, 5043.62]
+  - - [36096, 36096, 1, 256]
+    - [9, 4953.01]
+  - - [18944, 2048, 1, 256]
+    - [14, 4752.57]
+  - - [39680, 3072, 1, 256]
+    - [9, 4841.32]
+  - - [24320, 24320, 1, 256]
+    - [9, 4942.95]
+  - - [12544, 12544, 1, 256]
+    - [9, 4929.98]
+  - - [29184, 29184, 1, 384]
+    - [12, 5029.38]
+  - - [29568, 29568, 1, 384]
+    - [12, 5040.32]
+  - - [12928, 128, 1, 384]
+    - [37, 4086.94]
+  - - [25600, 2048, 1, 256]
+    - [14, 4766.46]
+  - - [26880, 2048, 1, 256]
+    - [14, 4780.68]
+  - - [44800, 2048, 1, 256]
+    - [14, 4809.67]
+  - - [1792, 3072, 1, 256]
+    - [22, 4509.43]
+  - - [36480, 36480, 1, 384]
+    - [12, 5046.82]
+  - - [30720, 30720, 1, 256]
+    - [14, 4918.08]
+  - - [25728, 25728, 1, 384]
+    - [9, 5038.88]
+  - - [34048, 34048, 1, 256]
+    - [9, 4947.82]
+  - - [16896, 3072, 1, 384]
+    - [14, 4967.18]
+  - - [2304, 2048, 1, 256]
+    - [25, 4456.76]
+  - - [12928, 128, 1, 256]
+    - [37, 3941.43]
+  - - [36096, 2048, 1, 256]
+    - [14, 4806.49]
+  - - [9728, 9728, 1, 256]
+    - [14, 4882.17]
+  - - [128, 128, 1, 256]
+    - [36, 186.912]
+  - - [11904, 3072, 1, 384]
+    - [14, 4955.93]
+  - - [33024, 33024, 1, 256]
+    - [9, 4946.58]
+  - - [10240, 3072, 1, 256]
+    - [9, 4743.68]
+  - - [15488, 128, 1, 384]
+    - [37, 4301.92]
+  - - [23168, 128, 1, 128]
+    - [37, 3897.17]
+  - - [39808, 128, 1, 384]
+    - [37, 4564.35]
+  - - [18176, 18176, 1, 256]
+    - [9, 4927.79]
+  - - [21504, 21504, 1, 256]
+    - [9, 4913.98]
+  - - [13824, 3072, 1, 256]
+    - [9, 4766.42]
+  - - [41088, 128, 1, 128]
+    - [37, 4181.28]
+  - - [36480, 3072, 1, 384]
+    - [14, 5010.5]
+  - - [29696, 2048, 1, 256]
+    - [14, 4777.78]
+  - - [25728, 3072, 1, 384]
+    - [9, 4996.21]
+  - - [16384, 16384, 1, 256]
+    - [9, 4903.36]
+  - - [1792, 2048, 1, 256]
+    - [25, 4410.91]
+  - - [1920, 1920, 1, 384]
+    - [24, 4414.31]
+  - - [43520, 2048, 1, 256]
+    - [14, 4798.13]
+  - - [43264, 3072, 1, 256]
+    - [9, 4842.5]
+  - - [31232, 2048, 1, 256]
+    - [14, 4779.0]
+  - - [3968, 128, 1, 128]
+    - [37, 2987.67]
+  - - [27008, 128, 1, 384]
+    - [34, 4595.96]
+  - - [27904, 27904, 1, 256]
+    - [8, 4934.31]
+  - - [24448, 128, 1, 384]
+    - [37, 4560.76]
+  - - [19968, 3072, 1, 384]
+    - [13, 4968.19]
+  - - [11008, 3072, 1, 256]
+    - [9, 4778.14]
+  - - [19712, 2048, 1, 256]
+    - [14, 4762.91]
+  - - [7680, 7680, 1, 384]
+    - [14, 4980.39]
+  - - [24192, 3072, 1, 384]
+    - [14, 4983.66]
+  - - [35968, 128, 1, 384]
+    - [34, 4651.88]
+  - - [37632, 37632, 1, 256]
+    - [9, 4941.1]
+  - - [4352, 2048, 1, 256]
+    - [28, 4560.49]
+  - - [7424, 3072, 1, 256]
+    - [9, 4713.92]
+  - - [44160, 3072, 1, 384]
+    - [9, 5014.42]
+  - - [14848, 14848, 1, 256]
+    - [9, 4898.96]
+  - - [8832, 8832, 1, 384]
+    - [9, 5012.35]
+  - - [37888, 2048, 1, 256]
+    - [14, 4785.87]
+  - - [23552, 23552, 1, 256]
+    - [14, 4906.6]
+  - - [4608, 4608, 1, 50000]
+    - [17, 5244.06]
+  - - [3584, 2048, 1, 256]
+    - [28, 4508.71]
+  - - [13056, 13056, 1, 256]
+    - [9, 4931.17]
+  - - [30720, 3072, 1, 384]
+    - [9, 4994.37]
+  - - [43776, 2048, 1, 256]
+    - [14, 4812.18]
+  - - [16640, 3072, 1, 256]
+    - [9, 4810.05]
+  - - [38528, 128, 1, 256]
+    - [37, 4508.88]
+  - - [19584, 19584, 1, 384]
+    - [9, 5045.62]
+  - - [3840, 3072, 1, 256]
+    - [9, 4630.33]
+  - - [38784, 3072, 1, 384]
+    - [14, 5010.83]
+  - - [16768, 128, 1, 384]
+    - [34, 4251.87]
+  - - [22784, 22784, 1, 256]
+    - [14, 4931.16]
+  - - [44160, 44160, 1, 384]
+    - [12, 5044.51]
+  - - [28160, 28160, 1, 256]
+    - [12, 4905.11]
+  - - [29952, 3072, 1, 384]
+    - [14, 5002.92]
+  - - [14592, 14592, 1, 256]
+    - [9, 4946.11]
+  - - [33792, 3072, 1, 256]
+    - [9, 4816.39]
+  - - [10240, 2048, 1, 256]
+    - [29, 4677.88]
+  - - [37632, 2048, 1, 256]
+    - [14, 4811.26]
+  - - [33024, 3072, 1, 256]
+    - [9, 4839.54]
+  - - [43264, 2048, 1, 256]
+    - [14, 4804.54]
+  - - [10368, 3072, 1, 384]
+    - [14, 4938.54]
+  - - [8448, 3072, 1, 384]
+    - [14, 4934.86]
+  - - [5760, 3072, 1, 384]
+    - [13, 4885.37]
+  - - [20992, 20992, 1, 256]
+    - [14, 4900.0]
+  - - [41216, 41216, 1, 256]
+    - [9, 4935.63]
+  - - [21760, 21760, 1, 256]
+    - [9, 4948.32]
+  - - [25344, 25344, 1, 256]
+    - [14, 4936.55]
+  - - [35968, 128, 1, 128]
+    - [38, 4143.0]
+  - - [512, 3072, 1, 256]
+    - [25, 4128.94]
+  - - [27136, 3072, 1, 256]
+    - [9, 4792.58]
+  - - [4608, 4608, 1, 256]
+    - [14, 4771.78]
+  - - [21248, 2048, 1, 256]
+    - [14, 4771.07]
+  - - [3456, 3456, 1, 384]
+    - [8, 4829.09]
+  - - [38656, 2048, 1, 256]
+    - [14, 4803.76]
+  - - [3840, 2048, 1, 256]
+    - [29, 4534.38]
+  - - [2560, 2048, 1, 256]
+    - [25, 4438.42]
+  - - [30464, 30464, 1, 256]
+    - [9, 4943.45]
+  - - [23552, 3072, 1, 256]
+    - [9, 4803.23]
+  - - [26112, 2048, 1, 256]
+    - [14, 4769.71]
+  - - [19200, 19200, 1, 256]
+    - [9, 4945.89]
+  - - [30976, 2048, 1, 256]
+    - [14, 4800.74]
+  - - [26112, 3072, 1, 384]
+    - [8, 4984.01]
+  - - [22272, 22272, 1, 256]
+    - [14, 4936.92]
+  - - [29952, 29952, 1, 256]
+    - [9, 4944.13]
+  - - [22272, 2048, 1, 256]
+    - [14, 4782.26]
+  - - [20480, 20480, 1, 256]
+    - [14, 4908.02]
+  - - [8448, 3072, 1, 256]
+    - [9, 4759.15]
+  - - [26880, 3072, 1, 384]
+    - [14, 4993.22]
+  - - [37376, 3072, 1, 256]
+    - [9, 4808.76]
+  - - [25344, 2048, 1, 256]
+    - [14, 4788.17]
+  - - [5376, 5376, 1, 384]
+    - [8, 4947.28]
+  - - [42624, 3072, 1, 384]
+    - [14, 5011.41]
+  - - [4096, 3072, 1, 256]
+    - [29, 4619.71]
+  - - [31488, 3072, 1, 256]
+    - [9, 4829.69]
+  - - [38144, 2048, 1, 256]
+    - [14, 4799.29]
+  - - [17408, 17408, 1, 256]
+    - [14, 4913.04]
+  - - [32768, 32768, 1, 256]
+    - [10, 4905.13]
+  - - [18816, 18816, 1, 384]
+    - [10, 5032.61]
+  - - [26368, 3072, 1, 256]
+    - [9, 4837.32]
+  - - [25856, 3072, 1, 256]
+    - [9, 4825.66]
+  - - [44288, 2048, 1, 256]
+    - [14, 4810.77]
+  - - [3840, 3840, 1, 384]
+    - [9, 4870.39]
+  - - [42240, 2048, 1, 256]
+    - [14, 4814.16]
+  - - [39680, 2048, 1, 256]
+    - [14, 4796.54]
+  - - [26880, 3072, 1, 256]
+    - [9, 4819.15]
+  - - [34944, 34944, 1, 384]
+    - [12, 5043.57]
+  - - [4608, 3072, 1, 384]
+    - [14, 4862.62]
+  - - [34560, 3072, 1, 384]
+    - [9, 5009.64]
+  - - [41216, 3072, 1, 256]
+    - [9, 4842.07]
+  - - [18048, 18048, 1, 384]
+    - [11, 5025.03]
+  - - [4352, 3072, 1, 256]
+    - [9, 4633.09]
+  - - [34560, 34560, 1, 384]
+    - [12, 5042.24]
+  - - [19968, 2048, 1, 256]
+    - [14, 4760.88]
+  - - [9088, 128, 1, 256]
+    - [34, 4182.52]
+  - - [28800, 3072, 1, 384]
+    - [14, 4997.92]
+  - - [38656, 3072, 1, 256]
+    - [9, 4839.95]
+  - - [24576, 24576, 1, 256]
+    - [14, 4922.48]
+  - - [32128, 128, 1, 384]
+    - [37, 4573.55]
+  - - [8448, 8448, 1, 256]
+    - [9, 4918.8]
+  - - [36864, 2048, 1, 256]
+    - [14, 4778.13]
+  - - [42752, 42752, 1, 256]
+    - [8, 4942.02]
+  - - [13312, 2048, 1, 256]
+    - [14, 4709.39]
+  - - [26496, 3072, 1, 384]
+    - [8, 4999.29]
+  - - [5376, 5376, 1, 256]
+    - [9, 4841.23]
+  - - [18048, 128, 1, 256]
+    - [37, 4307.97]
+  - - [3584, 3584, 1, 256]
+    - [9, 4668.55]
+  - - [37120, 37120, 1, 256]
+    - [9, 4941.96]
+  - - [20992, 3072, 1, 256]
+    - [9, 4792.6]
+  - - [39936, 39936, 1, 384]
+    - [12, 5032.16]
+  - - [20736, 20736, 1, 384]
+    - [9, 5031.05]
+  - - [9984, 2048, 1, 256]
+    - [29, 4698.82]
+  - - [10752, 3072, 1, 384]
+    - [14, 4939.85]
+  - - [7168, 2048, 1, 256]
+    - [29, 4641.23]
+  - - [35584, 35584, 1, 256]
+    - [9, 4939.06]
+  - - [26112, 26112, 1, 256]
+    - [9, 4912.04]
+  - - [43008, 3072, 1, 256]
+    - [9, 4823.65]
+  - - [6144, 3072, 1, 256]
+    - [8, 4681.83]
+  - - [256, 256, 1, 256]
+    - [19, 710.906]
+  - - [24576, 2048, 1, 256]
+    - [14, 4766.11]
+  - - [16896, 16896, 1, 384]
+    - [14, 5009.28]
+  - - [40704, 40704, 1, 384]
+    - [12, 5044.18]
+  - - [33280, 33280, 1, 256]
+    - [14, 4917.79]
+  - - [13056, 3072, 1, 256]
+    - [9, 4787.95]
+  - - [24064, 3072, 1, 256]
+    - [9, 4801.76]
+  - - [8448, 2048, 1, 256]
+    - [14, 4674.7]
   - - [32128, 128, 1, 128]
-    - [70, 4324.57]
+    - [38, 4099.57]
+  - - [15360, 3072, 1, 384]
+    - [9, 4962.75]
+  - - [12032, 3072, 1, 256]
+    - [9, 4787.18]
+  - - [40192, 2048, 1, 256]
+    - [14, 4805.47]
+  - - [41984, 3072, 1, 256]
+    - [9, 4811.99]
+  - - [7680, 2048, 1, 256]
+    - [14, 4641.64]
+  - - [42752, 3072, 1, 256]
+    - [9, 4845.52]
+  - - [21760, 2048, 1, 256]
+    - [14, 4761.64]
+  - - [5632, 5632, 1, 256]
+    - [9, 4794.28]
+  - - [32640, 3072, 1, 384]
+    - [14, 4997.21]
+  - - [768, 2048, 1, 256]
+    - [23, 4180.37]
+  - - [19456, 19456, 1, 256]
+    - [14, 4903.62]
+  - - [7936, 3072, 1, 256]
+    - [9, 4738.32]
+  - - [36864, 3072, 1, 384]
+    - [9, 4996.61]
+  - - [22016, 22016, 1, 256]
+    - [14, 4909.78]
+  - - [29568, 128, 1, 128]
+    - [37, 4035.67]
+  - - [14208, 128, 1, 256]
+    - [37, 4244.78]
+  - - [10368, 128, 1, 128]
+    - [37, 3276.8]
+  - - [13568, 13568, 1, 256]
+    - [9, 4929.85]
+  - - [21120, 3072, 1, 384]
+    - [14, 4985.38]
+  - - [1024, 2048, 1, 256]
+    - [24, 4204.82]
+  - - [30848, 128, 1, 384]
+    - [37, 4442.81]
+  - - [1408, 128, 1, 384]
+    - [37, 2028.31]
+  - - [21888, 3072, 1, 384]
+    - [9, 4995.34]
+  - - [5760, 5760, 1, 5760]
+    - [18, 5159.55]
+  - - [17664, 3072, 1, 256]
+    - [9, 4812.29]
+  - - [1536, 3072, 1, 256]
+    - [22, 4462.03]
+  - - [10752, 10752, 1, 384]
+    - [14, 4998.43]
+  - - [39936, 39936, 1, 256]
+    - [14, 4913.67]
+  - - [5376, 3072, 1, 256]
+    - [14, 4670.43]
+  - - [22528, 3072, 1, 256]
+    - [9, 4803.37]
+  - - [34048, 2048, 1, 256]
+    - [14, 4792.97]
+  - - [38912, 2048, 1, 256]
+    - [14, 4789.66]
+  - - [6144, 2048, 1, 256]
+    - [28, 4622.09]
+  - - [1920, 3072, 1, 384]
+    - [5, 4825.97]
+  - - [9984, 9984, 1, 256]
+    - [9, 4920.05]
+  - - [35072, 3072, 1, 256]
+    - [9, 4834.69]
+  - - [13056, 13056, 1, 384]
+    - [9, 5023.78]
+  - - [6912, 3072, 1, 384]
+    - [14, 4912.24]
+  - - [20224, 2048, 1, 256]
+    - [14, 4771.92]
+  - - [19712, 3072, 1, 256]
+    - [9, 4826.38]
+  - - [2816, 2048, 1, 256]
+    - [29, 4480.45]
+  - - [1536, 1536, 1, 256]
+    - [5, 4395.79]
+  - - [13824, 3072, 1, 384]
+    - [14, 4960.23]
+  - - [33280, 2048, 1, 256]
+    - [14, 4778.16]
+  - - [23168, 128, 1, 256]
+    - [37, 4268.83]
+  - - [19968, 19968, 1, 256]
+    - [9, 4916.04]
+  - - [44800, 44800, 1, 256]
+    - [9, 4946.5]
+  - - [11904, 11904, 1, 384]
+    - [11, 5015.11]
+  - - [15616, 3072, 1, 256]
+    - [9, 4798.58]
+  - - [25344, 3072, 1, 384]
+    - [14, 4985.49]
+  - - [14976, 14976, 1, 384]
+    - [9, 5021.87]
+  - - [35712, 35712, 1, 384]
+    - [12, 5043.92]
+  - - [16384, 3072, 1, 256]
+    - [9, 4781.46]
+  - - [39552, 3072, 1, 384]
+    - [14, 5002.96]
+  - - [2816, 2816, 1, 256]
+    - [9, 4581.25]
+  - - [12672, 12672, 1, 384]
+    - [9, 5022.34]
+  - - [43008, 43008, 1, 384]
+    - [12, 5032.01]
+  - - [41216, 2048, 1, 256]
+    - [14, 4805.9]
+  - - [41088, 41088, 1, 384]
+    - [12, 5046.15]
+  - - [5888, 3072, 1, 256]
+    - [9, 4701.98]
+  - - [10368, 128, 1, 384]
+    - [31, 3879.48]
+  - - [6912, 6912, 1, 384]
+    - [14, 4979.18]
+  - - [27008, 128, 1, 128]
+    - [37, 4000.9]
+  - - [16128, 16128, 1, 384]
+    - [11, 5027.9]
+  - - [1792, 1792, 1, 256]
+    - [24, 4283.48]
+  - - [5120, 5120, 1, 256]
+    - [14, 4783.78]
+  - - [25856, 25856, 1, 256]
+    - [9, 4933.64]
+  - - [40704, 2048, 1, 256]
+    - [14, 4803.46]
+  - - [8192, 3072, 1, 256]
+    - [9, 4723.06]
+  - - [35584, 3072, 1, 256]
+    - [9, 4844.88]
+  - - [12288, 12288, 1, 256]
+    - [9, 4898.9]
+  - - [3328, 2048, 1, 256]
+    - [28, 4531.56]
+  - - [6400, 6400, 1, 256]
+    - [9, 4861.45]
+  - - [2688, 128, 1, 256]
+    - [37, 2678.84]
+  - - [13568, 2048, 1, 256]
+    - [14, 4732.14]
+  - - [11648, 128, 1, 256]
+    - [37, 4050.1]
+  - - [43264, 43264, 1, 256]
+    - [14, 4943.12]
+  - - [41088, 3072, 1, 384]
+    - [9, 5014.34]
+  - - [28672, 3072, 1, 256]
+    - [9, 4807.59]
+  - - [20352, 3072, 1, 384]
+    - [14, 4989.07]
+  - - [2560, 3072, 1, 256]
+    - [25, 4550.38]
+  - - [37120, 2048, 1, 256]
+    - [14, 4797.51]
+  - - [19712, 19712, 1, 256]
+    - [9, 4935.51]
+  - - [40448, 3072, 1, 256]
+    - [9, 4813.39]
+  - - [23296, 2048, 1, 256]
+    - [14, 4775.35]
+  - - [34176, 34176, 1, 384]
+    - [12, 5041.26]
+  - - [43776, 3072, 1, 256]
+    - [9, 4847.05]
+  - - [38400, 2048, 1, 256]
+    - [14, 4792.03]
+  - - [32256, 3072, 1, 256]
+    - [8, 4795.63]
+  - - [31104, 31104, 1, 384]
+    - [12, 5042.35]
+  - - [36608, 36608, 1, 256]
+    - [9, 4943.46]
+  - - [43392, 3072, 1, 384]
+    - [9, 5019.54]
+  - - [24320, 2048, 1, 256]
+    - [14, 4773.1]
+  - - [18432, 3072, 1, 256]
+    - [9, 4789.75]
+  - - [39808, 128, 1, 256]
+    - [37, 4481.34]
+  - - [19968, 3072, 1, 256]
+    - [9, 4790.68]
+  - - [13824, 13824, 1, 384]
+    - [14, 4995.07]
+  - - [42624, 42624, 1, 384]
+    - [12, 5050.28]
+  - - [4992, 3072, 1, 384]
+    - [14, 4892.17]
+  - - [12800, 2048, 1, 256]
+    - [13, 4705.43]
+  - - [30336, 3072, 1, 384]
+    - [9, 5003.61]
+  - - [21120, 21120, 1, 384]
+    - [12, 5030.83]
+  - - [25856, 2048, 1, 256]
+    - [14, 4786.18]
+  - - [23296, 23296, 1, 256]
+    - [9, 4939.59]
+  - - [17408, 3072, 1, 256]
+    - [9, 4791.61]
+  - - [6912, 3072, 1, 256]
+    - [9, 4732.23]
+  - - [42240, 42240, 1, 256]
+    - [9, 4947.45]
+  - - [35840, 3072, 1, 256]
+    - [9, 4808.57]
+  - - [11008, 2048, 1, 256]
+    - [29, 4690.33]
+  - - [33408, 128, 1, 384]
+    - [35, 4605.83]
+  - - [768, 3072, 1, 256]
+    - [5, 4408.62]
+  - - [31744, 3072, 1, 256]
+    - [9, 4807.04]
+  - - [44544, 3072, 1, 256]
+    - [9, 4815.26]
+  - - [43648, 128, 1, 256]
+    - [37, 4512.42]
+  - - [9728, 2048, 1, 256]
+    - [29, 4667.84]
+  - - [22016, 2048, 1, 256]
+    - [14, 4758.63]
+  - - [24320, 3072, 1, 256]
+    - [9, 4830.29]
+  - - [5376, 3072, 1, 384]
+    - [14, 4900.16]
+  - - [1024, 3072, 1, 256]
+    - [24, 4323.1]
+  - - [41472, 3072, 1, 256]
+    - [9, 4810.57]
+  - - [19328, 128, 1, 384]
+    - [37, 4341.12]
+  - - [33792, 33792, 1, 256]
+    - [9, 4920.25]
+  - - [31488, 31488, 1, 256]
+    - [8, 4951.46]
+  - - [1280, 3072, 1, 256]
+    - [26, 4493.1]
+  - - [6528, 3072, 1, 384]
+    - [14, 4906.93]
+  - - [9600, 3072, 1, 384]
+    - [9, 4942.49]
+  - - [36096, 3072, 1, 256]
+    - [9, 4836.55]
+  - - [35328, 2048, 1, 256]
+    - [14, 4777.81]
+  - - [8960, 2048, 1, 256]
+    - [14, 4672.2]
+  - - [6400, 3072, 1, 256]
+    - [9, 4718.88]
+  - - [1408, 128, 1, 128]
+    - [37, 1624.55]
+  - - [768, 3072, 1, 384]
+    - [4, 4699.02]
+  - - [32768, 2048, 1, 256]
+    - [13, 4780.1]
+  - - [6144, 6144, 1, 256]
+    - [14, 4845.6]
+  - - [42240, 3072, 1, 384]
+    - [9, 5009.24]
+  - - [34816, 2048, 1, 256]
+    - [14, 4782.14]
+  - - [20352, 20352, 1, 384]
+    - [9, 5031.88]
+  - - [31744, 2048, 1, 256]
+    - [14, 4775.39]
+  - - [23168, 128, 1, 384]
+    - [34, 4385.22]
+  - - [33536, 33536, 1, 256]
+    - [8, 4934.85]
+  - - [32640, 32640, 1, 384]
+    - [12, 5043.9]
+  - - [13056, 2048, 1, 256]
+    - [14, 4725.19]
+  - - [20608, 128, 1, 128]
+    - [37, 3822.93]
+  - - [10368, 10368, 1, 384]
+    - [9, 5013.29]
+  - - [29184, 3072, 1, 384]
+    - [14, 4978.14]
+  - - [15360, 2048, 1, 256]
+    - [14, 4741.78]
+  - - [34688, 128, 1, 128]
+    - [38, 4159.31]
+  - - [33408, 3072, 1, 384]
+    - [9, 5002.62]
+  - - [1536, 3072, 1, 384]
+    - [14, 4745.29]
+  - - [23040, 3072, 1, 256]
+    - [9, 4805.64]
+  - - [19328, 128, 1, 256]
+    - [37, 4208.8]
+  - - [9216, 3072, 1, 384]
+    - [14, 4926.51]
+  - - [19456, 2048, 1, 256]
+    - [14, 4751.87]
+  - - [40960, 3072, 1, 256]
+    - [9, 4811.24]
+  - - [29184, 3072, 1, 256]
+    - [9, 4803.16]
+  - - [2688, 3072, 1, 384]
+    - [14, 4823.1]
+  - - [30464, 2048, 1, 256]
+    - [14, 4798.39]
+  - - [24192, 24192, 1, 384]
+    - [12, 5032.98]
+  - - [6912, 6912, 1, 256]
+    - [9, 4879.98]
+  - - [28416, 3072, 1, 384]
+    - [14, 4990.27]
+  - - [28288, 128, 1, 128]
+    - [38, 4052.73]
+  - - [17920, 2048, 1, 256]
+    - [14, 4745.45]
+  - - [27648, 3072, 1, 384]
+    - [14, 4990.9]
+  - - [15360, 15360, 1, 256]
+    - [9, 4908.22]
+  - - [18944, 18944, 1, 256]
+    - [14, 4911.54]
+  - - [384, 384, 1, 384]
+    - [24, 1705.52]
+  - - [4608, 3072, 1, 256]
+    - [9, 4644.57]
+  - - [37376, 37376, 1, 256]
+    - [12, 4913.61]
+  - - [31488, 31488, 1, 384]
+    - [12, 5043.19]
+  - - [11520, 2048, 1, 256]
+    - [14, 4723.31]
+  - - [26880, 26880, 1, 256]
+    - [9, 4947.07]
+  - - [28928, 3072, 1, 256]
+    - [9, 4838.84]
+  - - [44928, 128, 1, 128]
+    - [38, 4272.7]
+  - - [24448, 128, 1, 256]
+    - [37, 4426.03]
+  - - [13440, 3072, 1, 384]
+    - [14, 4964.2]
+  - - [23808, 3072, 1, 384]
+    - [8, 4983.79]
+  - - [256, 3072, 1, 256]
+    - [27, 3856.83]
+  - - [9216, 2048, 1, 256]
+    - [29, 4679.83]
+  - - [31872, 31872, 1, 384]
+    - [12, 5041.26]
+  - - [1408, 128, 1, 256]
+    - [37, 1909.66]
+  - - [17664, 2048, 1, 256]
+    - [14, 4762.72]
+  - - [9728, 3072, 1, 256]
+    - [9, 4738.5]
+  - - [38528, 128, 1, 384]
+    - [37, 4629.24]
+  - - [21504, 2048, 1, 256]
+    - [14, 4760.54]
+  - - [33024, 2048, 1, 256]
+    - [14, 4806.1]
+  - - [15488, 128, 1, 128]
+    - [37, 3662.75]
+  - - [39424, 2048, 1, 256]
+    - [14, 4777.67]
+  - - [3072, 2048, 1, 256]
+    - [29, 4478.41]
+  - - [39424, 3072, 1, 256]
+    - [9, 4810.89]
+  - - [15616, 15616, 1, 256]
+    - [9, 4934.91]
+  - - [39552, 39552, 1, 384]
+    - [12, 5044.38]
+  - - [25600, 3072, 1, 256]
+    - [9, 4801.9]
+  - - [14976, 3072, 1, 384]
+    - [14, 4974.32]
+  - - [4352, 4352, 1, 256]
+    - [9, 4789.61]
+  - - [12544, 3072, 1, 256]
+    - [9, 4791.72]
+  - - [28288, 128, 1, 384]
+    - [37, 4562.32]
+  - - [38400, 3072, 1, 256]
+    - [9, 4815.72]
+  - - [8064, 3072, 1, 384]
+    - [9, 4932.84]
+  - - [41856, 3072, 1, 384]
+    - [9, 5018.33]
+  - - [10368, 128, 1, 256]
+    - [38, 3639.02]
+  - - [3840, 3072, 1, 384]
+    - [14, 4827.0]
+  - - [29568, 3072, 1, 384]
+    - [14, 4991.02]
+  - - [32128, 128, 1, 256]
+    - [37, 4456.36]
+  - - [12288, 12288, 1, 384]
+    - [14, 4999.49]
+  - - [24832, 2048, 1, 256]
+    - [14, 4785.59]
+  - - [7680, 3072, 1, 256]
+    - [9, 4711.23]
+  - - [18688, 2048, 1, 256]
+    - [13, 4747.96]
+  - - [27904, 3072, 1, 256]
+    - [9, 4830.08]
+  - - [4608, 4608, 1, 4608]
+    - [17, 5198.68]
+  - - [5760, 5760, 1, 384]
+    - [9, 4959.13]
+  - - [35328, 3072, 1, 384]
+    - [14, 4990.25]
+  - - [8704, 8704, 1, 256]
+    - [14, 4860.28]
+  - - [17664, 17664, 1, 256]
+    - [9, 4947.44]
+  - - [8704, 2048, 1, 256]
+    - [29, 4668.34]
+  - - [9984, 3072, 1, 256]
+    - [9, 4770.07]
+  - - [5376, 2048, 1, 256]
+    - [29, 4609.43]
+  - - [2304, 2304, 1, 256]
+    - [9, 4483.23]
+  - - [2560, 2560, 1, 256]
+    - [25, 4541.75]
+  - - [35840, 2048, 1, 256]
+    - [14, 4776.62]
+  - - [6528, 128, 1, 128]
+    - [33, 2872.04]
+  - - [24576, 24576, 1, 384]
+    - [12, 5023.03]
+  - - [37248, 128, 1, 384]
+    - [37, 4520.08]
+  - - [34304, 34304, 1, 256]
+    - [10, 4909.95]
+  - - [14208, 128, 1, 128]
+    - [38, 3718.59]
+  - - [22528, 2048, 1, 256]
+    - [14, 4750.91]
+  - - [15104, 3072, 1, 256]
+    - [8, 4793.02]
+  - - [10752, 3072, 1, 256]
+    - [9, 4744.22]
+  - - [39808, 128, 1, 128]
+    - [37, 4160.59]
+  - - [18816, 3072, 1, 384]
+    - [14, 4991.15]
+  - - [42368, 128, 1, 384]
+    - [35, 4629.78]
+  - - [17664, 17664, 1, 384]
+    - [9, 5030.74]
+  - - [2304, 3072, 1, 256]
+    - [29, 4548.05]
+  - - [12800, 12800, 1, 256]
+    - [14, 4888.6]
+  - - [39168, 3072, 1, 384]
+    - [9, 5008.83]
+  - - [11136, 3072, 1, 384]
+    - [14, 4949.35]
+  - - [2304, 2304, 1, 384]
+    - [5, 4626.5]
+  - - [26624, 26624, 1, 256]
+    - [14, 4915.5]
+  - - [36864, 36864, 1, 256]
+    - [12, 4910.35]
+  - - [12288, 2048, 1, 256]
+    - [29, 4713.39]
+  - - [40704, 40704, 1, 256]
+    - [9, 4938.45]
+  - - [12032, 12032, 1, 256]
+    - [9, 4919.1]
+  - - [33024, 33024, 1, 384]
+    - [12, 5042.28]
+  - - [28800, 28800, 1, 384]
+    - [9, 5039.88]
+  - - [14208, 128, 1, 384]
+    - [37, 4433.42]
+  - - [41472, 2048, 1, 256]
+    - [14, 4792.77]
+  - - [22016, 3072, 1, 256]
+    - [8, 4787.66]
+  - - [22656, 22656, 1, 384]
+    - [9, 5035.91]
+  - - [26624, 3072, 1, 256]
+    - [9, 4799.2]
+  - - [41472, 41472, 1, 384]
+    - [10, 5031.66]
+  - - [27264, 3072, 1, 384]
+    - [8, 4991.08]
+  - - [39680, 39680, 1, 256]
+    - [9, 4943.75]
+  - - [44032, 44032, 1, 256]
+    - [12, 4914.17]
+  - - [25344, 3072, 1, 256]
+    - [9, 4831.41]
+  - - [10496, 3072, 1, 256]
+    - [9, 4771.54]
+  - - [22272, 3072, 1, 256]
+    - [9, 4819.29]
+  - - [15360, 3072, 1, 256]
+    - [8, 4774.62]
+  - - [43392, 43392, 1, 384]
+    - [12, 5048.33]
+  - - [42240, 42240, 1, 384]
+    - [12, 5046.69]
+  - - [38912, 38912, 1, 256]
+    - [14, 4920.17]
+  - - [10752, 2048, 1, 256]
+    - [29, 4685.59]
+  - - [23040, 23040, 1, 384]
+    - [12, 5020.32]
+  - - [13312, 13312, 1, 256]
+    - [14, 4891.4]
+  - - [128, 128, 1, 384]
+    - [39, 209.995]
+  - - [12288, 3072, 1, 256]
+    - [9, 4768.51]
+  - - [11136, 11136, 1, 384]
+    - [14, 5012.59]
+  - - [39168, 39168, 1, 256]
+    - [9, 4949.46]
+  - - [16896, 2048, 1, 256]
+    - [13, 4735.47]
+  - - [19200, 3072, 1, 256]
+    - [9, 4813.05]
+  - - [20736, 3072, 1, 256]
+    - [9, 4811.48]
+  - - [768, 768, 1, 384]
+    - [20, 3480.22]
+  - - [15744, 3072, 1, 384]
+    - [14, 4976.63]
+  - - [32512, 2048, 1, 256]
+    - [13, 4787.73]
+  - - [31232, 3072, 1, 256]
+    - [9, 4801.59]
+  - - [29184, 2048, 1, 256]
+    - [14, 4776.49]
+  - - [3584, 3072, 1, 256]
+    - [28, 4597.1]
+  - - [25344, 25344, 1, 384]
+    - [9, 5040.0]
+  - - [5248, 128, 1, 256]
+    - [32, 3506.66]
+  - - [30208, 30208, 1, 256]
+    - [14, 4913.31]
+  - - [20992, 2048, 1, 256]
+    - [14, 4748.49]
+  - - [33536, 3072, 1, 256]
+    - [9, 4835.04]
+  - - [40192, 40192, 1, 256]
+    - [9, 4951.49]
+  - - [29440, 2048, 1, 256]
+    - [14, 4796.05]
+  - - [15872, 15872, 1, 256]
+    - [14, 4908.5]
+  - - [44544, 44544, 1, 256]
+    - [14, 4925.67]
+  - - [27136, 2048, 1, 256]
+    - [14, 4765.42]
+  - - [11520, 11520, 1, 256]
+    - [9, 4927.86]
+  - - [35712, 3072, 1, 384]
+    - [14, 5006.39]
+  - - [12288, 3072, 1, 384]
+    - [14, 4950.72]
+  - - [11776, 2048, 1, 256]
+    - [14, 4696.21]
+  - - [15360, 15360, 1, 384]
+    - [14, 5006.79]
+  - - [9216, 3072, 1, 256]
+    - [9, 4743.67]
+  - - [23040, 23040, 1, 256]
+    - [9, 4921.45]
+  - - [26496, 26496, 1, 384]
+    - [12, 5038.29]
+  - - [11264, 11264, 1, 256]
+    - [14, 4882.79]
+  - - [18048, 128, 1, 384]
+    - [34, 4501.2]
+  - - [23424, 3072, 1, 384]
+    - [9, 4987.41]
+  - - [30976, 30976, 1, 256]
+    - [8, 4933.07]
+  - - [40960, 2048, 1, 256]
+    - [14, 4783.84]
+  - - [11648, 128, 1, 384]
+    - [31, 4249.73]
+  - - [2304, 3072, 1, 384]
+    - [5, 4820.36]
+  - - [23040, 3072, 1, 384]
+    - [14, 4984.24]
+  - - [19456, 3072, 1, 256]
+    - [9, 4795.05]
+  - - [6144, 6144, 1, 384]
+    - [14, 4942.89]
+  - - [27648, 2048, 1, 256]
+    - [14, 4770.27]
+  - - [28928, 28928, 1, 256]
+    - [14, 4937.18]
+  - - [12544, 2048, 1, 256]
+    - [14, 4714.05]
+  - - [11520, 11520, 1, 384]
+    - [14, 5020.03]
+  - - [43008, 43008, 1, 256]
+    - [9, 4926.27]
+  - - [7168, 3072, 1, 256]
+    - [9, 4712.54]
+  - - [3072, 3072, 1, 384]
+    - [14, 4831.58]
+  - - [29440, 29440, 1, 256]
+    - [9, 4941.34]
+  - - [30208, 2048, 1, 256]
+    - [14, 4777.7]
+  - - [36352, 36352, 1, 256]
+    - [9, 4907.78]
+  - - [32256, 32256, 1, 384]
+    - [12, 5028.89]
+  - - [23808, 23808, 1, 384]
+    - [12, 5036.49]
+  - - [9984, 9984, 1, 384]
+    - [9, 5008.45]
+  - - [8960, 3072, 1, 256]
+    - [9, 4754.03]
+  - - [37248, 128, 1, 256]
+    - [37, 4453.89]
+  - - [1, 1, 1, 64]
+    - [1, 0.00647773]
+  - - [6528, 6528, 1, 384]
+    - [9, 4987.46]
+  - - [7296, 7296, 1, 384]
+    - [9, 4993.92]
+  - - [4224, 3072, 1, 384]
+    - [13, 4876.53]
+  - - [37888, 37888, 1, 256]
+    - [10, 4912.3]
+  - - [36096, 3072, 1, 384]
+    - [14, 5000.11]
+  - - [28928, 2048, 1, 256]
+    - [14, 4783.09]
+  - - [35968, 128, 1, 256]
+    - [37, 4465.07]
+  - - [8704, 3072, 1, 256]
+    - [9, 4738.93]
+  - - [13824, 13824, 1, 256]
+    - [14, 4909.04]
+  - - [23808, 2048, 1, 256]
+    - [14, 4780.64]
+  - - [13056, 3072, 1, 384]
+    - [13, 4956.2]
+  - - [6144, 3072, 1, 384]
+    - [14, 4899.38]
+  - - [13568, 3072, 1, 256]
+    - [9, 4785.41]
+  - - [21504, 3072, 1, 256]
+    - [9, 4801.44]
+  - - [39168, 39168, 1, 384]
+    - [12, 5040.56]
+  - - [14080, 2048, 1, 256]
+    - [14, 4721.02]
+  - - [2688, 128, 1, 128]
+    - [37, 2293.76]
+  - - [37632, 37632, 1, 384]
+    - [12, 5042.41]
+  - - [24576, 3072, 1, 256]
+    - [9, 4806.36]
+  - - [40448, 2048, 1, 256]
+    - [14, 4785.18]
+  - - [16896, 3072, 1, 256]
+    - [8, 4779.76]
+  - - [29568, 128, 1, 256]
+    - [37, 4399.23]
+  - - [42368, 128, 1, 128]
+    - [38, 4214.17]
+  - - [14336, 14336, 1, 256]
+    - [14, 4896.25]
+  - - [41728, 3072, 1, 256]
+    - [9, 4844.07]
+  - - [8064, 8064, 1, 384]
+    - [9, 5003.24]
+  - - [28288, 128, 1, 256]
+    - [37, 4432.59]
+  - - [5888, 2048, 1, 256]
+    - [28, 4607.2]
+  - - [27904, 2048, 1, 256]
+    - [14, 4778.02]
+  - - [31488, 2048, 1, 256]
+    - [14, 4791.71]
+  - - [22656, 3072, 1, 384]
+    - [9, 4987.89]
+  - - [16512, 16512, 1, 384]
+    - [9, 5032.46]
+  - - [6400, 2048, 1, 256]
+    - [29, 4626.41]
+  - - [8192, 2048, 1, 256]
+    - [29, 4652.66]
+  - - [31872, 3072, 1, 384]
+    - [8, 4997.97]
+  - - [30720, 30720, 1, 384]
+    - [12, 5032.58]
+  - - [39168, 2048, 1, 256]
+    - [14, 4799.67]
+  - - [21888, 128, 1, 128]
+    - [38, 3897.97]
+  - - [21248, 21248, 1, 256]
+    - [9, 4944.88]
+  - - [33792, 2048, 1, 256]
+    - [14, 4789.96]
+  - - [12928, 128, 1, 128]
+    - [38, 3495.25]
+  - - [29696, 29696, 1, 256]
+    - [14, 4913.27]
+  - - [384, 3072, 1, 384]
+    - [5, 4524.43]
+  - - [30208, 3072, 1, 256]
+    - [9, 4813.73]
+  - - [28672, 28672, 1, 256]
+    - [9, 4908.07]
+  - - [32512, 32512, 1, 256]
+    - [9, 4930.53]
+  - - [2688, 2688, 1, 384]
+    - [9, 4703.56]
+  - - [32256, 3072, 1, 384]
+    - [9, 4984.53]
+  - - [2048, 3072, 1, 256]
+    - [25, 4521.15]
+  - - [9216, 9216, 1, 256]
+    - [14, 4886.08]
+  - - [6656, 6656, 1, 256]
+    - [14, 4834.44]
+  - - [6528, 128, 1, 384]
+    - [30, 3598.75]
+  - - [33408, 128, 1, 128]
+    - [37, 4076.23]
+  - - [23040, 2048, 1, 256]
+    - [14, 4764.3]
+  - - [34944, 3072, 1, 384]
+    - [14, 5002.79]
+  - - [43776, 3072, 1, 384]
+    - [14, 5003.78]
+  - - [36352, 3072, 1, 256]
+    - [9, 4806.67]
+  - - [30336, 30336, 1, 384]
+    - [9, 5043.1]
+  - - [11776, 3072, 1, 256]
+    - [9, 4761.84]
+  - - [16768, 128, 1, 128]
+    - [37, 3704.52]
+  - - [13440, 13440, 1, 384]
+    - [9, 5026.95]
+  - - [33024, 3072, 1, 384]
+    - [14, 4997.42]
+  - - [20608, 128, 1, 256]
+    - [37, 4181.84]
+  - - [12672, 3072, 1, 384]
+    - [14, 4962.19]
+  - - [6656, 2048, 1, 256]
+    - [28, 4619.86]
+  - - [4992, 4992, 1, 384]
+    - [9, 4934.36]
+  - - [32000, 2048, 1, 256]
+    - [14, 4795.19]
+  - - [6912, 2048, 1, 256]
+    - [13, 4642.66]
+  - - [34304, 2048, 1, 256]
+    - [14, 4788.69]
+  - - [25088, 2048, 1, 256]
+    - [13, 4764.73]
+  - - [7936, 7936, 1, 256]
+    - [9, 4884.07]
+  - - [16512, 3072, 1, 384]
+    - [9, 4974.34]
+  - - [41856, 41856, 1, 384]
+    - [12, 5048.24]
+  - - [7680, 3072, 1, 384]
+    - [14, 4906.89]
+  - - [44800, 3072, 1, 256]
+    - [9, 4845.14]
+  - - [37248, 3072, 1, 384]
+    - [9, 5002.34]
+  - - [5632, 2048, 1, 256]
+    - [29, 4584.79]
+  - - [5120, 2048, 1, 256]
+    - [28, 4595.87]
+  - - [24064, 2048, 1, 256]
+    - [14, 4758.27]
+  - - [44288, 44288, 1, 256]
+    - [9, 4953.6]
+  - - [37120, 3072, 1, 256]
+    - [9, 4840.38]
+  - - [7744, 7744, 1, 7744]
+    - [15, 5184.91]
+  - - [27392, 3072, 1, 256]
+    - [9, 4831.98]
+  - - [7424, 7424, 1, 256]
+    - [9, 4881.42]
+  - - [39424, 39424, 1, 256]
+    - [10, 4913.75]
+  - - [43648, 128, 1, 384]
+    - [37, 4586.9]
+  - - [14208, 14208, 1, 384]
+    - [9, 5027.29]
+  - - [44032, 2048, 1, 256]
+    - [14, 4794.48]
+  - - [36096, 36096, 1, 384]
+    - [12, 5035.57]
+  - - [5632, 3072, 1, 256]
+    - [9, 4671.15]
+  - - [25088, 3072, 1, 256]
+    - [9, 4802.17]
+  - - [44544, 2048, 1, 256]
+    - [14, 4797.35]
+  - - [20480, 3072, 1, 256]
+    - [9, 4791.49]
+  - - [9472, 2048, 1, 256]
+    - [29, 4680.36]
+  - - [44544, 44544, 1, 384]
+    - [12, 5036.22]
+  - - [35072, 2048, 1, 256]
+    - [14, 4793.39]
+  - - [22528, 22528, 1, 256]
+    - [14, 4904.7]
+  - - [4096, 4096, 1, 256]
+    - [9, 4699.5]
+  - - [4864, 2048, 1, 256]
+    - [29, 4579.0]
+  - - [4608, 4608, 1, 384]
+    - [14, 4895.84]
+  - - [7808, 128, 1, 128]
+    - [38, 3297.07]
+  - - [37632, 3072, 1, 256]
+    - [9, 4838.69]
+  - - [30720, 2048, 1, 256]
+    - [14, 4779.49]
+  - - [10496, 2048, 1, 256]
+    - [14, 4701.43]
+  - - [34304, 3072, 1, 256]
+    - [9, 4808.59]
+  - - [36352, 2048, 1, 256]
+    - [14, 4784.25]
+  - - [38144, 3072, 1, 256]
+    - [9, 4833.75]
+  - - [5248, 128, 1, 128]
+    - [38, 2977.26]
+  - - [9088, 128, 1, 128]
+    - [35, 3396.39]
+  - - [38912, 3072, 1, 256]
+    - [9, 4806.38]
+  - - [31744, 31744, 1, 256]
+    - [14, 4909.71]
+  - - [15872, 2048, 1, 256]
+    - [14, 4732.86]
+  - - [3968, 128, 1, 384]
+    - [37, 3970.58]
+  - - [17920, 17920, 1, 256]
+    - [14, 4908.84]
+  - - [5248, 128, 1, 384]
+    - [32, 3773.4]
+  - - [26112, 3072, 1, 256]
+    - [9, 4797.66]
+  - - [26880, 26880, 1, 384]
+    - [12, 5036.35]
+  - - [16128, 3072, 1, 256]
+    - [9, 4804.6]
+  - - [30464, 3072, 1, 256]
+    - [9, 4836.34]
+  - - [23808, 3072, 1, 256]
+    - [9, 4822.78]
+  - - [24960, 3072, 1, 384]
+    - [14, 4986.28]
+  - - [8192, 8192, 1, 256]
+    - [14, 4865.66]
+  - - [3968, 128, 1, 256]
+    - [37, 3640.07]
+  - - [41088, 128, 1, 256]
+    - [37, 4463.51]
+  - - [16128, 2048, 1, 256]
+    - [14, 4757.46]
+  - - [34560, 3072, 1, 256]
+    - [9, 4836.07]
+  - - [21888, 128, 1, 384]
+    - [37, 4457.4]
+  - - [12800, 3072, 1, 256]
+    - [9, 4764.72]
+  - - [28160, 2048, 1, 256]
+    - [14, 4767.79]
+  - - [16768, 128, 1, 256]
+    - [37, 4102.86]
+  - - [30976, 3072, 1, 256]
+    - [9, 4840.31]
+  - - [18176, 2048, 1, 256]
+    - [13, 4756.83]
+  - - [24064, 24064, 1, 256]
+    - [14, 4908.54]
+  - - [27648, 3072, 1, 256]
+    - [9, 4802.25]
+  - - [35584, 2048, 1, 256]
+    - [14, 4795.31]
+  - - [3072, 3072, 1, 256]
+    - [9, 4624.3]
+  - - [44928, 128, 1, 256]
+    - [37, 4557.33]
+  - - [9600, 9600, 1, 384]
+    - [9, 5008.75]
+  - - [9472, 3072, 1, 256]
+    - [9, 4760.65]
+  - - [27648, 27648, 1, 384]
+    - [10, 5021.65]
+  - - [24832, 24832, 1, 256]
+    - [9, 4935.41]
+  - - [38016, 3072, 1, 384]
+    - [14, 5008.54]
+  - - [33792, 3072, 1, 384]
+    - [14, 5001.36]
+  - - [8448, 8448, 1, 384]
+    - [9, 4999.3]
+  - - [128, 128, 1, 128]
+    - [36, 153.75]
+  - - [256, 2048, 1, 256]
+    - [21, 3711.8]
+  - - [16128, 3072, 1, 384]
+    - [14, 4980.77]
+  - - [6656, 3072, 1, 256]
+    - [9, 4690.4]
+  - - [10240, 10240, 1, 256]
+    - [14, 4871.33]
+  - - [26624, 2048, 1, 256]
+    - [14, 4772.45]
+  - - [32000, 3072, 1, 256]
+    - [9, 4828.47]
+  - - [40320, 40320, 1, 384]
+    - [12, 5041.89]
+  - - [36096, 2688, 1, 384]
+    - [48, 5019.43]
+  - - [11136, 2688, 1, 384]
+    - [48, 4957.17]
+  - - [35072, 1792, 1, 256]
+    - [50, 4829.08]
+  - - [29184, 1152, 1, 384]
+    - [48, 4954.66]
+  - - [31488, 1792, 1, 256]
+    - [50, 4813.01]
+  - - [41856, 2688, 1, 384]
+    - [48, 5024.03]
+  - - [28416, 2688, 1, 384]
+    - [48, 5009.45]
+  - - [14080, 1792, 1, 256]
+    - [50, 4743.85]
+  - - [20736, 768, 1, 384]
+    - [48, 4882.55]
+  - - [22016, 1281, 1, 256]
+    - [48, 4686.38]
+  - - [22656, 2688, 1, 384]
+    - [50, 5000.97]
+  - - [34816, 1792, 1, 256]
+    - [50, 4796.66]
+  - - [26112, 1536, 1, 256]
+    - [48, 4763.69]
+  - - [4992, 2688, 1, 384]
+    - [48, 4836.95]
+  - - [35328, 1920, 1, 384]
+    - [48, 5001.85]
+  - - [37120, 1792, 1, 256]
+    - [50, 4826.56]
+  - - [24320, 1792, 1, 256]
+    - [50, 4803.27]
+  - - [25344, 2688, 1, 384]
+    - [48, 5000.47]
+  - - [39936, 2688, 1, 384]
+    - [50, 5009.75]
+  - - [39936, 1153, 1, 384]
+    - [48, 4760.63]
+  - - [13568, 1536, 1, 256]
+    - [48, 4724.55]
+  - - [17664, 1153, 1, 384]
+    - [48, 4739.97]
+  - - [29440, 1792, 1, 256]
+    - [50, 4810.73]
+  - - [34304, 1281, 1, 256]
+    - [47, 4725.57]
+  - - [26112, 1792, 1, 256]
+    - [50, 4794.26]
+  - - [5376, 2688, 1, 384]
+    - [48, 4890.94]
+  - - [22784, 1281, 1, 256]
+    - [48, 4704.38]
+  - - [37888, 1281, 1, 256]
+    - [48, 4737.67]
+  - - [37632, 2688, 1, 384]
+    - [48, 5016.2]
+  - - [43264, 1792, 1, 256]
+    - [49, 4822.12]
+  - - [4608, 1792, 1, 256]
+    - [67, 4561.78]
+  - - [23040, 1792, 1, 256]
+    - [50, 4785.68]
+  - - [26368, 1792, 1, 256]
+    - [50, 4798.24]
+  - - [21248, 1281, 1, 256]
+    - [48, 4713.7]
+  - - [16512, 2688, 1, 384]
+    - [48, 4988.34]
+  - - [4608, 1153, 1, 384]
+    - [46, 4434.45]
+  - - [31872, 1152, 1, 384]
+    - [48, 4979.92]
+  - - [18176, 1281, 1, 256]
+    - [48, 4686.42]
+  - - [24960, 1153, 1, 384]
+    - [48, 4744.67]
+  - - [3584, 1792, 1, 256]
+    - [60, 4499.15]
+  - - [19968, 1792, 1, 256]
+    - [50, 4756.26]
+  - - [40960, 1792, 1, 256]
+    - [50, 4812.54]
+  - - [4992, 1152, 1, 384]
+    - [48, 4714.56]
+  - - [24832, 1792, 1, 256]
+    - [50, 4785.39]
+  - - [4224, 384, 1, 384]
+    - [57, 4010.14]
+  - - [6400, 1536, 1, 256]
+    - [67, 4580.27]
+  - - [21760, 1792, 1, 256]
+    - [50, 4790.31]
+  - - [29568, 1153, 1, 384]
+    - [48, 4768.44]
+  - - [16640, 1792, 1, 256]
+    - [50, 4755.92]
+  - - [43776, 1281, 1, 256]
+    - [48, 4776.64]
+  - - [24576, 1920, 1, 384]
+    - [48, 4961.61]
+  - - [30208, 256, 1, 256]
+    - [64, 4526.09]
+  - - [39168, 2688, 1, 384]
+    - [48, 5014.35]
+  - - [38784, 1153, 1, 384]
+    - [47, 4776.76]
+  - - [39552, 2688, 1, 384]
+    - [48, 5022.91]
+  - - [5760, 1153, 1, 384]
+    - [48, 4581.51]
+  - - [43008, 1536, 1, 384]
+    - [50, 4979.77]
+  - - [15104, 1281, 1, 256]
+    - [48, 4673.31]
+  - - [13568, 1792, 1, 256]
+    - [50, 4753.01]
+  - - [9216, 1153, 1, 384]
+    - [48, 4570.55]
+  - - [24832, 1281, 1, 256]
+    - [47, 4721.08]
+  - - [30720, 1153, 1, 384]
+    - [48, 4750.13]
+  - - [29696, 1281, 1, 256]
+    - [48, 4728.01]
+  - - [23808, 1024, 1, 256]
+    - [50, 4718.26]
+  - - [7424, 768, 1, 256]
+    - [48, 4490.58]
+  - - [21248, 256, 1, 256]
+    - [67, 4448.91]
+  - - [33408, 2688, 1, 384]
+    - [48, 5013.73]
+  - - [19456, 256, 1, 256]
+    - [64, 4378.67]
+  - - [23552, 768, 1, 256]
+    - [48, 4715.77]
+  - - [38016, 2688, 1, 384]
+    - [48, 5018.06]
+  - - [42240, 1792, 1, 256]
+    - [50, 4836.68]
+  - - [19712, 1281, 1, 256]
+    - [48, 4720.1]
+  - - [29440, 1281, 1, 256]
+    - [47, 4744.57]
+  - - [3328, 256, 1, 256]
+    - [41, 3479.64]
+  - - [27648, 1281, 1, 256]
+    - [48, 4713.14]
+  - - [20480, 1792, 1, 256]
+    - [50, 4764.03]
+  - - [37248, 1152, 1, 384]
+    - [48, 4983.28]
+  - - [43520, 1281, 1, 256]
+    - [48, 4743.47]
+  - - [9600, 384, 1, 384]
+    - [66, 4411.55]
+  - - [44032, 1792, 1, 256]
+    - [50, 4812.35]
+  - - [20736, 2688, 1, 384]
+    - [48, 4999.28]
+  - - [33408, 1153, 1, 384]
+    - [48, 4773.41]
+  - - [43264, 1281, 1, 256]
+    - [47, 4772.16]
+  - - [28672, 512, 1, 256]
+    - [67, 4646.05]
+  - - [26880, 512, 1, 256]
+    - [67, 4638.74]
+  - - [6144, 2688, 1, 384]
+    - [50, 4886.87]
+  - - [3456, 1153, 1, 384]
+    - [47, 4374.87]
+  - - [24064, 1280, 1, 256]
+    - [50, 4747.31]
+  - - [29184, 1024, 1, 256]
+    - [50, 4723.41]
+  - - [32256, 1536, 1, 384]
+    - [50, 4972.39]
+  - - [20352, 2688, 1, 384]
+    - [48, 4997.38]
+  - - [22016, 1024, 1, 256]
+    - [50, 4697.82]
+  - - [9216, 768, 1, 256]
+    - [47, 4501.49]
+  - - [22272, 2688, 1, 384]
+    - [48, 4998.43]
+  - - [9728, 1281, 1, 256]
+    - [48, 4561.81]
+  - - [40448, 1281, 1, 256]
+    - [48, 4729.43]
+  - - [32768, 1024, 1, 256]
+    - [50, 4746.03]
+  - - [40320, 1153, 1, 384]
+    - [48, 4776.52]
+  - - [27264, 1920, 1, 384]
+    - [49, 4989.03]
+  - - [7168, 1281, 1, 256]
+    - [47, 4501.77]
+  - - [33792, 384, 1, 384]
+    - [47, 4858.64]
+  - - [12288, 384, 1, 384]
+    - [48, 4717.12]
+  - - [10368, 1153, 1, 384]
+    - [48, 4652.05]
+  - - [17664, 256, 1, 256]
+    - [50, 4347.4]
+  - - [3840, 768, 1, 256]
+    - [59, 4201.78]
+  - - [1536, 256, 1, 256]
+    - [57, 2964.17]
+  - - [10752, 1281, 1, 256]
+    - [48, 4578.47]
+  - - [21504, 1153, 1, 384]
+    - [47, 4720.63]
+  - - [16512, 1153, 1, 384]
+    - [47, 4699.49]
+  - - [41088, 1153, 1, 384]
+    - [48, 4771.54]
+  - - [29184, 1281, 1, 256]
+    - [48, 4706.08]
+  - - [4352, 1280, 1, 256]
+    - [59, 4424.92]
+  - - [15360, 1153, 1, 384]
+    - [48, 4697.24]
+  - - [36864, 1281, 1, 256]
+    - [48, 4740.42]
+  - - [27264, 1153, 1, 384]
+    - [48, 4760.08]
+  - - [15360, 1792, 1, 256]
+    - [50, 4738.43]
+  - - [41472, 2688, 1, 384]
+    - [50, 5007.33]
+  - - [3840, 2688, 1, 384]
+    - [47, 4789.76]
+  - - [19456, 1792, 1, 256]
+    - [50, 4758.83]
+  - - [5120, 256, 1, 256]
+    - [63, 3990.77]
+  - - [30976, 1281, 1, 256]
+    - [48, 4757.82]
+  - - [34176, 768, 1, 384]
+    - [50, 4953.85]
+  - - [36480, 384, 1, 384]
+    - [48, 4869.46]
+  - - [18688, 1281, 1, 256]
+    - [48, 4701.76]
+  - - [7936, 1281, 1, 256]
+    - [48, 4515.41]
+  - - [10368, 1152, 1, 384]
+    - [48, 4831.12]
+  - - [23296, 1792, 1, 256]
+    - [50, 4790.95]
+  - - [14592, 1281, 1, 256]
+    - [48, 4655.08]
+  - - [43776, 1280, 1, 256]
+    - [50, 4823.57]
+  - - [26496, 1153, 1, 384]
+    - [48, 4755.46]
+  - - [11136, 1153, 1, 384]
+    - [48, 4643.34]
+  - - [8192, 1536, 1, 256]
+    - [67, 4614.41]
+  - - [31488, 2688, 1, 384]
+    - [48, 5013.74]
+  - - [8448, 1281, 1, 256]
+    - [48, 4537.78]
+  - - [18432, 1152, 1, 384]
+    - [48, 4928.15]
+  - - [34560, 2688, 1, 384]
+    - [48, 5026.99]
+  - - [35328, 1153, 1, 384]
+    - [48, 4765.04]
+  - - [10496, 1792, 1, 256]
+    - [49, 4694.69]
+  - - [1536, 384, 1, 384]
+    - [62, 3482.36]
+  - - [16896, 2688, 1, 384]
+    - [48, 4976.63]
+  - - [7680, 1792, 1, 256]
+    - [50, 4643.14]
+  - - [12672, 1153, 1, 384]
+    - [48, 4696.91]
+  - - [28672, 1792, 1, 256]
+    - [50, 4792.02]
+  - - [3456, 2304, 1, 384]
+    - [47, 4705.53]
+  - - [28416, 256, 1, 256]
+    - [67, 4518.32]
+  - - [43520, 1024, 1, 256]
+    - [50, 4761.64]
+  - - [42240, 768, 1, 384]
+    - [50, 4955.95]
+  - - [12800, 1792, 1, 256]
+    - [50, 4720.73]
+  - - [5760, 1920, 1, 384]
+    - [48, 4791.85]
+  - - [29184, 2688, 1, 384]
+    - [48, 5002.17]
+  - - [5120, 1281, 1, 256]
+    - [48, 4376.13]
+  - - [20352, 1153, 1, 384]
+    - [48, 4725.66]
+  - - [29952, 1153, 1, 384]
+    - [48, 4756.97]
+  - - [25344, 768, 1, 256]
+    - [48, 4741.76]
+  - - [27648, 2304, 1, 384]
+    - [48, 4997.5]
+  - - [24192, 1153, 1, 384]
+    - [48, 4747.81]
+  - - [18432, 1281, 1, 256]
+    - [48, 4668.73]
+  - - [14976, 1153, 1, 384]
+    - [48, 4709.14]
+  - - [12800, 768, 1, 256]
+    - [67, 4582.6]
+  - - [4608, 1281, 1, 256]
+    - [48, 4292.49]
+  - - [17664, 1792, 1, 256]
+    - [50, 4776.37]
+  - - [9984, 1281, 1, 256]
+    - [48, 4605.72]
+  - - [14848, 1024, 1, 256]
+    - [67, 4634.37]
+  - - [8448, 1792, 1, 256]
+    - [50, 4681.28]
+  - - [27392, 1024, 1, 256]
+    - [50, 4742.58]
+  - - [25856, 1280, 1, 256]
+    - [50, 4763.47]
+  - - [32768, 1281, 1, 256]
+    - [48, 4726.75]
+  - - [19584, 2304, 1, 384]
+    - [50, 4986.72]
+  - - [6656, 1792, 1, 256]
+    - [67, 4619.45]
+  - - [20224, 1792, 1, 256]
+    - [50, 4783.16]
+  - - [1792, 512, 1, 256]
+    - [41, 3679.23]
+  - - [11904, 1153, 1, 384]
+    - [48, 4662.03]
+  - - [39424, 1281, 1, 256]
+    - [48, 4728.66]
+  - - [33024, 1280, 1, 256]
+    - [50, 4796.93]
+  - - [25728, 2688, 1, 384]
+    - [48, 5018.34]
+  - - [41728, 1024, 1, 256]
+    - [50, 4777.24]
+  - - [38912, 1281, 1, 256]
+    - [48, 4737.67]
+  - - [21248, 1792, 1, 256]
+    - [50, 4781.87]
+  - - [4864, 1792, 1, 256]
+    - [60, 4548.99]
+  - - [8960, 1792, 1, 256]
+    - [50, 4676.88]
+  - - [25600, 1024, 1, 256]
+    - [50, 4706.09]
+  - - [26496, 1152, 1, 384]
+    - [48, 4966.94]
+  - - [11520, 2688, 1, 384]
+    - [48, 4976.42]
+  - - [9600, 2688, 1, 384]
+    - [47, 4956.31]
+  - - [7680, 1153, 1, 384]
+    - [47, 4562.25]
+  - - [18688, 1280, 1, 256]
+    - [50, 4735.44]
+  - - [15104, 1792, 1, 256]
+    - [50, 4749.53]
+  - - [39936, 1024, 1, 256]
+    - [50, 4743.1]
+  - - [19584, 1153, 1, 384]
+    - [48, 4743.67]
+  - - [38400, 2688, 1, 384]
+    - [48, 5014.11]
+  - - [10496, 256, 1, 256]
+    - [66, 4062.52]
+  - - [36352, 1281, 1, 256]
+    - [48, 4722.66]
+  - - [26880, 1153, 1, 384]
+    - [48, 4753.4]
+  - - [15104, 1280, 1, 256]
+    - [50, 4698.03]
+  - - [1920, 768, 1, 384]
+    - [43, 4220.57]
+  - - [26496, 2688, 1, 384]
+    - [50, 5003.87]
+  - - [31488, 1536, 1, 256]
+    - [48, 4805.69]
+  - - [8704, 1792, 1, 256]
+    - [67, 4664.04]
+  - - [36864, 1153, 1, 384]
+    - [48, 4761.26]
+  - - [7936, 1792, 1, 256]
+    - [67, 4649.62]
+  - - [21504, 1281, 1, 256]
+    - [48, 4693.65]
+  - - [36352, 1792, 1, 256]
+    - [50, 4799.17]
+  - - [9984, 1536, 1, 256]
+    - [48, 4676.33]
+  - - [2816, 1536, 1, 256]
+    - [53, 4363.56]
+  - - [34048, 1281, 1, 256]
+    - [48, 4762.65]
+  - - [22528, 1281, 1, 256]
+    - [48, 4679.1]
+  - - [30720, 1281, 1, 256]
+    - [48, 4719.92]
+  - - [23808, 2688, 1, 384]
+    - [48, 5005.87]
+  - - [38656, 1281, 1, 256]
+    - [48, 4749.46]
+  - - [4352, 1792, 1, 256]
+    - [67, 4560.69]
+  - - [6144, 2304, 1, 384]
+    - [50, 4863.48]
+  - - [25856, 1792, 1, 256]
+    - [50, 4812.04]
+  - - [6144, 1280, 1, 256]
+    - [64, 4554.08]
+  - - [35584, 256, 1, 256]
+    - [67, 4588.08]
+  - - [18176, 1792, 1, 256]
+    - [50, 4767.78]
+  - - [7680, 1281, 1, 256]
+    - [47, 4491.95]
+  - - [22784, 1792, 1, 256]
+    - [50, 4790.81]
+  - - [27392, 1281, 1, 256]
+    - [48, 4743.78]
+  - - [13824, 1920, 1, 384]
+    - [48, 4940.07]
+  - - [21504, 2688, 1, 384]
+    - [48, 4999.16]
+  - - [39936, 1792, 1, 256]
+    - [50, 4819.72]
+  - - [23296, 512, 1, 256]
+    - [67, 4616.37]
+  - - [17664, 384, 1, 384]
+    - [66, 4678.92]
+  - - [34816, 1281, 1, 256]
+    - [48, 4727.71]
+  - - [13056, 1281, 1, 256]
+    - [48, 4634.7]
+  - - [4352, 1281, 1, 256]
+    - [47, 4354.87]
+  - - [26112, 1153, 1, 384]
+    - [48, 4736.85]
+  - - [28416, 1792, 1, 256]
+    - [50, 4807.81]
+  - - [42240, 1153, 1, 384]
+    - [47, 4784.4]
+  - - [17664, 2688, 1, 384]
+    - [48, 4997.54]
+  - - [39936, 1281, 1, 256]
+    - [48, 4744.54]
+  - - [35584, 1792, 1, 256]
+    - [50, 4822.01]
+  - - [29568, 2688, 1, 384]
+    - [48, 5023.21]
+  - - [16128, 1281, 1, 256]
+    - [48, 4672.05]
+  - - [4608, 2688, 1, 384]
+    - [47, 4839.98]
+  - - [28416, 384, 1, 384]
+    - [48, 4848.32]
+  - - [35840, 1792, 1, 256]
+    - [50, 4802.23]
+  - - [41856, 1153, 1, 384]
+    - [48, 4788.83]
+  - - [18816, 1153, 1, 384]
+    - [48, 4729.66]
+  - - [22016, 1792, 1, 256]
+    - [50, 4778.16]
+  - - [41088, 2304, 1, 384]
+    - [48, 5015.57]
+  - - [11776, 1792, 1, 256]
+    - [50, 4693.37]
+  - - [12672, 2688, 1, 384]
+    - [47, 4970.86]
+  - - [33280, 1281, 1, 256]
+    - [48, 4728.81]
+  - - [40448, 1536, 1, 256]
+    - [48, 4786.45]
+  - - [30336, 2688, 1, 384]
+    - [48, 5020.45]
+  - - [35840, 512, 1, 256]
+    - [50, 4665.7]
+  - - [27904, 1281, 1, 256]
+    - [48, 4730.72]
+  - - [20736, 1536, 1, 256]
+    - [47, 4770.04]
+  - - [23808, 1281, 1, 256]
+    - [48, 4723.46]
+  - - [13312, 1792, 1, 256]
+    - [50, 4717.65]
+  - - [38400, 1280, 1, 256]
+    - [50, 4785.1]
+  - - [14336, 1792, 1, 256]
+    - [50, 4735.09]
+  - - [26880, 1536, 1, 384]
+    - [48, 4965.69]
+  - - [24320, 1536, 1, 256]
+    - [48, 4777.97]
+  - - [39936, 1152, 1, 384]
+    - [48, 4977.52]
+  - - [31488, 1153, 1, 384]
+    - [48, 4748.23]
+  - - [2560, 1280, 1, 256]
+    - [60, 4264.24]
+  - - [36096, 768, 1, 256]
+    - [48, 4784.38]
+  - - [33536, 1792, 1, 256]
+    - [50, 4817.23]
+  - - [39680, 1281, 1, 256]
+    - [48, 4770.19]
+  - - [11520, 1792, 1, 256]
+    - [50, 4718.25]
+  - - [4864, 1281, 1, 256]
+    - [48, 4330.23]
+  - - [5376, 1153, 1, 384]
+    - [48, 4480.87]
+  - - [10752, 1792, 1, 256]
+    - [50, 4701.56]
+  - - [21888, 2688, 1, 384]
+    - [48, 5003.63]
+  - - [2688, 1536, 1, 384]
+    - [66, 4561.13]
+  - - [43776, 2304, 1, 384]
+    - [48, 5011.15]
+  - - [26880, 1281, 1, 256]
+    - [48, 4732.99]
+  - - [26112, 2688, 1, 384]
+    - [48, 4995.36]
+  - - [5376, 512, 1, 256]
+    - [67, 4184.34]
+  - - [256, 257, 1, 256]
+    - [54, 714.888]
+  - - [3840, 1153, 1, 384]
+    - [45, 4488.78]
+  - - [1920, 1153, 1, 384]
+    - [47, 4399.11]
+  - - [13056, 1024, 1, 256]
+    - [67, 4628.82]
+  - - [20224, 1281, 1, 256]
+    - [48, 4705.54]
+  - - [11136, 1920, 1, 384]
+    - [48, 4930.19]
+  - - [18688, 1792, 1, 256]
+    - [50, 4770.18]
+  - - [42240, 2688, 1, 384]
+    - [50, 5012.04]
+  - - [19200, 1792, 1, 256]
+    - [50, 4785.62]
+  - - [21504, 1792, 1, 256]
+    - [50, 4777.79]
+  - - [5888, 1281, 1, 256]
+    - [48, 4452.74]
+  - - [10368, 2688, 1, 384]
+    - [48, 4971.37]
+  - - [384, 385, 1, 384]
+    - [57, 1705.85]
+  - - [41216, 512, 1, 256]
+    - [50, 4699.58]
+  - - [7936, 1280, 1, 256]
+    - [67, 4592.52]
+  - - [14208, 2688, 1, 384]
+    - [48, 4984.22]
+  - - [22272, 2304, 1, 384]
+    - [48, 4997.02]
+  - - [41728, 1792, 1, 256]
+    - [50, 4829.31]
+  - - [11520, 1153, 1, 384]
+    - [48, 4657.31]
+  - - [33536, 1281, 1, 256]
+    - [48, 4747.08]
+  - - [13056, 1153, 1, 384]
+    - [47, 4694.31]
+  - - [38656, 1536, 1, 256]
+    - [47, 4810.6]
+  - - [8832, 2304, 1, 384]
+    - [48, 4931.33]
+  - - [8448, 1153, 1, 384]
+    - [48, 4641.58]
+  - - [38400, 1792, 1, 256]
+    - [50, 4808.46]
+  - - [31744, 1792, 1, 256]
+    - [50, 4797.47]
+  - - [3072, 1792, 1, 256]
+    - [60, 4511.16]
+  - - [34560, 1024, 1, 256]
+    - [50, 4761.84]
+  - - [37632, 512, 1, 256]
+    - [50, 4693.33]
+  - - [2304, 1152, 1, 384]
+    - [45, 4290.36]
+  - - [33792, 1792, 1, 256]
+    - [50, 4805.2]
+  - - [4224, 1153, 1, 384]
+    - [45, 4432.56]
+  - - [26624, 1281, 1, 256]
+    - [48, 4707.94]
+  - - [12800, 1281, 1, 256]
+    - [48, 4600.39]
+  - - [6912, 1792, 1, 256]
+    - [50, 4628.77]
+  - - [19968, 1153, 1, 384]
+    - [48, 4721.78]
+  - - [4608, 1536, 1, 256]
+    - [51, 4506.42]
+  - - [43008, 512, 1, 256]
+    - [50, 4690.11]
+  - - [20352, 384, 1, 384]
+    - [47, 4798.26]
+  - - [5888, 1024, 1, 256]
+    - [64, 4487.45]
+  - - [6912, 2688, 1, 384]
+    - [48, 4904.25]
+  - - [42624, 1152, 1, 384]
+    - [48, 5002.25]
+  - - [38400, 2304, 1, 384]
+    - [50, 4997.65]
+  - - [6400, 1281, 1, 256]
+    - [47, 4437.19]
+  - - [1792, 1281, 1, 256]
+    - [45, 4269.55]
+  - - [36864, 1536, 1, 256]
+    - [47, 4778.38]
+  - - [31488, 768, 1, 384]
+    - [48, 4942.41]
+  - - [30720, 768, 1, 256]
+    - [48, 4747.97]
+  - - [24576, 2688, 1, 384]
+    - [48, 4992.39]
+  - - [25728, 1153, 1, 384]
+    - [48, 4760.42]
+  - - [37248, 1153, 1, 384]
+    - [48, 4780.35]
+  - - [7680, 2688, 1, 384]
+    - [48, 4912.64]
+  - - [41728, 1281, 1, 256]
+    - [47, 4768.78]
+  - - [41984, 1281, 1, 256]
+    - [48, 4739.37]
+  - - [13056, 1792, 1, 256]
+    - [50, 4732.36]
+  - - [6528, 1153, 1, 384]
+    - [47, 4595.34]
+  - - [9728, 1792, 1, 256]
+    - [50, 4674.4]
+  - - [36608, 1281, 1, 256]
+    - [48, 4764.0]
+  - - [11520, 2304, 1, 384]
+    - [48, 4949.86]
+  - - [3072, 1153, 1, 384]
+    - [70, 4205.74]
+  - - [28416, 1153, 1, 384]
+    - [48, 4767.5]
+  - - [40704, 2688, 1, 384]
+    - [48, 5012.57]
+  - - [31872, 2688, 1, 384]
+    - [48, 5016.16]
+  - - [9216, 1281, 1, 256]
+    - [48, 4539.56]
+  - - [42240, 1536, 1, 256]
+    - [48, 4817.01]
+  - - [32640, 1153, 1, 384]
+    - [48, 4779.48]
+  - - [4096, 1792, 1, 256]
+    - [60, 4539.21]
+  - - [12672, 768, 1, 384]
+    - [48, 4829.57]
+  - - [9216, 2688, 1, 384]
+    - [48, 4927.32]
+  - - [16128, 1792, 1, 256]
+    - [50, 4766.62]
+  - - [37376, 1792, 1, 256]
+    - [50, 4805.26]
+  - - [15616, 1792, 1, 256]
+    - [50, 4754.36]
+  - - [17664, 1281, 1, 256]
+    - [48, 4681.01]
+  - - [13824, 1153, 1, 384]
+    - [48, 4663.1]
+  - - [37888, 768, 1, 256]
+    - [48, 4761.38]
+  - - [33024, 2304, 1, 384]
+    - [48, 5009.0]
+  - - [9984, 1153, 1, 384]
+    - [48, 4632.8]
+  - - [2304, 1153, 1, 384]
+    - [61, 4218.09]
+  - - [15872, 256, 1, 256]
+    - [67, 4269.36]
+  - - [35712, 2304, 1, 384]
+    - [48, 5004.96]
+  - - [11520, 1280, 1, 256]
+    - [50, 4661.49]
+  - - [35712, 1153, 1, 384]
+    - [48, 4783.96]
+  - - [17152, 1281, 1, 256]
+    - [48, 4685.89]
+  - - [34048, 512, 1, 256]
+    - [67, 4671.46]
+  - - [40320, 1536, 1, 384]
+    - [50, 4981.17]
+  - - [13312, 1281, 1, 256]
+    - [48, 4624.45]
+  - - [19200, 1920, 1, 384]
+    - [47, 4972.1]
+  - - [11008, 768, 1, 256]
+    - [48, 4555.19]
+  - - [29952, 2688, 1, 384]
+    - [48, 5023.66]
+  - - [2816, 1281, 1, 256]
+    - [61, 4135.92]
+  - - [18816, 2688, 1, 384]
+    - [48, 5003.38]
+  - - [27648, 1792, 1, 256]
+    - [50, 4796.03]
+  - - [31872, 1153, 1, 384]
+    - [47, 4759.0]
+  - - [2304, 1281, 1, 256]
+    - [44, 4182.71]
+  - - [26880, 2688, 1, 384]
+    - [50, 5006.88]
+  - - [17152, 1536, 1, 256]
+    - [48, 4765.18]
+  - - [13824, 2688, 1, 384]
+    - [48, 4971.99]
+  - - [7424, 1281, 1, 256]
+    - [48, 4524.94]
+  - - [20480, 1281, 1, 256]
+    - [48, 4676.45]
+  - - [28928, 768, 1, 256]
+    - [48, 4758.6]
+  - - [6400, 1792, 1, 256]
+    - [67, 4630.93]
+  - - [28416, 1281, 1, 256]
+    - [48, 4752.17]
+  - - [9984, 768, 1, 384]
+    - [48, 4738.95]
+  - - [13312, 1280, 1, 256]
+    - [67, 4677.73]
+  - - [23424, 768, 1, 384]
+    - [50, 4906.12]
+  - - [40320, 2688, 1, 384]
+    - [50, 5013.68]
+  - - [38912, 1792, 1, 256]
+    - [50, 4813.24]
+  - - [24576, 1792, 1, 256]
+    - [50, 4783.24]
+  - - [24064, 1281, 1, 256]
+    - [48, 4702.55]
+  - - [43008, 1281, 1, 256]
+    - [48, 4749.16]
+  - - [11520, 1281, 1, 256]
+    - [48, 4630.36]
+  - - [12544, 512, 1, 256]
+    - [67, 4485.4]
+  - - [32000, 256, 1, 256]
+    - [50, 4552.29]
+  - - [11264, 1024, 1, 256]
+    - [67, 4601.08]
+  - - [21760, 1281, 1, 256]
+    - [48, 4711.77]
+  - - [25600, 1792, 1, 256]
+    - [50, 4785.75]
+  - - [30208, 1792, 1, 256]
+    - [50, 4790.7]
+  - - [27264, 2688, 1, 384]
+    - [48, 5011.12]
+  - - [8064, 1536, 1, 384]
+    - [50, 4826.03]
+  - - [14336, 512, 1, 256]
+    - [67, 4522.59]
+  - - [36608, 1792, 1, 256]
+    - [50, 4820.1]
+  - - [22656, 1153, 1, 384]
+    - [48, 4733.2]
+  - - [40192, 1281, 1, 256]
+    - [48, 4762.81]
+  - - [9984, 1792, 1, 256]
+    - [50, 4698.01]
+  - - [27648, 1280, 1, 256]
+    - [50, 4772.28]
+  - - [5632, 1281, 1, 256]
+    - [47, 4414.71]
+  - - [10752, 1153, 1, 384]
+    - [47, 4637.3]
+  - - [40704, 1153, 1, 384]
+    - [48, 4767.66]
+  - - [29952, 1281, 1, 256]
+    - [48, 4744.08]
+  - - [35328, 2688, 1, 384]
+    - [48, 5014.45]
+  - - [34560, 1152, 1, 384]
+    - [48, 4976.77]
+  - - [16896, 2304, 1, 384]
+    - [50, 4970.24]
+  - - [22528, 1792, 1, 256]
+    - [50, 4775.24]
+  - - [42752, 1281, 1, 256]
+    - [48, 4766.15]
+  - - [32256, 2688, 1, 384]
+    - [50, 5000.78]
+  - - [36608, 1280, 1, 256]
+    - [50, 4810.67]
+  - - [43008, 1792, 1, 256]
+    - [50, 4811.02]
+  - - [21888, 1153, 1, 384]
+    - [48, 4752.7]
+  - - [19712, 512, 1, 256]
+    - [67, 4588.5]
+  - - [14592, 1153, 1, 384]
+    - [48, 4697.55]
+  - - [4608, 768, 1, 384]
+    - [45, 4695.77]
+  - - [36480, 1153, 1, 384]
+    - [47, 4765.66]
+  - - [18816, 1536, 1, 384]
+    - [48, 4937.94]
+  - - [25088, 512, 1, 256]
+    - [64, 4607.83]
+  - - [26880, 1792, 1, 256]
+    - [50, 4814.49]
+  - - [2048, 768, 1, 256]
+    - [65, 4196.06]
+  - - [38016, 1153, 1, 384]
+    - [48, 4781.67]
+  - - [37120, 1281, 1, 256]
+    - [48, 4764.82]
+  - - [6912, 384, 1, 384]
+    - [69, 4280.98]
+  - - [34176, 2688, 1, 384]
+    - [48, 5012.1]
+  - - [29184, 1153, 1, 384]
+    - [47, 4743.35]
+  - - [25344, 1153, 1, 384]
+    - [48, 4740.16]
+  - - [9600, 1153, 1, 384]
+    - [48, 4617.61]
+  - - [16384, 1281, 1, 256]
+    - [48, 4665.44]
+  - - [7680, 1024, 1, 256]
+    - [67, 4555.73]
+  - - [27392, 1792, 1, 256]
+    - [50, 4812.62]
+  - - [15360, 1536, 1, 256]
+    - [48, 4720.8]
+  - - [39424, 1792, 1, 256]
+    - [50, 4805.31]
+  - - [30720, 1792, 1, 256]
+    - [50, 4800.35]
+  - - [21120, 1152, 1, 384]
+    - [48, 4952.4]
+  - - [31744, 1281, 1, 256]
+    - [48, 4720.66]
+  - - [33792, 256, 1, 256]
+    - [67, 4548.54]
+  - - [27136, 768, 1, 256]
+    - [48, 4734.95]
+  - - [28800, 1153, 1, 384]
+    - [48, 4769.32]
+  - - [8192, 1792, 1, 256]
+    - [67, 4648.81]
+  - - [27648, 2688, 1, 384]
+    - [50, 4993.81]
+  - - [3072, 1920, 1, 384]
+    - [45, 4794.51]
+  - - [17408, 1792, 1, 256]
+    - [50, 4765.8]
+  - - [26624, 256, 1, 256]
+    - [67, 4509.07]
+  - - [32512, 1792, 1, 256]
+    - [50, 4823.97]
+  - - [36864, 768, 1, 384]
+    - [50, 4935.28]
+  - - [30336, 2304, 1, 384]
+    - [47, 5004.46]
+  - - [5376, 1792, 1, 256]
+    - [67, 4606.03]
+  - - [12032, 1281, 1, 256]
+    - [48, 4629.18]
+  - - [5632, 768, 1, 256]
+    - [64, 4369.76]
+  - - [28672, 1281, 1, 256]
+    - [48, 4710.14]
+  - - [30464, 1281, 1, 256]
+    - [48, 4744.42]
+  - - [32256, 512, 1, 256]
+    - [67, 4659.1]
+  - - [18944, 1792, 1, 256]
+    - [50, 4756.03]
+  - - [38144, 1792, 1, 256]
+    - [50, 4829.07]
+  - - [30336, 1153, 1, 384]
+    - [48, 4758.49]
+  - - [23424, 2688, 1, 384]
+    - [48, 5004.11]
+  - - [25728, 384, 1, 384]
+    - [48, 4761.23]
+  - - [2048, 1281, 1, 256]
+    - [64, 3971.23]
+  - - [43392, 1920, 1, 384]
+    - [48, 5013.64]
+  - - [20480, 1280, 1, 256]
+    - [50, 4736.65]
+  - - [512, 513, 1, 256]
+    - [55, 2088.2]
+  - - [4096, 1024, 1, 256]
+    - [66, 4344.32]
+  - - [41856, 384, 1, 384]
+    - [48, 4923.83]
+  - - [33024, 2688, 1, 384]
+    - [48, 5008.77]
+  - - [38400, 1281, 1, 256]
+    - [48, 4727.86]
+  - - [6528, 2688, 1, 384]
+    - [48, 4915.49]
+  - - [41216, 1792, 1, 256]
+    - [50, 4834.25]
+  - - [14848, 1281, 1, 256]
+    - [47, 4640.68]
+  - - [12288, 2688, 1, 384]
+    - [48, 4954.21]
+  - - [8832, 1153, 1, 384]
+    - [47, 4666.78]
+  - - [28032, 2688, 1, 384]
+    - [48, 5015.81]
+  - - [25344, 1281, 1, 256]
+    - [48, 4725.61]
+  - - [13440, 2688, 1, 384]
+    - [48, 4980.56]
+  - - [14208, 1153, 1, 384]
+    - [48, 4701.23]
+  - - [32512, 1281, 1, 256]
+    - [48, 4755.51]
+  - - [12288, 256, 1, 256]
+    - [52, 4279.9]
+  - - [38784, 2688, 1, 384]
+    - [48, 5016.86]
+  - - [42240, 1281, 1, 256]
+    - [48, 4771.55]
+  - - [16384, 768, 1, 256]
+    - [47, 4623.41]
+  - - [7296, 768, 1, 384]
+    - [48, 4588.58]
+  - - [14592, 1792, 1, 256]
+    - [50, 4751.23]
+  - - [31232, 1792, 1, 256]
+    - [50, 4794.84]
+  - - [41472, 1281, 1, 256]
+    - [48, 4747.6]
+  - - [19968, 1281, 1, 256]
+    - [48, 4669.3]
+  - - [9472, 1281, 1, 256]
+    - [48, 4570.64]
+  - - [21760, 768, 1, 256]
+    - [48, 4713.95]
+  - - [29568, 1536, 1, 384]
+    - [47, 4977.48]
+  - - [38016, 1920, 1, 384]
+    - [48, 5000.97]
+  - - [12288, 1792, 1, 256]
+    - [50, 4726.61]
+  - - [7168, 1792, 1, 256]
+    - [67, 4637.99]
+  - - [4992, 1153, 1, 384]
+    - [47, 4395.82]
+  - - [23552, 1281, 1, 256]
+    - [47, 4694.48]
+  - - [30720, 2688, 1, 384]
+    - [48, 5005.29]
+  - - [33792, 1281, 1, 256]
+    - [48, 4727.97]
+  - - [37888, 1792, 1, 256]
+    - [50, 4803.88]
+  - - [32256, 1281, 1, 256]
+    - [48, 4723.46]
+  - - [33792, 1153, 1, 384]
+    - [48, 4755.35]
+  - - [18048, 2688, 1, 384]
+    - [48, 4998.01]
+  - - [11776, 1281, 1, 256]
+    - [48, 4608.32]
+  - - [34944, 2688, 1, 384]
+    - [48, 5024.78]
+  - - [24192, 2688, 1, 384]
+    - [48, 5013.09]
+  - - [40192, 1792, 1, 256]
+    - [50, 4814.29]
+  - - [32640, 2688, 1, 384]
+    - [48, 5010.34]
+  - - [34304, 1792, 1, 256]
+    - [50, 4796.29]
+  - - [17280, 2688, 1, 384]
+    - [48, 4998.23]
+  - - [35328, 1792, 1, 256]
+    - [50, 4809.71]
+  - - [32640, 1920, 1, 384]
+    - [48, 5007.99]
+  - - [13440, 1536, 1, 384]
+    - [50, 4901.58]
+  - - [35840, 1281, 1, 256]
+    - [48, 4723.89]
+  - - [36096, 1153, 1, 384]
+    - [48, 4786.97]
+  - - [31232, 1281, 1, 256]
+    - [48, 4718.99]
+  - - [30976, 1024, 1, 256]
+    - [50, 4748.19]
+  - - [14336, 1281, 1, 256]
+    - [48, 4623.25]
+  - - [25600, 1281, 1, 256]
+    - [48, 4700.01]
+  - - [18944, 1281, 1, 256]
+    - [48, 4669.16]
+  - - [26624, 1792, 1, 256]
+    - [50, 4790.86]
+  - - [11008, 1281, 1, 256]
+    - [48, 4602.37]
+  - - [18944, 1536, 1, 256]
+    - [48, 4750.33]
+  - - [7296, 2688, 1, 384]
+    - [48, 4949.31]
+  - - [33024, 1281, 1, 256]
+    - [48, 4756.07]
+  - - [23040, 1153, 1, 384]
+    - [48, 4719.8]
+  - - [17408, 1281, 1, 256]
+    - [48, 4660.63]
+  - - [11904, 2688, 1, 384]
+    - [48, 4975.95]
+  - - [1152, 1153, 1, 384]
+    - [56, 3862.85]
+  - - [29952, 1792, 1, 256]
+    - [50, 4817.72]
+  - - [23296, 1281, 1, 256]
+    - [48, 4727.12]
+  - - [19584, 2688, 1, 384]
+    - [48, 5001.35]
+  - - [6144, 1153, 1, 384]
+    - [48, 4526.24]
+  - - [7168, 512, 1, 256]
+    - [64, 4387.84]
+  - - [16128, 2688, 1, 384]
+    - [48, 4989.63]
+  - - [31104, 1153, 1, 384]
+    - [48, 4765.83]
+  - - [3840, 1281, 1, 256]
+    - [48, 4322.65]
+  - - [8064, 2688, 1, 384]
+    - [48, 4928.35]
+  - - [43264, 768, 1, 256]
+    - [48, 4799.71]
+  - - [19456, 1281, 1, 256]
+    - [48, 4659.75]
+  - - [20992, 1792, 1, 256]
+    - [50, 4763.52]
+  - - [35072, 1536, 1, 256]
+    - [47, 4811.15]
+  - - [16128, 1153, 1, 384]
+    - [48, 4704.52]
+  - - [43776, 2688, 1, 384]
+    - [48, 5017.35]
+  - - [8064, 1153, 1, 384]
+    - [48, 4605.72]
+  - - [40960, 1281, 1, 256]
+    - [48, 4733.27]
+  - - [5632, 1792, 1, 256]
+    - [64, 4586.54]
+  - - [38656, 1792, 1, 256]
+    - [50, 4821.77]
+  - - [16896, 1280, 1, 256]
+    - [50, 4718.64]
+  - - [28160, 1281, 1, 256]
+    - [48, 4713.97]
+  - - [35712, 2688, 1, 384]
+    - [48, 5022.49]
+  - - [11264, 1792, 1, 256]
+    - [50, 4693.86]
+  - - [21120, 1153, 1, 384]
+    - [47, 4739.54]
+  - - [34560, 1792, 1, 256]
+    - [50, 4821.86]
+  - - [42624, 1153, 1, 384]
+    - [48, 4793.85]
+  - - [10496, 1281, 1, 256]
+    - [47, 4591.8]
+  - - [9472, 1024, 1, 256]
+    - [67, 4589.02]
+  - - [3584, 512, 1, 256]
+    - [67, 4142.53]
+  - - [34176, 1153, 1, 384]
+    - [48, 4774.42]
+  - - [8704, 256, 1, 256]
+    - [68, 4140.72]
+  - - [7424, 1792, 1, 256]
+    - [67, 4650.92]
+  - - [38144, 1281, 1, 256]
+    - [48, 4764.38]
+  - - [14848, 1792, 1, 256]
+    - [50, 4729.98]
+  - - [25856, 1281, 1, 256]
+    - [48, 4735.98]
+  - - [6144, 1792, 1, 256]
+    - [60, 4604.31]
+  - - [43008, 1153, 1, 384]
+    - [48, 4776.95]
+  - - [9728, 1280, 1, 256]
+    - [67, 4626.79]
+  - - [32000, 1281, 1, 256]
+    - [48, 4748.14]
+  - - [25088, 1281, 1, 256]
+    - [48, 4698.82]
+  - - [43520, 1792, 1, 256]
+    - [50, 4813.37]
+  - - [5376, 1281, 1, 256]
+    - [48, 4472.31]
+  - - [33024, 1792, 1, 256]
+    - [50, 4823.8]
+  - - [41472, 1153, 1, 384]
+    - [48, 4763.06]
+  - - [28800, 768, 1, 384]
+    - [48, 4925.35]
+  - - [6912, 256, 1, 256]
+    - [58, 4038.74]
+  - - [31232, 1280, 1, 256]
+    - [50, 4776.4]
+  - - [7296, 1153, 1, 384]
+    - [47, 4543.35]
+  - - [42624, 2688, 1, 384]
+    - [48, 5025.24]
+  - - [30464, 1792, 1, 256]
+    - [50, 4822.97]
+  - - [8960, 512, 1, 256]
+    - [67, 4386.69]
+  - - [40704, 1920, 1, 384]
+    - [50, 5002.17]
+  - - [41216, 1281, 1, 256]
+    - [48, 4769.44]
+  - - [40960, 256, 1, 256]
+    - [50, 4593.66]
+  - - [9984, 2688, 1, 384]
+    - [48, 4938.75]
+  - - [6656, 1281, 1, 256]
+    - [48, 4480.54]
+  - - [19968, 768, 1, 256]
+    - [48, 4674.76]
+  - - [28032, 1153, 1, 384]
+    - [48, 4764.6]
+  - - [11008, 1792, 1, 256]
+    - [50, 4705.85]
+  - - [10240, 1281, 1, 256]
+    - [48, 4582.51]
+  - - [39680, 1792, 1, 256]
+    - [50, 4820.63]
+  - - [1536, 1153, 1, 384]
+    - [45, 4165.04]
+  - - [11264, 1281, 1, 256]
+    - [47, 4594.82]
+  - - [20736, 1153, 1, 384]
+    - [48, 4731.06]
+  - - [24960, 2688, 1, 384]
+    - [50, 5003.59]
+  - - [24576, 1281, 1, 256]
+    - [48, 4712.41]
+  - - [22272, 1792, 1, 256]
+    - [50, 4791.74]
+  - - [11776, 1536, 1, 256]
+    - [47, 4672.38]
+  - - [27904, 1792, 1, 256]
+    - [50, 4799.49]
+  - - [25344, 1792, 1, 256]
+    - [50, 4805.65]
+  - - [37632, 1281, 1, 256]
+    - [48, 4759.89]
+  - - [14976, 2688, 1, 384]
+    - [47, 4979.35]
+  - - [41984, 1280, 1, 256]
+    - [50, 4796.97]
+  - - [3584, 1281, 1, 256]
+    - [47, 4353.05]
+  - - [23808, 1153, 1, 384]
+    - [48, 4749.75]
+  - - [35328, 1281, 1, 256]
+    - [48, 4726.16]
+  - - [31104, 384, 1, 384]
+    - [48, 4838.05]
+  - - [29952, 1920, 1, 384]
+    - [48, 4994.75]
+  - - [13056, 2688, 1, 384]
+    - [48, 4976.33]
+  - - [20736, 1281, 1, 256]
+    - [48, 4712.72]
+  - - [36096, 1281, 1, 256]
+    - [47, 4760.08]
+  - - [16640, 1024, 1, 256]
+    - [64, 4659.14]
+  - - [12544, 1281, 1, 256]
+    - [48, 4621.22]
+  - - [768, 769, 1, 256]
+    - [40, 3197.79]
+  - - [33792, 2688, 1, 384]
+    - [48, 5013.43]
+  - - [29440, 1280, 1, 256]
+    - [50, 4789.06]
+  - - [24064, 1792, 1, 256]
+    - [50, 4778.72]
+  - - [23040, 256, 1, 256]
+    - [50, 4477.9]
+  - - [14208, 2304, 1, 384]
+    - [48, 4950.35]
+  - - [26368, 1281, 1, 256]
+    - [48, 4739.23]
+  - - [2688, 1153, 1, 384]
+    - [48, 4224.48]
+  - - [32512, 768, 1, 256]
+    - [48, 4773.09]
+  - - [10752, 1536, 1, 384]
+    - [50, 4878.3]
+  - - [30464, 512, 1, 256]
+    - [50, 4657.51]
+  - - [34560, 1153, 1, 384]
+    - [48, 4777.06]
+  - - [29696, 1536, 1, 256]
+    - [48, 4769.37]
+  - - [34816, 1280, 1, 256]
+    - [50, 4783.12]
+  - - [5760, 2688, 1, 384]
+    - [48, 4889.65]
+  - - [43392, 1153, 1, 384]
+    - [48, 4787.6]
+  - - [13824, 1281, 1, 256]
+    - [48, 4630.44]
+  - - [5120, 1792, 1, 256]
+    - [67, 4586.45]
+  - - [15744, 1153, 1, 384]
+    - [47, 4683.97]
+  - - [15744, 1152, 1, 384]
+    - [48, 4899.57]
+  - - [23552, 1792, 1, 256]
+    - [50, 4780.85]
+  - - [14592, 768, 1, 256]
+    - [67, 4635.04]
+  - - [3328, 1281, 1, 256]
+    - [48, 4217.04]
+  - - [27136, 1792, 1, 256]
+    - [50, 4792.01]
+  - - [34560, 1281, 1, 256]
+    - [48, 4763.72]
+  - - [42496, 1281, 1, 256]
+    - [48, 4740.25]
+  - - [37376, 1281, 1, 256]
+    - [48, 4733.21]
+  - - [8832, 2688, 1, 384]
+    - [48, 4941.63]
+  - - [16384, 1792, 1, 256]
+    - [50, 4737.29]
+  - - [42752, 1792, 1, 256]
+    - [50, 4828.59]
+  - - [12288, 1281, 1, 256]
+    - [47, 4597.78]
+  - - [14592, 2688, 1, 384]
+    - [48, 4978.89]
+  - - [37632, 1536, 1, 384]
+    - [48, 4986.8]
+  - - [3840, 1792, 1, 256]
+    - [50, 4501.71]
+  - - [39168, 1792, 1, 256]
+    - [50, 4821.81]
+  - - [29184, 1792, 1, 256]
+    - [50, 4800.02]
+  - - [8960, 1281, 1, 256]
+    - [47, 4562.59]
+  - - [19712, 1792, 1, 256]
+    - [50, 4776.32]
+  - - [16896, 1281, 1, 256]
+    - [48, 4659.58]
+  - - [24192, 1536, 1, 384]
+    - [50, 4959.76]
+  - - [24576, 1153, 1, 384]
+    - [48, 4740.05]
+  - - [34944, 1153, 1, 384]
+    - [48, 4779.53]
+  - - [44032, 1536, 1, 256]
+    - [48, 4794.92]
+  - - [36096, 1792, 1, 256]
+    - [50, 4824.3]
+  - - [42496, 1792, 1, 256]
+    - [50, 4807.63]
+  - - [19200, 1281, 1, 256]
+    - [48, 4682.99]
+  - - [18432, 1024, 1, 256]
+    - [67, 4671.51]
+  - - [18048, 768, 1, 384]
+    - [50, 4833.25]
+  - - [3328, 1792, 1, 256]
+    - [67, 4515.34]
+  - - [44032, 1281, 1, 256]
+    - [48, 4727.75]
+  - - [37376, 256, 1, 256]
+    - [67, 4565.14]
+  - - [33280, 1792, 1, 256]
+    - [50, 4802.54]
+  - - [1024, 1025, 1, 256]
+    - [45, 3873.97]
+  - - [13056, 1152, 1, 384]
+    - [48, 4870.76]
+  - - [17280, 1153, 1, 384]
+    - [48, 4733.91]
+  - - [28928, 1792, 1, 256]
+    - [50, 4816.49]
+  - - [18176, 768, 1, 256]
+    - [48, 4679.62]
+  - - [34304, 768, 1, 256]
+    - [48, 4747.33]
+  - - [43008, 2688, 1, 384]
+    - [48, 5017.6]
+  - - [17920, 512, 1, 256]
+    - [64, 4534.38]
+  - - [20224, 1024, 1, 256]
+    - [50, 4691.51]
+  - - [36352, 1024, 1, 256]
+    - [50, 4742.06]
+  - - [15872, 1281, 1, 256]
+    - [48, 4647.98]
+  - - [43392, 2688, 1, 384]
+    - [48, 5024.48]
+  - - [31488, 1281, 1, 256]
+    - [48, 4749.18]
+  - - [5376, 1536, 1, 384]
+    - [49, 4817.82]
+  - - [13440, 1153, 1, 384]
+    - [48, 4659.82]
+  - - [20736, 1792, 1, 256]
+    - [50, 4787.65]
+  - - [22272, 1280, 1, 256]
+    - [50, 4762.4]
+  - - [19968, 2688, 1, 384]
+    - [48, 4986.6]
+  - - [40448, 1792, 1, 256]
+    - [50, 4805.8]
+  - - [768, 769, 1, 384]
+    - [42, 3429.95]
+  - - [2304, 1024, 1, 256]
+    - [58, 4314.14]
+  - - [41472, 768, 1, 256]
+    - [48, 4774.96]
+  - - [26112, 1281, 1, 256]
+    - [48, 4697.34]
+  - - [16640, 1281, 1, 256]
+    - [48, 4686.41]
+  - - [24832, 256, 1, 256]
+    - [67, 4447.88]
+  - - [39424, 512, 1, 256]
+    - [67, 4680.94]
+  - - [36864, 2688, 1, 384]
+    - [48, 5007.54]
+  - - [22272, 1153, 1, 384]
+    - [48, 4740.03]
+  - - [39168, 1153, 1, 384]
+    - [48, 4778.17]
+  - - [39168, 1281, 1, 256]
+    - [48, 4765.94]
+  - - [21120, 2688, 1, 384]
+    - [48, 4991.18]
+  - - [21504, 1536, 1, 384]
+    - [50, 4946.4]
+  - - [37248, 2688, 1, 384]
+    - [48, 5021.82]
+  - - [1280, 1281, 1, 256]
+    - [58, 3842.53]
+  - - [30208, 1281, 1, 256]
+    - [48, 4713.96]
+  - - [17920, 1792, 1, 256]
+    - [50, 4751.93]
+  - - [35584, 1281, 1, 256]
+    - [48, 4767.64]
+  - - [18432, 1153, 1, 384]
+    - [47, 4703.42]
+  - - [25088, 1792, 1, 256]
+    - [50, 4787.67]
+  - - [30976, 1792, 1, 256]
+    - [50, 4808.38]
+  - - [17152, 1792, 1, 256]
+    - [50, 4767.18]
+  - - [17920, 1281, 1, 256]
+    - [48, 4656.44]
+  - - [24320, 1281, 1, 256]
+    - [47, 4727.12]
+  - - [9216, 1792, 1, 256]
+    - [50, 4685.13]
+  - - [36864, 1792, 1, 256]
+    - [50, 4809.47]
+  - - [32256, 1153, 1, 384]
+    - [48, 4750.59]
+  - - [23040, 2688, 1, 384]
+    - [48, 4996.41]
+  - - [19200, 2688, 1, 384]
+    - [48, 5002.95]
+  - - [4096, 1281, 1, 256]
+    - [48, 4343.64]
+  - - [31104, 2688, 1, 384]
+    - [48, 5018.55]
+  - - [3072, 1281, 1, 256]
+    - [47, 4171.85]
+  - - [16128, 1536, 1, 384]
+    - [50, 4930.48]
+  - - [6144, 1281, 1, 256]
+    - [48, 4443.84]
+  - - [16896, 1792, 1, 256]
+    - [50, 4766.49]
+  - - [13568, 1281, 1, 256]
+    - [48, 4649.36]
+  - - [21504, 512, 1, 256]
+    - [67, 4591.1]
+  - - [33024, 1153, 1, 384]
+    - [48, 4775.81]
+  - - [22272, 1281, 1, 256]
+    - [48, 4720.89]
+  - - [8448, 2688, 1, 384]
+    - [48, 4941.38]
+  - - [43776, 1792, 1, 256]
+    - [50, 4835.25]
+  - - [26112, 768, 1, 384]
+    - [49, 4886.63]
+  - - [39552, 1153, 1, 384]
+    - [48, 4779.82]
+  - - [28928, 1281, 1, 256]
+    - [48, 4741.46]
+  - - [6912, 1281, 1, 256]
+    - [48, 4512.09]
+  - - [15360, 2688, 1, 384]
+    - [48, 4975.48]
+  - - [12288, 1153, 1, 384]
+    - [48, 4660.87]
+  - - [39552, 768, 1, 384]
+    - [48, 4951.42]
+  - - [42752, 256, 1, 256]
+    - [50, 4621.9]
+  - - [23808, 1792, 1, 256]
+    - [50, 4803.14]
+  - - [32000, 1792, 1, 256]
+    - [50, 4806.26]
+  - - [15872, 1792, 1, 256]
+    - [50, 4746.86]
+  - - [34944, 1536, 1, 384]
+    - [47, 4973.79]
+  - - [41472, 1792, 1, 256]
+    - [50, 4813.86]
+  - - [14080, 256, 1, 256]
+    - [68, 4362.46]
+  - - [8704, 1281, 1, 256]
+    - [47, 4522.4]
+  - - [6912, 1153, 1, 384]
+    - [48, 4512.12]
+  - - [41984, 1792, 1, 256]
+    - [50, 4810.2]
+  - - [19200, 1153, 1, 384]
+    - [48, 4730.57]
+  - - [14080, 1281, 1, 256]
+    - [48, 4647.83]
+  - - [34048, 1792, 1, 256]
+    - [50, 4820.2]
+  - - [8192, 1281, 1, 256]
+    - [48, 4524.78]
+  - - [7680, 1152, 1, 384]
+    - [48, 4774.02]
+  - - [15360, 768, 1, 384]
+    - [49, 4864.32]
+  - - [5888, 1792, 1, 256]
+    - [50, 4604.73]
+  - - [18432, 1792, 1, 256]
+    - [50, 4769.26]
+  - - [41088, 2688, 1, 384]
+    - [48, 5020.68]
+  - - [37632, 1153, 1, 384]
+    - [48, 4768.48]
+  - - [15744, 2688, 1, 384]
+    - [48, 5005.8]
+  - - [43776, 1153, 1, 384]
+    - [48, 4788.54]
+  - - [27136, 1281, 1, 256]
+    - [48, 4708.2]
+  - - [28800, 2688, 1, 384]
+    - [48, 5020.15]
+  - - [18048, 1153, 1, 384]
+    - [48, 4707.0]
+  - - [35072, 1281, 1, 256]
+    - [48, 4754.44]
+  - - [33280, 1536, 1, 256]
+    - [48, 4782.63]
+  - - [9472, 1792, 1, 256]
+    - [67, 4673.97]
+  - - [15360, 1281, 1, 256]
+    - [47, 4619.83]
+  - - [2560, 1281, 1, 256]
+    - [48, 4186.7]
+  - - [29696, 1792, 1, 256]
+    - [50, 4799.3]
+  - - [10752, 2688, 1, 384]
+    - [48, 4951.16]
+  - - [39168, 384, 1, 384]
+    - [48, 4866.49]
+  - - [23040, 1281, 1, 256]
+    - [48, 4696.1]
+  - - [21888, 1920, 1, 384]
+    - [47, 4980.86]
+  - - [40192, 1280, 1, 256]
+    - [50, 4812.23]
+  - - [15616, 1281, 1, 256]
+    - [47, 4669.08]
+  - - [23808, 1152, 1, 384]
+    - [48, 4960.2]
+  - - [24960, 2304, 1, 384]
+    - [48, 4987.31]
+  - - [18432, 2688, 1, 384]
+    - [48, 4980.93]
+  - - [37632, 1792, 1, 256]
+    - [50, 4830.86]
+  - - [38144, 1024, 1, 256]
+    - [50, 4768.98]
+  - - [39680, 768, 1, 256]
+    - [48, 4796.26]
+  - - [32256, 1792, 1, 256]
+    - [50, 4803.63]
+  - - [38400, 1153, 1, 384]
+    - [47, 4767.02]
+  - - [22528, 1536, 1, 256]
+    - [47, 4755.81]
+  - - [27648, 1153, 1, 384]
+    - [48, 4743.4]
+  - - [12032, 1792, 1, 256]
+    - [50, 4722.54]
+  - - [20992, 1281, 1, 256]
+    - [48, 4673.73]
+  - - [14976, 384, 1, 384]
+    - [50, 4691.72]
+  - - [16896, 1153, 1, 384]
+    - [48, 4705.1]
+  - - [28160, 1792, 1, 256]
+    - [50, 4791.85]
+  - - [32768, 1792, 1, 256]
+    - [50, 4801.33]
+  - - [12544, 1792, 1, 256]
+    - [50, 4719.5]
+  - - [36480, 2688, 1, 384]
+    - [48, 5015.93]
+  - - [10240, 1792, 1, 256]
+    - [50, 4673.5]
+  - - [13824, 1792, 1, 256]
+    - [50, 4741.59]
+  - - [16128, 512, 1, 256]
+    - [50, 4548.43]
+  - - [23040, 384, 1, 384]
+    - [48, 4759.58]
+  - - [27904, 1536, 1, 256]
+    - [48, 4804.82]
+  - - [4224, 2688, 1, 384]
+    - [50, 4844.21]
+  - - [40704, 1792, 1, 256]
+    - [50, 4821.64]
+  - - [23424, 1153, 1, 384]
+    - [47, 4746.81]
+  - - [39168, 256, 1, 256]
+    - [49, 4563.56]
+  - - [8448, 1920, 1, 384]
+    - [48, 4891.27]
+  - - [16512, 1920, 1, 384]
+    - [48, 4966.21]
+  - - [1536, 1281, 1, 256]
+    - [59, 3993.89]
+  - - [40704, 1281, 1, 256]
+    - [48, 4758.82]
+  - - [10752, 512, 1, 256]
+    - [51, 4449.63]
 - null


### PR DESCRIPTION
-  Re-tuned all DGEMM NT sizes with Tensile DataInitTypeBeta set to 2
-  More DGEMM NT sizes are tuned, including k=256,n=1792 and k=384,n=2688
-  For certain DGEMM NT sizes, take leading dimensions into account when tuning
