### PR TITLE
restore support of rocBLAS build without an AMD GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ if( BUILD_WITH_TENSILE )
   else()
     # Use the virtual-env setup and download package from specified repot:
     set( tensile_fork "ROCmSoftwarePlatform" CACHE STRING "Tensile fork to use" )
-    set( tensile_tag d81a997e7cace7da2edfb8c5d40a9b6b2387bdf9 CACHE STRING "Tensile tag to download" )
+    set( tensile_tag 94a44425095b6abb3b9f064d2082d2b18716c243 CACHE STRING "Tensile tag to download" )
     virtualenv_install("git+https://github.com/${tensile_fork}/Tensile.git@${tensile_tag}")
     message (STATUS "using GIT Tensile fork=${tensile_fork} from branch=${tensile_tag}")
   endif()


### PR DESCRIPTION
Use Tensile commit 94a44425095b6abb3b9f064d2082d2b18716c243 to build rocBLAS.