### PR TITLE
Fixed an issue where the build woulf fail if `/usr/bin/python` was python3

### DIFF
--- a/cmake/virtualenv.cmake
+++ b/cmake/virtualenv.cmake
@@ -1,8 +1,10 @@
 # find_package(PythonInterp)
 # # TODO: Check PYTHON_VERSION_MAJOR
 
-find_program(VIRTUALENV_PYTHON_EXE python)
-
+find_program(VIRTUALENV_PYTHON_EXE python2)
+if(NOT VIRTUALENV_PYTHON_EXE)
+    find_program(VIRTUALENV_PYTHON_EXE python)
+endif()
 
 set(VIRTUALENV_SOURCE_DIR ${CMAKE_BINARY_DIR}/virtualenv-source CACHE PATH "Path to virtualenv source")
 set(VIRTUALENV_HOME_DIR ${CMAKE_BINARY_DIR}/virtualenv CACHE PATH "Path to virtual environment")


### PR DESCRIPTION

resolves #499 

Summary of proposed changes:
A minor tweak to the relevant file where it first tries to find a binary explicitly named `python2` and will use that if it does, if not, then it makes the check already in upstream.

This fixes the build for the following scenario:
```
ls -l /usr/bin/python*

python3
python2
python -> python3
```

Which happens in newer distros (in my case, Arch)