### PR TITLE
DGEMM NT tuning for Feb 24 sizes with Raman's 2 6x4 replacement kernels

### DIFF
--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
@@ -15293,6 +15293,6566 @@
     _staggerStrideShift: 2
     fractionalPerpOverhangA: 0
     fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 896
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 93
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x32x4_SE_PLR0_SNLL1_TT4_4_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 896
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 94
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x32x4_SE_PLR0_SNLL0_TT4_4_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 95
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR1_SNLL1_TT4_6_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 96
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR0_SNLL1_TT4_6_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 97
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR0_SNLL0_TT4_6_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 32
+    LSPA: 2
+    LSPB: 4
+    LVCA: 64
+    LVCB: 16
+    LVPA: 1
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 128
+    MacroTile1: 32
+    MacroTileA: 128
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 98
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x32x4_SE_PLR0_SNLL1_TT8_4_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [8, 4]
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 128
+    LSCB: 32
+    LSPA: 2
+    LSPB: 4
+    LVCA: 64
+    LVCB: 16
+    LVPA: 1
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 128
+    MacroTile1: 32
+    MacroTileA: 128
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 99
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT128x32x4_SE_PLR0_SNLL0_TT8_4_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [8, 4]
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 100
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x4_SE_PLR1_SNLL1_TT4_8_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 128
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 64
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 101
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x128x4_SE_PLR1_SNLL1_TT4_8_WG16_16_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 128
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 64
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 102
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x128x4_SE_PLR1_SNLL0_TT4_8_WG16_16_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 103
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR0_SNLL1_TT4_6_WG16_8_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 104
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR0_SNLL0_TT4_6_WG16_8_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 48
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 24
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 192
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 192
+    LdsOffsetB_Blk: 704
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 48
+    MacroTile1: 64
+    MacroTileA: 48
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 105
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_PLR0_SNLL0_TT6_4_WG8_16_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 16
+    SubGroupA: 8
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 16, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 48
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 96
+    MacroTile1: 64
+    MacroTileA: 96
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 106
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT96x64x4_SE_PLR0_SNLL0_TT6_4_WG16_16_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 32
+    LSPA: 2
+    LSPB: 4
+    LVCA: 48
+    LVCB: 16
+    LVPA: 1
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 128
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 896
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 96
+    MacroTile1: 32
+    MacroTileA: 96
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 107
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT96x32x4_SE_PLR1_SNLL1_TT6_4_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 108
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR0_SNLL1_TT4_6_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 109
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR1_SNLL0_TT4_6_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 192
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 110
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x4_SE_PLR0_SNLL0_TT4_6_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1024
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 768
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 111
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x4_SE_PLR1_SNLL1_TT4_8_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 8]
+    ThreadTile0: 4
+    ThreadTile1: 8
+    ThreadTileA: 4
+    ThreadTileB: 8
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 48
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 24
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 960
+    LdsNumElementsAlignedA: 192
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 512
+    LdsOffsetB: 192
+    LdsOffsetB_Blk: 704
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 48
+    MacroTile1: 64
+    MacroTileA: 48
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 112
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_PLR0_SNLL0_TT6_4_WG8_16_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 8
+    SubGroup1: 16
+    SubGroupA: 8
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [8, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 64
+    LSPA: 4
+    LSPB: 4
+    LVCA: 48
+    LVCB: 32
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 384
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 384
+    LdsOffsetB_Blk: 1408
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 96
+    MacroTile1: 64
+    MacroTileA: 96
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 113
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT96x64x4_SE_PLR0_SNLL0_TT6_4_WG16_16_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 4
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 96
+    LSPA: 4
+    LSPB: 4
+    LVCA: 32
+    LVCB: 48
+    LVPA: 2
+    LVPB: 2
+    LdcEqualsLdd: true
+    LdsNumElements: 1664
+    LdsNumElementsAlignedA: 256
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 256
+    LdsOffsetB_Blk: 1280
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 4
+    MacroTile0: 64
+    MacroTile1: 96
+    MacroTileA: 64
+    MacroTileB: 96
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 114
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x96x4_SE_PLR0_SNLL0_TT4_6_WG16_16_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 3
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 115
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x32x8_SE_PLR1_SNLL1_TT4_4_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 116
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x32x8_SE_PLR1_SNLL0_TT4_4_WG16_8_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 117
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR1_SNLL1_TT4_4_WG16_16_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 118
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR0_SNLL1_TT4_4_WG16_16_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 119
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR1_SNLL0_TT4_4_WG16_16_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 120
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR0_SNLL0_TT4_4_WG16_16_1_WGM1
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 32
+    LSPA: 2
+    LSPB: 8
+    LVCA: 48
+    LVCB: 16
+    LVPA: 1
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 1792
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 96
+    MacroTile1: 32
+    MacroTileA: 96
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 121
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT96x32x8_SE_PLR1_SNLL1_TT6_4_WG16_8_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 122
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR1_SNLL1_TT4_4_WG16_16_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 123
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR0_SNLL1_TT4_4_WG16_16_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 124
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR1_SNLL0_TT4_4_WG16_16_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 125
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR0_SNLL0_TT4_4_WG16_16_1_WGM4
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 32
+    LSPA: 4
+    LSPB: 8
+    LVCA: 32
+    LVCB: 16
+    LVPA: 2
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 1792
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 32
+    MacroTileA: 64
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 126
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x32x8_SE_PLR1_SNLL1_TT4_4_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 96
+    LSCB: 32
+    LSPA: 2
+    LSPB: 8
+    LVCA: 48
+    LVCB: 16
+    LVPA: 1
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 768
+    LdsNumElementsAlignedB: 256
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 768
+    LdsOffsetB_Blk: 1792
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 96
+    MacroTile1: 32
+    MacroTileA: 96
+    MacroTileB: 32
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 1
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 127
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT96x32x8_SE_PLR1_SNLL1_TT6_4_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [6, 4]
+    ThreadTile0: 6
+    ThreadTile1: 4
+    ThreadTileA: 6
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 48
+    LSPA: 4
+    LSPB: 5
+    LVCA: 32
+    LVCB: 24
+    LVPA: 2
+    LVPB: 3
+    LdcEqualsLdd: true
+    LdsNumElements: 1920
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 384
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 48
+    MacroTileA: 64
+    MacroTileB: 48
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 24
+    NumGlobalWriteVectorsPerThread: 12
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 128
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 128
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x48x8_SE_PLR1_SNLL1_TT4_6_WG16_8_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 8
+    SubGroupA: 16
+    SubGroupB: 8
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 6]
+    ThreadTile0: 4
+    ThreadTile1: 6
+    ThreadTileA: 4
+    ThreadTileB: 6
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 3
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 129
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR1_SNLL1_TT4_4_WG16_16_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 130
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR0_SNLL1_TT4_4_WG16_16_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: true
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: true
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 131
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR1_SNLL0_TT4_4_WG16_16_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
+  - AggressivePerfMode: 1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertMinApproxSize: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: false
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CheckDimOverflow: 0
+    CheckTensorDimAsserts: false
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DisableKernelPieces: 0
+    EdgeType: ShiftPtr
+    ExpandPointerSwap: true
+    FractionalLoad: true
+    GlobalLoadVectorWidthA: 2
+    GlobalLoadVectorWidthB: 2
+    GlobalRead2A: true
+    GlobalRead2B: true
+    GlobalReadCoalesceGroupA: true
+    GlobalReadCoalesceGroupB: true
+    GlobalReadCoalesceVectorA: true
+    GlobalReadCoalesceVectorB: true
+    GlobalReadVectorWidth: 2
+    GlobalSplitU: 1
+    GlobalSplitUSummationAssignmentRoundRobin: true
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: false
+    InnerUnroll: 1
+    KernelLanguage: Assembly
+    LSCA: 64
+    LSCB: 64
+    LSPA: 8
+    LSPB: 8
+    LVCA: 32
+    LVCB: 32
+    LVPA: 4
+    LVPB: 4
+    LdcEqualsLdd: true
+    LdsNumElements: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LocalDotLayout: 1
+    LocalRead2A: true
+    LocalRead2B: true
+    LocalSplitU: 1
+    LocalWrite2A: true
+    LocalWrite2B: true
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopDoWhile: false
+    LoopTail: true
+    LoopUnroll: 8
+    MacroTile0: 64
+    MacroTile1: 64
+    MacroTileA: 64
+    MacroTileB: 64
+    MacroTileShapeMax: 64
+    MacroTileShapeMin: 1
+    MaxOccupancy: 40
+    MinGlobalWriteVectorWidth: 1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NumElementsPerThread: 16
+    NumGlobalWriteVectorsPerThread: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 256
+    PackBatchDims: 0
+    PackFreeDims: 1
+    PackGranularity: 2
+    PackedC0Indices: [I]
+    PackedC1Indices: [J]
+    PerformanceSyncLocation: -1
+    PerformanceWaitCount: -1
+    PerformanceWaitLocation: -1
+    PersistentKernel: 0
+    PrefetchGlobalRead: true
+    PrefetchLocalRead: false
+    ProblemType:
+      AssignedDerivedParameters: true
+      Batched: true
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      DataType: 1
+      DestDataType: 1
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesSummation: 1
+      NumIndiciesLD: 4
+      OperationType: GEMM
+      SilentHighPrecisionAccumulate: false
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseInitialStrides: false
+    ReplacementKernel: true
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 132
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_MT64x64x8_SE_PLR0_SNLL0_TT4_4_WG16_16_1_WGM8
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
+    SuppressNoLoadLoop: false
+    ThreadTile: [4, 4]
+    ThreadTile0: 4
+    ThreadTile1: 4
+    ThreadTileA: 4
+    ThreadTileB: 4
+    UnrollMemFence: false
+    UseSgprForGRO: false
+    Valid: true
+    VectorAtomicWidth: 1
+    VectorStore: true
+    VectorWidth: 2
+    WorkGroup: [16, 16, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingType: B
+    _staggerStrideShift: 2
+    fractionalPerpOverhangA: 0
+    fractionalPerpOverhangB: 0
 - [2, 3, 0, 1]
 - - - [38144, 38144, 1, 256]
     - [14, 4943.8]
@@ -15386,8 +21946,6 @@
     - [9, 4930.11]
   - - [5888, 5888, 1, 256]
     - [9, 4847.58]
-  - - [1536, 2048, 1, 256]
-    - [25, 4331.47]
   - - [28032, 28032, 1, 384]
     - [8, 5039.79]
   - - [42496, 42496, 1, 256]
@@ -15398,8 +21956,6 @@
     - [14, 4915.12]
   - - [11008, 11008, 1, 256]
     - [9, 4903.83]
-  - - [2816, 3072, 1, 256]
-    - [29, 4596.5]
   - - [19328, 128, 1, 128]
     - [37, 3802.47]
   - - [32000, 32000, 1, 256]
@@ -15434,8 +21990,6 @@
     - [12, 4936.95]
   - - [20736, 20736, 1, 256]
     - [9, 4947.98]
-  - - [1280, 2048, 1, 256]
-    - [26, 4362.26]
   - - [7168, 7168, 1, 256]
     - [14, 4838.49]
   - - [18432, 18432, 1, 256]
@@ -15470,8 +22024,6 @@
     - [9, 4887.21]
   - - [9088, 128, 1, 384]
     - [34, 4442.06]
-  - - [512, 2048, 1, 256]
-    - [6, 3952.23]
   - - [17152, 17152, 1, 256]
     - [9, 4931.31]
   - - [44928, 128, 1, 384]
@@ -15540,10 +22092,6 @@
     - [12, 5040.32]
   - - [12928, 128, 1, 384]
     - [37, 4086.94]
-  - - [44800, 2048, 1, 256]
-    - [14, 4809.67]
-  - - [1792, 3072, 1, 256]
-    - [22, 4509.43]
   - - [36480, 36480, 1, 384]
     - [12, 5046.82]
   - - [30720, 30720, 1, 256]
@@ -15576,8 +22124,6 @@
     - [37, 4181.28]
   - - [16384, 16384, 1, 256]
     - [9, 4903.36]
-  - - [1792, 2048, 1, 256]
-    - [25, 4410.91]
   - - [1920, 1920, 1, 384]
     - [24, 4414.31]
   - - [3968, 128, 1, 128]
@@ -15628,8 +22174,6 @@
     - [14, 4936.55]
   - - [35968, 128, 1, 128]
     - [38, 4143.0]
-  - - [512, 3072, 1, 256]
-    - [25, 4128.94]
   - - [4608, 4608, 1, 256]
     - [14, 4771.78]
   - - [3456, 3456, 1, 384]
@@ -15698,8 +22242,6 @@
     - [38, 4099.57]
   - - [5632, 5632, 1, 256]
     - [9, 4794.28]
-  - - [768, 2048, 1, 256]
-    - [23, 4180.37]
   - - [19456, 19456, 1, 256]
     - [14, 4903.62]
   - - [22016, 22016, 1, 256]
@@ -15712,16 +22254,12 @@
     - [37, 3276.8]
   - - [13568, 13568, 1, 256]
     - [9, 4929.85]
-  - - [1024, 2048, 1, 256]
-    - [24, 4204.82]
   - - [30848, 128, 1, 384]
     - [37, 4442.81]
   - - [1408, 128, 1, 384]
     - [37, 2028.31]
   - - [5760, 5760, 1, 5760]
     - [18, 5159.55]
-  - - [1536, 3072, 1, 256]
-    - [22, 4462.03]
   - - [10752, 10752, 1, 384]
     - [14, 4998.43]
   - - [39936, 39936, 1, 256]
@@ -15774,8 +22312,6 @@
     - [37, 4050.1]
   - - [43264, 43264, 1, 256]
     - [14, 4943.12]
-  - - [2560, 3072, 1, 256]
-    - [25, 4550.38]
   - - [19712, 19712, 1, 256]
     - [9, 4935.51]
   - - [34176, 34176, 1, 384]
@@ -15798,20 +22334,14 @@
     - [9, 4947.45]
   - - [33408, 128, 1, 384]
     - [35, 4605.83]
-  - - [768, 3072, 1, 256]
-    - [5, 4408.62]
   - - [43648, 128, 1, 256]
     - [37, 4512.42]
-  - - [1024, 3072, 1, 256]
-    - [24, 4323.1]
   - - [19328, 128, 1, 384]
     - [37, 4341.12]
   - - [33792, 33792, 1, 256]
     - [9, 4920.25]
   - - [31488, 31488, 1, 256]
     - [8, 4951.46]
-  - - [1280, 3072, 1, 256]
-    - [26, 4493.1]
   - - [1408, 128, 1, 128]
     - [37, 1624.55]
   - - [768, 3072, 1, 384]
@@ -15858,8 +22388,6 @@
     - [38, 4272.7]
   - - [24448, 128, 1, 256]
     - [37, 4426.03]
-  - - [256, 3072, 1, 256]
-    - [27, 3856.83]
   - - [31872, 31872, 1, 384]
     - [12, 5041.26]
   - - [1408, 128, 1, 256]
@@ -15906,8 +22434,6 @@
     - [35, 4629.78]
   - - [17664, 17664, 1, 384]
     - [9, 5030.74]
-  - - [2304, 3072, 1, 256]
-    - [29, 4548.05]
   - - [12800, 12800, 1, 256]
     - [14, 4888.6]
   - - [2304, 2304, 1, 384]
@@ -16050,8 +22576,6 @@
     - [9, 4930.53]
   - - [2688, 2688, 1, 384]
     - [9, 4703.56]
-  - - [2048, 3072, 1, 256]
-    - [25, 4521.15]
   - - [9216, 9216, 1, 256]
     - [14, 4886.08]
   - - [6656, 6656, 1, 256]
@@ -16074,8 +22598,6 @@
     - [9, 4884.07]
   - - [41856, 41856, 1, 384]
     - [12, 5048.24]
-  - - [44800, 3072, 1, 256]
-    - [9, 4845.14]
   - - [44288, 44288, 1, 256]
     - [9, 4953.6]
   - - [7744, 7744, 1, 7744]
@@ -16090,8 +22612,6 @@
     - [9, 5027.29]
   - - [36096, 36096, 1, 384]
     - [12, 5035.57]
-  - - [44544, 2048, 1, 256]
-    - [14, 4797.35]
   - - [44544, 44544, 1, 384]
     - [12, 5036.22]
   - - [22528, 22528, 1, 256]
@@ -16140,252 +22660,76 @@
     - [9, 4999.3]
   - - [128, 128, 1, 128]
     - [36, 153.75]
-  - - [256, 2048, 1, 256]
-    - [21, 3711.8]
   - - [10240, 10240, 1, 256]
     - [14, 4871.33]
   - - [40320, 40320, 1, 384]
     - [12, 5041.89]
-  - - [30464, 256, 1, 256]
-    - [83, 4542.43]
-  - - [25088, 256, 1, 256]
-    - [83, 4468.82]
-  - - [6656, 1281, 1, 256]
-    - [54, 4501.62]
-  - - [28672, 768, 1, 256]
-    - [54, 4755.0]
-  - - [41728, 768, 1, 256]
-    - [54, 4800.61]
-  - - [36352, 768, 1, 256]
-    - [54, 4789.76]
-  - - [41728, 1536, 1, 256]
-    - [54, 4821.32]
-  - - [15104, 1024, 1, 256]
-    - [83, 4650.05]
   - - [18048, 3072, 1, 384]
     - [53, 4976.0]
   - - [2304, 1153, 1, 384]
     - [73, 4220.18]
-  - - [28928, 1281, 1, 256]
-    - [54, 4738.72]
   - - [18432, 2688, 1, 384]
     - [54, 4980.46]
-  - - [35328, 1280, 1, 256]
-    - [58, 4788.1]
   - - [3840, 2304, 1, 384]
     - [53, 4762.52]
-  - - [22272, 512, 1, 256]
-    - [83, 4605.06]
   - - [41856, 384, 1, 384]
     - [53, 4914.42]
   - - [30720, 1152, 1, 384]
     - [53, 4975.45]
-  - - [28416, 768, 1, 256]
-    - [54, 4763.0]
   - - [43008, 2304, 1, 384]
     - [58, 5000.2]
-  - - [20992, 1024, 1, 256]
-    - [58, 4689.89]
-  - - [38400, 1536, 1, 256]
-    - [54, 4789.23]
-  - - [7936, 1792, 1, 256]
-    - [83, 4649.39]
-  - - [42240, 1536, 1, 256]
-    - [54, 4823.78]
-  - - [33536, 1536, 1, 256]
-    - [54, 4814.77]
-  - - [23808, 1792, 1, 256]
-    - [58, 4794.46]
-  - - [8192, 1280, 1, 256]
-    - [83, 4599.97]
-  - - [32512, 1792, 1, 256]
-    - [58, 4808.85]
-  - - [3072, 256, 1, 256]
-    - [56, 3901.68]
   - - [26496, 768, 1, 384]
     - [53, 4924.0]
-  - - [37120, 1792, 1, 256]
-    - [58, 4825.08]
-  - - [11520, 2048, 1, 256]
-    - [58, 4718.0]
-  - - [20480, 2048, 1, 256]
-    - [58, 4759.07]
   - - [43776, 3072, 1, 384]
     - [54, 5014.4]
-  - - [18176, 1280, 1, 256]
-    - [58, 4736.99]
-  - - [19968, 2048, 1, 256]
-    - [58, 4773.21]
-  - - [33024, 1280, 1, 256]
-    - [58, 4805.45]
-  - - [32768, 1024, 1, 256]
-    - [58, 4754.54]
   - - [30336, 1536, 1, 384]
     - [58, 4974.95]
-  - - [4096, 1281, 1, 256]
-    - [54, 4350.95]
   - - [38400, 384, 1, 384]
     - [54, 4880.8]
-  - - [7168, 512, 1, 256]
-    - [84, 4365.01]
-  - - [34816, 1281, 1, 256]
-    - [53, 4753.54]
-  - - [9984, 1280, 1, 256]
-    - [83, 4632.89]
-  - - [33536, 1280, 1, 256]
-    - [57, 4783.93]
   - - [28800, 384, 1, 384]
     - [53, 4796.4]
-  - - [13824, 1792, 1, 256]
-    - [58, 4742.73]
   - - [3840, 3072, 1, 384]
     - [54, 4825.56]
-  - - [43008, 512, 1, 256]
-    - [57, 4704.52]
-  - - [28160, 1281, 1, 256]
-    - [54, 4749.67]
-  - - [41728, 1281, 1, 256]
-    - [54, 4772.44]
-  - - [5632, 2048, 1, 256]
-    - [83, 4611.72]
-  - - [41216, 2048, 1, 256]
-    - [58, 4805.9]
-  - - [18688, 1281, 1, 256]
-    - [54, 4700.32]
-  - - [8192, 1792, 1, 256]
-    - [83, 4650.42]
   - - [44160, 3072, 1, 384]
     - [54, 5014.27]
   - - [41472, 1153, 1, 384]
     - [54, 4774.86]
-  - - [19712, 512, 1, 256]
-    - [80, 4572.91]
   - - [33408, 1920, 1, 384]
     - [54, 4993.44]
-  - - [20992, 1280, 1, 256]
-    - [58, 4758.08]
-  - - [10752, 1536, 1, 256]
-    - [54, 4661.98]
-  - - [43008, 2048, 1, 256]
-    - [58, 4810.26]
   - - [6912, 384, 1, 384]
     - [85, 4285.3]
-  - - [9472, 1792, 1, 256]
-    - [83, 4679.41]
   - - [21504, 1153, 1, 384]
     - [54, 4755.34]
-  - - [37120, 1281, 1, 256]
-    - [54, 4751.73]
-  - - [20736, 1024, 1, 256]
-    - [58, 4708.78]
-  - - [6144, 768, 1, 256]
-    - [80, 4441.03]
   - - [24576, 1920, 1, 384]
     - [54, 4996.19]
-  - - [35840, 512, 1, 256]
-    - [58, 4674.62]
   - - [23040, 3072, 1, 384]
     - [54, 4993.0]
   - - [28032, 1152, 1, 384]
     - [54, 4958.04]
   - - [35328, 1153, 1, 384]
     - [54, 4764.12]
-  - - [41984, 1792, 1, 256]
-    - [58, 4830.23]
-  - - [18176, 256, 1, 256]
-    - [57, 4406.56]
   - - [33792, 2688, 1, 384]
     - [54, 5010.32]
-  - - [17920, 2048, 1, 256]
-    - [58, 4754.1]
   - - [8448, 768, 1, 384]
     - [54, 4666.98]
-  - - [21760, 768, 1, 256]
-    - [54, 4715.2]
-  - - [24064, 1280, 1, 256]
-    - [58, 4764.87]
-  - - [16384, 1280, 1, 256]
-    - [58, 4716.35]
-  - - [23296, 1280, 1, 256]
-    - [58, 4756.28]
-  - - [24320, 1281, 1, 256]
-    - [54, 4720.85]
-  - - [20992, 256, 1, 256]
-    - [83, 4419.6]
-  - - [19712, 2048, 1, 256]
-    - [58, 4758.36]
-  - - [32768, 768, 1, 256]
-    - [53, 4765.41]
   - - [8064, 2688, 1, 384]
     - [54, 4918.57]
-  - - [16896, 1536, 1, 256]
-    - [54, 4729.75]
   - - [33408, 2304, 1, 384]
     - [54, 5005.26]
   - - [31872, 1536, 1, 384]
     - [53, 4961.7]
-  - - [2560, 1280, 1, 256]
-    - [70, 4282.53]
-  - - [23808, 768, 1, 256]
-    - [53, 4722.59]
-  - - [28416, 1281, 1, 256]
-    - [54, 4737.29]
-  - - [43008, 1281, 1, 256]
-    - [54, 4761.93]
-  - - [14848, 1792, 1, 256]
-    - [58, 4740.38]
-  - - [8960, 1792, 1, 256]
-    - [58, 4679.01]
-  - - [22016, 1792, 1, 256]
-    - [58, 4788.22]
-  - - [42496, 1536, 1, 256]
-    - [54, 4818.54]
   - - [41088, 1920, 1, 384]
     - [54, 5004.32]
-  - - [9472, 1024, 1, 256]
-    - [83, 4585.63]
-  - - [39168, 768, 1, 256]
-    - [54, 4797.85]
   - - [17280, 3072, 1, 384]
     - [58, 4974.84]
-  - - [6144, 2048, 1, 256]
-    - [83, 4627.93]
-  - - [5120, 1280, 1, 256]
-    - [83, 4545.69]
   - - [37632, 3072, 1, 384]
     - [54, 5005.85]
-  - - [19456, 512, 1, 256]
-    - [83, 4553.82]
-  - - [5888, 1280, 1, 256]
-    - [83, 4551.29]
-  - - [22016, 512, 1, 256]
-    - [83, 4597.38]
-  - - [24064, 1024, 1, 256]
-    - [58, 4717.21]
   - - [38016, 1153, 1, 384]
     - [54, 4766.18]
-  - - [30976, 1792, 1, 256]
-    - [58, 4800.52]
-  - - [4352, 1024, 1, 256]
-    - [83, 4437.73]
-  - - [7936, 256, 1, 256]
-    - [82, 4104.27]
-  - - [7936, 512, 1, 256]
-    - [82, 4315.41]
   - - [32640, 1152, 1, 384]
     - [54, 4988.29]
   - - [27264, 1153, 1, 384]
     - [54, 4754.61]
-  - - [25344, 768, 1, 256]
-    - [54, 4734.73]
-  - - [19200, 1792, 1, 256]
-    - [58, 4780.64]
-  - - [14080, 1280, 1, 256]
-    - [58, 4684.57]
-  - - [15616, 1536, 1, 256]
-    - [54, 4735.24]
-  - - [7168, 256, 1, 256]
-    - [72, 4130.87]
   - - [30336, 1153, 1, 384]
     - [54, 4774.67]
   - - [18048, 384, 1, 384]
@@ -16394,32 +22738,16 @@
     - [53, 4995.1]
   - - [41088, 2304, 1, 384]
     - [54, 5013.44]
-  - - [17664, 1792, 1, 256]
-    - [58, 4766.37]
   - - [3840, 1153, 1, 384]
     - [54, 4480.73]
   - - [16128, 2304, 1, 384]
     - [54, 4975.6]
-  - - [10240, 1792, 1, 256]
-    - [58, 4688.81]
-  - - [41216, 1024, 1, 256]
-    - [58, 4761.13]
   - - [5376, 1536, 1, 384]
     - [59, 4759.68]
   - - [39552, 3072, 1, 384]
     - [54, 5007.73]
-  - - [39424, 2048, 1, 256]
-    - [58, 4802.71]
-  - - [26112, 256, 1, 256]
-    - [59, 4510.0]
   - - [23808, 3072, 1, 384]
     - [54, 4987.65]
-  - - [28160, 1280, 1, 256]
-    - [58, 4772.27]
-  - - [9728, 512, 1, 256]
-    - [83, 4455.79]
-  - - [34816, 2048, 1, 256]
-    - [58, 4801.26]
   - - [24192, 1153, 1, 384]
     - [54, 4749.07]
   - - [16128, 1536, 1, 384]
@@ -16428,172 +22756,60 @@
     - [58, 4746.55]
   - - [36480, 2688, 1, 384]
     - [54, 5016.76]
-  - - [29440, 1281, 1, 256]
-    - [54, 4737.12]
   - - [21504, 1152, 1, 384]
     - [54, 4942.78]
-  - - [37376, 1792, 1, 256]
-    - [58, 4824.84]
   - - [38400, 1153, 1, 384]
     - [54, 4772.96]
-  - - [5376, 256, 1, 256]
-    - [73, 3690.0]
-  - - [6400, 1281, 1, 256]
-    - [54, 4446.59]
   - - [39168, 1153, 1, 384]
     - [54, 4772.76]
-  - - [40192, 1280, 1, 256]
-    - [58, 4799.74]
-  - - [10240, 1024, 1, 256]
-    - [80, 4593.67]
-  - - [38912, 256, 1, 256]
-    - [80, 4567.85]
   - - [21888, 1153, 1, 384]
     - [53, 4731.82]
-  - - [15872, 1280, 1, 256]
-    - [58, 4719.55]
-  - - [20224, 1024, 1, 256]
-    - [58, 4689.03]
   - - [19968, 1152, 1, 384]
     - [54, 4935.19]
-  - - [19456, 256, 1, 256]
-    - [79, 4408.95]
   - - [28416, 2304, 1, 384]
     - [58, 4999.62]
-  - - [29184, 1536, 1, 256]
-    - [54, 4765.23]
-  - - [40960, 512, 1, 256]
-    - [58, 4691.12]
-  - - [19968, 512, 1, 256]
-    - [83, 4583.3]
-  - - [37376, 1281, 1, 256]
-    - [54, 4764.93]
   - - [26880, 768, 1, 384]
     - [54, 4925.95]
-  - - [21248, 512, 1, 256]
-    - [83, 4601.51]
-  - - [26112, 1281, 1, 256]
-    - [54, 4719.4]
-  - - [8448, 1281, 1, 256]
-    - [54, 4563.19]
   - - [15360, 768, 1, 384]
     - [54, 4830.5]
-  - - [25600, 1024, 1, 256]
-    - [58, 4718.8]
   - - [42624, 768, 1, 384]
     - [58, 4943.89]
-  - - [39680, 1024, 1, 256]
-    - [58, 4762.24]
-  - - [22784, 1536, 1, 256]
-    - [54, 4787.24]
-  - - [17152, 1280, 1, 256]
-    - [58, 4730.0]
-  - - [12800, 1024, 1, 256]
-    - [83, 4628.2]
-  - - [18176, 512, 1, 256]
-    - [83, 4565.67]
-  - - [26624, 512, 1, 256]
-    - [83, 4632.62]
   - - [13056, 3072, 1, 384]
     - [57, 4961.56]
-  - - [15104, 1281, 1, 256]
-    - [54, 4646.13]
-  - - [21760, 256, 1, 256]
-    - [82, 4386.81]
-  - - [25344, 1281, 1, 256]
-    - [53, 4730.77]
   - - [43008, 1920, 1, 384]
     - [54, 5006.56]
   - - [34944, 384, 1, 384]
     - [53, 4833.68]
   - - [19584, 384, 1, 384]
     - [53, 4684.91]
-  - - [9216, 512, 1, 256]
-    - [58, 4426.06]
   - - [44160, 2688, 1, 384]
     - [54, 5024.47]
-  - - [12288, 1281, 1, 256]
-    - [54, 4635.44]
-  - - [11776, 1280, 1, 256]
-    - [83, 4655.61]
-  - - [3072, 1281, 1, 256]
-    - [82, 4177.39]
-  - - [15360, 1792, 1, 256]
-    - [58, 4757.5]
-  - - [41216, 512, 1, 256]
-    - [58, 4691.42]
   - - [4992, 1536, 1, 384]
     - [58, 4711.65]
   - - [39168, 768, 1, 384]
     - [54, 4956.79]
-  - - [23296, 768, 1, 256]
-    - [54, 4730.61]
   - - [16896, 1153, 1, 384]
     - [53, 4720.07]
-  - - [17920, 1792, 1, 256]
-    - [58, 4768.03]
-  - - [1792, 1280, 1, 256]
-    - [43, 4297.45]
-  - - [19456, 2048, 1, 256]
-    - [58, 4763.05]
   - - [6144, 1536, 1, 384]
     - [57, 4824.64]
-  - - [9984, 1536, 1, 256]
-    - [83, 4659.68]
-  - - [17664, 2048, 1, 256]
-    - [58, 4761.85]
   - - [26112, 1152, 1, 384]
     - [54, 4963.44]
-  - - [25600, 1792, 1, 256]
-    - [58, 4796.62]
-  - - [10496, 1024, 1, 256]
-    - [83, 4613.15]
-  - - [24064, 512, 1, 256]
-    - [80, 4625.08]
-  - - [12800, 1792, 1, 256]
-    - [58, 4723.62]
   - - [1152, 384, 1, 384]
     - [68, 3538.94]
-  - - [41472, 1280, 1, 256]
-    - [58, 4813.87]
   - - [19968, 384, 1, 384]
     - [58, 4706.83]
-  - - [21504, 2048, 1, 256]
-    - [57, 4769.0]
-  - - [42240, 1792, 1, 256]
-    - [58, 4830.56]
-  - - [9216, 2048, 1, 256]
-    - [58, 4680.02]
   - - [43392, 1153, 1, 384]
     - [54, 4786.79]
-  - - [16640, 768, 1, 256]
-    - [54, 4661.67]
-  - - [41984, 1280, 1, 256]
-    - [58, 4810.12]
-  - - [27648, 1792, 1, 256]
-    - [57, 4808.61]
-  - - [25088, 1536, 1, 256]
-    - [54, 4762.85]
   - - [29952, 1536, 1, 384]
     - [58, 4975.05]
-  - - [19200, 256, 1, 256]
-    - [83, 4407.63]
   - - [17280, 1153, 1, 384]
     - [54, 4721.29]
   - - [10752, 2688, 1, 384]
     - [53, 4940.06]
-  - - [30720, 1792, 1, 256]
-    - [58, 4811.82]
   - - [33408, 1153, 1, 384]
     - [54, 4753.16]
   - - [42240, 2688, 1, 384]
     - [54, 5027.28]
-  - - [18432, 768, 1, 256]
-    - [54, 4684.43]
-  - - [27136, 2048, 1, 256]
-    - [58, 4785.04]
-  - - [10240, 512, 1, 256]
-    - [82, 4397.12]
   - - [36096, 1536, 1, 384]
     - [58, 4974.18]
   - - [1920, 384, 1, 384]
@@ -16604,18 +22820,6 @@
     - [54, 4967.0]
   - - [1536, 384, 1, 384]
     - [78, 3471.68]
-  - - [36608, 2048, 1, 256]
-    - [58, 4802.99]
-  - - [20224, 256, 1, 256]
-    - [83, 4419.18]
-  - - [30208, 512, 1, 256]
-    - [80, 4639.59]
-  - - [12288, 1280, 1, 256]
-    - [57, 4667.47]
-  - - [20480, 1281, 1, 256]
-    - [54, 4701.59]
-  - - [24320, 1536, 1, 256]
-    - [54, 4786.29]
   - - [42624, 2688, 1, 384]
     - [54, 5020.72]
   - - [29184, 3072, 1, 384]
@@ -16624,16 +22828,8 @@
     - [54, 4925.74]
   - - [27264, 3072, 1, 384]
     - [54, 5002.82]
-  - - [21760, 512, 1, 256]
-    - [83, 4604.96]
-  - - [37888, 2048, 1, 256]
-    - [58, 4803.88]
   - - [7680, 1152, 1, 384]
     - [54, 4770.81]
-  - - [23552, 1792, 1, 256]
-    - [58, 4790.18]
-  - - [27392, 2048, 1, 256]
-    - [58, 4789.34]
   - - [24960, 1153, 1, 384]
     - [54, 4733.13]
   - - [18048, 1536, 1, 384]
@@ -16646,62 +22842,28 @@
     - [53, 4975.13]
   - - [17664, 2688, 1, 384]
     - [54, 4998.2]
-  - - [1024, 1280, 1, 256]
-    - [67, 4062.29]
   - - [15360, 1920, 1, 384]
     - [54, 4944.65]
-  - - [23040, 2048, 1, 256]
-    - [58, 4784.61]
-  - - [16640, 1792, 1, 256]
-    - [58, 4753.32]
-  - - [36096, 256, 1, 256]
-    - [58, 4542.92]
-  - - [37632, 768, 1, 256]
-    - [54, 4786.85]
-  - - [9984, 256, 1, 256]
-    - [83, 4163.35]
-  - - [23040, 512, 1, 256]
-    - [83, 4611.66]
   - - [3840, 384, 1, 384]
     - [46, 4211.78]
-  - - [34816, 1280, 1, 256]
-    - [58, 4791.56]
   - - [18816, 1920, 1, 384]
     - [54, 4976.13]
   - - [33024, 768, 1, 384]
     - [58, 4938.33]
-  - - [28672, 256, 1, 256]
-    - [82, 4506.11]
-  - - [32768, 1281, 1, 256]
-    - [54, 4743.28]
-  - - [17920, 768, 1, 256]
-    - [54, 4638.01]
   - - [40704, 1153, 1, 384]
     - [54, 4789.41]
   - - [21888, 1920, 1, 384]
     - [54, 4986.65]
-  - - [43008, 1280, 1, 256]
-    - [58, 4811.16]
-  - - [44032, 1792, 1, 256]
-    - [58, 4825.97]
   - - [18816, 3072, 1, 384]
     - [58, 4990.17]
   - - [37248, 1536, 1, 384]
     - [54, 4991.0]
   - - [34176, 2304, 1, 384]
     - [54, 5004.96]
-  - - [3328, 1280, 1, 256]
-    - [70, 4357.2]
   - - [16896, 2304, 1, 384]
     - [54, 4983.23]
   - - [40320, 3072, 1, 384]
     - [54, 5007.94]
-  - - [6656, 1792, 1, 256]
-    - [83, 4623.08]
-  - - [34304, 1024, 1, 256]
-    - [58, 4733.44]
-  - - [26880, 512, 1, 256]
-    - [83, 4637.52]
   - - [32640, 1153, 1, 384]
     - [54, 4772.66]
   - - [6144, 1920, 1, 384]
@@ -16710,138 +22872,54 @@
     - [54, 4904.31]
   - - [8832, 1153, 1, 384]
     - [54, 4648.8]
-  - - [17152, 1792, 1, 256]
-    - [58, 4758.3]
-  - - [1792, 512, 1, 256]
-    - [42, 3656.3]
-  - - [35840, 768, 1, 256]
-    - [53, 4751.98]
-  - - [24064, 1536, 1, 256]
-    - [54, 4761.65]
-  - - [20992, 1536, 1, 256]
-    - [54, 4766.81]
-  - - [32256, 1281, 1, 256]
-    - [54, 4738.7]
   - - [22272, 1920, 1, 384]
     - [54, 4983.64]
   - - [32640, 3072, 1, 384]
     - [54, 5010.56]
-  - - [24832, 512, 1, 256]
-    - [83, 4626.42]
   - - [33408, 1536, 1, 384]
     - [58, 4967.79]
   - - [5760, 3072, 1, 384]
     - [58, 4891.71]
-  - - [28672, 1281, 1, 256]
-    - [54, 4735.77]
-  - - [35072, 2048, 1, 256]
-    - [58, 4790.79]
-  - - [31232, 1024, 1, 256]
-    - [58, 4754.52]
   - - [27648, 3072, 1, 384]
     - [54, 4993.37]
-  - - [36864, 768, 1, 256]
-    - [54, 4781.85]
-  - - [42496, 1792, 1, 256]
-    - [58, 4824.33]
-  - - [32256, 1792, 1, 256]
-    - [58, 4819.91]
   - - [17280, 384, 1, 384]
     - [53, 4769.11]
-  - - [19456, 1280, 1, 256]
-    - [58, 4733.98]
   - - [26880, 2688, 1, 384]
     - [54, 5005.72]
   - - [36864, 1153, 1, 384]
     - [54, 4769.78]
-  - - [27136, 1536, 1, 256]
-    - [54, 4757.5]
   - - [36864, 1920, 1, 384]
     - [54, 4992.34]
   - - [41088, 384, 1, 384]
     - [54, 4865.78]
-  - - [6656, 1280, 1, 256]
-    - [80, 4553.32]
-  - - [14848, 1536, 1, 256]
-    - [54, 4714.83]
   - - [4224, 1152, 1, 384]
     - [79, 4568.62]
   - - [12288, 1153, 1, 384]
     - [54, 4669.03]
   - - [384, 768, 1, 384]
     - [63, 2496.61]
-  - - [38912, 768, 1, 256]
-    - [54, 4784.98]
-  - - [18688, 2048, 1, 256]
-    - [58, 4746.4]
   - - [27648, 1920, 1, 384]
     - [54, 5001.99]
   - - [5760, 1152, 1, 384]
     - [54, 4760.91]
-  - - [31232, 2048, 1, 256]
-    - [58, 4791.36]
-  - - [38400, 1280, 1, 256]
-    - [57, 4800.0]
   - - [33792, 1536, 1, 384]
     - [58, 4977.76]
-  - - [28928, 1024, 1, 256]
-    - [58, 4734.0]
-  - - [7936, 1280, 1, 256]
-    - [83, 4603.91]
-  - - [24320, 256, 1, 256]
-    - [83, 4470.03]
-  - - [22272, 1024, 1, 256]
-    - [57, 4698.75]
   - - [40704, 2688, 1, 384]
     - [54, 5015.99]
-  - - [43520, 1280, 1, 256]
-    - [58, 4816.87]
-  - - [36096, 1792, 1, 256]
-    - [58, 4814.2]
-  - - [8192, 1281, 1, 256]
-    - [54, 4550.84]
   - - [37632, 2304, 1, 384]
     - [54, 5005.92]
   - - [24192, 1152, 1, 384]
     - [54, 4961.05]
-  - - [22784, 1024, 1, 256]
-    - [83, 4703.35]
-  - - [11776, 1792, 1, 256]
-    - [58, 4700.07]
   - - [42240, 3072, 1, 384]
     - [58, 5004.17]
-  - - [18688, 1792, 1, 256]
-    - [58, 4777.52]
-  - - [32256, 2048, 1, 256]
-    - [58, 4795.94]
   - - [16896, 1920, 1, 384]
     - [54, 4970.43]
-  - - [20224, 512, 1, 256]
-    - [83, 4595.7]
   - - [18048, 1153, 1, 384]
     - [54, 4715.89]
-  - - [12032, 256, 1, 256]
-    - [57, 4266.01]
-  - - [34816, 1024, 1, 256]
-    - [58, 4757.41]
-  - - [24320, 512, 1, 256]
-    - [83, 4624.1]
   - - [32640, 2304, 1, 384]
     - [58, 5006.2]
-  - - [29184, 1281, 1, 256]
-    - [54, 4743.78]
-  - - [13056, 1281, 1, 256]
-    - [54, 4633.5]
-  - - [15616, 2048, 1, 256]
-    - [57, 4728.05]
-  - - [19200, 1281, 1, 256]
-    - [54, 4691.22]
-  - - [8960, 512, 1, 256]
-    - [80, 4376.88]
   - - [13824, 384, 1, 384]
     - [54, 4631.54]
-  - - [18432, 1280, 1, 256]
-    - [58, 4740.37]
   - - [36096, 1152, 1, 384]
     - [54, 4988.85]
   - - [15744, 1920, 1, 384]
@@ -16850,70 +22928,30 @@
     - [58, 4873.84]
   - - [33408, 1152, 1, 384]
     - [54, 4965.87]
-  - - [34816, 1536, 1, 256]
-    - [54, 4784.51]
-  - - [33536, 1792, 1, 256]
-    - [58, 4814.4]
   - - [11904, 2304, 1, 384]
     - [58, 4939.36]
-  - - [25600, 768, 1, 256]
-    - [54, 4745.58]
   - - [24576, 2304, 1, 384]
     - [58, 4975.94]
   - - [33024, 1536, 1, 384]
     - [54, 4974.96]
   - - [6528, 1152, 1, 384]
     - [53, 4680.05]
-  - - [31744, 1536, 1, 256]
-    - [54, 4805.15]
   - - [20736, 768, 1, 384]
     - [54, 4876.63]
-  - - [16640, 2048, 1, 256]
-    - [58, 4748.92]
-  - - [2816, 1280, 1, 256]
-    - [71, 4378.19]
-  - - [3840, 1281, 1, 256]
-    - [54, 4297.28]
-  - - [3584, 1280, 1, 256]
-    - [44, 4415.72]
-  - - [27136, 512, 1, 256]
-    - [83, 4647.92]
   - - [37632, 1152, 1, 384]
     - [54, 4981.09]
-  - - [19456, 1281, 1, 256]
-    - [54, 4705.67]
-  - - [19200, 1536, 1, 256]
-    - [54, 4762.53]
-  - - [36096, 768, 1, 256]
-    - [54, 4778.06]
   - - [12288, 1920, 1, 384]
     - [54, 4936.31]
-  - - [9728, 1024, 1, 256]
-    - [83, 4590.54]
-  - - [25088, 1281, 1, 256]
-    - [54, 4723.1]
   - - [36096, 2304, 1, 384]
     - [58, 5006.12]
   - - [6912, 1153, 1, 384]
     - [54, 4503.36]
   - - [13056, 2688, 1, 384]
     - [54, 4973.1]
-  - - [30208, 256, 1, 256]
-    - [58, 4519.89]
   - - [20352, 2688, 1, 384]
     - [54, 4981.59]
-  - - [21504, 768, 1, 256]
-    - [54, 4697.0]
-  - - [34048, 768, 1, 256]
-    - [54, 4778.78]
   - - [14592, 2304, 1, 384]
     - [58, 4967.32]
-  - - [5888, 1024, 1, 256]
-    - [83, 4476.52]
-  - - [9728, 256, 1, 256]
-    - [82, 4088.85]
-  - - [5376, 512, 1, 256]
-    - [82, 4172.45]
   - - [16128, 1920, 1, 384]
     - [54, 4969.52]
   - - [9216, 1536, 1, 384]
@@ -16922,110 +22960,40 @@
     - [54, 4965.73]
   - - [35712, 1920, 1, 384]
     - [54, 5002.04]
-  - - [29696, 1281, 1, 256]
-    - [54, 4733.16]
-  - - [3584, 1792, 1, 256]
-    - [71, 4497.18]
-  - - [38400, 256, 1, 256]
-    - [80, 4562.66]
-  - - [29440, 2048, 1, 256]
-    - [58, 4787.9]
   - - [9216, 2688, 1, 384]
     - [58, 4938.47]
   - - [16128, 2688, 1, 384]
     - [54, 4982.4]
-  - - [11520, 1792, 1, 256]
-    - [58, 4715.73]
-  - - [39168, 1281, 1, 256]
-    - [54, 4762.83]
   - - [19200, 3072, 1, 384]
     - [58, 4984.78]
-  - - [24576, 1280, 1, 256]
-    - [58, 4773.04]
-  - - [42496, 2048, 1, 256]
-    - [58, 4811.88]
   - - [23808, 2688, 1, 384]
     - [54, 4995.49]
-  - - [19968, 256, 1, 256]
-    - [86, 4381.94]
   - - [18048, 768, 1, 384]
     - [58, 4844.52]
-  - - [34048, 1792, 1, 256]
-    - [58, 4817.05]
-  - - [32768, 512, 1, 256]
-    - [83, 4666.82]
   - - [14592, 2688, 1, 384]
     - [54, 4985.88]
-  - - [20224, 768, 1, 256]
-    - [54, 4714.04]
-  - - [11776, 512, 1, 256]
-    - [80, 4498.97]
   - - [15360, 1152, 1, 384]
     - [54, 4899.89]
-  - - [38400, 1024, 1, 256]
-    - [58, 4764.81]
-  - - [8704, 1281, 1, 256]
-    - [54, 4547.47]
-  - - [2304, 1024, 1, 256]
-    - [69, 4314.15]
   - - [40320, 1152, 1, 384]
     - [54, 4980.48]
-  - - [26624, 768, 1, 256]
-    - [54, 4742.42]
   - - [25344, 2688, 1, 384]
     - [54, 5000.78]
-  - - [9728, 1536, 1, 256]
-    - [53, 4642.02]
-  - - [21760, 2048, 1, 256]
-    - [58, 4758.78]
-  - - [25088, 768, 1, 256]
-    - [54, 4725.16]
-  - - [16640, 1024, 1, 256]
-    - [83, 4669.32]
   - - [43008, 1152, 1, 384]
     - [54, 4980.46]
-  - - [9216, 1536, 1, 256]
-    - [83, 4656.03]
   - - [19200, 1152, 1, 384]
     - [54, 4923.07]
   - - [19584, 1152, 1, 384]
     - [53, 4918.1]
-  - - [8192, 1536, 1, 256]
-    - [53, 4617.32]
-  - - [25600, 1281, 1, 256]
-    - [54, 4724.77]
-  - - [6400, 2048, 1, 256]
-    - [83, 4636.13]
-  - - [28416, 1792, 1, 256]
-    - [58, 4806.75]
-  - - [3328, 1281, 1, 256]
-    - [53, 4207.29]
-  - - [11008, 1536, 1, 256]
-    - [54, 4688.4]
-  - - [31232, 1281, 1, 256]
-    - [54, 4748.22]
-  - - [8448, 1536, 1, 256]
-    - [54, 4637.7]
   - - [14208, 1920, 1, 384]
     - [54, 4945.28]
-  - - [20480, 768, 1, 256]
-    - [54, 4691.4]
   - - [5376, 1152, 1, 384]
     - [54, 4716.35]
   - - [14976, 2688, 1, 384]
     - [54, 4967.39]
   - - [36480, 1152, 1, 384]
     - [54, 4981.47]
-  - - [14592, 2048, 1, 256]
-    - [58, 4741.8]
-  - - [15872, 1792, 1, 256]
-    - [58, 4760.4]
-  - - [37120, 768, 1, 256]
-    - [54, 4793.18]
   - - [39936, 1920, 1, 384]
     - [54, 5004.42]
-  - - [27648, 1281, 1, 256]
-    - [54, 4729.08]
   - - [11136, 1152, 1, 384]
     - [54, 4862.99]
   - - [17280, 2304, 1, 384]
@@ -17038,132 +23006,46 @@
     - [53, 4805.23]
   - - [19968, 1153, 1, 384]
     - [54, 4742.25]
-  - - [24576, 1792, 1, 256]
-    - [58, 4803.05]
   - - [26496, 1152, 1, 384]
     - [54, 4962.9]
   - - [18432, 768, 1, 384]
     - [53, 4868.36]
-  - - [13056, 1792, 1, 256]
-    - [58, 4730.12]
   - - [4608, 768, 1, 384]
     - [58, 4714.67]
-  - - [22784, 256, 1, 256]
-    - [58, 4491.02]
-  - - [17920, 256, 1, 256]
-    - [82, 4352.23]
-  - - [41984, 1024, 1, 256]
-    - [58, 4772.46]
   - - [34944, 1920, 1, 384]
     - [54, 5010.1]
-  - - [42240, 256, 1, 256]
-    - [83, 4587.43]
   - - [13824, 2688, 1, 384]
     - [54, 4966.11]
-  - - [13312, 1280, 1, 256]
-    - [83, 4677.33]
-  - - [24576, 512, 1, 256]
-    - [83, 4636.19]
-  - - [4864, 2048, 1, 256]
-    - [80, 4581.31]
-  - - [26880, 1792, 1, 256]
-    - [58, 4804.81]
   - - [8832, 3072, 1, 384]
     - [58, 4924.87]
-  - - [43520, 1536, 1, 256]
-    - [54, 4787.64]
-  - - [19712, 1792, 1, 256]
-    - [58, 4774.61]
-  - - [43776, 2048, 1, 256]
-    - [58, 4821.85]
-  - - [36864, 1792, 1, 256]
-    - [58, 4830.62]
   - - [39936, 2304, 1, 384]
     - [58, 4990.91]
-  - - [7936, 1024, 1, 256]
-    - [80, 4548.26]
   - - [16896, 3072, 1, 384]
     - [54, 4980.59]
-  - - [28160, 256, 1, 256]
-    - [82, 4490.69]
-  - - [39680, 512, 1, 256]
-    - [58, 4686.37]
-  - - [35072, 1280, 1, 256]
-    - [58, 4794.89]
   - - [7680, 2688, 1, 384]
     - [53, 4910.94]
-  - - [15360, 1280, 1, 256]
-    - [57, 4698.98]
-  - - [23552, 1281, 1, 256]
-    - [54, 4723.19]
-  - - [28928, 768, 1, 256]
-    - [54, 4759.4]
   - - [19968, 2304, 1, 384]
     - [54, 4971.64]
   - - [27648, 2688, 1, 384]
     - [54, 5009.45]
-  - - [9984, 512, 1, 256]
-    - [83, 4415.65]
-  - - [22784, 2048, 1, 256]
-    - [58, 4776.93]
-  - - [12544, 1281, 1, 256]
-    - [53, 4611.49]
   - - [4224, 768, 1, 384]
     - [79, 4421.17]
-  - - [1792, 256, 1, 256]
-    - [67, 3374.73]
-  - - [6400, 1536, 1, 256]
-    - [83, 4581.94]
-  - - [17408, 1280, 1, 256]
-    - [58, 4731.31]
   - - [35328, 3072, 1, 384]
     - [54, 5004.8]
-  - - [17920, 1280, 1, 256]
-    - [58, 4709.53]
   - - [11520, 3072, 1, 384]
     - [54, 4953.11]
-  - - [4096, 768, 1, 256]
-    - [47, 4325.89]
   - - [24192, 1920, 1, 384]
     - [54, 4988.39]
-  - - [31488, 1280, 1, 256]
-    - [58, 4797.9]
-  - - [42496, 512, 1, 256]
-    - [58, 4688.27]
-  - - [25600, 1280, 1, 256]
-    - [58, 4765.06]
   - - [32640, 1920, 1, 384]
     - [53, 4990.67]
-  - - [3840, 1280, 1, 256]
-    - [71, 4443.75]
   - - [4992, 3072, 1, 384]
     - [58, 4872.74]
-  - - [29184, 768, 1, 256]
-    - [54, 4755.35]
-  - - [35584, 512, 1, 256]
-    - [83, 4670.98]
-  - - [36608, 1024, 1, 256]
-    - [57, 4753.88]
   - - [12672, 384, 1, 384]
     - [79, 4565.94]
   - - [34176, 2688, 1, 384]
     - [54, 5015.98]
-  - - [12544, 768, 1, 256]
-    - [83, 4599.84]
   - - [35328, 1536, 1, 384]
     - [54, 4982.95]
-  - - [37376, 1536, 1, 256]
-    - [54, 4786.0]
-  - - [32768, 1792, 1, 256]
-    - [58, 4816.1]
-  - - [27136, 1792, 1, 256]
-    - [58, 4805.04]
-  - - [2560, 1536, 1, 256]
-    - [69, 4372.87]
-  - - [39936, 1536, 1, 256]
-    - [53, 4809.05]
-  - - [14080, 768, 1, 256]
-    - [54, 4634.75]
   - - [20736, 1153, 1, 384]
     - [54, 4733.01]
   - - [3072, 1152, 1, 384]
@@ -17174,8 +23056,6 @@
     - [54, 4973.01]
   - - [8832, 2688, 1, 384]
     - [54, 4934.14]
-  - - [36352, 1281, 1, 256]
-    - [54, 4756.2]
   - - [18048, 1920, 1, 384]
     - [54, 4960.5]
   - - [31488, 768, 1, 384]
@@ -17190,114 +23070,46 @@
     - [54, 4947.1]
   - - [38784, 1153, 1, 384]
     - [54, 4766.9]
-  - - [12288, 1792, 1, 256]
-    - [58, 4742.52]
-  - - [20224, 2048, 1, 256]
-    - [58, 4769.6]
-  - - [36352, 1792, 1, 256]
-    - [58, 4815.58]
-  - - [10496, 1792, 1, 256]
-    - [58, 4700.19]
-  - - [34560, 1024, 1, 256]
-    - [58, 4757.74]
-  - - [23552, 1280, 1, 256]
-    - [58, 4760.26]
   - - [33024, 3072, 1, 384]
     - [58, 4997.81]
   - - [34944, 3072, 1, 384]
     - [54, 5008.65]
   - - [39552, 384, 1, 384]
     - [54, 4886.05]
-  - - [39424, 1792, 1, 256]
-    - [58, 4824.13]
   - - [31872, 1152, 1, 384]
     - [54, 4970.23]
-  - - [37632, 256, 1, 256]
-    - [83, 4583.43]
-  - - [21760, 1280, 1, 256]
-    - [58, 4747.98]
   - - [768, 1152, 1, 384]
     - [50, 3812.15]
-  - - [34560, 512, 1, 256]
-    - [83, 4666.29]
   - - [29184, 2688, 1, 384]
     - [54, 5006.03]
   - - [10752, 3072, 1, 384]
     - [58, 4946.18]
   - - [20352, 768, 1, 384]
     - [54, 4891.01]
-  - - [16128, 768, 1, 256]
-    - [53, 4646.95]
-  - - [26880, 256, 1, 256]
-    - [58, 4496.65]
   - - [4608, 2688, 1, 384]
     - [54, 4839.98]
-  - - [19968, 1280, 1, 256]
-    - [58, 4744.28]
   - - [36480, 1153, 1, 384]
     - [54, 4772.03]
   - - [7296, 1153, 1, 384]
     - [77, 4534.67]
-  - - [42752, 256, 1, 256]
-    - [83, 4606.7]
   - - [21504, 2688, 1, 384]
     - [54, 5001.68]
   - - [34176, 768, 1, 384]
     - [54, 4961.76]
-  - - [38912, 1792, 1, 256]
-    - [58, 4820.21]
-  - - [41216, 768, 1, 256]
-    - [54, 4800.02]
-  - - [11008, 1024, 1, 256]
-    - [80, 4595.33]
-  - - [18176, 768, 1, 256]
-    - [54, 4687.48]
   - - [29568, 384, 1, 384]
     - [53, 4853.05]
   - - [3072, 1920, 1, 384]
     - [53, 4785.6]
-  - - [39680, 1280, 1, 256]
-    - [58, 4798.34]
-  - - [37888, 512, 1, 256]
-    - [83, 4676.49]
   - - [21504, 1920, 1, 384]
     - [54, 4976.17]
   - - [23808, 1536, 1, 384]
     - [54, 4947.9]
-  - - [15872, 256, 1, 256]
-    - [83, 4291.2]
-  - - [7424, 1024, 1, 256]
-    - [83, 4550.5]
-  - - [32256, 768, 1, 256]
-    - [54, 4752.4]
-  - - [32768, 2048, 1, 256]
-    - [58, 4793.87]
-  - - [11264, 1281, 1, 256]
-    - [54, 4600.55]
-  - - [23040, 1536, 1, 256]
-    - [54, 4759.05]
-  - - [39424, 1280, 1, 256]
-    - [58, 4808.05]
   - - [15360, 1153, 1, 384]
     - [53, 4713.52]
-  - - [29952, 1536, 1, 256]
-    - [54, 4801.15]
   - - [30336, 3072, 1, 384]
     - [54, 5009.94]
-  - - [43008, 256, 1, 256]
-    - [80, 4597.1]
-  - - [14336, 1281, 1, 256]
-    - [54, 4651.8]
   - - [26112, 3072, 1, 384]
     - [54, 4991.86]
-  - - [27392, 768, 1, 256]
-    - [54, 4757.16]
-  - - [38144, 256, 1, 256]
-    - [58, 4578.73]
-  - - [22016, 768, 1, 256]
-    - [54, 4724.84]
-  - - [11776, 1281, 1, 256]
-    - [54, 4628.21]
   - - [8832, 1536, 1, 384]
     - [58, 4830.43]
   - - [11136, 1153, 1, 384]
@@ -17306,150 +23118,58 @@
     - [54, 4985.09]
   - - [42240, 384, 1, 384]
     - [53, 4864.07]
-  - - [43520, 1281, 1, 256]
-    - [54, 4773.04]
-  - - [31488, 1792, 1, 256]
-    - [58, 4803.6]
-  - - [27904, 1280, 1, 256]
-    - [58, 4780.01]
-  - - [37632, 1792, 1, 256]
-    - [58, 4823.63]
-  - - [8960, 1536, 1, 256]
-    - [83, 4639.96]
-  - - [20480, 1792, 1, 256]
-    - [58, 4774.78]
-  - - [40960, 1281, 1, 256]
-    - [54, 4776.97]
   - - [28800, 2688, 1, 384]
     - [54, 5002.11]
-  - - [30720, 1024, 1, 256]
-    - [58, 4731.98]
-  - - [5632, 1281, 1, 256]
-    - [54, 4456.03]
   - - [31488, 2688, 1, 384]
     - [54, 5003.77]
-  - - [18688, 1280, 1, 256]
-    - [58, 4741.31]
-  - - [31744, 1280, 1, 256]
-    - [58, 4791.11]
   - - [10368, 3072, 1, 384]
     - [58, 4939.74]
   - - [12672, 1920, 1, 384]
     - [54, 4953.88]
-  - - [43008, 768, 1, 256]
-    - [54, 4810.4]
-  - - [29952, 1280, 1, 256]
-    - [58, 4786.34]
-  - - [30464, 1281, 1, 256]
-    - [54, 4735.52]
   - - [30720, 1536, 1, 384]
     - [58, 4974.52]
   - - [8064, 3072, 1, 384]
     - [53, 4916.83]
-  - - [13824, 256, 1, 256]
-    - [57, 4373.28]
   - - [23424, 1153, 1, 384]
     - [54, 4739.18]
   - - [17280, 1152, 1, 384]
     - [54, 4912.42]
   - - [13824, 768, 1, 384]
     - [58, 4838.66]
-  - - [36352, 1280, 1, 256]
-    - [58, 4789.64]
   - - [9216, 1152, 1, 384]
     - [54, 4884.81]
-  - - [24832, 2048, 1, 256]
-    - [58, 4775.07]
   - - [6528, 1920, 1, 384]
     - [54, 4877.74]
   - - [28800, 3072, 1, 384]
     - [54, 5003.78]
-  - - [7424, 1280, 1, 256]
-    - [83, 4558.35]
-  - - [8704, 2048, 1, 256]
-    - [83, 4672.55]
-  - - [38144, 1792, 1, 256]
-    - [58, 4822.1]
-  - - [40704, 1536, 1, 256]
-    - [54, 4813.73]
-  - - [36608, 1281, 1, 256]
-    - [54, 4746.67]
-  - - [43520, 2048, 1, 256]
-    - [58, 4802.0]
-  - - [24064, 256, 1, 256]
-    - [83, 4473.16]
   - - [10752, 384, 1, 384]
     - [79, 4575.87]
   - - [38016, 1536, 1, 384]
     - [58, 4975.98]
-  - - [8192, 2048, 1, 256]
-    - [80, 4662.16]
   - - [39552, 1152, 1, 384]
     - [54, 4977.34]
-  - - [37632, 1536, 1, 256]
-    - [54, 4814.83]
-  - - [13568, 256, 1, 256]
-    - [57, 4341.76]
   - - [22272, 1153, 1, 384]
     - [54, 4743.23]
   - - [25344, 2304, 1, 384]
     - [58, 4997.0]
-  - - [21504, 1536, 1, 256]
-    - [54, 4775.41]
-  - - [22528, 1281, 1, 256]
-    - [54, 4726.4]
   - - [14592, 3072, 1, 384]
     - [58, 4964.13]
-  - - [36608, 1792, 1, 256]
-    - [58, 4827.8]
   - - [28032, 1920, 1, 384]
     - [54, 4998.51]
-  - - [37632, 1280, 1, 256]
-    - [58, 4813.74]
-  - - [19968, 1281, 1, 256]
-    - [54, 4709.87]
-  - - [40448, 1536, 1, 256]
-    - [54, 4821.74]
-  - - [33792, 256, 1, 256]
-    - [83, 4547.42]
   - - [20736, 2688, 1, 384]
     - [54, 4999.38]
   - - [15744, 1536, 1, 384]
     - [54, 4925.53]
   - - [25728, 1152, 1, 384]
     - [54, 4961.4]
-  - - [10496, 512, 1, 256]
-    - [83, 4436.13]
-  - - [7936, 1536, 1, 256]
-    - [54, 4645.91]
   - - [16512, 1536, 1, 384]
     - [58, 4916.69]
   - - [3072, 2304, 1, 384]
     - [57, 4795.53]
-  - - [5632, 1024, 1, 256]
-    - [80, 4494.63]
-  - - [26624, 1024, 1, 256]
-    - [58, 4714.1]
-  - - [38400, 512, 1, 256]
-    - [83, 4676.79]
-  - - [35328, 1536, 1, 256]
-    - [54, 4806.43]
-  - - [24832, 256, 1, 256]
-    - [79, 4443.51]
-  - - [7424, 512, 1, 256]
-    - [82, 4312.53]
-  - - [22528, 1536, 1, 256]
-    - [54, 4772.21]
-  - - [43520, 768, 1, 256]
-    - [54, 4806.85]
   - - [5760, 2688, 1, 384]
     - [53, 4885.8]
   - - [37248, 1153, 1, 384]
     - [54, 4778.69]
-  - - [23040, 1792, 1, 256]
-    - [58, 4798.11]
-  - - [5376, 1280, 1, 256]
-    - [82, 4489.77]
   - - [10368, 1153, 1, 384]
     - [54, 4650.73]
   - - [36864, 3072, 1, 384]
@@ -17462,446 +23182,184 @@
     - [58, 4926.41]
   - - [10368, 1152, 1, 384]
     - [54, 4833.77]
-  - - [512, 768, 1, 256]
-    - [62, 2981.73]
   - - [36096, 3072, 1, 384]
     - [58, 4998.24]
-  - - [29184, 1280, 1, 256]
-    - [58, 4793.49]
-  - - [2304, 768, 1, 256]
-    - [69, 4100.16]
-  - - [20224, 1281, 1, 256]
-    - [53, 4690.77]
-  - - [39424, 256, 1, 256]
-    - [83, 4578.42]
-  - - [28928, 512, 1, 256]
-    - [58, 4648.68]
-  - - [2304, 1281, 1, 256]
-    - [43, 4174.4]
   - - [24576, 1536, 1, 384]
     - [54, 4959.6]
   - - [31104, 2304, 1, 384]
     - [58, 5000.88]
   - - [2688, 1153, 1, 384]
     - [82, 4198.25]
-  - - [3840, 512, 1, 256]
-    - [59, 4176.21]
-  - - [12032, 1281, 1, 256]
-    - [53, 4626.79]
   - - [38400, 2304, 1, 384]
     - [54, 5006.02]
-  - - [6656, 1024, 1, 256]
-    - [83, 4503.49]
   - - [32256, 384, 1, 384]
     - [54, 4850.44]
   - - [38016, 1152, 1, 384]
     - [54, 4980.77]
   - - [20352, 384, 1, 384]
     - [54, 4783.58]
-  - - [37120, 1536, 1, 256]
-    - [54, 4809.73]
-  - - [19200, 2048, 1, 256]
-    - [58, 4765.72]
-  - - [25344, 512, 1, 256]
-    - [58, 4628.65]
   - - [15360, 2688, 1, 384]
     - [54, 4972.49]
-  - - [5888, 256, 1, 256]
-    - [73, 3953.65]
-  - - [19712, 768, 1, 256]
-    - [54, 4708.58]
   - - [10752, 1153, 1, 384]
     - [54, 4652.71]
-  - - [20736, 1281, 1, 256]
-    - [54, 4702.69]
-  - - [22016, 1024, 1, 256]
-    - [58, 4706.86]
-  - - [6400, 1280, 1, 256]
-    - [83, 4533.8]
   - - [29952, 2688, 1, 384]
     - [54, 4996.93]
   - - [7680, 384, 1, 384]
     - [57, 4390.07]
-  - - [26368, 2048, 1, 256]
-    - [58, 4766.85]
   - - [43008, 2688, 1, 384]
     - [54, 5016.71]
-  - - [25088, 1024, 1, 256]
-    - [58, 4710.14]
   - - [13440, 1920, 1, 384]
     - [54, 4949.38]
   - - [4992, 1152, 1, 384]
     - [58, 4706.52]
-  - - [14080, 512, 1, 256]
-    - [83, 4518.4]
   - - [9984, 2304, 1, 384]
     - [58, 4929.36]
-  - - [4864, 256, 1, 256]
-    - [67, 3881.72]
-  - - [15872, 512, 1, 256]
-    - [80, 4531.22]
-  - - [4864, 1281, 1, 256]
-    - [83, 4321.78]
-  - - [9984, 1792, 1, 256]
-    - [58, 4693.58]
-  - - [41472, 1792, 1, 256]
-    - [58, 4832.21]
   - - [6528, 2688, 1, 384]
     - [54, 4895.06]
   - - [38016, 2688, 1, 384]
     - [54, 5022.4]
   - - [4608, 1152, 1, 384]
     - [54, 4639.97]
-  - - [39168, 512, 1, 256]
-    - [58, 4694.77]
-  - - [35072, 1536, 1, 256]
-    - [54, 4805.32]
   - - [9600, 2304, 1, 384]
     - [58, 4915.54]
-  - - [35584, 1536, 1, 256]
-    - [54, 4802.11]
-  - - [7936, 1281, 1, 256]
-    - [54, 4530.19]
-  - - [28160, 1792, 1, 256]
-    - [58, 4811.56]
-  - - [3328, 2048, 1, 256]
-    - [83, 4516.08]
   - - [32640, 384, 1, 384]
     - [54, 4866.3]
-  - - [23296, 1536, 1, 256]
-    - [54, 4775.5]
   - - [7680, 3072, 1, 384]
     - [57, 4903.82]
   - - [2304, 1536, 1, 384]
     - [44, 4756.25]
-  - - [27904, 1281, 1, 256]
-    - [54, 4729.16]
   - - [40320, 1536, 1, 384]
     - [58, 4970.14]
-  - - [17408, 2048, 1, 256]
-    - [58, 4747.51]
   - - [13440, 1536, 1, 384]
     - [58, 4898.8]
-  - - [26368, 1281, 1, 256]
-    - [54, 4735.19]
   - - [18432, 1152, 1, 384]
     - [54, 4919.24]
-  - - [5632, 1792, 1, 256]
-    - [83, 4596.34]
   - - [40320, 2688, 1, 384]
     - [58, 5011.34]
   - - [30336, 2304, 1, 384]
     - [54, 5007.68]
-  - - [32000, 1281, 1, 256]
-    - [54, 4751.92]
   - - [24192, 2688, 1, 384]
     - [54, 4999.28]
-  - - [33536, 1281, 1, 256]
-    - [54, 4743.97]
-  - - [7680, 1024, 1, 256]
-    - [83, 4541.34]
-  - - [15616, 1792, 1, 256]
-    - [58, 4747.56]
-  - - [10496, 1281, 1, 256]
-    - [54, 4600.64]
   - - [16896, 1152, 1, 384]
     - [54, 4903.98]
-  - - [40704, 2048, 1, 256]
-    - [58, 4807.66]
   - - [38016, 3072, 1, 384]
     - [54, 5009.48]
-  - - [43776, 1792, 1, 256]
-    - [58, 4833.52]
   - - [43392, 2304, 1, 384]
     - [54, 5010.45]
-  - - [24064, 1792, 1, 256]
-    - [58, 4794.57]
   - - [13440, 1152, 1, 384]
     - [54, 4881.78]
   - - [1152, 769, 1, 384]
     - [45, 3758.09]
-  - - [33280, 1792, 1, 256]
-    - [58, 4814.96]
-  - - [33280, 1024, 1, 256]
-    - [58, 4746.34]
   - - [36096, 1153, 1, 384]
     - [54, 4767.94]
-  - - [8704, 512, 1, 256]
-    - [80, 4380.47]
-  - - [31232, 1280, 1, 256]
-    - [58, 4786.67]
   - - [33792, 1920, 1, 384]
     - [54, 4995.58]
-  - - [11520, 256, 1, 256]
-    - [58, 4149.12]
   - - [11520, 1153, 1, 384]
     - [54, 4618.18]
   - - [12288, 3072, 1, 384]
     - [58, 4967.49]
-  - - [5120, 1536, 1, 256]
-    - [83, 4547.49]
   - - [28416, 3072, 1, 384]
     - [58, 5006.26]
-  - - [21248, 1280, 1, 256]
-    - [58, 4751.68]
   - - [35328, 768, 1, 384]
     - [58, 4919.38]
-  - - [19968, 1792, 1, 256]
-    - [58, 4773.81]
   - - [22656, 2688, 1, 384]
     - [54, 5003.16]
-  - - [34304, 2048, 1, 256]
-    - [58, 4790.68]
   - - [25728, 2688, 1, 384]
     - [54, 5012.43]
   - - [23040, 768, 1, 384]
     - [58, 4897.63]
-  - - [18688, 1024, 1, 256]
-    - [83, 4680.11]
-  - - [28160, 1536, 1, 256]
-    - [54, 4793.33]
   - - [29952, 2304, 1, 384]
     - [54, 5000.57]
-  - - [25344, 1024, 1, 256]
-    - [58, 4718.86]
   - - [33024, 1920, 1, 384]
     - [54, 4997.81]
-  - - [13056, 1024, 1, 256]
-    - [80, 4632.33]
   - - [14976, 768, 1, 384]
     - [53, 4802.12]
-  - - [18944, 1536, 1, 256]
-    - [54, 4751.3]
   - - [42624, 1920, 1, 384]
     - [53, 5006.57]
   - - [32640, 2688, 1, 384]
     - [57, 4994.42]
-  - - [18688, 1536, 1, 256]
-    - [54, 4757.74]
-  - - [34816, 512, 1, 256]
-    - [80, 4664.72]
-  - - [27136, 1280, 1, 256]
-    - [58, 4775.27]
-  - - [34048, 1280, 1, 256]
-    - [58, 4799.31]
   - - [33408, 384, 1, 384]
     - [54, 4866.26]
   - - [11520, 1536, 1, 384]
     - [58, 4894.24]
-  - - [13312, 1281, 1, 256]
-    - [54, 4641.37]
-  - - [27392, 1024, 1, 256]
-    - [58, 4735.83]
-  - - [17408, 1536, 1, 256]
-    - [54, 4746.82]
-  - - [2048, 1281, 1, 256]
-    - [69, 3996.74]
-  - - [35840, 1792, 1, 256]
-    - [58, 4822.91]
   - - [6912, 768, 1, 384]
     - [58, 4617.69]
-  - - [23296, 256, 1, 256]
-    - [80, 4480.88]
-  - - [26112, 1280, 1, 256]
-    - [58, 4780.53]
-  - - [39680, 1792, 1, 256]
-    - [58, 4826.05]
   - - [28032, 3072, 1, 384]
     - [54, 5002.38]
-  - - [13312, 1792, 1, 256]
-    - [58, 4717.22]
-  - - [21504, 1281, 1, 256]
-    - [54, 4713.99]
-  - - [8960, 1281, 1, 256]
-    - [53, 4549.31]
   - - [39552, 1920, 1, 384]
     - [54, 5009.09]
   - - [11904, 384, 1, 384]
     - [54, 4660.46]
-  - - [44032, 1536, 1, 256]
-    - [54, 4818.84]
   - - [32256, 1920, 1, 384]
     - [58, 4980.59]
-  - - [33792, 512, 1, 256]
-    - [83, 4662.1]
   - - [15360, 384, 1, 384]
     - [54, 4791.67]
-  - - [37376, 1024, 1, 256]
-    - [58, 4751.28]
-  - - [12800, 2048, 1, 256]
-    - [57, 4706.62]
-  - - [18944, 2048, 1, 256]
-    - [58, 4761.6]
-  - - [21760, 1024, 1, 256]
-    - [58, 4709.43]
   - - [42240, 1153, 1, 384]
     - [54, 4788.17]
-  - - [38656, 1792, 1, 256]
-    - [58, 4822.4]
-  - - [44032, 1281, 1, 256]
-    - [54, 4770.36]
-  - - [11008, 1281, 1, 256]
-    - [54, 4604.96]
   - - [10752, 1536, 1, 384]
     - [57, 4875.9]
   - - [16128, 1152, 1, 384]
     - [54, 4890.27]
   - - [6144, 1153, 1, 384]
     - [53, 4553.82]
-  - - [2048, 1024, 1, 256]
-    - [75, 4148.93]
-  - - [13312, 1536, 1, 256]
-    - [54, 4712.02]
   - - [24576, 2688, 1, 384]
     - [54, 5004.88]
-  - - [29440, 1792, 1, 256]
-    - [58, 4800.55]
   - - [12672, 2688, 1, 384]
     - [54, 4970.04]
-  - - [21248, 2048, 1, 256]
-    - [58, 4770.26]
   - - [5376, 768, 1, 384]
     - [82, 4567.96]
-  - - [14592, 768, 1, 256]
-    - [54, 4633.24]
   - - [10752, 1920, 1, 384]
     - [54, 4908.99]
-  - - [6144, 512, 1, 256]
-    - [59, 4323.1]
   - - [40704, 1536, 1, 384]
     - [58, 4983.48]
-  - - [26368, 512, 1, 256]
-    - [83, 4641.81]
-  - - [27904, 256, 1, 256]
-    - [83, 4497.14]
   - - [8832, 1152, 1, 384]
     - [54, 4844.5]
-  - - [25088, 1280, 1, 256]
-    - [58, 4772.57]
-  - - [10240, 1280, 1, 256]
-    - [83, 4651.55]
   - - [32256, 768, 1, 384]
     - [57, 4924.26]
   - - [11904, 1536, 1, 384]
     - [58, 4884.56]
-  - - [7168, 1536, 1, 256]
-    - [83, 4598.3]
   - - [35712, 1153, 1, 384]
     - [54, 4767.69]
-  - - [12032, 1536, 1, 256]
-    - [54, 4680.63]
-  - - [22528, 512, 1, 256]
-    - [83, 4629.65]
-  - - [26624, 256, 1, 256]
-    - [82, 4488.66]
-  - - [25088, 2048, 1, 256]
-    - [58, 4776.64]
-  - - [11264, 1792, 1, 256]
-    - [83, 4696.09]
-  - - [18176, 1792, 1, 256]
-    - [58, 4762.99]
-  - - [20736, 2048, 1, 256]
-    - [58, 4779.58]
   - - [32256, 1153, 1, 384]
     - [53, 4756.29]
-  - - [8960, 768, 1, 256]
-    - [54, 4495.73]
-  - - [21248, 1281, 1, 256]
-    - [54, 4703.01]
   - - [18432, 1536, 1, 384]
     - [58, 4925.89]
   - - [34560, 3072, 1, 384]
     - [58, 4992.31]
   - - [18816, 2688, 1, 384]
     - [58, 4980.44]
-  - - [39680, 768, 1, 256]
-    - [54, 4792.61]
-  - - [31488, 1536, 1, 256]
-    - [54, 4801.15]
-  - - [10752, 2048, 1, 256]
-    - [83, 4684.04]
-  - - [40448, 1281, 1, 256]
-    - [54, 4752.95]
-  - - [20736, 1792, 1, 256]
-    - [58, 4792.19]
   - - [28800, 1152, 1, 384]
     - [54, 4967.33]
-  - - [21504, 1792, 1, 256]
-    - [58, 4791.07]
-  - - [17408, 1281, 1, 256]
-    - [54, 4686.03]
   - - [28416, 1153, 1, 384]
     - [53, 4746.99]
-  - - [17152, 1281, 1, 256]
-    - [54, 4678.88]
-  - - [39936, 768, 1, 256]
-    - [54, 4794.19]
-  - - [40704, 1280, 1, 256]
-    - [58, 4811.09]
   - - [26112, 1153, 1, 384]
     - [54, 4768.9]
-  - - [9472, 768, 1, 256]
-    - [80, 4541.24]
-  - - [19456, 1536, 1, 256]
-    - [54, 4765.07]
   - - [11520, 2688, 1, 384]
     - [54, 4968.93]
   - - [19584, 3072, 1, 384]
     - [54, 4990.07]
-  - - [40448, 1792, 1, 256]
-    - [58, 4820.79]
   - - [28416, 384, 1, 384]
     - [54, 4851.91]
-  - - [32000, 2048, 1, 256]
-    - [58, 4795.14]
-  - - [12288, 1024, 1, 256]
-    - [80, 4614.14]
-  - - [7168, 1792, 1, 256]
-    - [83, 4639.3]
-  - - [30464, 1792, 1, 256]
-    - [58, 4809.36]
   - - [24960, 1152, 1, 384]
     - [53, 4941.95]
   - - [8448, 3072, 1, 384]
     - [58, 4934.77]
-  - - [22272, 768, 1, 256]
-    - [54, 4721.85]
   - - [25344, 1153, 1, 384]
     - [54, 4737.68]
   - - [22272, 2688, 1, 384]
     - [54, 4997.56]
   - - [24960, 2304, 1, 384]
     - [53, 4978.18]
-  - - [12032, 2048, 1, 256]
-    - [58, 4704.55]
   - - [11520, 768, 1, 384]
     - [58, 4755.58]
-  - - [36864, 1536, 1, 256]
-    - [54, 4806.21]
-  - - [5888, 1281, 1, 256]
-    - [53, 4426.21]
-  - - [16896, 1024, 1, 256]
-    - [58, 4669.77]
   - - [35712, 2688, 1, 384]
     - [54, 5015.3]
-  - - [22784, 768, 1, 256]
-    - [53, 4719.65]
-  - - [44288, 1281, 1, 256]
-    - [54, 4770.6]
   - - [23424, 1152, 1, 384]
     - [54, 4958.67]
-  - - [44288, 1792, 1, 256]
-    - [58, 4835.17]
   - - [24960, 3072, 1, 384]
     - [58, 4993.05]
   - - [29952, 1920, 1, 384]
     - [54, 5008.35]
-  - - [4096, 1792, 1, 256]
-    - [71, 4561.24]
-  - - [11776, 1536, 1, 256]
-    - [54, 4708.68]
-  - - [23040, 1024, 1, 256]
-    - [58, 4716.97]
   - - [30720, 384, 1, 384]
     - [54, 4814.28]
   - - [13440, 384, 1, 384]
@@ -17910,168 +23368,66 @@
     - [54, 4987.49]
   - - [25728, 3072, 1, 384]
     - [58, 4995.52]
-  - - [15360, 1536, 1, 256]
-    - [58, 4721.25]
   - - [33408, 2688, 1, 384]
     - [54, 5011.23]
-  - - [16384, 1281, 1, 256]
-    - [54, 4676.81]
   - - [40704, 3072, 1, 384]
     - [54, 5020.07]
-  - - [36608, 1280, 1, 256]
-    - [58, 4803.59]
-  - - [43520, 1024, 1, 256]
-    - [58, 4773.19]
-  - - [30464, 512, 1, 256]
-    - [58, 4652.74]
-  - - [22272, 256, 1, 256]
-    - [80, 4441.39]
-  - - [19456, 1792, 1, 256]
-    - [58, 4777.79]
   - - [38400, 1152, 1, 384]
     - [54, 4995.51]
-  - - [26880, 768, 1, 256]
-    - [53, 4747.07]
-  - - [15104, 1536, 1, 256]
-    - [54, 4724.25]
   - - [3840, 1152, 1, 384]
     - [79, 4607.0]
-  - - [39424, 512, 1, 256]
-    - [83, 4684.16]
   - - [7680, 1153, 1, 384]
     - [53, 4562.99]
-  - - [6912, 512, 1, 256]
-    - [58, 4354.79]
-  - - [2560, 1281, 1, 256]
-    - [44, 4201.78]
-  - - [5632, 1280, 1, 256]
-    - [83, 4526.82]
   - - [35328, 2688, 1, 384]
     - [54, 5015.72]
-  - - [23552, 2048, 1, 256]
-    - [58, 4780.35]
   - - [21120, 1536, 1, 384]
     - [54, 4947.29]
-  - - [3328, 512, 1, 256]
-    - [82, 3952.59]
   - - [21120, 2688, 1, 384]
     - [54, 4986.85]
   - - [40320, 1153, 1, 384]
     - [54, 4783.53]
   - - [38784, 1152, 1, 384]
     - [54, 4982.34]
-  - - [10496, 256, 1, 256]
-    - [80, 4053.9]
-  - - [22016, 256, 1, 256]
-    - [58, 4406.97]
-  - - [43520, 1792, 1, 256]
-    - [58, 4829.72]
-  - - [15872, 1281, 1, 256]
-    - [53, 4663.81]
   - - [19584, 1920, 1, 384]
     - [54, 4971.73]
-  - - [5120, 256, 1, 256]
-    - [79, 4082.05]
-  - - [20224, 1792, 1, 256]
-    - [58, 4780.89]
-  - - [35584, 256, 1, 256]
-    - [83, 4549.42]
-  - - [39936, 2048, 1, 256]
-    - [58, 4804.62]
-  - - [15616, 1280, 1, 256]
-    - [58, 4690.93]
-  - - [37376, 512, 1, 256]
-    - [58, 4671.54]
-  - - [27648, 1536, 1, 256]
-    - [54, 4793.66]
-  - - [5888, 768, 1, 256]
-    - [53, 4371.71]
   - - [11904, 1152, 1, 384]
     - [53, 4871.01]
   - - [43392, 1920, 1, 384]
     - [54, 5007.9]
-  - - [10240, 2048, 1, 256]
-    - [83, 4691.95]
   - - [17664, 1536, 1, 384]
     - [54, 4929.34]
   - - [34176, 1920, 1, 384]
     - [54, 5002.6]
   - - [16512, 2688, 1, 384]
     - [54, 4991.73]
-  - - [10240, 1536, 1, 256]
-    - [54, 4675.06]
   - - [18816, 2304, 1, 384]
     - [54, 4978.77]
-  - - [22784, 1792, 1, 256]
-    - [58, 4792.13]
-  - - [42240, 1281, 1, 256]
-    - [54, 4773.92]
   - - [36864, 768, 1, 384]
     - [58, 4945.52]
-  - - [26368, 1792, 1, 256]
-    - [58, 4799.62]
-  - - [3072, 1280, 1, 256]
-    - [69, 4473.13]
   - - [14592, 1536, 1, 384]
     - [57, 4917.67]
   - - [11136, 2304, 1, 384]
     - [54, 4927.99]
-  - - [41728, 2048, 1, 256]
-    - [58, 4805.41]
   - - [9600, 2688, 1, 384]
     - [54, 4942.66]
-  - - [33280, 1281, 1, 256]
-    - [54, 4749.8]
-  - - [25856, 1792, 1, 256]
-    - [58, 4795.31]
   - - [13824, 1153, 1, 384]
     - [54, 4659.56]
-  - - [22528, 2048, 1, 256]
-    - [58, 4774.97]
-  - - [30720, 1281, 1, 256]
-    - [54, 4742.05]
-  - - [32256, 1280, 1, 256]
-    - [58, 4790.54]
-  - - [6144, 1536, 1, 256]
-    - [83, 4565.23]
   - - [9216, 2304, 1, 384]
     - [58, 4909.87]
-  - - [10752, 768, 1, 256]
-    - [58, 4571.25]
   - - [3456, 1920, 1, 384]
     - [54, 4778.06]
-  - - [24576, 768, 1, 256]
-    - [54, 4756.31]
   - - [14208, 768, 1, 384]
     - [58, 4833.11]
-  - - [9216, 1792, 1, 256]
-    - [58, 4682.64]
   - - [38784, 384, 1, 384]
     - [54, 4909.29]
-  - - [37888, 1281, 1, 256]
-    - [54, 4753.99]
-  - - [36352, 2048, 1, 256]
-    - [58, 4796.77]
-  - - [6656, 256, 1, 256]
-    - [72, 3873.96]
-  - - [37632, 1281, 1, 256]
-    - [54, 4749.93]
   - - [35712, 768, 1, 384]
     - [53, 4938.25]
-  - - [43264, 2048, 1, 256]
-    - [58, 4809.55]
   - - [21120, 768, 1, 384]
     - [58, 4857.7]
-  - - [44288, 1280, 1, 256]
-    - [58, 4813.36]
   - - [4992, 2688, 1, 384]
     - [54, 4838.95]
   - - [16128, 3072, 1, 384]
     - [53, 4973.38]
-  - - [38912, 1024, 1, 256]
-    - [58, 4742.32]
-  - - [33024, 1792, 1, 256]
-    - [58, 4806.6]
   - - [41472, 768, 1, 384]
     - [58, 4944.05]
   - - [4992, 1153, 1, 384]
@@ -18080,322 +23436,140 @@
     - [58, 4744.3]
   - - [43392, 3072, 1, 384]
     - [54, 5011.13]
-  - - [24832, 1792, 1, 256]
-    - [58, 4787.49]
-  - - [42240, 1280, 1, 256]
-    - [58, 4818.76]
-  - - [31232, 1792, 1, 256]
-    - [58, 4807.39]
   - - [44160, 1153, 1, 384]
     - [54, 4780.19]
-  - - [34816, 768, 1, 256]
-    - [54, 4790.0]
-  - - [30208, 1792, 1, 256]
-    - [58, 4811.67]
-  - - [21760, 1792, 1, 256]
-    - [58, 4785.63]
-  - - [22784, 1281, 1, 256]
-    - [54, 4709.96]
-  - - [5376, 768, 1, 256]
-    - [83, 4390.85]
-  - - [31744, 2048, 1, 256]
-    - [58, 4789.41]
-  - - [16128, 256, 1, 256]
-    - [82, 4353.23]
   - - [37632, 1536, 1, 384]
     - [53, 4972.41]
-  - - [11264, 1280, 1, 256]
-    - [83, 4663.64]
-  - - [18432, 1792, 1, 256]
-    - [58, 4774.55]
   - - [15744, 1153, 1, 384]
     - [54, 4668.79]
-  - - [37376, 1280, 1, 256]
-    - [58, 4800.18]
   - - [17664, 768, 1, 384]
     - [54, 4864.53]
-  - - [10496, 768, 1, 256]
-    - [83, 4572.77]
   - - [3456, 2304, 1, 384]
     - [58, 4725.6]
   - - [38784, 2304, 1, 384]
     - [54, 5006.74]
-  - - [9216, 768, 1, 256]
-    - [83, 4556.74]
   - - [8448, 2688, 1, 384]
     - [54, 4950.25]
   - - [30720, 1153, 1, 384]
     - [54, 4756.85]
   - - [36864, 2304, 1, 384]
     - [54, 4996.22]
-  - - [40960, 768, 1, 256]
-    - [54, 4789.95]
   - - [24192, 1536, 1, 384]
     - [58, 4961.97]
-  - - [33280, 1536, 1, 256]
-    - [54, 4804.9]
-  - - [43264, 1281, 1, 256]
-    - [54, 4757.37]
-  - - [3072, 1536, 1, 256]
-    - [44, 4456.11]
-  - - [39168, 256, 1, 256]
-    - [58, 4589.68]
-  - - [14848, 1024, 1, 256]
-    - [80, 4653.87]
   - - [40704, 1920, 1, 384]
     - [54, 5013.97]
   - - [39552, 2688, 1, 384]
     - [54, 5012.93]
-  - - [30976, 1280, 1, 256]
-    - [57, 4779.9]
-  - - [24576, 2048, 1, 256]
-    - [58, 4788.86]
-  - - [8448, 1024, 1, 256]
-    - [83, 4559.78]
-  - - [2816, 1536, 1, 256]
-    - [47, 4381.52]
   - - [26112, 768, 1, 384]
     - [54, 4898.82]
   - - [31488, 384, 1, 384]
     - [54, 4885.0]
-  - - [9984, 768, 1, 256]
-    - [54, 4531.25]
   - - [29184, 1536, 1, 384]
     - [58, 4965.74]
   - - [12288, 1152, 1, 384]
     - [58, 4860.18]
   - - [32640, 1536, 1, 384]
     - [54, 4977.11]
-  - - [27648, 2048, 1, 256]
-    - [58, 4800.03]
   - - [5376, 2688, 1, 384]
     - [54, 4891.8]
   - - [13056, 768, 1, 384]
     - [58, 4792.36]
   - - [13824, 2304, 1, 384]
     - [58, 4935.43]
-  - - [42240, 2048, 1, 256]
-    - [58, 4801.51]
   - - [29952, 768, 1, 384]
     - [54, 4924.85]
-  - - [24832, 1280, 1, 256]
-    - [58, 4768.27]
   - - [1536, 1152, 1, 384]
     - [72, 4337.83]
   - - [28032, 2304, 1, 384]
     - [53, 4997.69]
   - - [16896, 768, 1, 384]
     - [58, 4850.32]
-  - - [41472, 512, 1, 256]
-    - [58, 4699.83]
-  - - [40448, 1280, 1, 256]
-    - [57, 4800.16]
   - - [30336, 1920, 1, 384]
     - [54, 4993.11]
-  - - [33536, 2048, 1, 256]
-    - [58, 4798.51]
   - - [14976, 384, 1, 384]
     - [82, 4675.04]
-  - - [37888, 1792, 1, 256]
-    - [58, 4812.98]
-  - - [27136, 1024, 1, 256]
-    - [58, 4733.15]
-  - - [38912, 1536, 1, 256]
-    - [54, 4807.77]
-  - - [31744, 1281, 1, 256]
-    - [54, 4747.36]
-  - - [38144, 768, 1, 256]
-    - [54, 4793.92]
   - - [27264, 2304, 1, 384]
     - [54, 4996.78]
   - - [39552, 1153, 1, 384]
     - [54, 4779.56]
   - - [7680, 1536, 1, 384]
     - [57, 4825.15]
-  - - [24576, 1281, 1, 256]
-    - [53, 4708.89]
   - - [16896, 384, 1, 384]
     - [53, 4689.82]
-  - - [40704, 1281, 1, 256]
-    - [53, 4761.74]
-  - - [10240, 768, 1, 256]
-    - [83, 4568.96]
-  - - [27392, 1536, 1, 256]
-    - [54, 4794.86]
-  - - [30464, 2048, 1, 256]
-    - [58, 4788.83]
   - - [30336, 1152, 1, 384]
     - [53, 4968.41]
   - - [30720, 2688, 1, 384]
     - [54, 5003.59]
-  - - [29184, 1024, 1, 256]
-    - [58, 4742.62]
-  - - [37120, 1280, 1, 256]
-    - [58, 4805.95]
-  - - [30720, 2048, 1, 256]
-    - [58, 4797.32]
-  - - [25344, 1536, 1, 256]
-    - [54, 4777.5]
   - - [37632, 1153, 1, 384]
     - [54, 4761.67]
-  - - [40960, 1280, 1, 256]
-    - [58, 4816.13]
-  - - [34048, 256, 1, 256]
-    - [80, 4526.1]
   - - [1920, 1153, 1, 384]
     - [44, 4410.98]
-  - - [20480, 1280, 1, 256]
-    - [58, 4749.52]
   - - [36096, 2688, 1, 384]
     - [54, 5005.94]
-  - - [8960, 256, 1, 256]
-    - [57, 4217.2]
   - - [5760, 1920, 1, 384]
     - [54, 4789.48]
   - - [39552, 1536, 1, 384]
     - [58, 4980.13]
-  - - [25856, 1281, 1, 256]
-    - [54, 4725.53]
   - - [40704, 2304, 1, 384]
     - [54, 5007.3]
-  - - [22272, 1792, 1, 256]
-    - [58, 4785.99]
-  - - [43776, 1281, 1, 256]
-    - [54, 4772.2]
-  - - [16896, 1281, 1, 256]
-    - [54, 4669.48]
-  - - [19712, 256, 1, 256]
-    - [82, 4384.49]
   - - [9216, 1153, 1, 384]
     - [54, 4581.63]
   - - [25728, 384, 1, 384]
     - [54, 4761.95]
-  - - [37376, 2048, 1, 256]
-    - [58, 4798.84]
   - - [43776, 2304, 1, 384]
     - [54, 5018.37]
   - - [27648, 1152, 1, 384]
     - [54, 4975.02]
-  - - [26368, 1536, 1, 256]
-    - [54, 4796.95]
-  - - [41472, 1024, 1, 256]
-    - [58, 4775.3]
   - - [31488, 1152, 1, 384]
     - [54, 4966.8]
-  - - [8704, 1280, 1, 256]
-    - [83, 4608.23]
-  - - [26624, 2048, 1, 256]
-    - [58, 4786.85]
   - - [39168, 1152, 1, 384]
     - [54, 4993.91]
   - - [42240, 1536, 1, 384]
     - [58, 4989.22]
-  - - [41472, 768, 1, 256]
-    - [54, 4807.4]
-  - - [36096, 2048, 1, 256]
-    - [58, 4797.67]
-  - - [3328, 1792, 1, 256]
-    - [71, 4500.97]
-  - - [32000, 1280, 1, 256]
-    - [58, 4789.51]
   - - [20352, 1152, 1, 384]
     - [58, 4919.18]
   - - [8448, 1920, 1, 384]
     - [54, 4868.33]
-  - - [16384, 1024, 1, 256]
-    - [83, 4648.03]
   - - [32256, 1536, 1, 384]
     - [58, 4973.64]
-  - - [7680, 1280, 1, 256]
-    - [83, 4578.6]
   - - [25344, 1152, 1, 384]
     - [54, 4952.11]
-  - - [33024, 768, 1, 256]
-    - [53, 4772.7]
   - - [21888, 2304, 1, 384]
     - [53, 4979.92]
   - - [44160, 2304, 1, 384]
     - [58, 5006.17]
   - - [30336, 2688, 1, 384]
     - [54, 5003.67]
-  - - [13056, 2048, 1, 256]
-    - [58, 4732.91]
   - - [14208, 3072, 1, 384]
     - [58, 4960.88]
-  - - [7936, 768, 1, 256]
-    - [83, 4454.38]
-  - - [16128, 1281, 1, 256]
-    - [54, 4666.61]
-  - - [15360, 2048, 1, 256]
-    - [58, 4739.44]
-  - - [28672, 1792, 1, 256]
-    - [58, 4793.28]
-  - - [7680, 2048, 1, 256]
-    - [83, 4666.61]
-  - - [41728, 1280, 1, 256]
-    - [58, 4813.44]
-  - - [40704, 1792, 1, 256]
-    - [58, 4827.07]
   - - [6144, 2688, 1, 384]
     - [54, 4907.9]
-  - - [33536, 256, 1, 256]
-    - [82, 4542.82]
-  - - [1536, 1280, 1, 256]
-    - [60, 4208.34]
   - - [39168, 1536, 1, 384]
     - [58, 4985.33]
   - - [11904, 1920, 1, 384]
     - [54, 4911.57]
-  - - [25856, 256, 1, 256]
-    - [59, 4466.26]
-  - - [9216, 1280, 1, 256]
-    - [83, 4640.29]
-  - - [23552, 768, 1, 256]
-    - [54, 4732.93]
   - - [31104, 1920, 1, 384]
     - [54, 5006.15]
-  - - [12032, 1792, 1, 256]
-    - [58, 4715.76]
-  - - [39168, 1280, 1, 256]
-    - [58, 4811.93]
-  - - [40192, 1792, 1, 256]
-    - [58, 4822.2]
   - - [8064, 1536, 1, 384]
     - [57, 4812.75]
   - - [22272, 1152, 1, 384]
     - [54, 4946.29]
-  - - [32000, 1792, 1, 256]
-    - [58, 4811.12]
-  - - [12288, 768, 1, 256]
-    - [80, 4604.56]
   - - [21120, 1920, 1, 384]
     - [54, 4983.79]
   - - [29952, 1152, 1, 384]
     - [54, 4972.01]
   - - [22656, 2304, 1, 384]
     - [54, 4996.56]
-  - - [12032, 768, 1, 256]
-    - [54, 4592.66]
-  - - [21504, 256, 1, 256]
-    - [80, 4458.64]
   - - [9600, 1152, 1, 384]
     - [54, 4791.42]
-  - - [34304, 1281, 1, 256]
-    - [54, 4752.25]
   - - [19968, 2688, 1, 384]
     - [54, 5002.09]
-  - - [20480, 512, 1, 256]
-    - [83, 4593.98]
   - - [22656, 3072, 1, 384]
     - [53, 4993.93]
   - - [10752, 768, 1, 384]
     - [57, 4815.48]
-  - - [10752, 1792, 1, 256]
-    - [58, 4720.46]
   - - [41856, 768, 1, 384]
     - [54, 4963.18]
-  - - [29440, 1024, 1, 256]
-    - [58, 4735.84]
   - - [19584, 2688, 1, 384]
     - [54, 4996.85]
   - - [16128, 1153, 1, 384]
@@ -18406,186 +23580,68 @@
     - [53, 4822.96]
   - - [14592, 768, 1, 384]
     - [58, 4803.5]
-  - - [38656, 1281, 1, 256]
-    - [54, 4762.74]
-  - - [30208, 1280, 1, 256]
-    - [58, 4783.3]
-  - - [3840, 1792, 1, 256]
-    - [83, 4482.92]
-  - - [8448, 1280, 1, 256]
-    - [58, 4584.09]
-  - - [23808, 256, 1, 256]
-    - [83, 4429.1]
   - - [24576, 3072, 1, 384]
     - [53, 4985.87]
-  - - [37888, 1280, 1, 256]
-    - [58, 4808.86]
   - - [14592, 1152, 1, 384]
     - [54, 4921.5]
-  - - [37120, 256, 1, 256]
-    - [83, 4563.82]
   - - [18432, 2304, 1, 384]
     - [58, 4958.54]
-  - - [35840, 1280, 1, 256]
-    - [58, 4801.41]
-  - - [768, 1024, 1, 256]
-    - [76, 3929.09]
-  - - [8192, 768, 1, 256]
-    - [80, 4504.96]
   - - [20736, 384, 1, 384]
     - [54, 4704.94]
-  - - [42752, 1280, 1, 256]
-    - [58, 4808.33]
-  - - [28672, 1024, 1, 256]
-    - [58, 4724.55]
-  - - [7168, 768, 1, 256]
-    - [61, 4410.64]
   - - [9216, 1920, 1, 384]
     - [54, 4935.77]
-  - - [33280, 2048, 1, 256]
-    - [58, 4794.91]
-  - - [37888, 1536, 1, 256]
-    - [54, 4811.95]
-  - - [8448, 768, 1, 256]
-    - [80, 4522.29]
-  - - [7168, 1280, 1, 256]
-    - [83, 4569.67]
-  - - [3584, 2048, 1, 256]
-    - [83, 4522.17]
   - - [31872, 2688, 1, 384]
     - [53, 5014.55]
-  - - [30208, 1281, 1, 256]
-    - [54, 4745.48]
-  - - [33792, 1536, 1, 256]
-    - [53, 4791.83]
-  - - [44032, 2048, 1, 256]
-    - [58, 4810.95]
-  - - [7424, 256, 1, 256]
-    - [57, 4077.6]
   - - [41472, 1152, 1, 384]
     - [54, 4987.95]
-  - - [5376, 2048, 1, 256]
-    - [83, 4616.98]
   - - [14976, 1920, 1, 384]
     - [54, 4957.49]
   - - [13824, 1152, 1, 384]
     - [58, 4870.57]
   - - [33024, 2688, 1, 384]
     - [54, 5014.99]
-  - - [5376, 1792, 1, 256]
-    - [83, 4600.87]
   - - [43008, 1153, 1, 384]
     - [53, 4774.12]
   - - [1536, 768, 1, 384]
     - [58, 4513.6]
-  - - [9728, 1792, 1, 256]
-    - [58, 4683.03]
-  - - [42496, 1281, 1, 256]
-    - [54, 4767.89]
-  - - [11520, 1024, 1, 256]
-    - [83, 4621.26]
-  - - [2816, 1792, 1, 256]
-    - [70, 4424.14]
-  - - [4096, 1280, 1, 256]
-    - [80, 4493.1]
-  - - [43776, 1280, 1, 256]
-    - [58, 4821.56]
   - - [34176, 1153, 1, 384]
     - [54, 4761.81]
-  - - [13568, 1792, 1, 256]
-    - [58, 4726.16]
-  - - [29184, 2048, 1, 256]
-    - [58, 4793.19]
   - - [33024, 2304, 1, 384]
     - [54, 5008.01]
-  - - [4352, 768, 1, 256]
-    - [83, 4306.62]
   - - [41856, 1153, 1, 384]
     - [54, 4781.96]
-  - - [28672, 512, 1, 256]
-    - [80, 4640.31]
-  - - [9216, 1024, 1, 256]
-    - [58, 4564.2]
-  - - [5888, 1792, 1, 256]
-    - [83, 4587.83]
-  - - [27392, 1281, 1, 256]
-    - [54, 4738.68]
   - - [31488, 1153, 1, 384]
     - [54, 4765.83]
   - - [17280, 768, 1, 384]
     - [54, 4871.78]
   - - [29184, 1153, 1, 384]
     - [54, 4761.81]
-  - - [19968, 768, 1, 256]
-    - [53, 4696.69]
-  - - [35584, 1792, 1, 256]
-    - [58, 4822.29]
   - - [21504, 3072, 1, 384]
     - [54, 4998.14]
   - - [3456, 1153, 1, 384]
     - [43, 4357.92]
-  - - [26112, 1792, 1, 256]
-    - [58, 4801.48]
-  - - [30976, 1024, 1, 256]
-    - [58, 4737.23]
   - - [37632, 2688, 1, 384]
     - [54, 5015.73]
   - - [14208, 2688, 1, 384]
     - [54, 4978.95]
-  - - [24320, 1280, 1, 256]
-    - [58, 4756.47]
-  - - [32512, 256, 1, 256]
-    - [83, 4565.28]
-  - - [27136, 1281, 1, 256]
-    - [54, 4732.44]
-  - - [20736, 1536, 1, 256]
-    - [53, 4767.04]
-  - - [38656, 512, 1, 256]
-    - [83, 4683.95]
   - - [38016, 2304, 1, 384]
     - [54, 5009.7]
   - - [16896, 2688, 1, 384]
     - [54, 4998.03]
-  - - [16384, 768, 1, 256]
-    - [80, 4637.79]
-  - - [34560, 1792, 1, 256]
-    - [58, 4819.98]
-  - - [16128, 512, 1, 256]
-    - [83, 4538.28]
-  - - [7680, 768, 1, 256]
-    - [82, 4473.13]
   - - [4224, 1153, 1, 384]
     - [53, 4436.77]
-  - - [38144, 1280, 1, 256]
-    - [58, 4803.48]
-  - - [2304, 1280, 1, 256]
-    - [70, 4194.31]
-  - - [31488, 2048, 1, 256]
-    - [58, 4798.4]
   - - [31104, 768, 1, 384]
     - [54, 4937.32]
-  - - [32512, 512, 1, 256]
-    - [83, 4663.81]
   - - [41472, 2304, 1, 384]
     - [54, 5011.85]
-  - - [12800, 768, 1, 256]
-    - [83, 4580.27]
   - - [10752, 1152, 1, 384]
     - [53, 4835.45]
-  - - [21760, 1281, 1, 256]
-    - [54, 4714.89]
   - - [9216, 3072, 1, 384]
     - [57, 4928.13]
   - - [23424, 2688, 1, 384]
     - [54, 4997.16]
-  - - [11264, 2048, 1, 256]
-    - [83, 4705.34]
   - - [18048, 1152, 1, 384]
     - [53, 4933.06]
-  - - [11776, 256, 1, 256]
-    - [58, 4201.61]
-  - - [13568, 1536, 1, 256]
-    - [53, 4722.05]
   - - [39936, 3072, 1, 384]
     - [54, 5007.46]
   - - [22656, 384, 1, 384]
@@ -18594,418 +23650,160 @@
     - [58, 4951.96]
   - - [41472, 384, 1, 384]
     - [54, 4885.2]
-  - - [11776, 2048, 1, 256]
-    - [58, 4696.07]
   - - [26496, 2688, 1, 384]
     - [54, 5010.88]
   - - [16512, 2304, 1, 384]
     - [54, 4977.77]
-  - - [8704, 1024, 1, 256]
-    - [83, 4580.63]
   - - [31104, 1153, 1, 384]
     - [54, 4761.88]
-  - - [39424, 1281, 1, 256]
-    - [54, 4752.23]
-  - - [35840, 1536, 1, 256]
-    - [54, 4797.28]
-  - - [24320, 2048, 1, 256]
-    - [58, 4773.32]
   - - [9600, 1153, 1, 384]
     - [54, 4598.23]
-  - - [7680, 256, 1, 256]
-    - [60, 4195.7]
   - - [16512, 1153, 1, 384]
     - [54, 4701.43]
-  - - [44032, 1280, 1, 256]
-    - [58, 4812.61]
-  - - [35840, 1281, 1, 256]
-    - [54, 4759.55]
   - - [11520, 1920, 1, 384]
     - [54, 4923.98]
-  - - [39680, 2048, 1, 256]
-    - [58, 4807.98]
-  - - [38656, 1280, 1, 256]
-    - [58, 4808.08]
-  - - [2816, 1281, 1, 256]
-    - [69, 4126.31]
   - - [39552, 768, 1, 384]
     - [54, 4946.13]
-  - - [40448, 2048, 1, 256]
-    - [58, 4808.23]
-  - - [26368, 768, 1, 256]
-    - [54, 4747.57]
   - - [5376, 1153, 1, 384]
     - [54, 4471.77]
   - - [26112, 384, 1, 384]
     - [54, 4788.78]
-  - - [31744, 256, 1, 256]
-    - [80, 4554.63]
-  - - [6144, 1281, 1, 256]
-    - [54, 4455.64]
   - - [23808, 1152, 1, 384]
     - [54, 4955.54]
-  - - [34560, 2048, 1, 256]
-    - [58, 4797.2]
-  - - [32768, 1280, 1, 256]
-    - [58, 4786.65]
   - - [29568, 3072, 1, 384]
     - [58, 4988.31]
-  - - [30720, 1280, 1, 256]
-    - [58, 4801.63]
-  - - [3584, 1281, 1, 256]
-    - [54, 4354.34]
-  - - [25856, 2048, 1, 256]
-    - [58, 4779.97]
-  - - [43264, 1792, 1, 256]
-    - [58, 4816.31]
-  - - [39680, 1536, 1, 256]
-    - [53, 4807.79]
-  - - [30720, 512, 1, 256]
-    - [83, 4664.01]
-  - - [28160, 512, 1, 256]
-    - [83, 4664.34]
   - - [12672, 2304, 1, 384]
     - [54, 4937.98]
   - - [11136, 768, 1, 384]
     - [54, 4802.78]
   - - [1152, 1152, 1, 384]
     - [65, 3860.67]
-  - - [40960, 1792, 1, 256]
-    - [58, 4826.98]
   - - [6144, 2304, 1, 384]
     - [53, 4884.29]
-  - - [23296, 1792, 1, 256]
-    - [58, 4793.28]
   - - [14208, 2304, 1, 384]
     - [54, 4952.69]
-  - - [40192, 1024, 1, 256]
-    - [58, 4758.93]
-  - - [40704, 256, 1, 256]
-    - [57, 4584.1]
-  - - [40704, 512, 1, 256]
-    - [58, 4697.76]
-  - - [3840, 256, 1, 256]
-    - [48, 3817.63]
   - - [19584, 2304, 1, 384]
     - [54, 4982.82]
-  - - [23040, 256, 1, 256]
-    - [59, 4468.9]
-  - - [20992, 1281, 1, 256]
-    - [54, 4706.07]
   - - [34560, 2688, 1, 384]
     - [54, 5009.37]
-  - - [44288, 1536, 1, 256]
-    - [54, 4818.32]
   - - [38400, 3072, 1, 384]
     - [54, 5017.18]
-  - - [7168, 1281, 1, 256]
-    - [54, 4533.03]
-  - - [29440, 1280, 1, 256]
-    - [58, 4785.36]
   - - [36480, 768, 1, 384]
     - [53, 4934.23]
-  - - [34560, 1281, 1, 256]
-    - [54, 4744.98]
   - - [15744, 1152, 1, 384]
     - [53, 4883.63]
-  - - [34048, 512, 1, 256]
-    - [83, 4662.48]
-  - - [11008, 2048, 1, 256]
-    - [58, 4695.22]
-  - - [43008, 1024, 1, 256]
-    - [58, 4761.42]
   - - [15744, 2688, 1, 384]
     - [54, 4982.54]
-  - - [33792, 1280, 1, 256]
-    - [58, 4802.64]
-  - - [1536, 512, 1, 256]
-    - [51, 3907.74]
-  - - [38400, 2048, 1, 256]
-    - [58, 4809.38]
-  - - [24576, 1024, 1, 256]
-    - [58, 4714.5]
   - - [39168, 3072, 1, 384]
     - [54, 5013.87]
-  - - [12544, 512, 1, 256]
-    - [83, 4484.91]
-  - - [25600, 2048, 1, 256]
-    - [58, 4776.84]
-  - - [32512, 2048, 1, 256]
-    - [58, 4790.42]
-  - - [36352, 1024, 1, 256]
-    - [58, 4750.19]
   - - [14976, 1536, 1, 384]
     - [54, 4920.57]
   - - [6144, 3072, 1, 384]
     - [58, 4887.76]
-  - - [12288, 512, 1, 256]
-    - [80, 4450.19]
-  - - [12032, 512, 1, 256]
-    - [83, 4475.7]
-  - - [36608, 256, 1, 256]
-    - [58, 4590.08]
-  - - [15872, 2048, 1, 256]
-    - [58, 4742.68]
   - - [31872, 1153, 1, 384]
     - [54, 4770.65]
-  - - [25856, 1024, 1, 256]
-    - [58, 4728.22]
-  - - [26880, 2048, 1, 256]
-    - [58, 4793.82]
   - - [24576, 1153, 1, 384]
     - [54, 4744.43]
   - - [41088, 3072, 1, 384]
     - [58, 5002.19]
-  - - [14080, 256, 1, 256]
-    - [83, 4300.65]
   - - [34176, 3072, 1, 384]
     - [58, 5001.42]
   - - [6144, 1152, 1, 384]
     - [58, 4818.3]
-  - - [9984, 2048, 1, 256]
-    - [58, 4686.54]
-  - - [32512, 768, 1, 256]
-    - [54, 4779.66]
-  - - [36096, 1281, 1, 256]
-    - [54, 4753.66]
-  - - [26112, 1536, 1, 256]
-    - [54, 4778.23]
-  - - [16128, 1792, 1, 256]
-    - [58, 4761.35]
   - - [7296, 384, 1, 384]
     - [82, 4461.84]
-  - - [4352, 2048, 1, 256]
-    - [83, 4560.85]
   - - [36096, 384, 1, 384]
     - [54, 4861.68]
   - - [33792, 1153, 1, 384]
     - [54, 4772.04]
-  - - [28416, 2048, 1, 256]
-    - [58, 4788.38]
   - - [1920, 768, 1, 384]
     - [74, 4210.53]
   - - [34560, 1536, 1, 384]
     - [54, 4972.95]
-  - - [28672, 2048, 1, 256]
-    - [58, 4785.86]
-  - - [11008, 768, 1, 256]
-    - [54, 4542.57]
   - - [8448, 2304, 1, 384]
     - [54, 4901.92]
-  - - [26368, 1280, 1, 256]
-    - [58, 4780.28]
-  - - [39680, 1281, 1, 256]
-    - [54, 4767.46]
-  - - [17664, 256, 1, 256]
-    - [58, 4349.37]
-  - - [28160, 2048, 1, 256]
-    - [58, 4793.68]
   - - [9984, 2688, 1, 384]
     - [54, 4939.14]
   - - [16512, 1152, 1, 384]
     - [54, 4896.62]
-  - - [6912, 1281, 1, 256]
-    - [54, 4535.2]
   - - [8064, 1153, 1, 384]
     - [54, 4611.67]
-  - - [6912, 1792, 1, 256]
-    - [58, 4615.83]
-  - - [13824, 512, 1, 256]
-    - [83, 4512.25]
-  - - [14336, 1792, 1, 256]
-    - [58, 4744.94]
-  - - [42752, 1281, 1, 256]
-    - [54, 4767.9]
   - - [8064, 768, 1, 384]
     - [54, 4704.03]
-  - - [5888, 2048, 1, 256]
-    - [83, 4622.38]
-  - - [34304, 1280, 1, 256]
-    - [58, 4787.53]
-  - - [24832, 1024, 1, 256]
-    - [58, 4718.85]
   - - [44160, 1152, 1, 384]
     - [54, 4989.47]
-  - - [35840, 2048, 1, 256]
-    - [58, 4794.81]
   - - [26112, 2688, 1, 384]
     - [54, 5000.26]
-  - - [34560, 1280, 1, 256]
-    - [58, 4797.76]
-  - - [38912, 2048, 1, 256]
-    - [58, 4804.64]
-  - - [20224, 1280, 1, 256]
-    - [58, 4744.28]
-  - - [13824, 2048, 1, 256]
-    - [58, 4735.12]
-  - - [23040, 1281, 1, 256]
-    - [54, 4706.16]
-  - - [37120, 1024, 1, 256]
-    - [58, 4751.82]
-  - - [33024, 1024, 1, 256]
-    - [58, 4758.61]
-  - - [16384, 1792, 1, 256]
-    - [58, 4753.72]
-  - - [43264, 1024, 1, 256]
-    - [58, 4769.78]
   - - [21120, 1152, 1, 384]
     - [54, 4958.4]
-  - - [27392, 1792, 1, 256]
-    - [58, 4803.79]
-  - - [2048, 512, 1, 256]
-    - [45, 3968.6]
-  - - [6656, 1536, 1, 256]
-    - [83, 4582.66]
-  - - [40960, 256, 1, 256]
-    - [83, 4607.86]
   - - [6528, 3072, 1, 384]
     - [54, 4903.31]
   - - [39936, 768, 1, 384]
     - [54, 4946.83]
   - - [20736, 1152, 1, 384]
     - [54, 4955.03]
-  - - [22272, 1280, 1, 256]
-    - [58, 4758.05]
   - - [19200, 1920, 1, 384]
     - [58, 4968.75]
   - - [38400, 768, 1, 384]
     - [58, 4947.5]
-  - - [29952, 256, 1, 256]
-    - [58, 4498.84]
   - - [19200, 1153, 1, 384]
     - [54, 4733.84]
   - - [29952, 3072, 1, 384]
     - [54, 5005.19]
-  - - [43008, 1792, 1, 256]
-    - [58, 4831.71]
   - - [19200, 2304, 1, 384]
     - [53, 4973.81]
   - - [8448, 1536, 1, 384]
     - [58, 4863.01]
-  - - [18176, 2048, 1, 256]
-    - [58, 4766.16]
   - - [13824, 1536, 1, 384]
     - [58, 4902.08]
   - - [6912, 1152, 1, 384]
     - [58, 4722.38]
-  - - [6144, 1792, 1, 256]
-    - [83, 4616.68]
-  - - [38144, 1024, 1, 256]
-    - [58, 4763.89]
   - - [32640, 768, 1, 384]
     - [54, 4946.11]
-  - - [36608, 1536, 1, 256]
-    - [54, 4796.37]
   - - [9600, 768, 1, 384]
     - [58, 4743.89]
   - - [29568, 1152, 1, 384]
     - [54, 4970.94]
   - - [34560, 2304, 1, 384]
     - [54, 5003.32]
-  - - [24320, 1792, 1, 256]
-    - [58, 4790.08]
-  - - [256, 512, 1, 256]
-    - [62, 1441.34]
-  - - [26112, 2048, 1, 256]
-    - [58, 4790.67]
-  - - [36096, 1280, 1, 256]
-    - [58, 4798.2]
-  - - [29952, 1792, 1, 256]
-    - [58, 4817.32]
-  - - [12288, 256, 1, 256]
-    - [59, 4310.14]
-  - - [36864, 512, 1, 256]
-    - [58, 4688.01]
   - - [10368, 768, 1, 384]
     - [54, 4706.68]
-  - - [32512, 1281, 1, 256]
-    - [53, 4753.56]
   - - [28800, 1153, 1, 384]
     - [53, 4744.69]
-  - - [27904, 2048, 1, 256]
-    - [58, 4789.98]
-  - - [14336, 512, 1, 256]
-    - [83, 4520.42]
   - - [768, 768, 1, 384]
     - [78, 3482.36]
   - - [2688, 1152, 1, 384]
     - [58, 4580.46]
-  - - [10752, 1280, 1, 256]
-    - [58, 4643.63]
-  - - [8960, 1280, 1, 256]
-    - [83, 4619.57]
   - - [20736, 1536, 1, 384]
     - [58, 4937.58]
   - - [19584, 1153, 1, 384]
     - [54, 4733.21]
-  - - [23296, 2048, 1, 256]
-    - [57, 4770.65]
-  - - [22528, 1792, 1, 256]
-    - [58, 4782.84]
-  - - [6400, 768, 1, 256]
-    - [80, 4444.37]
   - - [28800, 768, 1, 384]
     - [54, 4919.76]
-  - - [9728, 1280, 1, 256]
-    - [58, 4622.23]
-  - - [18432, 2048, 1, 256]
-    - [58, 4756.59]
   - - [42240, 768, 1, 384]
     - [54, 4964.33]
-  - - [38144, 2048, 1, 256]
-    - [58, 4800.53]
-  - - [23808, 1281, 1, 256]
-    - [54, 4732.16]
   - - [34176, 384, 1, 384]
     - [54, 4844.7]
   - - [40320, 2304, 1, 384]
     - [53, 4996.6]
   - - [22656, 1153, 1, 384]
     - [54, 4730.71]
-  - - [26112, 512, 1, 256]
-    - [83, 4635.34]
   - - [18816, 1153, 1, 384]
     - [54, 4724.3]
-  - - [22016, 2048, 1, 256]
-    - [58, 4776.99]
   - - [13440, 1153, 1, 384]
     - [54, 4651.66]
   - - [28416, 2688, 1, 384]
     - [58, 5004.98]
   - - [30720, 1920, 1, 384]
     - [54, 4998.82]
-  - - [7424, 1792, 1, 256]
-    - [83, 4633.46]
-  - - [16128, 1280, 1, 256]
-    - [58, 4725.01]
   - - [8064, 1152, 1, 384]
     - [58, 4796.25]
-  - - [16128, 2048, 1, 256]
-    - [58, 4739.33]
-  - - [7424, 2048, 1, 256]
-    - [83, 4646.32]
   - - [39936, 1536, 1, 384]
     - [54, 4982.15]
-  - - [37888, 768, 1, 256]
-    - [54, 4800.29]
-  - - [21248, 1536, 1, 256]
-    - [54, 4778.36]
-  - - [23296, 512, 1, 256]
-    - [83, 4613.86]
-  - - [18944, 1792, 1, 256]
-    - [58, 4765.63]
   - - [10368, 1536, 1, 384]
     - [53, 4857.73]
-  - - [39168, 1024, 1, 256]
-    - [58, 4766.25]
-  - - [3840, 1024, 1, 256]
-    - [83, 4408.87]
   - - [768, 769, 1, 384]
     - [42, 3419.59]
-  - - [29696, 1536, 1, 256]
-    - [54, 4798.14]
-  - - [27904, 1536, 1, 256]
-    - [54, 4799.7]
   - - [21888, 1536, 1, 384]
     - [53, 4949.57]
   - - [38784, 2688, 1, 384]
@@ -19014,32 +23812,16 @@
     - [54, 4984.17]
   - - [27648, 2304, 1, 384]
     - [58, 4997.34]
-  - - [13056, 1280, 1, 256]
-    - [58, 4684.83]
-  - - [14848, 2048, 1, 256]
-    - [57, 4728.73]
   - - [34944, 1153, 1, 384]
     - [54, 4789.65]
   - - [41088, 2688, 1, 384]
     - [54, 5018.71]
-  - - [8448, 1792, 1, 256]
-    - [58, 4662.13]
-  - - [19712, 1281, 1, 256]
-    - [54, 4694.33]
   - - [11136, 1920, 1, 384]
     - [54, 4929.72]
   - - [35712, 384, 1, 384]
     - [53, 4892.37]
-  - - [5120, 512, 1, 256]
-    - [80, 4217.5]
-  - - [7680, 1792, 1, 256]
-    - [83, 4641.92]
-  - - [33792, 1792, 1, 256]
-    - [58, 4820.44]
   - - [22656, 1152, 1, 384]
     - [54, 4942.93]
-  - - [14592, 1281, 1, 256]
-    - [53, 4645.15]
   - - [36864, 1536, 1, 384]
     - [54, 4983.74]
   - - [14592, 1153, 1, 384]
@@ -19050,302 +23832,140 @@
     - [54, 4692.61]
   - - [37248, 768, 1, 384]
     - [58, 4956.36]
-  - - [15104, 1792, 1, 256]
-    - [58, 4743.68]
-  - - [3584, 768, 1, 256]
-    - [70, 4184.35]
-  - - [12032, 1280, 1, 256]
-    - [83, 4663.87]
   - - [23424, 3072, 1, 384]
     - [58, 4997.56]
-  - - [36352, 256, 1, 256]
-    - [58, 4586.76]
-  - - [8704, 1536, 1, 256]
-    - [80, 4624.07]
-  - - [35328, 1281, 1, 256]
-    - [54, 4745.28]
-  - - [18944, 1280, 1, 256]
-    - [58, 4732.39]
-  - - [12800, 1281, 1, 256]
-    - [54, 4629.62]
   - - [23040, 2688, 1, 384]
     - [54, 4992.59]
-  - - [39424, 1024, 1, 256]
-    - [58, 4758.7]
-  - - [26880, 1024, 1, 256]
-    - [58, 4729.53]
-  - - [24832, 1281, 1, 256]
-    - [54, 4729.75]
   - - [4224, 3072, 1, 384]
     - [58, 4867.95]
-  - - [2048, 1280, 1, 256]
-    - [69, 4377.05]
-  - - [35328, 256, 1, 256]
-    - [59, 4550.78]
   - - [6912, 2304, 1, 384]
     - [54, 4878.5]
-  - - [12544, 1280, 1, 256]
-    - [58, 4664.57]
-  - - [25344, 1792, 1, 256]
-    - [58, 4789.58]
   - - [24192, 3072, 1, 384]
     - [58, 4992.8]
   - - [17664, 3072, 1, 384]
     - [54, 4983.33]
-  - - [4352, 1792, 1, 256]
-    - [83, 4561.95]
   - - [27648, 1153, 1, 384]
     - [54, 4756.01]
-  - - [23808, 1280, 1, 256]
-    - [58, 4761.6]
   - - [37632, 1920, 1, 384]
     - [54, 5001.9]
-  - - [17408, 256, 1, 256]
-    - [82, 4302.5]
-  - - [40192, 2048, 1, 256]
-    - [58, 4805.82]
   - - [36096, 768, 1, 384]
     - [54, 4957.69]
   - - [4224, 2688, 1, 384]
     - [58, 4850.68]
-  - - [18432, 1024, 1, 256]
-    - [58, 4691.47]
-  - - [35584, 1281, 1, 256]
-    - [54, 4760.25]
-  - - [10752, 256, 1, 256]
-    - [79, 4132.32]
   - - [40704, 1152, 1, 384]
     - [54, 4978.42]
-  - - [44288, 2048, 1, 256]
-    - [58, 4809.14]
-  - - [9472, 256, 1, 256]
-    - [79, 4006.95]
   - - [8448, 1153, 1, 384]
     - [53, 4621.16]
   - - [7680, 768, 1, 384]
     - [54, 4763.85]
-  - - [26624, 1792, 1, 256]
-    - [57, 4795.9]
-  - - [38912, 1281, 1, 256]
-    - [54, 4768.05]
   - - [25344, 3072, 1, 384]
     - [54, 4995.46]
   - - [13440, 3072, 1, 384]
     - [58, 4957.5]
-  - - [34304, 1792, 1, 256]
-    - [58, 4816.2]
-  - - [36864, 1024, 1, 256]
-    - [58, 4752.75]
   - - [38016, 1920, 1, 384]
     - [54, 5010.41]
-  - - [32512, 1280, 1, 256]
-    - [57, 4784.49]
   - - [36864, 384, 1, 384]
     - [54, 4871.33]
   - - [35712, 2304, 1, 384]
     - [54, 5004.48]
   - - [34560, 1152, 1, 384]
     - [54, 4975.67]
-  - - [28928, 2048, 1, 256]
-    - [58, 4798.59]
   - - [42240, 1152, 1, 384]
     - [54, 4991.03]
   - - [31872, 3072, 1, 384]
     - [54, 5006.09]
-  - - [29952, 1281, 1, 256]
-    - [54, 4736.21]
   - - [43008, 3072, 1, 384]
     - [54, 5007.97]
-  - - [35840, 256, 1, 256]
-    - [80, 4573.94]
   - - [37248, 2688, 1, 384]
     - [54, 5008.56]
   - - [42624, 1153, 1, 384]
     - [54, 4779.62]
   - - [29568, 1920, 1, 384]
     - [54, 4997.46]
-  - - [31488, 1281, 1, 256]
-    - [54, 4743.51]
-  - - [18432, 1281, 1, 256]
-    - [54, 4699.22]
   - - [4992, 384, 1, 384]
     - [53, 4455.81]
-  - - [7168, 2048, 1, 256]
-    - [80, 4643.98]
-  - - [4864, 1536, 1, 256]
-    - [83, 4526.23]
-  - - [5632, 256, 1, 256]
-    - [73, 3827.24]
-  - - [12800, 1280, 1, 256]
-    - [58, 4672.59]
-  - - [18688, 768, 1, 256]
-    - [54, 4679.81]
   - - [384, 385, 1, 384]
     - [67, 1699.72]
-  - - [9216, 1281, 1, 256]
-    - [54, 4551.6]
   - - [38400, 2688, 1, 384]
     - [54, 5028.21]
-  - - [18944, 1281, 1, 256]
-    - [54, 4688.05]
   - - [25728, 768, 1, 384]
     - [53, 4892.89]
   - - [9600, 384, 1, 384]
     - [82, 4418.71]
-  - - [14848, 1281, 1, 256]
-    - [54, 4661.3]
-  - - [22272, 1536, 1, 256]
-    - [54, 4782.81]
-  - - [37376, 256, 1, 256]
-    - [80, 4552.92]
-  - - [11264, 1024, 1, 256]
-    - [83, 4618.07]
   - - [11136, 3072, 1, 384]
     - [54, 4953.38]
-  - - [43776, 1536, 1, 256]
-    - [54, 4819.2]
-  - - [6400, 1792, 1, 256]
-    - [83, 4630.06]
-  - - [31744, 1792, 1, 256]
-    - [58, 4811.23]
   - - [8832, 1920, 1, 384]
     - [53, 4869.19]
   - - [43776, 1920, 1, 384]
     - [54, 5004.77]
-  - - [14592, 1024, 1, 256]
-    - [59, 4646.3]
   - - [3072, 1153, 1, 384]
     - [87, 4208.86]
   - - [14976, 3072, 1, 384]
     - [53, 4964.71]
-  - - [14336, 768, 1, 256]
-    - [80, 4623.34]
   - - [21120, 1153, 1, 384]
     - [53, 4722.78]
   - - [38784, 3072, 1, 384]
     - [58, 5003.44]
   - - [12288, 384, 1, 384]
     - [53, 4699.02]
-  - - [23552, 1024, 1, 256]
-    - [58, 4706.38]
-  - - [1536, 256, 1, 256]
-    - [63, 2960.69]
   - - [38784, 768, 1, 384]
     - [54, 4953.34]
-  - - [34048, 2048, 1, 256]
-    - [58, 4797.72]
   - - [36480, 1536, 1, 384]
     - [58, 4979.68]
   - - [29184, 384, 1, 384]
     - [53, 4829.16]
-  - - [35072, 1024, 1, 256]
-    - [58, 4751.57]
   - - [15744, 768, 1, 384]
     - [58, 4854.56]
   - - [27264, 1920, 1, 384]
     - [54, 4996.32]
   - - [43392, 1152, 1, 384]
     - [54, 4985.1]
-  - - [35584, 2048, 1, 256]
-    - [58, 4796.55]
-  - - [37120, 2048, 1, 256]
-    - [58, 4798.08]
   - - [33792, 2304, 1, 384]
     - [54, 4992.42]
   - - [384, 384, 1, 384]
     - [79, 1705.52]
-  - - [21504, 512, 1, 256]
-    - [80, 4607.62]
-  - - [14336, 1024, 1, 256]
-    - [83, 4652.72]
   - - [9984, 1153, 1, 384]
     - [54, 4637.86]
-  - - [35328, 1024, 1, 256]
-    - [58, 4766.25]
   - - [8832, 2304, 1, 384]
     - [58, 4918.67]
-  - - [5376, 1281, 1, 256]
-    - [54, 4464.61]
   - - [18432, 3072, 1, 384]
     - [54, 4992.21]
   - - [41088, 1152, 1, 384]
     - [54, 4977.11]
-  - - [6144, 1024, 1, 256]
-    - [83, 4525.72]
   - - [39168, 2688, 1, 384]
     - [54, 5027.17]
-  - - [15104, 2048, 1, 256]
-    - [58, 4723.95]
   - - [39936, 1152, 1, 384]
     - [54, 4980.38]
   - - [43776, 1153, 1, 384]
     - [54, 4784.95]
   - - [31104, 384, 1, 384]
     - [54, 4835.4]
-  - - [24320, 768, 1, 256]
-    - [54, 4729.3]
-  - - [18176, 1281, 1, 256]
-    - [54, 4687.6]
-  - - [24832, 768, 1, 256]
-    - [54, 4739.6]
   - - [16512, 3072, 1, 384]
     - [58, 4976.13]
   - - [39168, 384, 1, 384]
     - [54, 4873.07]
   - - [18816, 1152, 1, 384]
     - [54, 4909.98]
-  - - [37888, 1024, 1, 256]
-    - [58, 4738.15]
   - - [43776, 1152, 1, 384]
     - [54, 4989.26]
-  - - [29952, 2048, 1, 256]
-    - [58, 4803.17]
   - - [35328, 1920, 1, 384]
     - [54, 5000.27]
   - - [29952, 1153, 1, 384]
     - [54, 4764.22]
-  - - [4608, 1280, 1, 256]
-    - [83, 4464.66]
   - - [38016, 384, 1, 384]
     - [54, 4841.34]
-  - - [28672, 1280, 1, 256]
-    - [58, 4775.36]
-  - - [36864, 1281, 1, 256]
-    - [54, 4754.3]
-  - - [35584, 1280, 1, 256]
-    - [58, 4798.11]
-  - - [20992, 2048, 1, 256]
-    - [58, 4770.72]
-  - - [43264, 512, 1, 256]
-    - [83, 4694.6]
   - - [41856, 1152, 1, 384]
     - [54, 4993.95]
   - - [43008, 1536, 1, 384]
     - [54, 4994.71]
-  - - [14592, 1792, 1, 256]
-    - [58, 4754.61]
-  - - [34048, 1281, 1, 256]
-    - [54, 4750.33]
-  - - [34560, 768, 1, 256]
-    - [54, 4771.21]
   - - [35328, 2304, 1, 384]
     - [58, 4989.08]
-  - - [14848, 768, 1, 256]
-    - [58, 4626.07]
-  - - [1792, 768, 1, 256]
-    - [73, 3759.3]
-  - - [30464, 768, 1, 256]
-    - [54, 4765.65]
   - - [11520, 1152, 1, 384]
     - [54, 4882.24]
-  - - [14336, 1280, 1, 256]
-    - [57, 4681.33]
   - - [36864, 1152, 1, 384]
     - [58, 4972.27]
   - - [37248, 2304, 1, 384]
     - [58, 4996.85]
-  - - [36096, 512, 1, 256]
-    - [58, 4679.88]
   - - [26880, 3072, 1, 384]
     - [58, 4997.79]
   - - [28032, 1153, 1, 384]
@@ -19356,48 +23976,16 @@
     - [70, 4454.1]
   - - [39936, 1153, 1, 384]
     - [53, 4763.76]
-  - - [4352, 1536, 1, 256]
-    - [83, 4501.0]
-  - - [11520, 1281, 1, 256]
-    - [53, 4605.75]
-  - - [17408, 1792, 1, 256]
-    - [58, 4762.39]
   - - [17664, 384, 1, 384]
     - [82, 4684.98]
-  - - [26368, 256, 1, 256]
-    - [82, 4492.65]
-  - - [25856, 1280, 1, 256]
-    - [58, 4773.56]
-  - - [11520, 1536, 1, 256]
-    - [54, 4697.26]
-  - - [4608, 1024, 1, 256]
-    - [80, 4432.56]
-  - - [33280, 1280, 1, 256]
-    - [58, 4791.47]
   - - [18048, 2688, 1, 384]
     - [54, 4988.01]
   - - [7296, 2688, 1, 384]
     - [54, 4929.62]
-  - - [12544, 2048, 1, 256]
-    - [58, 4712.57]
-  - - [1280, 256, 1, 256]
-    - [63, 2548.18]
   - - [13056, 2304, 1, 384]
     - [54, 4951.53]
-  - - [3840, 2048, 1, 256]
-    - [83, 4526.23]
-  - - [21248, 1792, 1, 256]
-    - [58, 4788.55]
-  - - [40192, 1536, 1, 256]
-    - [54, 4799.66]
-  - - [10752, 1024, 1, 256]
-    - [80, 4610.03]
   - - [42624, 1536, 1, 384]
     - [58, 4981.58]
-  - - [42752, 2048, 1, 256]
-    - [58, 4811.31]
-  - - [6912, 1536, 1, 256]
-    - [80, 4596.03]
   - - [2688, 1536, 1, 384]
     - [82, 4553.79]
   - - [29568, 1153, 1, 384]
@@ -19406,218 +23994,86 @@
     - [54, 5015.97]
   - - [18816, 1536, 1, 384]
     - [53, 4919.82]
-  - - [15360, 1281, 1, 256]
-    - [54, 4664.15]
-  - - [12800, 1536, 1, 256]
-    - [83, 4683.58]
   - - [32256, 3072, 1, 384]
     - [54, 5005.99]
-  - - [27136, 768, 1, 256]
-    - [53, 4749.45]
-  - - [36608, 768, 1, 256]
-    - [54, 4778.41]
-  - - [7680, 1281, 1, 256]
-    - [54, 4515.8]
   - - [33792, 3072, 1, 384]
     - [54, 5008.65]
-  - - [26624, 1280, 1, 256]
-    - [58, 4772.2]
   - - [9984, 3072, 1, 384]
     - [54, 4941.1]
-  - - [19712, 1280, 1, 256]
-    - [58, 4746.64]
-  - - [14080, 2048, 1, 256]
-    - [58, 4724.65]
   - - [34560, 1153, 1, 384]
     - [54, 4762.85]
-  - - [42496, 1280, 1, 256]
-    - [58, 4806.53]
-  - - [39424, 768, 1, 256]
-    - [54, 4762.04]
   - - [13056, 1536, 1, 384]
     - [58, 4894.21]
   - - [35328, 384, 1, 384]
     - [54, 4863.98]
   - - [26496, 384, 1, 384]
     - [54, 4857.03]
-  - - [1792, 1281, 1, 256]
-    - [44, 4272.04]
   - - [34944, 1536, 1, 384]
     - [54, 4977.25]
   - - [23424, 768, 1, 384]
     - [58, 4900.42]
-  - - [12544, 1024, 1, 256]
-    - [83, 4628.07]
   - - [38400, 1920, 1, 384]
     - [54, 5014.41]
-  - - [36608, 512, 1, 256]
-    - [83, 4668.86]
-  - - [13312, 2048, 1, 256]
-    - [58, 4720.35]
   - - [15360, 2304, 1, 384]
     - [54, 4941.01]
   - - [27264, 2688, 1, 384]
     - [54, 4997.74]
-  - - [3072, 1792, 1, 256]
-    - [71, 4512.32]
   - - [11136, 1536, 1, 384]
     - [58, 4862.51]
-  - - [9728, 1281, 1, 256]
-    - [54, 4559.2]
-  - - [28416, 512, 1, 256]
-    - [83, 4646.15]
-  - - [9472, 1281, 1, 256]
-    - [54, 4548.16]
   - - [5760, 1153, 1, 384]
     - [54, 4539.43]
   - - [41472, 3072, 1, 384]
     - [54, 5016.11]
-  - - [30464, 1280, 1, 256]
-    - [58, 4794.27]
-  - - [23040, 1280, 1, 256]
-    - [58, 4768.66]
-  - - [32512, 1024, 1, 256]
-    - [58, 4746.08]
   - - [23040, 1153, 1, 384]
     - [54, 4738.31]
-  - - [9728, 2048, 1, 256]
-    - [58, 4696.04]
-  - - [30208, 2048, 1, 256]
-    - [58, 4787.7]
-  - - [22528, 1280, 1, 256]
-    - [58, 4768.97]
   - - [12288, 1536, 1, 384]
     - [58, 4905.89]
-  - - [24576, 256, 1, 256]
-    - [82, 4448.22]
   - - [14592, 384, 1, 384]
     - [54, 4627.27]
-  - - [14080, 1281, 1, 256]
-    - [54, 4644.47]
-  - - [5632, 768, 1, 256]
-    - [83, 4377.36]
-  - - [4608, 1792, 1, 256]
-    - [83, 4553.92]
-  - - [30976, 768, 1, 256]
-    - [54, 4757.91]
-  - - [5120, 1281, 1, 256]
-    - [54, 4396.29]
-  - - [7680, 512, 1, 256]
-    - [80, 4312.91]
-  - - [43776, 1024, 1, 256]
-    - [58, 4772.52]
   - - [6528, 2304, 1, 384]
     - [54, 4860.93]
   - - [25728, 1153, 1, 384]
     - [54, 4744.88]
-  - - [11520, 1280, 1, 256]
-    - [58, 4655.97]
-  - - [36352, 512, 1, 256]
-    - [58, 4665.08]
   - - [30720, 2304, 1, 384]
     - [54, 4997.63]
-  - - [36864, 1280, 1, 256]
-    - [58, 4811.97]
-  - - [6912, 1280, 1, 256]
-    - [83, 4581.9]
   - - [24576, 1152, 1, 384]
     - [53, 4944.53]
-  - - [18944, 1024, 1, 256]
-    - [83, 4675.26]
   - - [4608, 1153, 1, 384]
     - [52, 4445.27]
-  - - [35072, 1792, 1, 256]
-    - [58, 4817.63]
-  - - [8192, 512, 1, 256]
-    - [83, 4357.01]
-  - - [28416, 256, 1, 256]
-    - [83, 4517.44]
-  - - [38656, 1536, 1, 256]
-    - [54, 4818.53]
-  - - [7424, 768, 1, 256]
-    - [83, 4493.34]
-  - - [7424, 1281, 1, 256]
-    - [54, 4509.18]
-  - - [2048, 768, 1, 256]
-    - [69, 4199.55]
-  - - [26624, 1281, 1, 256]
-    - [54, 4741.69]
-  - - [41216, 256, 1, 256]
-    - [57, 4593.76]
   - - [4992, 768, 1, 384]
     - [86, 4537.11]
-  - - [23552, 1536, 1, 256]
-    - [54, 4779.05]
-  - - [22272, 2048, 1, 256]
-    - [58, 4774.99]
-  - - [40960, 2048, 1, 256]
-    - [58, 4809.98]
   - - [34944, 2688, 1, 384]
     - [53, 5015.17]
   - - [768, 385, 1, 384]
     - [62, 2498.7]
   - - [24960, 2688, 1, 384]
     - [54, 5006.67]
-  - - [42496, 256, 1, 256]
-    - [58, 4593.62]
   - - [9984, 384, 1, 384]
     - [87, 4542.15]
   - - [12672, 3072, 1, 384]
     - [53, 4959.76]
-  - - [33792, 1281, 1, 256]
-    - [54, 4749.05]
-  - - [39936, 1280, 1, 256]
-    - [58, 4805.67]
-  - - [17152, 1536, 1, 256]
-    - [53, 4734.4]
   - - [18432, 1920, 1, 384]
     - [54, 4965.05]
-  - - [25088, 1792, 1, 256]
-    - [58, 4785.84]
-  - - [38912, 1280, 1, 256]
-    - [58, 4807.88]
   - - [3840, 2688, 1, 384]
     - [53, 4780.74]
-  - - [33024, 2048, 1, 256]
-    - [58, 4796.15]
   - - [26496, 1153, 1, 384]
     - [54, 4755.39]
   - - [13824, 1920, 1, 384]
     - [54, 4943.04]
-  - - [12544, 1792, 1, 256]
-    - [58, 4704.23]
   - - [26880, 1153, 1, 384]
     - [54, 4742.79]
   - - [17280, 2688, 1, 384]
     - [54, 4991.57]
-  - - [37632, 2048, 1, 256]
-    - [57, 4801.33]
-  - - [19200, 1280, 1, 256]
-    - [58, 4737.12]
-  - - [25088, 512, 1, 256]
-    - [58, 4617.67]
-  - - [17920, 1281, 1, 256]
-    - [54, 4693.48]
   - - [5376, 3072, 1, 384]
     - [58, 4909.27]
-  - - [32000, 512, 1, 256]
-    - [83, 4658.47]
-  - - [17664, 1281, 1, 256]
-    - [53, 4673.92]
   - - [15360, 1536, 1, 384]
     - [58, 4913.82]
-  - - [4096, 512, 1, 256]
-    - [82, 4160.51]
-  - - [22528, 1024, 1, 256]
-    - [58, 4699.35]
   - - [43776, 2688, 1, 384]
     - [54, 5019.33]
   - - [24960, 1920, 1, 384]
     - [54, 4990.97]
   - - [31872, 768, 1, 384]
     - [54, 4936.78]
-  - - [9472, 1280, 1, 256]
-    - [83, 4606.66]
   - - [23808, 1153, 1, 384]
     - [54, 4751.73]
   - - [23040, 384, 1, 384]
@@ -19626,30 +24082,14 @@
     - [44, 4434.77]
   - - [11904, 2688, 1, 384]
     - [54, 4948.94]
-  - - [35328, 2048, 1, 256]
-    - [58, 4802.79]
   - - [17664, 1152, 1, 384]
     - [53, 4921.27]
-  - - [11008, 1792, 1, 256]
-    - [58, 4695.0]
-  - - [22272, 1281, 1, 256]
-    - [54, 4706.66]
-  - - [13824, 1280, 1, 256]
-    - [57, 4681.53]
   - - [12672, 1153, 1, 384]
     - [54, 4659.93]
   - - [7296, 1152, 1, 384]
     - [54, 4749.42]
-  - - [5888, 512, 1, 256]
-    - [82, 4203.44]
   - - [7296, 768, 1, 384]
     - [53, 4618.53]
-  - - [21504, 1280, 1, 256]
-    - [58, 4756.35]
-  - - [29440, 1536, 1, 256]
-    - [53, 4795.16]
-  - - [16896, 1280, 1, 256]
-    - [58, 4728.97]
   - - [1152, 1153, 1, 384]
     - [64, 3859.34]
   - - [27264, 1152, 1, 384]
@@ -19658,26 +24098,6 @@
     - [58, 4924.18]
   - - [11904, 3072, 1, 384]
     - [58, 4934.55]
-  - - [38912, 512, 1, 256]
-    - [83, 4683.1]
-  - - [29696, 2048, 1, 256]
-    - [58, 4794.79]
-  - - [15104, 1280, 1, 256]
-    - [83, 4696.96]
-  - - [18176, 1024, 1, 256]
-    - [83, 4680.48]
-  - - [34304, 768, 1, 256]
-    - [54, 4786.01]
-  - - [16896, 2048, 1, 256]
-    - [58, 4752.75]
-  - - [38656, 2048, 1, 256]
-    - [58, 4806.54]
-  - - [43264, 1280, 1, 256]
-    - [58, 4806.0]
-  - - [41472, 2048, 1, 256]
-    - [58, 4808.63]
-  - - [6912, 2048, 1, 256]
-    - [83, 4649.34]
   - - [37248, 1152, 1, 384]
     - [54, 4983.1]
   - - [20736, 3072, 1, 384]
@@ -19686,40 +24106,20 @@
     - [82, 4459.81]
   - - [11904, 1153, 1, 384]
     - [54, 4648.05]
-  - - [14336, 256, 1, 256]
-    - [83, 4371.51]
   - - [12288, 768, 1, 384]
     - [58, 4831.07]
   - - [33792, 768, 1, 384]
     - [54, 4936.33]
   - - [21888, 2688, 1, 384]
     - [54, 4999.3]
-  - - [13568, 2048, 1, 256]
-    - [58, 4732.01]
   - - [15360, 3072, 1, 384]
     - [54, 4967.21]
   - - [2688, 1920, 1, 384]
     - [82, 4611.87]
-  - - [40192, 1281, 1, 256]
-    - [54, 4760.81]
   - - [21504, 1536, 1, 384]
     - [58, 4947.64]
-  - - [41984, 1281, 1, 256]
-    - [54, 4762.32]
-  - - [8960, 2048, 1, 256]
-    - [83, 4677.42]
-  - - [23808, 1024, 1, 256]
-    - [58, 4719.69]
   - - [19968, 768, 1, 384]
     - [58, 4886.98]
-  - - [5632, 512, 1, 256]
-    - [83, 4303.86]
-  - - [8448, 2048, 1, 256]
-    - [58, 4673.71]
-  - - [4096, 2048, 1, 256]
-    - [80, 4547.45]
-  - - [27392, 1280, 1, 256]
-    - [58, 4787.92]
   - - [4608, 3072, 1, 384]
     - [58, 4872.38]
   - - [35328, 1152, 1, 384]
@@ -19730,240 +24130,82 @@
     - [54, 5009.18]
   - - [19200, 2688, 1, 384]
     - [58, 4986.14]
-  - - [39168, 1792, 1, 256]
-    - [58, 4822.64]
   - - [31104, 3072, 1, 384]
     - [58, 5003.6]
   - - [31488, 2304, 1, 384]
     - [54, 4993.86]
-  - - [31232, 1536, 1, 256]
-    - [54, 4773.52]
   - - [35712, 3072, 1, 384]
     - [58, 5009.56]
-  - - [36096, 1024, 1, 256]
-    - [58, 4760.12]
-  - - [8704, 256, 1, 256]
-    - [57, 4135.91]
-  - - [35328, 1792, 1, 256]
-    - [58, 4815.65]
-  - - [17664, 1280, 1, 256]
-    - [58, 4721.31]
   - - [18432, 1153, 1, 384]
     - [54, 4706.24]
-  - - [19968, 1024, 1, 256]
-    - [83, 4683.02]
-  - - [6144, 1280, 1, 256]
-    - [80, 4559.85]
   - - [12288, 2688, 1, 384]
     - [53, 4956.38]
-  - - [10240, 256, 1, 256]
-    - [79, 4153.8]
-  - - [41728, 1024, 1, 256]
-    - [58, 4771.91]
-  - - [22016, 1280, 1, 256]
-    - [58, 4758.33]
   - - [21120, 3072, 1, 384]
     - [58, 4982.52]
   - - [12288, 2304, 1, 384]
     - [53, 4931.88]
-  - - [29696, 1280, 1, 256]
-    - [58, 4783.22]
   - - [28416, 768, 1, 384]
     - [54, 4916.82]
   - - [33408, 3072, 1, 384]
     - [54, 4993.68]
   - - [36480, 384, 1, 384]
     - [54, 4863.47]
-  - - [41984, 1536, 1, 256]
-    - [54, 4825.15]
-  - - [34304, 512, 1, 256]
-    - [83, 4673.32]
   - - [4224, 384, 1, 384]
     - [82, 4010.14]
-  - - [30976, 1281, 1, 256]
-    - [54, 4743.16]
-  - - [28416, 1280, 1, 256]
-    - [58, 4775.35]
-  - - [3072, 2048, 1, 256]
-    - [83, 4492.9]
-  - - [30976, 2048, 1, 256]
-    - [58, 4792.25]
-  - - [38400, 1281, 1, 256]
-    - [54, 4759.31]
-  - - [15616, 256, 1, 256]
-    - [79, 4253.58]
-  - - [38144, 1281, 1, 256]
-    - [54, 4759.67]
-  - - [23808, 2048, 1, 256]
-    - [58, 4784.75]
-  - - [20480, 1536, 1, 256]
-    - [54, 4751.07]
-  - - [39936, 1281, 1, 256]
-    - [54, 4757.85]
   - - [27264, 1536, 1, 384]
     - [54, 4969.03]
   - - [12672, 1152, 1, 384]
     - [53, 4858.29]
   - - [28416, 1152, 1, 384]
     - [54, 4961.14]
-  - - [32000, 256, 1, 256]
-    - [58, 4569.76]
   - - [6528, 1153, 1, 384]
     - [53, 4587.46]
-  - - [33024, 1281, 1, 256]
-    - [54, 4759.83]
-  - - [25600, 1536, 1, 256]
-    - [54, 4786.84]
-  - - [10240, 1281, 1, 256]
-    - [54, 4604.38]
-  - - [3584, 256, 1, 256]
-    - [55, 3658.58]
   - - [9216, 384, 1, 384]
     - [57, 4671.87]
-  - - [9984, 1281, 1, 256]
-    - [54, 4604.68]
-  - - [38656, 256, 1, 256]
-    - [83, 4590.08]
-  - - [24576, 1536, 1, 256]
-    - [54, 4781.92]
-  - - [11264, 768, 1, 256]
-    - [83, 4589.64]
-  - - [15616, 1281, 1, 256]
-    - [54, 4652.62]
-  - - [25856, 1536, 1, 256]
-    - [54, 4787.98]
-  - - [40448, 256, 1, 256]
-    - [80, 4564.36]
-  - - [17152, 2048, 1, 256]
-    - [58, 4751.85]
-  - - [8704, 1792, 1, 256]
-    - [57, 4660.34]
   - - [34944, 1152, 1, 384]
     - [58, 4972.63]
-  - - [18432, 512, 1, 256]
-    - [58, 4579.08]
-  - - [33792, 2048, 1, 256]
-    - [58, 4793.49]
-  - - [33024, 1536, 1, 256]
-    - [54, 4798.1]
   - - [34560, 768, 1, 384]
     - [54, 4949.96]
-  - - [39168, 2048, 1, 256]
-    - [58, 4811.51]
-  - - [7936, 2048, 1, 256]
-    - [83, 4651.59]
-  - - [8192, 1024, 1, 256]
-    - [80, 4534.0]
-  - - [42752, 1792, 1, 256]
-    - [58, 4821.04]
-  - - [14592, 1280, 1, 256]
-    - [58, 4715.12]
-  - - [20736, 768, 1, 256]
-    - [53, 4689.93]
-  - - [27648, 1280, 1, 256]
-    - [58, 4780.84]
-  - - [10752, 512, 1, 256]
-    - [59, 4459.2]
   - - [31488, 3072, 1, 384]
     - [54, 5005.47]
   - - [39936, 2688, 1, 384]
     - [54, 5028.3]
   - - [8064, 1920, 1, 384]
     - [53, 4871.23]
-  - - [14848, 1280, 1, 256]
-    - [58, 4681.33]
-  - - [38656, 768, 1, 256]
-    - [54, 4796.94]
   - - [13056, 1153, 1, 384]
     - [54, 4697.06]
   - - [9984, 1152, 1, 384]
     - [54, 4816.36]
-  - - [25344, 2048, 1, 256]
-    - [58, 4795.71]
-  - - [39936, 1792, 1, 256]
-    - [58, 4815.46]
-  - - [29696, 1792, 1, 256]
-    - [58, 4805.39]
   - - [26880, 1536, 1, 384]
     - [54, 4961.16]
-  - - [4864, 1280, 1, 256]
-    - [83, 4507.46]
   - - [33792, 384, 1, 384]
     - [54, 4853.35]
-  - - [6656, 2048, 1, 256]
-    - [83, 4640.51]
-  - - [42752, 512, 1, 256]
-    - [58, 4707.47]
-  - - [9472, 2048, 1, 256]
-    - [83, 4688.5]
   - - [4608, 384, 1, 384]
     - [81, 4328.98]
-  - - [37632, 512, 1, 256]
-    - [58, 4683.17]
-  - - [20480, 1024, 1, 256]
-    - [58, 4686.54]
-  - - [34560, 256, 1, 256]
-    - [83, 4571.91]
-  - - [13056, 1536, 1, 256]
-    - [53, 4700.79]
-  - - [29184, 1792, 1, 256]
-    - [58, 4811.82]
-  - - [2560, 1024, 1, 256]
-    - [69, 4347.56]
-  - - [5120, 1792, 1, 256]
-    - [71, 4592.55]
   - - [28032, 2688, 1, 384]
     - [54, 5015.88]
   - - [7296, 3072, 1, 384]
     - [54, 4921.05]
-  - - [27904, 1792, 1, 256]
-    - [58, 4805.62]
   - - [41472, 2688, 1, 384]
     - [54, 5028.2]
-  - - [6912, 256, 1, 256]
-    - [69, 4037.3]
   - - [29568, 2688, 1, 384]
     - [54, 5009.14]
   - - [37248, 1920, 1, 384]
     - [54, 4999.35]
-  - - [16384, 2048, 1, 256]
-    - [58, 4742.15]
-  - - [41216, 1792, 1, 256]
-    - [58, 4815.54]
   - - [6912, 2688, 1, 384]
     - [54, 4884.78]
-  - - [11264, 1536, 1, 256]
-    - [54, 4697.71]
-  - - [26880, 1280, 1, 256]
-    - [58, 4788.85]
-  - - [36864, 2048, 1, 256]
-    - [58, 4803.83]
   - - [33024, 1152, 1, 384]
     - [54, 4976.89]
-  - - [25344, 1280, 1, 256]
-    - [58, 4774.59]
   - - [31104, 1152, 1, 384]
     - [54, 4969.95]
-  - - [11008, 512, 1, 256]
-    - [83, 4447.17]
   - - [31104, 2688, 1, 384]
     - [54, 5015.92]
   - - [5376, 1920, 1, 384]
     - [53, 4786.52]
-  - - [8448, 256, 1, 256]
-    - [58, 4081.75]
-  - - [23552, 512, 1, 256]
-    - [83, 4617.4]
-  - - [20992, 1792, 1, 256]
-    - [58, 4781.97]
   - - [21888, 1152, 1, 384]
     - [54, 4936.25]
   - - [40320, 1920, 1, 384]
     - [54, 4991.36]
-  - - [10496, 1280, 1, 256]
-    - [58, 4625.24]
-  - - [22528, 768, 1, 256]
-    - [53, 4715.11]
   - - [41856, 3072, 1, 384]
     - [58, 5015.47]
   - - [37248, 3072, 1, 384]
@@ -19972,50 +24214,24 @@
     - [54, 5020.04]
   - - [14208, 1153, 1, 384]
     - [53, 4687.64]
-  - - [34304, 256, 1, 256]
-    - [83, 4550.17]
-  - - [16896, 1792, 1, 256]
-    - [58, 4771.89]
-  - - [30720, 768, 1, 256]
-    - [54, 4770.17]
-  - - [34816, 1792, 1, 256]
-    - [58, 4825.12]
-  - - [35072, 1281, 1, 256]
-    - [54, 4752.4]
-  - - [27648, 1024, 1, 256]
-    - [58, 4749.64]
   - - [9984, 768, 1, 384]
     - [58, 4729.51]
   - - [3456, 2688, 1, 384]
     - [58, 4804.52]
-  - - [11008, 1280, 1, 256]
-    - [80, 4643.06]
-  - - [32256, 256, 1, 256]
-    - [59, 4545.69]
   - - [41088, 1153, 1, 384]
     - [54, 4777.86]
   - - [13056, 1152, 1, 384]
     - [54, 4846.24]
-  - - [22784, 1280, 1, 256]
-    - [57, 4755.93]
   - - [32256, 1152, 1, 384]
     - [54, 4982.06]
-  - - [4608, 2048, 1, 256]
-    - [83, 4570.07]
   - - [6912, 3072, 1, 384]
     - [58, 4906.92]
   - - [14976, 1152, 1, 384]
     - [54, 4920.46]
   - - [21888, 3072, 1, 384]
     - [54, 4980.16]
-  - - [32256, 512, 1, 256]
-    - [83, 4663.63]
-  - - [10496, 2048, 1, 256]
-    - [57, 4687.81]
   - - [1536, 1153, 1, 384]
     - [44, 4196.91]
-  - - [39936, 1024, 1, 256]
-    - [58, 4769.38]
   - - [8064, 384, 1, 384]
     - [58, 4557.98]
   - - [16512, 384, 1, 384]
@@ -20024,12 +24240,6 @@
     - [54, 4974.7]
   - - [35712, 1152, 1, 384]
     - [53, 4970.19]
-  - - [39424, 1536, 1, 256]
-    - [54, 4783.14]
-  - - [16640, 1280, 1, 256]
-    - [58, 4711.07]
-  - - [42752, 768, 1, 256]
-    - [54, 4796.17]
   - - [43392, 2688, 1, 384]
     - [54, 5026.27]
   - - [6528, 384, 1, 384]
@@ -20038,1708 +24248,4058 @@
     - [58, 4953.54]
   - - [11136, 384, 1, 384]
     - [54, 4702.92]
-  - - [28928, 1792, 1, 256]
-    - [58, 4800.74]
-  - - [17920, 512, 1, 256]
-    - [83, 4572.16]
   - - [14208, 384, 1, 384]
     - [58, 4697.86]
   - - [36480, 1920, 1, 384]
     - [54, 5012.07]
-  - - [10752, 1281, 1, 256]
-    - [54, 4587.04]
   - - [36480, 3072, 1, 384]
     - [54, 4997.05]
-  - - [21248, 256, 1, 256]
-    - [83, 4451.19]
   - - [29568, 1536, 1, 384]
     - [58, 4970.85]
   - - [33792, 1152, 1, 384]
     - [53, 4980.04]
   - - [36864, 2688, 1, 384]
     - [54, 5010.21]
-  - - [20736, 1280, 1, 256]
-    - [58, 4752.65]
-  - - [24064, 2048, 1, 256]
-    - [58, 4770.94]
-  - - [22016, 1281, 1, 256]
-    - [54, 4712.94]
   - - [23808, 768, 1, 384]
     - [54, 4895.19]
-  - - [17664, 512, 1, 256]
-    - [83, 4562.62]
-  - - [6400, 1024, 1, 256]
-    - [83, 4503.71]
   - - [42624, 1152, 1, 384]
     - [54, 4985.64]
-  - - [12288, 2048, 1, 256]
-    - [58, 4720.44]
   - - [8448, 1152, 1, 384]
     - [53, 4837.08]
-  - - [14592, 512, 1, 256]
-    - [83, 4515.54]
-  - - [23296, 1281, 1, 256]
-    - [54, 4709.64]
   - - [28032, 384, 1, 384]
     - [54, 4820.51]
-  - - [35072, 768, 1, 256]
-    - [54, 4781.86]
   - - [29568, 768, 1, 384]
     - [58, 4926.64]
   - - [2304, 768, 1, 384]
     - [67, 4308.13]
-  - - [26880, 1281, 1, 256]
-    - [54, 4727.72]
-  - - [16640, 1281, 1, 256]
-    - [54, 4667.17]
   - - [33024, 1153, 1, 384]
     - [53, 4765.11]
   - - [12672, 768, 1, 384]
     - [58, 4817.37]
-  - - [16384, 512, 1, 256]
-    - [83, 4541.67]
-  - - [38400, 1792, 1, 256]
-    - [58, 4834.32]
-  - - [24064, 1281, 1, 256]
-    - [53, 4715.03]
-  - - [43264, 768, 1, 256]
-    - [54, 4805.57]
-  - - [28928, 1280, 1, 256]
-    - [58, 4788.6]
   - - [15744, 2304, 1, 384]
     - [54, 4966.59]
-  - - [16384, 4097, 1, 256]
-    - [54, 4732.6]
-  - - [40448, 3072, 1, 256]
-    - [54, 4841.08]
-  - - [8960, 5888, 1, 256]
-    - [54, 4817.12]
-  - - [39680, 9216, 1, 256]
-    - [54, 4848.37]
-  - - [3072, 2817, 1, 256]
-    - [54, 4469.74]
-  - - [22272, 9729, 1, 256]
-    - [54, 4788.04]
-  - - [21248, 8961, 1, 256]
-    - [54, 4853.34]
-  - - [27136, 3072, 1, 256]
-    - [54, 4829.68]
-  - - [38144, 3072, 1, 256]
-    - [54, 4829.11]
-  - - [23808, 9216, 1, 256]
-    - [54, 4842.03]
-  - - [40192, 257, 1, 256]
-    - [54, 4137.94]
-  - - [25600, 13057, 1, 256]
-    - [54, 4805.75]
-  - - [12288, 3072, 1, 256]
-    - [54, 4777.28]
-  - - [33792, 21505, 1, 256]
-    - [54, 4804.39]
-  - - [33792, 9216, 1, 256]
-    - [54, 4858.09]
-  - - [16128, 3840, 1, 256]
-    - [54, 4850.3]
-  - - [20992, 3072, 1, 256]
-    - [53, 4813.11]
-  - - [7936, 4865, 1, 256]
-    - [54, 4770.18]
-  - - [36352, 24064, 1, 256]
-    - [54, 4857.31]
-  - - [30208, 9216, 1, 256]
-    - [54, 4858.56]
-  - - [14592, 9216, 1, 256]
-    - [54, 4844.05]
-  - - [22784, 10497, 1, 256]
-    - [54, 4851.17]
-  - - [30976, 3072, 1, 256]
-    - [54, 4835.32]
-  - - [19456, 9216, 1, 256]
-    - [54, 4842.71]
-  - - [36608, 9216, 1, 256]
-    - [54, 4856.67]
-  - - [34816, 22529, 1, 256]
-    - [54, 4801.39]
-  - - [43008, 9216, 1, 256]
-    - [54, 4862.58]
-  - - [15104, 2816, 1, 256]
-    - [54, 4806.14]
-  - - [31232, 18689, 1, 256]
-    - [54, 4835.27]
-  - - [512, 257, 1, 256]
-    - [67, 1405.92]
-  - - [42240, 27648, 1, 256]
-    - [54, 4862.77]
-  - - [7680, 3072, 1, 256]
-    - [54, 4737.25]
-  - - [24576, 3072, 1, 256]
-    - [54, 4830.1]
-  - - [37632, 25089, 1, 256]
-    - [54, 4810.38]
-  - - [42752, 9216, 1, 256]
-    - [54, 4863.22]
-  - - [42240, 9216, 1, 256]
-    - [54, 4865.15]
-  - - [27904, 15617, 1, 256]
-    - [54, 4860.44]
-  - - [22528, 3072, 1, 256]
-    - [54, 4817.37]
-  - - [19456, 7169, 1, 256]
-    - [54, 4765.77]
-  - - [25856, 13313, 1, 256]
-    - [54, 4786.98]
-  - - [11008, 3072, 1, 256]
-    - [54, 4761.12]
-  - - [42752, 2817, 1, 256]
-    - [54, 4820.67]
-  - - [32000, 19457, 1, 256]
-    - [53, 4799.61]
-  - - [5632, 2560, 1, 256]
-    - [80, 4637.39]
-  - - [21248, 8705, 1, 256]
-    - [54, 4789.79]
-  - - [10240, 6913, 1, 256]
-    - [54, 4773.07]
-  - - [21760, 9472, 1, 256]
-    - [54, 4864.76]
-  - - [31232, 18944, 1, 256]
-    - [54, 4843.08]
-  - - [12544, 257, 1, 256]
-    - [53, 3635.02]
-  - - [22016, 9473, 1, 256]
-    - [54, 4817.41]
-  - - [9216, 6144, 1, 256]
-    - [54, 4809.2]
-  - - [36864, 24577, 1, 256]
-    - [59, 4802.49]
-  - - [7936, 4609, 1, 256]
-    - [54, 4698.49]
-  - - [34560, 3072, 1, 256]
-    - [54, 4843.65]
-  - - [43776, 3072, 1, 256]
-    - [53, 4823.5]
-  - - [7680, 4353, 1, 256]
-    - [54, 4737.58]
-  - - [26368, 13825, 1, 256]
-    - [54, 4798.61]
-  - - [41216, 1025, 1, 256]
-    - [54, 4598.64]
-  - - [43520, 9216, 1, 256]
-    - [54, 4846.38]
-  - - [4608, 1536, 1, 256]
-    - [83, 4525.78]
-  - - [34304, 21761, 1, 256]
-    - [54, 4825.79]
-  - - [12800, 513, 1, 256]
-    - [53, 4170.38]
-  - - [34816, 3072, 1, 256]
-    - [54, 4842.18]
-  - - [14592, 2049, 1, 256]
-    - [54, 4670.92]
-  - - [39424, 26881, 1, 256]
-    - [54, 4837.63]
-  - - [25856, 13569, 1, 256]
-    - [54, 4845.11]
-  - - [32768, 9216, 1, 256]
-    - [54, 4863.74]
-  - - [21504, 9217, 1, 256]
-    - [54, 4787.26]
-  - - [1792, 1537, 1, 256]
-    - [82, 4100.39]
-  - - [41472, 27648, 1, 256]
-    - [54, 4855.74]
-  - - [21248, 9216, 1, 256]
-    - [54, 4850.5]
-  - - [12032, 8961, 1, 256]
-    - [54, 4838.51]
-  - - [37632, 3072, 1, 256]
-    - [54, 4837.14]
-  - - [20224, 7681, 1, 256]
-    - [54, 4767.1]
-  - - [43264, 9216, 1, 256]
-    - [54, 4863.85]
-  - - [44544, 4609, 1, 256]
-    - [54, 4749.64]
-  - - [23808, 11265, 1, 256]
-    - [54, 4793.22]
-  - - [22784, 10496, 1, 256]
-    - [54, 4874.24]
-  - - [26880, 9216, 1, 256]
-    - [54, 4855.78]
-  - - [24832, 9216, 1, 256]
-    - [54, 4844.27]
-  - - [2304, 2305, 1, 256]
-    - [44, 4391.87]
-  - - [39936, 3072, 1, 256]
-    - [54, 4827.77]
-  - - [22528, 10241, 1, 256]
-    - [54, 4795.55]
-  - - [34304, 3072, 1, 256]
-    - [54, 4839.61]
-  - - [22272, 3072, 1, 256]
-    - [54, 4825.82]
-  - - [12032, 3072, 1, 256]
-    - [54, 4777.9]
-  - - [44032, 4097, 1, 256]
-    - [54, 4767.2]
-  - - [41728, 1793, 1, 256]
-    - [54, 4758.15]
-  - - [37376, 24833, 1, 256]
-    - [54, 4835.95]
-  - - [35328, 23040, 1, 256]
-    - [54, 4859.28]
-  - - [37888, 25600, 1, 256]
-    - [54, 4854.24]
-  - - [28928, 16640, 1, 256]
-    - [54, 4890.3]
-  - - [7168, 4097, 1, 256]
-    - [53, 4676.79]
-  - - [34560, 22272, 1, 256]
-    - [54, 4885.84]
-  - - [24832, 12289, 1, 256]
-    - [54, 4789.82]
-  - - [33024, 9216, 1, 256]
-    - [54, 4851.8]
-  - - [5888, 3072, 1, 256]
-    - [54, 4704.28]
-  - - [22272, 9984, 1, 256]
-    - [54, 4884.53]
-  - - [28160, 15617, 1, 256]
-    - [54, 4828.2]
-  - - [7424, 4097, 1, 256]
-    - [54, 4692.49]
-  - - [42752, 2816, 1, 256]
-    - [58, 4845.6]
-  - - [38400, 26112, 1, 256]
-    - [54, 4860.93]
-  - - [27136, 9216, 1, 256]
-    - [54, 4859.37]
-  - - [8448, 5121, 1, 256]
-    - [54, 4730.78]
-  - - [33792, 21504, 1, 256]
-    - [54, 4860.38]
-  - - [24576, 12289, 1, 256]
-    - [59, 4788.61]
-  - - [41472, 1536, 1, 256]
-    - [54, 4814.38]
-  - - [2560, 2561, 1, 256]
-    - [83, 4388.15]
-  - - [41472, 1281, 1, 256]
-    - [54, 4728.19]
-  - - [8704, 5632, 1, 256]
-    - [58, 4771.84]
-  - - [16896, 4609, 1, 256]
-    - [54, 4727.05]
-  - - [256, 256, 1, 256]
-    - [67, 648.27]
-  - - [38400, 9216, 1, 256]
-    - [54, 4846.26]
-  - - [12288, 9216, 1, 256]
-    - [54, 4827.94]
-  - - [31744, 19201, 1, 256]
-    - [54, 4830.99]
-  - - [17152, 3072, 1, 256]
-    - [54, 4804.48]
-  - - [43776, 27648, 1, 256]
-    - [54, 4861.24]
-  - - [22784, 10241, 1, 256]
-    - [54, 4792.73]
-  - - [35840, 23553, 1, 256]
-    - [54, 4807.87]
-  - - [24064, 11776, 1, 256]
-    - [54, 4833.44]
-  - - [2560, 2305, 1, 256]
-    - [83, 4308.63]
-  - - [44544, 27648, 1, 256]
-    - [54, 4856.68]
-  - - [7680, 4609, 1, 256]
-    - [53, 4687.68]
-  - - [25344, 12801, 1, 256]
-    - [54, 4807.03]
-  - - [7424, 4352, 1, 256]
-    - [53, 4780.58]
-  - - [30976, 18689, 1, 256]
-    - [53, 4859.63]
-  - - [5376, 2304, 1, 256]
-    - [53, 4653.5]
-  - - [27648, 9216, 1, 256]
-    - [54, 4860.68]
-  - - [6656, 3072, 1, 256]
-    - [54, 4731.79]
-  - - [18688, 6401, 1, 256]
-    - [54, 4825.93]
-  - - [13824, 1281, 1, 256]
-    - [54, 4626.09]
-  - - [23296, 11009, 1, 256]
-    - [54, 4857.29]
-  - - [40704, 27648, 1, 256]
-    - [54, 4862.53]
-  - - [41472, 1537, 1, 256]
-    - [54, 4637.24]
-  - - [40448, 512, 1, 256]
-    - [58, 4688.69]
-  - - [9472, 3072, 1, 256]
-    - [54, 4758.95]
-  - - [42240, 2304, 1, 256]
-    - [54, 4863.88]
-  - - [24576, 12033, 1, 256]
-    - [54, 4832.98]
-  - - [4352, 1280, 1, 256]
-    - [82, 4428.77]
-  - - [7168, 3841, 1, 256]
-    - [54, 4687.47]
-  - - [23296, 9216, 1, 256]
-    - [54, 4855.73]
-  - - [24320, 12032, 1, 256]
-    - [54, 4887.34]
-  - - [27648, 15361, 1, 256]
-    - [59, 4793.18]
-  - - [33536, 20993, 1, 256]
-    - [59, 4799.74]
-  - - [1024, 1024, 1, 256]
-    - [48, 3963.9]
-  - - [1792, 1792, 1, 256]
-    - [70, 4272.78]
-  - - [10496, 7169, 1, 256]
-    - [54, 4763.52]
-  - - [39424, 3072, 1, 256]
-    - [54, 4835.23]
-  - - [1536, 1536, 1, 256]
-    - [69, 4346.44]
-  - - [33536, 21248, 1, 256]
-    - [54, 4880.55]
-  - - [12544, 3072, 1, 256]
-    - [54, 4785.77]
-  - - [34304, 9216, 1, 256]
-    - [54, 4855.11]
-  - - [11008, 7681, 1, 256]
-    - [53, 4755.27]
-  - - [13312, 9216, 1, 256]
-    - [54, 4833.44]
-  - - [44032, 4096, 1, 256]
-    - [58, 4828.34]
-  - - [14080, 1792, 1, 256]
-    - [58, 4738.14]
-  - - [9984, 3072, 1, 256]
-    - [54, 4761.28]
-  - - [2048, 1793, 1, 256]
-    - [92, 4166.89]
-  - - [14080, 1537, 1, 256]
-    - [53, 4549.85]
-  - - [14848, 3072, 1, 256]
-    - [54, 4794.67]
-  - - [23552, 11009, 1, 256]
-    - [54, 4819.87]
-  - - [3328, 3072, 1, 256]
-    - [80, 4609.46]
-  - - [23040, 10753, 1, 256]
-    - [54, 4783.2]
-  - - [44032, 3841, 1, 256]
-    - [54, 4768.46]
-  - - [38144, 9216, 1, 256]
-    - [54, 4865.19]
-  - - [32768, 3072, 1, 256]
-    - [54, 4838.05]
-  - - [27648, 15360, 1, 256]
-    - [54, 4863.0]
-  - - [28416, 16128, 1, 256]
-    - [54, 4888.15]
-  - - [2304, 2049, 1, 256]
-    - [83, 4249.48]
-  - - [38656, 26113, 1, 256]
-    - [54, 4807.76]
-  - - [13824, 3072, 1, 256]
-    - [54, 4789.69]
-  - - [4096, 769, 1, 256]
-    - [84, 4009.33]
-  - - [19456, 6913, 1, 256]
-    - [54, 4796.27]
-  - - [6400, 3072, 1, 256]
-    - [53, 4713.23]
-  - - [26880, 14593, 1, 256]
-    - [54, 4855.44]
-  - - [11264, 8192, 1, 256]
-    - [58, 4807.22]
-  - - [14336, 2049, 1, 256]
-    - [54, 4667.24]
-  - - [32512, 9216, 1, 256]
-    - [54, 4865.0]
-  - - [23808, 11520, 1, 256]
-    - [54, 4873.45]
-  - - [27136, 14848, 1, 256]
-    - [54, 4841.99]
-  - - [37888, 9216, 1, 256]
-    - [54, 4845.7]
-  - - [40704, 9216, 1, 256]
-    - [54, 4856.86]
-  - - [40704, 768, 1, 256]
-    - [54, 4794.69]
-  - - [40960, 1024, 1, 256]
-    - [58, 4767.61]
-  - - [32512, 19969, 1, 256]
-    - [54, 4803.32]
-  - - [17152, 4609, 1, 256]
-    - [54, 4738.31]
-  - - [5376, 2305, 1, 256]
-    - [53, 4525.09]
-  - - [10240, 3072, 1, 256]
-    - [54, 4774.28]
-  - - [15360, 3073, 1, 256]
-    - [53, 4679.11]
-  - - [43264, 3328, 1, 256]
-    - [58, 4839.34]
-  - - [10752, 3072, 1, 256]
-    - [54, 4767.44]
-  - - [27904, 15361, 1, 256]
-    - [54, 4799.35]
-  - - [9472, 6145, 1, 256]
-    - [54, 4737.08]
-  - - [43520, 3072, 1, 256]
-    - [54, 4835.81]
-  - - [13824, 9216, 1, 256]
-    - [53, 4835.13]
-  - - [24064, 11777, 1, 256]
-    - [54, 4785.02]
-  - - [34048, 21505, 1, 256]
-    - [59, 4805.57]
-  - - [33280, 20737, 1, 256]
-    - [54, 4829.44]
-  - - [17664, 5376, 1, 256]
-    - [54, 4861.18]
-  - - [30720, 18433, 1, 256]
-    - [54, 4808.1]
-  - - [37632, 25344, 1, 256]
-    - [54, 4892.95]
-  - - [17408, 3072, 1, 256]
-    - [54, 4792.21]
-  - - [38400, 26113, 1, 256]
-    - [59, 4803.88]
-  - - [32768, 20481, 1, 256]
-    - [54, 4808.87]
-  - - [41728, 1792, 1, 256]
-    - [58, 4825.95]
-  - - [5632, 2305, 1, 256]
-    - [54, 4552.01]
-  - - [20992, 8704, 1, 256]
-    - [58, 4825.14]
-  - - [10752, 7681, 1, 256]
-    - [54, 4752.09]
-  - - [32000, 3072, 1, 256]
-    - [54, 4835.6]
-  - - [42752, 3072, 1, 256]
-    - [54, 4834.37]
-  - - [38144, 25857, 1, 256]
-    - [54, 4861.16]
-  - - [36608, 24321, 1, 256]
-    - [54, 4871.96]
-  - - [4096, 1024, 1, 256]
-    - [83, 4403.47]
-  - - [17408, 5121, 1, 256]
-    - [54, 4764.8]
-  - - [41728, 3072, 1, 256]
-    - [54, 4841.81]
-  - - [35840, 3072, 1, 256]
-    - [54, 4840.11]
-  - - [25344, 3072, 1, 256]
-    - [54, 4817.73]
-  - - [13056, 513, 1, 256]
-    - [54, 4211.16]
-  - - [15872, 3584, 1, 256]
-    - [58, 4778.01]
-  - - [15360, 2817, 1, 256]
-    - [54, 4749.38]
-  - - [35072, 3072, 1, 256]
-    - [54, 4838.66]
-  - - [27648, 3072, 1, 256]
-    - [54, 4820.4]
-  - - [39168, 3072, 1, 256]
-    - [54, 4844.36]
-  - - [31488, 19200, 1, 256]
-    - [54, 4887.22]
-  - - [11264, 7937, 1, 256]
-    - [54, 4789.96]
-  - - [43008, 27648, 1, 256]
-    - [54, 4864.84]
-  - - [35072, 22529, 1, 256]
-    - [54, 4809.85]
-  - - [40192, 27648, 1, 256]
-    - [54, 4858.32]
-  - - [29184, 3072, 1, 256]
-    - [54, 4833.71]
-  - - [39680, 27392, 1, 256]
-    - [54, 4888.78]
-  - - [5888, 2816, 1, 256]
-    - [54, 4673.48]
-  - - [8704, 5633, 1, 256]
-    - [54, 4740.1]
-  - - [44544, 4353, 1, 256]
-    - [54, 4805.95]
-  - - [25856, 9216, 1, 256]
-    - [53, 4854.28]
-  - - [9472, 6401, 1, 256]
-    - [54, 4807.51]
-  - - [23552, 9216, 1, 256]
-    - [54, 4853.11]
-  - - [30208, 17665, 1, 256]
-    - [54, 4829.1]
-  - - [44544, 4608, 1, 256]
-    - [54, 4857.35]
-  - - [2048, 2048, 1, 256]
-    - [71, 4431.1]
-  - - [512, 512, 1, 256]
-    - [70, 2650.43]
-  - - [43776, 9216, 1, 256]
-    - [54, 4863.23]
-  - - [28416, 16129, 1, 256]
-    - [54, 4857.54]
-  - - [39680, 27137, 1, 256]
-    - [54, 4811.7]
-  - - [25344, 13056, 1, 256]
-    - [54, 4889.49]
-  - - [20736, 3072, 1, 256]
-    - [54, 4814.04]
-  - - [28416, 9216, 1, 256]
-    - [54, 4866.14]
-  - - [28928, 16641, 1, 256]
-    - [54, 4872.08]
-  - - [21504, 9216, 1, 256]
-    - [54, 4848.79]
-  - - [42496, 2561, 1, 256]
-    - [54, 4733.22]
-  - - [6144, 3073, 1, 256]
-    - [54, 4612.04]
-  - - [37376, 9216, 1, 256]
-    - [54, 4858.19]
-  - - [41728, 1537, 1, 256]
-    - [54, 4629.24]
-  - - [17152, 4864, 1, 256]
-    - [54, 4829.72]
-  - - [40192, 256, 1, 256]
-    - [58, 4572.64]
-  - - [42496, 2305, 1, 256]
-    - [54, 4722.06]
-  - - [19712, 9216, 1, 256]
-    - [54, 4847.33]
-  - - [24576, 9216, 1, 256]
-    - [54, 4851.34]
-  - - [3328, 257, 1, 256]
-    - [90, 3374.78]
-  - - [31232, 9216, 1, 256]
-    - [54, 4853.09]
-  - - [16384, 9216, 1, 256]
-    - [54, 4850.88]
-  - - [2304, 2304, 1, 256]
-    - [70, 4445.1]
-  - - [37888, 25601, 1, 256]
-    - [54, 4804.23]
-  - - [38400, 3072, 1, 256]
-    - [54, 4832.39]
-  - - [21248, 3072, 1, 256]
-    - [54, 4819.15]
-  - - [41984, 2049, 1, 256]
-    - [54, 4716.37]
-  - - [18176, 5889, 1, 256]
-    - [54, 4827.02]
-  - - [26624, 14081, 1, 256]
-    - [54, 4828.46]
-  - - [22016, 3072, 1, 256]
-    - [54, 4821.9]
-  - - [44288, 4097, 1, 256]
-    - [54, 4760.97]
-  - - [11776, 8705, 1, 256]
-    - [54, 4776.17]
-  - - [14592, 3072, 1, 256]
-    - [54, 4800.07]
-  - - [7680, 4608, 1, 256]
-    - [54, 4773.89]
-  - - [23296, 10753, 1, 256]
-    - [54, 4779.93]
-  - - [23552, 3072, 1, 256]
-    - [54, 4820.54]
-  - - [35584, 3072, 1, 256]
-    - [54, 4840.72]
-  - - [30720, 18432, 1, 256]
-    - [54, 4854.39]
-  - - [35584, 23296, 1, 256]
-    - [54, 4884.38]
-  - - [19968, 7425, 1, 256]
-    - [54, 4812.27]
-  - - [36608, 24320, 1, 256]
-    - [54, 4892.83]
-  - - [24320, 9216, 1, 256]
-    - [54, 4855.49]
-  - - [34560, 9216, 1, 256]
-    - [54, 4858.45]
-  - - [2560, 2560, 1, 256]
-    - [71, 4519.73]
-  - - [41216, 3072, 1, 256]
-    - [54, 4834.24]
-  - - [29952, 3072, 1, 256]
-    - [54, 4835.69]
-  - - [17920, 5633, 1, 256]
-    - [54, 4752.41]
-  - - [36096, 23808, 1, 256]
-    - [54, 4881.42]
-  - - [6400, 3073, 1, 256]
-    - [53, 4602.87]
-  - - [10240, 7168, 1, 256]
-    - [54, 4800.2]
-  - - [23040, 10752, 1, 256]
-    - [54, 4848.48]
-  - - [9216, 6145, 1, 256]
-    - [53, 4728.6]
-  - - [35072, 9216, 1, 256]
-    - [54, 4857.1]
-  - - [40704, 513, 1, 256]
-    - [54, 4475.08]
-  - - [11520, 3072, 1, 256]
-    - [54, 4775.7]
-  - - [39680, 3072, 1, 256]
-    - [54, 4849.24]
-  - - [5376, 2049, 1, 256]
-    - [54, 4514.52]
-  - - [40960, 3072, 1, 256]
-    - [54, 4840.51]
-  - - [37376, 25088, 1, 256]
-    - [54, 4850.71]
-  - - [9728, 6656, 1, 256]
-    - [58, 4784.69]
-  - - [44544, 3072, 1, 256]
-    - [54, 4842.26]
-  - - [20480, 7937, 1, 256]
-    - [54, 4809.81]
-  - - [37376, 25089, 1, 256]
-    - [54, 4799.69]
-  - - [33024, 3072, 1, 256]
-    - [54, 4837.81]
-  - - [24832, 12545, 1, 256]
-    - [54, 4842.31]
-  - - [22528, 9985, 1, 256]
-    - [54, 4824.77]
-  - - [17408, 5120, 1, 256]
-    - [58, 4811.0]
-  - - [14336, 9216, 1, 256]
-    - [54, 4836.81]
-  - - [40192, 9216, 1, 256]
-    - [54, 4850.86]
-  - - [41728, 27648, 1, 256]
-    - [54, 4855.6]
-  - - [15872, 3329, 1, 256]
-    - [54, 4750.87]
-  - - [32768, 20225, 1, 256]
-    - [54, 4841.74]
-  - - [39168, 26880, 1, 256]
-    - [54, 4891.36]
-  - - [33792, 3072, 1, 256]
-    - [54, 4834.93]
-  - - [18944, 3072, 1, 256]
-    - [54, 4812.19]
-  - - [33280, 20993, 1, 256]
-    - [54, 4799.61]
-  - - [41472, 3072, 1, 256]
-    - [54, 4838.6]
-  - - [23808, 3072, 1, 256]
-    - [54, 4814.69]
-  - - [7424, 4353, 1, 256]
-    - [54, 4768.56]
-  - - [34816, 22273, 1, 256]
-    - [54, 4840.08]
-  - - [24576, 12288, 1, 256]
-    - [54, 4855.53]
-  - - [32512, 20225, 1, 256]
-    - [54, 4858.04]
-  - - [1024, 1025, 1, 256]
-    - [44, 3889.67]
-  - - [29440, 16897, 1, 256]
-    - [54, 4805.42]
-  - - [21760, 3072, 1, 256]
-    - [54, 4821.2]
-  - - [29696, 17153, 1, 256]
-    - [54, 4839.0]
-  - - [17152, 9216, 1, 256]
-    - [54, 4848.74]
-  - - [14848, 2560, 1, 256]
-    - [58, 4757.03]
-  - - [18176, 5888, 1, 256]
-    - [54, 4846.66]
-  - - [16640, 4097, 1, 256]
-    - [54, 4739.66]
-  - - [30720, 18177, 1, 256]
-    - [54, 4843.2]
-  - - [17920, 3072, 1, 256]
-    - [54, 4802.24]
-  - - [27392, 15105, 1, 256]
-    - [54, 4874.26]
-  - - [41728, 9216, 1, 256]
-    - [54, 4850.7]
-  - - [34304, 22017, 1, 256]
-    - [54, 4810.68]
-  - - [31488, 3072, 1, 256]
-    - [54, 4832.06]
-  - - [10496, 3072, 1, 256]
-    - [54, 4773.97]
-  - - [14592, 2305, 1, 256]
-    - [54, 4693.88]
-  - - [38400, 25857, 1, 256]
-    - [54, 4839.65]
-  - - [40192, 3072, 1, 256]
-    - [54, 4829.11]
-  - - [19456, 7168, 1, 256]
-    - [54, 4815.91]
-  - - [40960, 1025, 1, 256]
-    - [54, 4588.02]
-  - - [7936, 3072, 1, 256]
-    - [54, 4745.67]
-  - - [43264, 3072, 1, 256]
-    - [54, 4844.73]
-  - - [20992, 8449, 1, 256]
-    - [54, 4799.96]
-  - - [13824, 1537, 1, 256]
-    - [54, 4541.27]
-  - - [10752, 7680, 1, 256]
-    - [54, 4823.06]
-  - - [43520, 3584, 1, 256]
-    - [58, 4825.58]
-  - - [26880, 3072, 1, 256]
-    - [54, 4821.13]
-  - - [34048, 9216, 1, 256]
-    - [54, 4858.04]
-  - - [15872, 9216, 1, 256]
-    - [54, 4848.3]
-  - - [4864, 1537, 1, 256]
-    - [83, 4351.63]
-  - - [14336, 3072, 1, 256]
-    - [54, 4795.45]
-  - - [29440, 3072, 1, 256]
-    - [54, 4832.31]
-  - - [22272, 9985, 1, 256]
-    - [54, 4842.83]
-  - - [10496, 7424, 1, 256]
-    - [54, 4843.37]
-  - - [19200, 9216, 1, 256]
-    - [54, 4845.36]
-  - - [9984, 6913, 1, 256]
-    - [54, 4791.76]
-  - - [18176, 5633, 1, 256]
-    - [54, 4772.45]
-  - - [27904, 15616, 1, 256]
-    - [54, 4878.81]
-  - - [19968, 7681, 1, 256]
-    - [54, 4772.04]
-  - - [25088, 12545, 1, 256]
-    - [54, 4828.36]
-  - - [16640, 9216, 1, 256]
-    - [54, 4841.51]
-  - - [28928, 16385, 1, 256]
-    - [54, 4808.13]
-  - - [37120, 24833, 1, 256]
-    - [54, 4873.51]
-  - - [29696, 17408, 1, 256]
-    - [54, 4845.91]
-  - - [18432, 6144, 1, 256]
-    - [54, 4831.81]
-  - - [28672, 16385, 1, 256]
-    - [54, 4797.41]
-  - - [30464, 9216, 1, 256]
-    - [54, 4859.0]
-  - - [35328, 22785, 1, 256]
-    - [54, 4840.12]
-  - - [3584, 257, 1, 256]
-    - [90, 3568.38]
-  - - [35328, 9216, 1, 256]
-    - [54, 4853.05]
-  - - [42240, 2049, 1, 256]
-    - [54, 4734.95]
-  - - [20992, 8705, 1, 256]
-    - [54, 4781.54]
-  - - [30464, 18177, 1, 256]
-    - [54, 4861.12]
-  - - [41216, 1280, 1, 256]
-    - [58, 4800.47]
-  - - [11520, 8449, 1, 256]
-    - [54, 4816.84]
-  - - [16384, 3072, 1, 256]
-    - [54, 4806.15]
-  - - [17152, 4865, 1, 256]
-    - [54, 4814.12]
-  - - [13056, 9216, 1, 256]
-    - [54, 4840.46]
-  - - [18944, 6401, 1, 256]
-    - [54, 4800.53]
-  - - [18688, 6145, 1, 256]
-    - [54, 4765.55]
-  - - [44288, 9216, 1, 256]
-    - [54, 4854.55]
-  - - [17920, 9216, 1, 256]
-    - [54, 4844.99]
-  - - [36352, 9216, 1, 256]
-    - [54, 4854.76]
-  - - [18688, 9216, 1, 256]
-    - [54, 4851.02]
-  - - [41216, 1281, 1, 256]
-    - [54, 4751.93]
-  - - [32256, 3072, 1, 256]
-    - [54, 4832.61]
-  - - [24832, 12544, 1, 256]
-    - [54, 4865.68]
-  - - [15616, 3073, 1, 256]
-    - [54, 4687.4]
-  - - [11008, 7937, 1, 256]
-    - [54, 4820.27]
-  - - [40704, 3072, 1, 256]
-    - [54, 4830.82]
-  - - [16128, 9216, 1, 256]
-    - [54, 4841.08]
-  - - [35072, 22784, 1, 256]
-    - [54, 4896.89]
-  - - [5120, 1793, 1, 256]
-    - [54, 4511.48]
-  - - [39936, 9216, 1, 256]
-    - [54, 4862.92]
-  - - [25344, 9216, 1, 256]
-    - [54, 4849.57]
-  - - [29184, 9216, 1, 256]
-    - [54, 4857.11]
-  - - [20992, 9216, 1, 256]
-    - [54, 4841.11]
-  - - [29952, 9216, 1, 256]
-    - [54, 4854.37]
-  - - [16640, 4353, 1, 256]
-    - [54, 4831.34]
-  - - [23808, 11521, 1, 256]
-    - [54, 4851.64]
-  - - [44544, 9216, 1, 256]
-    - [54, 4861.94]
-  - - [18176, 9216, 1, 256]
-    - [54, 4844.52]
-  - - [42240, 3072, 1, 256]
-    - [54, 4835.83]
-  - - [31744, 19457, 1, 256]
-    - [54, 4812.86]
-  - - [26112, 13569, 1, 256]
-    - [54, 4825.79]
-  - - [24832, 3072, 1, 256]
-    - [54, 4821.75]
-  - - [18432, 9216, 1, 256]
-    - [54, 4854.99]
-  - - [15104, 3072, 1, 256]
-    - [54, 4795.5]
-  - - [38656, 9216, 1, 256]
-    - [54, 4855.18]
-  - - [25856, 13568, 1, 256]
-    - [54, 4881.71]
-  - - [33280, 3072, 1, 256]
-    - [54, 4836.9]
-  - - [13824, 1536, 1, 256]
-    - [54, 4715.81]
-  - - [16896, 4353, 1, 256]
-    - [54, 4786.74]
-  - - [30976, 18433, 1, 256]
-    - [54, 4795.47]
-  - - [8448, 3072, 1, 256]
-    - [54, 4742.3]
-  - - [33024, 20737, 1, 256]
-    - [54, 4863.04]
-  - - [25600, 13312, 1, 256]
-    - [54, 4835.92]
-  - - [28160, 3072, 1, 256]
-    - [54, 4827.6]
-  - - [10240, 7169, 1, 256]
-    - [54, 4765.76]
-  - - [26368, 9216, 1, 256]
-    - [54, 4847.0]
-  - - [38144, 25856, 1, 256]
-    - [54, 4886.56]
-  - - [768, 769, 1, 256]
-    - [42, 3241.67]
-  - - [33536, 9216, 1, 256]
-    - [54, 4857.5]
-  - - [11776, 8704, 1, 256]
-    - [54, 4813.15]
-  - - [25088, 12801, 1, 256]
-    - [54, 4794.46]
-  - - [19712, 7169, 1, 256]
-    - [54, 4785.05]
-  - - [21760, 9473, 1, 256]
-    - [54, 4849.3]
-  - - [43520, 27648, 1, 256]
-    - [54, 4852.27]
-  - - [32768, 20480, 1, 256]
-    - [54, 4850.09]
-  - - [41984, 27648, 1, 256]
-    - [54, 4861.23]
-  - - [44032, 3072, 1, 256]
-    - [54, 4845.19]
-  - - [8960, 3072, 1, 256]
-    - [53, 4745.33]
-  - - [17664, 5121, 1, 256]
-    - [54, 4761.54]
-  - - [34560, 22017, 1, 256]
-    - [54, 4808.75]
-  - - [26112, 3072, 1, 256]
-    - [54, 4830.52]
-  - - [39424, 27136, 1, 256]
-    - [54, 4848.46]
-  - - [27904, 9216, 1, 256]
-    - [54, 4844.28]
-  - - [19712, 7424, 1, 256]
-    - [54, 4861.38]
-  - - [37888, 3072, 1, 256]
-    - [54, 4842.82]
-  - - [4352, 1281, 1, 256]
-    - [53, 4338.45]
-  - - [11264, 3072, 1, 256]
-    - [54, 4775.71]
-  - - [38912, 9216, 1, 256]
-    - [54, 4854.57]
-  - - [39424, 9216, 1, 256]
-    - [54, 4862.17]
-  - - [17920, 5377, 1, 256]
-    - [54, 4782.15]
-  - - [12800, 3072, 1, 256]
-    - [53, 4784.74]
-  - - [34560, 22273, 1, 256]
-    - [54, 4860.14]
-  - - [42496, 27648, 1, 256]
-    - [54, 4857.19]
-  - - [18688, 6400, 1, 256]
-    - [54, 4850.8]
-  - - [1536, 1537, 1, 256]
-    - [73, 3954.29]
-  - - [38656, 26368, 1, 256]
-    - [54, 4878.21]
-  - - [32000, 19712, 1, 256]
-    - [54, 4891.39]
-  - - [27392, 9216, 1, 256]
-    - [54, 4855.62]
-  - - [43264, 3073, 1, 256]
-    - [54, 4722.11]
-  - - [30464, 3072, 1, 256]
-    - [54, 4835.59]
-  - - [26112, 13824, 1, 256]
-    - [54, 4859.55]
-  - - [28160, 15873, 1, 256]
-    - [54, 4810.19]
-  - - [36864, 9216, 1, 256]
-    - [54, 4849.69]
-  - - [43008, 2817, 1, 256]
-    - [54, 4794.15]
-  - - [4352, 3072, 1, 256]
-    - [53, 4635.85]
-  - - [6400, 3329, 1, 256]
-    - [54, 4701.12]
-  - - [10752, 7425, 1, 256]
-    - [54, 4793.06]
-  - - [29696, 3072, 1, 256]
-    - [54, 4836.25]
-  - - [18688, 3072, 1, 256]
-    - [54, 4809.55]
-  - - [21504, 8961, 1, 256]
-    - [54, 4831.87]
-  - - [40704, 769, 1, 256]
-    - [54, 4499.04]
-  - - [16896, 4608, 1, 256]
-    - [54, 4824.68]
-  - - [24320, 3072, 1, 256]
-    - [54, 4815.16]
-  - - [44032, 27648, 1, 256]
-    - [54, 4860.89]
-  - - [2816, 2561, 1, 256]
-    - [54, 4418.48]
-  - - [35840, 23552, 1, 256]
-    - [54, 4844.44]
-  - - [1280, 1281, 1, 256]
-    - [69, 3828.52]
-  - - [8192, 5120, 1, 256]
-    - [57, 4747.71]
-  - - [11264, 8193, 1, 256]
-    - [54, 4775.31]
-  - - [35584, 9216, 1, 256]
-    - [54, 4854.67]
-  - - [4864, 3072, 1, 256]
-    - [54, 4668.99]
-  - - [24320, 11777, 1, 256]
-    - [54, 4797.38]
-  - - [5632, 3072, 1, 256]
-    - [54, 4704.09]
-  - - [30208, 17921, 1, 256]
-    - [54, 4805.57]
-  - - [7168, 3072, 1, 256]
-    - [53, 4728.36]
-  - - [28416, 15873, 1, 256]
-    - [54, 4803.48]
-  - - [32512, 3072, 1, 256]
-    - [54, 4840.53]
-  - - [40960, 9216, 1, 256]
-    - [54, 4857.12]
-  - - [16384, 4096, 1, 256]
-    - [57, 4784.63]
-  - - [15360, 9216, 1, 256]
-    - [54, 4838.7]
-  - - [6912, 3840, 1, 256]
-    - [54, 4788.96]
-  - - [43776, 3840, 1, 256]
-    - [54, 4874.4]
-  - - [41984, 2048, 1, 256]
-    - [58, 4811.47]
-  - - [23040, 10497, 1, 256]
-    - [54, 4835.13]
-  - - [30208, 17920, 1, 256]
-    - [54, 4850.17]
-  - - [25088, 3072, 1, 256]
-    - [54, 4806.33]
-  - - [27648, 15105, 1, 256]
-    - [54, 4837.85]
-  - - [33024, 20736, 1, 256]
-    - [54, 4891.1]
-  - - [13568, 3072, 1, 256]
-    - [54, 4783.86]
-  - - [8192, 5121, 1, 256]
-    - [54, 4712.79]
-  - - [37120, 3072, 1, 256]
-    - [54, 4833.81]
-  - - [32000, 19713, 1, 256]
-    - [54, 4864.6]
-  - - [37632, 9216, 1, 256]
-    - [54, 4859.47]
-  - - [6144, 2817, 1, 256]
-    - [54, 4648.5]
-  - - [38912, 26369, 1, 256]
-    - [54, 4838.78]
-  - - [14336, 2048, 1, 256]
-    - [58, 4732.4]
-  - - [36608, 3072, 1, 256]
-    - [54, 4826.21]
-  - - [3840, 768, 1, 256]
-    - [44, 4195.24]
-  - - [19200, 6657, 1, 256]
-    - [54, 4780.06]
-  - - [33280, 9216, 1, 256]
-    - [54, 4853.3]
-  - - [24320, 12033, 1, 256]
-    - [54, 4855.07]
-  - - [19968, 9216, 1, 256]
-    - [54, 4848.51]
-  - - [8192, 4865, 1, 256]
-    - [54, 4742.24]
-  - - [9728, 6657, 1, 256]
-    - [54, 4757.12]
-  - - [35072, 22785, 1, 256]
-    - [54, 4865.22]
-  - - [20736, 9216, 1, 256]
-    - [54, 4845.89]
-  - - [10496, 7425, 1, 256]
-    - [54, 4831.82]
-  - - [17408, 9216, 1, 256]
-    - [54, 4848.15]
-  - - [26368, 3072, 1, 256]
-    - [54, 4828.31]
-  - - [36864, 24321, 1, 256]
-    - [54, 4844.04]
-  - - [5120, 2049, 1, 256]
-    - [54, 4476.71]
-  - - [4608, 1281, 1, 256]
-    - [54, 4292.01]
-  - - [33024, 20481, 1, 256]
-    - [54, 4811.06]
-  - - [29184, 16896, 1, 256]
-    - [54, 4855.64]
-  - - [18944, 6656, 1, 256]
-    - [58, 4820.92]
-  - - [7424, 3072, 1, 256]
-    - [53, 4725.52]
-  - - [35584, 23297, 1, 256]
-    - [54, 4858.09]
-  - - [29952, 17665, 1, 256]
-    - [54, 4851.14]
-  - - [6912, 3841, 1, 256]
-    - [54, 4712.88]
-  - - [20480, 3072, 1, 256]
-    - [54, 4819.94]
-  - - [28672, 9216, 1, 256]
-    - [54, 4863.41]
-  - - [25600, 13313, 1, 256]
-    - [54, 4792.85]
-  - - [42752, 2561, 1, 256]
-    - [54, 4727.71]
-  - - [14080, 1793, 1, 256]
-    - [54, 4675.08]
-  - - [4352, 1025, 1, 256]
-    - [54, 4275.74]
-  - - [6656, 3329, 1, 256]
-    - [54, 4671.41]
-  - - [3584, 512, 1, 256]
-    - [83, 4135.23]
-  - - [42496, 3072, 1, 256]
-    - [54, 4842.08]
-  - - [41984, 1793, 1, 256]
-    - [54, 4717.5]
-  - - [29184, 16641, 1, 256]
-    - [54, 4847.5]
-  - - [33792, 21249, 1, 256]
-    - [54, 4843.22]
-  - - [7168, 4096, 1, 256]
-    - [54, 4724.19]
-  - - [26624, 14337, 1, 256]
-    - [54, 4790.39]
-  - - [7936, 4864, 1, 256]
-    - [54, 4792.51]
-  - - [44032, 9216, 1, 256]
-    - [54, 4856.46]
-  - - [22528, 9216, 1, 256]
-    - [54, 4856.1]
-  - - [12800, 257, 1, 256]
-    - [54, 3692.29]
-  - - [16896, 9216, 1, 256]
-    - [54, 4849.0]
-  - - [35328, 23041, 1, 256]
-    - [59, 4803.57]
-  - - [22784, 3072, 1, 256]
-    - [54, 4817.67]
-  - - [17664, 9216, 1, 256]
-    - [54, 4845.25]
-  - - [18176, 3072, 1, 256]
-    - [54, 4802.83]
-  - - [2816, 2816, 1, 256]
-    - [71, 4540.68]
-  - - [9984, 6657, 1, 256]
-    - [54, 4753.65]
-  - - [17408, 4865, 1, 256]
-    - [54, 4791.0]
-  - - [41472, 9216, 1, 256]
-    - [54, 4854.94]
-  - - [42752, 27648, 1, 256]
-    - [54, 4854.75]
-  - - [27392, 15104, 1, 256]
-    - [54, 4881.85]
-  - - [29440, 17152, 1, 256]
-    - [54, 4883.93]
-  - - [19200, 3072, 1, 256]
-    - [54, 4815.38]
-  - - [41216, 9216, 1, 256]
-    - [54, 4853.14]
-  - - [8960, 5633, 1, 256]
-    - [54, 4736.0]
-  - - [17920, 5632, 1, 256]
-    - [58, 4806.97]
-  - - [9216, 5889, 1, 256]
-    - [54, 4775.39]
-  - - [12544, 256, 1, 256]
-    - [80, 4156.98]
-  - - [29952, 17409, 1, 256]
-    - [54, 4809.49]
-  - - [5376, 3072, 1, 256]
-    - [54, 4689.91]
-  - - [38656, 3072, 1, 256]
-    - [54, 4839.12]
-  - - [13568, 1280, 1, 256]
-    - [58, 4703.92]
-  - - [16128, 3585, 1, 256]
-    - [54, 4738.64]
-  - - [32256, 9216, 1, 256]
-    - [54, 4863.46]
-  - - [20736, 8449, 1, 256]
-    - [54, 4837.17]
-  - - [19968, 7680, 1, 256]
-    - [54, 4843.47]
-  - - [22272, 9216, 1, 256]
-    - [54, 4858.41]
-  - - [13312, 1024, 1, 256]
-    - [83, 4640.26]
-  - - [14080, 9216, 1, 256]
-    - [54, 4841.98]
-  - - [18432, 5889, 1, 256]
-    - [54, 4814.21]
-  - - [18944, 9216, 1, 256]
-    - [54, 4846.8]
-  - - [40960, 769, 1, 256]
-    - [54, 4481.14]
-  - - [6656, 3585, 1, 256]
-    - [54, 4662.78]
-  - - [42496, 9216, 1, 256]
-    - [54, 4862.87]
-  - - [8448, 5376, 1, 256]
-    - [54, 4825.76]
-  - - [5120, 3072, 1, 256]
-    - [54, 4679.84]
-  - - [34048, 21761, 1, 256]
-    - [54, 4865.49]
-  - - [26112, 13825, 1, 256]
-    - [54, 4786.19]
-  - - [25600, 9216, 1, 256]
-    - [54, 4862.69]
-  - - [20480, 8192, 1, 256]
-    - [58, 4823.05]
-  - - [13312, 1025, 1, 256]
-    - [54, 4470.27]
-  - - [31744, 9216, 1, 256]
-    - [54, 4859.49]
-  - - [13056, 3072, 1, 256]
-    - [54, 4782.15]
-  - - [24064, 11521, 1, 256]
-    - [54, 4816.64]
-  - - [3840, 769, 1, 256]
-    - [88, 3991.33]
-  - - [31744, 19456, 1, 256]
-    - [54, 4856.81]
-  - - [38912, 26624, 1, 256]
-    - [54, 4852.28]
-  - - [19456, 3072, 1, 256]
-    - [54, 4817.94]
-  - - [26368, 14080, 1, 256]
-    - [54, 4873.65]
-  - - [34048, 21760, 1, 256]
-    - [54, 4891.92]
-  - - [3328, 256, 1, 256]
-    - [41, 3513.27]
-  - - [43520, 3329, 1, 256]
-    - [54, 4782.0]
-  - - [28672, 16384, 1, 256]
-    - [54, 4852.61]
-  - - [40448, 27648, 1, 256]
-    - [54, 4864.56]
-  - - [36864, 3072, 1, 256]
-    - [54, 4839.35]
-  - - [20224, 3072, 1, 256]
-    - [54, 4811.01]
-  - - [32256, 19713, 1, 256]
-    - [54, 4836.37]
-  - - [12800, 9216, 1, 256]
-    - [54, 4851.83]
-  - - [4608, 1537, 1, 256]
-    - [53, 4318.19]
-  - - [31488, 18945, 1, 256]
-    - [54, 4805.54]
-  - - [13568, 9216, 1, 256]
-    - [54, 4835.72]
-  - - [9728, 6401, 1, 256]
-    - [54, 4778.49]
-  - - [41216, 27648, 1, 256]
-    - [54, 4863.99]
-  - - [33536, 3072, 1, 256]
-    - [54, 4839.47]
-  - - [26880, 14592, 1, 256]
-    - [54, 4895.56]
-  - - [19968, 3072, 1, 256]
-    - [54, 4810.58]
-  - - [15104, 9216, 1, 256]
-    - [54, 4845.0]
-  - - [11520, 8193, 1, 256]
-    - [54, 4775.92]
-  - - [28672, 16129, 1, 256]
-    - [54, 4833.36]
-  - - [27392, 14849, 1, 256]
-    - [54, 4793.36]
-  - - [15872, 3072, 1, 256]
-    - [54, 4808.93]
-  - - [29440, 9216, 1, 256]
-    - [54, 4850.95]
+  - - [36096, 1281, 1, 256]
+    - [110, 4686.88]
   - - [24064, 3072, 1, 256]
-    - [54, 4830.14]
-  - - [37888, 25345, 1, 256]
-    - [54, 4833.09]
-  - - [28928, 9216, 1, 256]
-    - [54, 4860.16]
-  - - [256, 257, 1, 256]
-    - [62, 728.493]
-  - - [5888, 2561, 1, 256]
-    - [54, 4561.24]
-  - - [1024, 769, 1, 256]
-    - [41, 3283.22]
-  - - [6144, 3072, 1, 256]
-    - [54, 4691.11]
-  - - [43008, 3073, 1, 256]
-    - [54, 4724.32]
-  - - [43520, 3585, 1, 256]
-    - [54, 4770.45]
-  - - [13056, 768, 1, 256]
-    - [54, 4605.48]
-  - - [36096, 3072, 1, 256]
-    - [54, 4836.22]
-  - - [33536, 21249, 1, 256]
-    - [54, 4857.39]
-  - - [14848, 9216, 1, 256]
-    - [54, 4845.87]
-  - - [36096, 23553, 1, 256]
-    - [54, 4811.63]
-  - - [38656, 26369, 1, 256]
-    - [54, 4868.28]
-  - - [15616, 3072, 1, 256]
-    - [54, 4790.42]
-  - - [44288, 4352, 1, 256]
-    - [54, 4857.91]
-  - - [43008, 3072, 1, 256]
-    - [54, 4835.43]
-  - - [28672, 3072, 1, 256]
-    - [54, 4829.96]
-  - - [13312, 769, 1, 256]
-    - [54, 4335.67]
-  - - [32512, 20224, 1, 256]
-    - [54, 4882.7]
-  - - [4864, 1793, 1, 256]
-    - [54, 4479.57]
-  - - [9728, 3072, 1, 256]
-    - [54, 4760.44]
-  - - [34816, 22528, 1, 256]
-    - [54, 4848.03]
-  - - [44288, 27648, 1, 256]
-    - [54, 4853.76]
+    - [112, 4806.79]
+  - - [256, 512, 1, 256]
+    - [115, 1412.22]
   - - [40960, 27648, 1, 256]
-    - [54, 4862.72]
-  - - [41984, 3072, 1, 256]
-    - [54, 4845.49]
-  - - [30976, 9216, 1, 256]
-    - [54, 4850.72]
-  - - [39168, 26881, 1, 256]
-    - [54, 4862.44]
-  - - [37632, 25345, 1, 256]
-    - [54, 4863.01]
-  - - [35840, 9216, 1, 256]
-    - [54, 4859.36]
-  - - [18432, 6145, 1, 256]
-    - [54, 4750.88]
-  - - [43776, 3841, 1, 256]
-    - [54, 4792.19]
-  - - [11008, 7936, 1, 256]
-    - [54, 4840.78]
-  - - [36352, 3072, 1, 256]
-    - [54, 4828.5]
-  - - [15104, 2817, 1, 256]
-    - [54, 4767.19]
-  - - [42240, 2305, 1, 256]
-    - [54, 4752.61]
-  - - [25088, 9216, 1, 256]
-    - [54, 4851.27]
-  - - [27136, 14849, 1, 256]
-    - [54, 4802.87]
-  - - [31232, 3072, 1, 256]
-    - [54, 4834.47]
-  - - [17664, 3072, 1, 256]
-    - [53, 4802.11]
-  - - [44288, 4353, 1, 256]
-    - [54, 4847.91]
-  - - [38912, 3072, 1, 256]
-    - [54, 4833.71]
-  - - [33280, 20992, 1, 256]
-    - [54, 4852.52]
-  - - [27392, 3072, 1, 256]
-    - [54, 4826.01]
-  - - [3840, 513, 1, 256]
-    - [89, 3872.08]
-  - - [44288, 3072, 1, 256]
-    - [54, 4841.14]
-  - - [11776, 3072, 1, 256]
-    - [54, 4780.13]
-  - - [3584, 513, 1, 256]
-    - [75, 3701.47]
-  - - [25344, 13057, 1, 256]
-    - [54, 4842.41]
-  - - [39936, 27648, 1, 256]
-    - [54, 4851.43]
-  - - [9472, 6400, 1, 256]
-    - [54, 4821.76]
-  - - [14080, 3072, 1, 256]
-    - [54, 4788.85]
-  - - [13312, 3072, 1, 256]
-    - [54, 4798.76]
-  - - [20480, 8193, 1, 256]
-    - [54, 4782.16]
-  - - [4864, 1792, 1, 256]
-    - [71, 4547.88]
-  - - [36352, 23809, 1, 256]
-    - [54, 4833.39]
-  - - [29696, 9216, 1, 256]
-    - [54, 4854.59]
-  - - [13056, 769, 1, 256]
-    - [54, 4315.41]
-  - - [23040, 3072, 1, 256]
-    - [54, 4816.94]
-  - - [2816, 2817, 1, 256]
-    - [54, 4516.03]
-  - - [29184, 16897, 1, 256]
-    - [54, 4807.22]
-  - - [37376, 3072, 1, 256]
-    - [54, 4842.99]
-  - - [20736, 8448, 1, 256]
-    - [54, 4886.19]
-  - - [27904, 3072, 1, 256]
-    - [54, 4827.44]
-  - - [8192, 3072, 1, 256]
-    - [53, 4735.29]
-  - - [26112, 9216, 1, 256]
-    - [54, 4852.71]
-  - - [20224, 7936, 1, 256]
-    - [54, 4851.34]
-  - - [35584, 23041, 1, 256]
-    - [54, 4798.98]
-  - - [1280, 1025, 1, 256]
-    - [73, 3536.99]
-  - - [39168, 26625, 1, 256]
-    - [54, 4811.53]
-  - - [28160, 15872, 1, 256]
-    - [54, 4836.97]
-  - - [30720, 9216, 1, 256]
-    - [54, 4857.94]
-  - - [8704, 5377, 1, 256]
-    - [53, 4742.16]
-  - - [11520, 8448, 1, 256]
-    - [54, 4860.62]
-  - - [8448, 5377, 1, 256]
-    - [54, 4760.27]
-  - - [34816, 9216, 1, 256]
-    - [54, 4856.82]
-  - - [23552, 11264, 1, 256]
-    - [58, 4833.29]
-  - - [38912, 26625, 1, 256]
-    - [54, 4804.15]
-  - - [31488, 9216, 1, 256]
-    - [54, 4860.26]
-  - - [35328, 3072, 1, 256]
-    - [54, 4837.02]
-  - - [28416, 3072, 1, 256]
-    - [54, 4826.49]
-  - - [14848, 2305, 1, 256]
-    - [54, 4667.82]
-  - - [41984, 9216, 1, 256]
-    - [53, 4843.93]
-  - - [8704, 3072, 1, 256]
-    - [54, 4749.19]
-  - - [24064, 9216, 1, 256]
-    - [54, 4847.28]
-  - - [14848, 2561, 1, 256]
-    - [53, 4660.64]
-  - - [26624, 9216, 1, 256]
-    - [54, 4852.4]
-  - - [21760, 9216, 1, 256]
-    - [54, 4847.61]
-  - - [512, 513, 1, 256]
-    - [63, 2083.02]
-  - - [15616, 3329, 1, 256]
-    - [54, 4774.94]
-  - - [32000, 9216, 1, 256]
-    - [54, 4853.96]
-  - - [18432, 3072, 1, 256]
-    - [54, 4813.23]
-  - - [23552, 11265, 1, 256]
-    - [54, 4796.64]
-  - - [43264, 27648, 1, 256]
-    - [54, 4860.38]
-  - - [16640, 3072, 1, 256]
-    - [54, 4796.58]
-  - - [9984, 6912, 1, 256]
-    - [54, 4854.32]
-  - - [5888, 2817, 1, 256]
-    - [54, 4667.32]
-  - - [22016, 9728, 1, 256]
-    - [58, 4830.62]
-  - - [32256, 19969, 1, 256]
-    - [59, 4804.7]
-  - - [35840, 23297, 1, 256]
-    - [54, 4838.08]
-  - - [1280, 1280, 1, 256]
-    - [70, 3840.95]
-  - - [29952, 17664, 1, 256]
-    - [54, 4897.06]
-  - - [25600, 3072, 1, 256]
-    - [54, 4822.75]
-  - - [39936, 27393, 1, 256]
-    - [54, 4841.7]
-  - - [19712, 7425, 1, 256]
-    - [54, 4842.13]
-  - - [16128, 3072, 1, 256]
-    - [54, 4799.8]
-  - - [16384, 3841, 1, 256]
-    - [54, 4738.66]
-  - - [12800, 512, 1, 256]
-    - [80, 4518.26]
-  - - [20224, 9216, 1, 256]
-    - [54, 4854.79]
-  - - [6656, 3584, 1, 256]
-    - [58, 4714.01]
-  - - [15616, 9216, 1, 256]
-    - [54, 4848.73]
-  - - [13568, 1281, 1, 256]
-    - [54, 4646.64]
-  - - [4096, 3072, 1, 256]
-    - [80, 4629.27]
-  - - [40448, 513, 1, 256]
-    - [54, 4473.0]
-  - - [30464, 18176, 1, 256]
-    - [54, 4886.32]
-  - - [16640, 4352, 1, 256]
-    - [54, 4832.5]
-  - - [12032, 8960, 1, 256]
-    - [54, 4865.23]
-  - - [20736, 8193, 1, 256]
-    - [54, 4790.17]
-  - - [37120, 24577, 1, 256]
-    - [54, 4800.11]
-  - - [28160, 9216, 1, 256]
-    - [54, 4859.42]
-  - - [11776, 8449, 1, 256]
-    - [54, 4789.95]
-  - - [22016, 9216, 1, 256]
-    - [54, 4843.73]
-  - - [31232, 18945, 1, 256]
-    - [54, 4809.06]
-  - - [39168, 9216, 1, 256]
-    - [54, 4854.87]
-  - - [3072, 3072, 1, 256]
-    - [83, 4584.64]
-  - - [2048, 2049, 1, 256]
-    - [43, 4227.41]
-  - - [23296, 11008, 1, 256]
-    - [54, 4868.98]
-  - - [1536, 1281, 1, 256]
-    - [70, 3981.27]
-  - - [36096, 23809, 1, 256]
-    - [54, 4852.57]
-  - - [37120, 9216, 1, 256]
-    - [54, 4853.32]
-  - - [4608, 3072, 1, 256]
-    - [54, 4656.03]
-  - - [20224, 7937, 1, 256]
-    - [54, 4841.53]
-  - - [18944, 6657, 1, 256]
-    - [54, 4776.08]
-  - - [13568, 1025, 1, 256]
-    - [54, 4461.23]
-  - - [23040, 9216, 1, 256]
-    - [54, 4856.81]
-  - - [25856, 3072, 1, 256]
-    - [54, 4836.17]
-  - - [20480, 9216, 1, 256]
-    - [54, 4842.41]
-  - - [40448, 257, 1, 256]
-    - [54, 4136.59]
-  - - [32256, 19968, 1, 256]
-    - [54, 4858.54]
-  - - [19200, 6913, 1, 256]
-    - [54, 4833.04]
-  - - [6912, 3585, 1, 256]
-    - [53, 4666.58]
-  - - [26368, 14081, 1, 256]
-    - [54, 4860.34]
-  - - [19200, 6912, 1, 256]
-    - [54, 4870.64]
-  - - [34304, 22016, 1, 256]
-    - [58, 4840.38]
-  - - [15872, 3585, 1, 256]
-    - [54, 4734.73]
-  - - [5632, 2561, 1, 256]
-    - [53, 4561.71]
-  - - [28928, 3072, 1, 256]
-    - [54, 4831.89]
-  - - [36096, 9216, 1, 256]
-    - [54, 4851.93]
-  - - [768, 513, 1, 256]
-    - [67, 2956.03]
-  - - [39680, 27393, 1, 256]
-    - [54, 4853.26]
-  - - [38144, 25601, 1, 256]
-    - [54, 4816.09]
-  - - [21504, 3072, 1, 256]
-    - [54, 4820.54]
-  - - [768, 768, 1, 256]
-    - [42, 3254.22]
-  - - [14336, 1793, 1, 256]
-    - [53, 4657.66]
-  - - [23296, 3072, 1, 256]
-    - [54, 4822.71]
-  - - [25088, 12800, 1, 256]
-    - [58, 4831.42]
-  - - [43776, 3585, 1, 256]
-    - [54, 4763.33]
-  - - [19712, 3072, 1, 256]
-    - [54, 4816.9]
-  - - [27136, 14593, 1, 256]
-    - [54, 4818.14]
-  - - [22784, 9216, 1, 256]
-    - [54, 4851.46]
-  - - [29696, 17409, 1, 256]
-    - [54, 4804.93]
-  - - [21760, 9217, 1, 256]
-    - [54, 4782.51]
-  - - [1792, 1793, 1, 256]
-    - [44, 4160.14]
-  - - [3584, 3072, 1, 256]
-    - [83, 4615.17]
-  - - [15104, 2561, 1, 256]
-    - [54, 4677.04]
-  - - [30464, 17921, 1, 256]
-    - [54, 4800.09]
-  - - [30208, 3072, 1, 256]
-    - [54, 4835.88]
-  - - [37120, 24832, 1, 256]
-    - [54, 4889.72]
-  - - [22016, 9729, 1, 256]
-    - [54, 4789.49]
-  - - [36352, 24065, 1, 256]
-    - [54, 4808.98]
-  - - [15616, 3328, 1, 256]
-    - [58, 4798.78]
-  - - [26880, 14337, 1, 256]
-    - [54, 4791.91]
+    - [112, 4849.11]
+  - - [11264, 1792, 1, 256]
+    - [105, 4705.84]
+  - - [22016, 512, 1, 256]
+    - [112, 4560.18]
   - - [31744, 3072, 1, 256]
-    - [54, 4842.36]
-  - - [4096, 1025, 1, 256]
-    - [91, 4180.12]
-  - - [12032, 8705, 1, 256]
-    - [54, 4784.46]
-  - - [3840, 3072, 1, 256]
-    - [54, 4644.29]
-  - - [26624, 14336, 1, 256]
-    - [58, 4833.54]
-  - - [36608, 24065, 1, 256]
-    - [54, 4802.64]
-  - - [12288, 8961, 1, 256]
-    - [54, 4821.02]
-  - - [21248, 8960, 1, 256]
-    - [54, 4872.03]
-  - - [16896, 3072, 1, 256]
-    - [54, 4798.2]
-  - - [8960, 5889, 1, 256]
-    - [54, 4799.18]
-  - - [39424, 27137, 1, 256]
-    - [59, 4801.19]
-  - - [31488, 19201, 1, 256]
-    - [54, 4865.55]
-  - - [36864, 24576, 1, 256]
-    - [54, 4861.19]
-  - - [29440, 17153, 1, 256]
-    - [54, 4862.97]
-  - - [14592, 2304, 1, 256]
-    - [54, 4815.1]
-  - - [17664, 5377, 1, 256]
-    - [54, 4807.48]
-  - - [15360, 3072, 1, 256]
-    - [54, 4798.82]
-  - - [6912, 3072, 1, 256]
-    - [54, 4720.89]
-  - - [26624, 3072, 1, 256]
-    - [54, 4830.25]
-  - - [6400, 3328, 1, 256]
-    - [54, 4707.82]
-  - - [9216, 3072, 1, 256]
-    - [54, 4748.89]
-  - - [16128, 3841, 1, 256]
-    - [54, 4764.57]
+    - [112, 4805.75]
+  - - [13056, 1792, 1, 256]
+    - [105, 4730.72]
+  - - [35328, 22785, 1, 256]
+    - [105, 4827.72]
+  - - [28160, 15872, 1, 256]
+    - [112, 4841.73]
+  - - [39168, 1792, 1, 256]
+    - [105, 4824.09]
+  - - [2560, 2561, 1, 256]
+    - [132, 4336.0]
+  - - [35328, 1536, 1, 256]
+    - [112, 4783.72]
+  - - [37376, 3072, 1, 256]
+    - [112, 4822.4]
+  - - [23808, 11265, 1, 256]
+    - [112, 4782.95]
+  - - [36096, 2048, 1, 256]
+    - [112, 4812.7]
+  - - [27136, 1280, 1, 256]
+    - [105, 4775.78]
+  - - [28928, 3072, 1, 256]
+    - [112, 4804.79]
+  - - [13568, 1792, 1, 256]
+    - [105, 4735.51]
+  - - [16640, 4353, 1, 256]
+    - [105, 4745.34]
+  - - [33792, 1280, 1, 256]
+    - [112, 4800.56]
+  - - [12544, 2048, 1, 256]
+    - [112, 4702.05]
+  - - [38912, 26624, 1, 256]
+    - [112, 4846.7]
+  - - [6912, 3585, 1, 256]
+    - [108, 4605.19]
+  - - [32768, 1792, 1, 256]
+    - [105, 4819.31]
   - - [30976, 18688, 1, 256]
-    - [54, 4877.79]
-  - - [42496, 2560, 1, 256]
-    - [58, 4809.71]
-  - - [34048, 3072, 1, 256]
-    - [53, 4835.46]
-  - - [12544, 9216, 1, 256]
-    - [54, 4837.33]
-  - - [30720, 3072, 1, 256]
-    - [54, 4833.38]
-  - - [43264, 3329, 1, 256]
-    - [54, 4807.62]
-  - - [22528, 10240, 1, 256]
-    - [54, 4834.22]
-  - - [5120, 2048, 1, 256]
-    - [83, 4602.81]
+    - [105, 4861.51]
+  - - [32256, 512, 1, 256]
+    - [112, 4646.61]
+  - - [512, 2048, 1, 256]
+    - [102, 3942.94]
+  - - [13312, 2048, 1, 256]
+    - [112, 4721.25]
+  - - [10496, 3072, 1, 256]
+    - [112, 4733.13]
+  - - [15872, 3584, 1, 256]
+    - [112, 4789.08]
+  - - [33792, 512, 1, 256]
+    - [112, 4653.68]
+  - - [6400, 1792, 1, 256]
+    - [105, 4582.65]
+  - - [39680, 27393, 1, 256]
+    - [105, 4847.82]
+  - - [36864, 24577, 1, 256]
+    - [112, 4801.26]
+  - - [38400, 1280, 1, 256]
+    - [105, 4806.01]
+  - - [26112, 1536, 1, 256]
+    - [112, 4767.32]
+  - - [26368, 1536, 1, 256]
+    - [112, 4766.96]
+  - - [16896, 4353, 1, 256]
+    - [105, 4734.69]
+  - - [14336, 1793, 1, 256]
+    - [110, 4576.93]
+  - - [1280, 1025, 1, 256]
+    - [95, 3510.37]
+  - - [3840, 3072, 1, 256]
+    - [112, 4594.27]
+  - - [2560, 3072, 1, 256]
+    - [132, 4510.01]
+  - - [6656, 1536, 1, 256]
+    - [132, 4550.15]
+  - - [27136, 1792, 1, 256]
+    - [105, 4797.26]
+  - - [43776, 3072, 1, 256]
+    - [112, 4830.08]
+  - - [23296, 1792, 1, 256]
+    - [105, 4789.92]
+  - - [20224, 256, 1, 256]
+    - [123, 4406.25]
+  - - [42496, 2048, 1, 256]
+    - [112, 4812.87]
+  - - [11264, 7937, 1, 256]
+    - [105, 4763.52]
+  - - [768, 3072, 1, 256]
+    - [105, 4332.71]
+  - - [6912, 3841, 1, 256]
+    - [105, 4655.93]
+  - - [40960, 769, 1, 256]
+    - [110, 4426.24]
+  - - [39680, 1281, 1, 256]
+    - [110, 4686.15]
+  - - [9984, 1280, 1, 256]
+    - [105, 4637.61]
+  - - [41984, 1536, 1, 256]
+    - [112, 4799.96]
+  - - [34304, 1281, 1, 256]
+    - [110, 4685.58]
+  - - [34048, 256, 1, 256]
+    - [112, 4499.45]
+  - - [31232, 1024, 1, 256]
+    - [112, 4745.15]
+  - - [11264, 8192, 1, 256]
+    - [112, 4817.07]
+  - - [6400, 3072, 1, 256]
+    - [112, 4658.1]
   - - [40448, 9216, 1, 256]
-    - [54, 4849.21]
+    - [112, 4847.45]
+  - - [7680, 4353, 1, 256]
+    - [105, 4688.27]
+  - - [23296, 3072, 1, 256]
+    - [112, 4802.59]
+  - - [7936, 4609, 1, 256]
+    - [112, 4645.16]
+  - - [20736, 8448, 1, 256]
+    - [105, 4854.4]
+  - - [17408, 1792, 1, 256]
+    - [105, 4751.74]
+  - - [768, 1024, 1, 256]
+    - [127, 3853.88]
+  - - [1792, 1793, 1, 256]
+    - [131, 4111.89]
+  - - [38656, 3072, 1, 256]
+    - [112, 4817.62]
+  - - [12544, 9216, 1, 256]
+    - [112, 4804.76]
+  - - [28160, 1792, 1, 256]
+    - [112, 4803.4]
+  - - [13824, 3072, 1, 256]
+    - [112, 4776.98]
+  - - [42752, 1792, 1, 256]
+    - [105, 4826.97]
+  - - [35584, 23041, 1, 256]
+    - [112, 4794.02]
+  - - [13056, 3072, 1, 256]
+    - [112, 4777.34]
+  - - [40960, 1024, 1, 256]
+    - [112, 4772.7]
+  - - [2048, 2048, 1, 256]
+    - [120, 4396.99]
+  - - [9984, 512, 1, 256]
+    - [132, 4380.18]
+  - - [11264, 1024, 1, 256]
+    - [112, 4570.6]
+  - - [23552, 512, 1, 256]
+    - [112, 4598.14]
+  - - [37888, 768, 1, 256]
+    - [112, 4753.6]
+  - - [17664, 2048, 1, 256]
+    - [112, 4757.34]
+  - - [36608, 256, 1, 256]
+    - [112, 4580.96]
+  - - [42752, 1281, 1, 256]
+    - [110, 4691.57]
+  - - [19456, 3072, 1, 256]
+    - [112, 4793.97]
+  - - [22784, 1024, 1, 256]
+    - [112, 4703.94]
+  - - [15872, 9216, 1, 256]
+    - [112, 4825.66]
+  - - [39424, 1024, 1, 256]
+    - [112, 4754.94]
+  - - [30976, 1792, 1, 256]
+    - [105, 4817.44]
+  - - [26368, 14081, 1, 256]
+    - [105, 4825.57]
+  - - [21760, 1281, 1, 256]
+    - [110, 4645.28]
+  - - [35328, 23041, 1, 256]
+    - [112, 4803.3]
+  - - [16128, 1280, 1, 256]
+    - [105, 4715.39]
+  - - [22528, 1281, 1, 256]
+    - [110, 4644.04]
+  - - [27648, 15105, 1, 256]
+    - [105, 4820.03]
+  - - [25856, 13568, 1, 256]
+    - [105, 4865.18]
+  - - [36864, 768, 1, 256]
+    - [112, 4744.54]
+  - - [23296, 9216, 1, 256]
+    - [112, 4833.37]
+  - - [32000, 1281, 1, 256]
+    - [110, 4678.78]
+  - - [18176, 1281, 1, 256]
+    - [110, 4617.3]
+  - - [2048, 1024, 1, 256]
+    - [111, 4128.51]
+  - - [38144, 256, 1, 256]
+    - [105, 4591.52]
+  - - [21248, 1280, 1, 256]
+    - [105, 4747.02]
+  - - [19712, 1281, 1, 256]
+    - [110, 4635.08]
+  - - [1792, 1280, 1, 256]
+    - [97, 4237.89]
+  - - [12032, 1792, 1, 256]
+    - [112, 4715.76]
+  - - [23040, 3072, 1, 256]
+    - [112, 4816.43]
+  - - [11520, 1536, 1, 256]
+    - [112, 4661.3]
+  - - [16128, 768, 1, 256]
+    - [112, 4619.33]
+  - - [15360, 3072, 1, 256]
+    - [112, 4780.97]
+  - - [38912, 26369, 1, 256]
+    - [105, 4821.94]
+  - - [27392, 2048, 1, 256]
+    - [112, 4783.91]
+  - - [25344, 13056, 1, 256]
+    - [105, 4861.4]
+  - - [39168, 26880, 1, 256]
+    - [105, 4869.85]
+  - - [39424, 768, 1, 256]
+    - [105, 4747.92]
+  - - [16384, 1280, 1, 256]
+    - [112, 4703.62]
+  - - [10496, 1792, 1, 256]
+    - [112, 4707.17]
+  - - [28672, 3072, 1, 256]
+    - [112, 4803.5]
+  - - [5888, 1280, 1, 256]
+    - [132, 4520.99]
+  - - [27392, 768, 1, 256]
+    - [105, 4727.93]
+  - - [39680, 768, 1, 256]
+    - [105, 4757.88]
+  - - [11520, 8193, 1, 256]
+    - [112, 4750.9]
+  - - [17408, 4865, 1, 256]
+    - [105, 4739.68]
+  - - [35840, 1281, 1, 256]
+    - [110, 4683.9]
+  - - [14080, 1537, 1, 256]
+    - [112, 4486.77]
+  - - [29184, 768, 1, 256]
+    - [105, 4722.32]
+  - - [2560, 1280, 1, 256]
+    - [120, 4237.53]
+  - - [19200, 6913, 1, 256]
+    - [105, 4786.8]
+  - - [33536, 9216, 1, 256]
+    - [112, 4838.6]
+  - - [5632, 3072, 1, 256]
+    - [112, 4634.01]
+  - - [32768, 20480, 1, 256]
+    - [112, 4838.3]
+  - - [34560, 2048, 1, 256]
+    - [112, 4802.74]
+  - - [29440, 9216, 1, 256]
+    - [112, 4831.11]
+  - - [40960, 1792, 1, 256]
+    - [105, 4817.73]
+  - - [10240, 3072, 1, 256]
+    - [112, 4728.98]
+  - - [20992, 1792, 1, 256]
+    - [105, 4779.79]
+  - - [42240, 9216, 1, 256]
+    - [112, 4847.62]
+  - - [14080, 2048, 1, 256]
+    - [112, 4723.56]
+  - - [5120, 256, 1, 256]
+    - [119, 3981.3]
+  - - [6144, 512, 1, 256]
+    - [113, 4254.58]
+  - - [19200, 6912, 1, 256]
+    - [105, 4851.5]
+  - - [8704, 1280, 1, 256]
+    - [105, 4568.37]
+  - - [43264, 512, 1, 256]
+    - [112, 4697.4]
+  - - [27392, 1792, 1, 256]
+    - [105, 4816.09]
+  - - [43264, 1024, 1, 256]
+    - [112, 4773.96]
+  - - [2048, 2049, 1, 256]
+    - [108, 4210.83]
+  - - [42496, 1536, 1, 256]
+    - [112, 4791.51]
+  - - [20480, 512, 1, 256]
+    - [132, 4569.58]
+  - - [29440, 16897, 1, 256]
+    - [112, 4792.23]
+  - - [3584, 768, 1, 256]
+    - [120, 4157.68]
+  - - [20480, 8192, 1, 256]
+    - [112, 4841.21]
+  - - [15360, 1536, 1, 256]
+    - [112, 4706.97]
+  - - [11264, 8193, 1, 256]
+    - [112, 4734.97]
+  - - [27136, 2048, 1, 256]
+    - [112, 4785.75]
+  - - [19968, 1281, 1, 256]
+    - [110, 4630.34]
+  - - [26880, 14337, 1, 256]
+    - [112, 4785.05]
+  - - [28928, 16641, 1, 256]
+    - [105, 4830.02]
+  - - [15360, 2817, 1, 256]
+    - [104, 4696.23]
+  - - [15616, 1280, 1, 256]
+    - [105, 4704.56]
+  - - [1536, 1537, 1, 256]
+    - [132, 3880.16]
+  - - [44288, 1536, 1, 256]
+    - [112, 4799.78]
+  - - [7936, 1536, 1, 256]
+    - [132, 4575.07]
+  - - [18176, 5633, 1, 256]
+    - [112, 4733.05]
+  - - [44032, 1280, 1, 256]
+    - [105, 4807.61]
+  - - [38912, 1024, 1, 256]
+    - [112, 4741.35]
+  - - [8448, 3072, 1, 256]
+    - [112, 4720.2]
+  - - [17920, 5632, 1, 256]
+    - [112, 4811.34]
+  - - [19456, 512, 1, 256]
+    - [130, 4499.82]
+  - - [3328, 1281, 1, 256]
+    - [110, 4125.86]
+  - - [22528, 10240, 1, 256]
+    - [112, 4838.15]
+  - - [24576, 2048, 1, 256]
+    - [112, 4789.0]
+  - - [1792, 2048, 1, 256]
+    - [118, 4381.29]
+  - - [33280, 2048, 1, 256]
+    - [112, 4797.92]
+  - - [25600, 1536, 1, 256]
+    - [112, 4757.87]
+  - - [38400, 1281, 1, 256]
+    - [110, 4683.13]
+  - - [17664, 256, 1, 256]
+    - [112, 4327.9]
+  - - [39936, 3072, 1, 256]
+    - [112, 4826.34]
+  - - [7168, 4096, 1, 256]
+    - [112, 4707.51]
+  - - [10240, 768, 1, 256]
+    - [132, 4535.2]
+  - - [41216, 1280, 1, 256]
+    - [112, 4805.19]
+  - - [24832, 1024, 1, 256]
+    - [112, 4716.66]
+  - - [35328, 3072, 1, 256]
+    - [112, 4821.88]
+  - - [20480, 3072, 1, 256]
+    - [112, 4793.95]
+  - - [24832, 1792, 1, 256]
+    - [112, 4787.33]
+  - - [4352, 1280, 1, 256]
+    - [132, 4388.97]
+  - - [37376, 25088, 1, 256]
+    - [112, 4838.25]
+  - - [7168, 4097, 1, 256]
+    - [110, 4624.21]
+  - - [19200, 256, 1, 256]
+    - [132, 4387.96]
+  - - [21504, 768, 1, 256]
+    - [112, 4671.67]
+  - - [13312, 3072, 1, 256]
+    - [112, 4759.84]
+  - - [35072, 768, 1, 256]
+    - [105, 4745.78]
+  - - [22784, 2048, 1, 256]
+    - [112, 4790.72]
+  - - [40960, 1025, 1, 256]
+    - [110, 4531.46]
+  - - [28672, 256, 1, 256]
+    - [112, 4491.89]
+  - - [26880, 1280, 1, 256]
+    - [105, 4781.47]
+  - - [12032, 1536, 1, 256]
+    - [112, 4665.12]
+  - - [9216, 768, 1, 256]
+    - [132, 4519.45]
+  - - [44288, 27648, 1, 256]
+    - [112, 4840.09]
+  - - [23808, 1280, 1, 256]
+    - [105, 4769.52]
+  - - [32512, 1792, 1, 256]
+    - [105, 4801.67]
+  - - [39424, 256, 1, 256]
+    - [112, 4582.96]
+  - - [23808, 11520, 1, 256]
+    - [105, 4864.68]
+  - - [12032, 1281, 1, 256]
+    - [110, 4572.11]
+  - - [25600, 13057, 1, 256]
+    - [105, 4806.69]
+  - - [31744, 1281, 1, 256]
+    - [110, 4674.03]
+  - - [11520, 2048, 1, 256]
+    - [112, 4696.14]
+  - - [12032, 1280, 1, 256]
+    - [105, 4659.9]
+  - - [30208, 1281, 1, 256]
+    - [110, 4667.93]
+  - - [40448, 1792, 1, 256]
+    - [105, 4827.86]
+  - - [25088, 12800, 1, 256]
+    - [112, 4843.84]
+  - - [8448, 256, 1, 256]
+    - [112, 4030.64]
+  - - [22784, 10496, 1, 256]
+    - [105, 4856.96]
+  - - [38400, 26113, 1, 256]
+    - [112, 4803.59]
+  - - [32512, 2048, 1, 256]
+    - [112, 4804.79]
+  - - [9728, 3072, 1, 256]
+    - [112, 4725.86]
+  - - [5888, 1024, 1, 256]
+    - [132, 4430.27]
+  - - [20736, 1792, 1, 256]
+    - [112, 4788.52]
+  - - [11776, 1280, 1, 256]
+    - [105, 4652.02]
+  - - [7680, 3072, 1, 256]
+    - [112, 4705.51]
+  - - [5376, 2305, 1, 256]
+    - [105, 4459.45]
+  - - [6912, 3840, 1, 256]
+    - [105, 4752.39]
+  - - [18944, 1024, 1, 256]
+    - [112, 4671.91]
+  - - [11008, 2048, 1, 256]
+    - [112, 4690.18]
+  - - [35328, 256, 1, 256]
+    - [112, 4555.08]
+  - - [10752, 1024, 1, 256]
+    - [132, 4562.86]
+  - - [12800, 3072, 1, 256]
+    - [112, 4743.88]
+  - - [25856, 2048, 1, 256]
+    - [112, 4776.13]
+  - - [43520, 3584, 1, 256]
+    - [112, 4823.02]
+  - - [16640, 1024, 1, 256]
+    - [112, 4645.65]
+  - - [12288, 3072, 1, 256]
+    - [112, 4776.34]
+  - - [12800, 1536, 1, 256]
+    - [112, 4651.21]
+  - - [21504, 8961, 1, 256]
+    - [105, 4791.57]
+  - - [19456, 1281, 1, 256]
+    - [110, 4637.27]
+  - - [2816, 2816, 1, 256]
+    - [132, 4486.89]
+  - - [39680, 9216, 1, 256]
+    - [112, 4838.39]
+  - - [18432, 1281, 1, 256]
+    - [110, 4625.58]
+  - - [33024, 9216, 1, 256]
+    - [112, 4849.55]
+  - - [24576, 512, 1, 256]
+    - [112, 4579.77]
+  - - [3584, 513, 1, 256]
+    - [100, 3685.25]
+  - - [14336, 1024, 1, 256]
+    - [112, 4612.52]
+  - - [5888, 1281, 1, 256]
+    - [108, 4358.66]
+  - - [1280, 3072, 1, 256]
+    - [120, 4396.55]
+  - - [13056, 9216, 1, 256]
+    - [112, 4817.3]
+  - - [44032, 2048, 1, 256]
+    - [112, 4816.89]
+  - - [40448, 2048, 1, 256]
+    - [112, 4807.27]
+  - - [22016, 768, 1, 256]
+    - [105, 4658.33]
+  - - [33024, 1536, 1, 256]
+    - [112, 4789.81]
+  - - [36352, 1281, 1, 256]
+    - [108, 4682.96]
+  - - [26880, 9216, 1, 256]
+    - [112, 4841.05]
+  - - [23552, 1792, 1, 256]
+    - [105, 4799.37]
+  - - [38144, 1792, 1, 256]
+    - [105, 4819.61]
+  - - [44032, 27648, 1, 256]
+    - [112, 4839.85]
+  - - [7680, 768, 1, 256]
+    - [112, 4493.36]
+  - - [32000, 19712, 1, 256]
+    - [105, 4865.45]
+  - - [26880, 14593, 1, 256]
+    - [105, 4830.64]
+  - - [24064, 9216, 1, 256]
+    - [112, 4833.01]
+  - - [39424, 26881, 1, 256]
+    - [105, 4827.41]
+  - - [27392, 3072, 1, 256]
+    - [112, 4815.09]
+  - - [43264, 9216, 1, 256]
+    - [112, 4839.72]
+  - - [42752, 256, 1, 256]
+    - [105, 4624.34]
+  - - [10752, 1792, 1, 256]
+    - [105, 4698.7]
+  - - [8960, 5633, 1, 256]
+    - [112, 4694.36]
+  - - [4096, 1024, 1, 256]
+    - [130, 4352.77]
+  - - [11264, 2048, 1, 256]
+    - [112, 4697.86]
+  - - [5120, 2048, 1, 256]
+    - [112, 4570.83]
+  - - [34560, 3072, 1, 256]
+    - [112, 4817.62]
+  - - [23808, 9216, 1, 256]
+    - [112, 4830.54]
+  - - [29696, 17153, 1, 256]
+    - [105, 4818.13]
+  - - [24576, 256, 1, 256]
+    - [130, 4444.79]
+  - - [2560, 2305, 1, 256]
+    - [130, 4254.27]
+  - - [11776, 1536, 1, 256]
+    - [110, 4645.94]
+  - - [13568, 1536, 1, 256]
+    - [112, 4675.2]
+  - - [39936, 2048, 1, 256]
+    - [112, 4814.26]
+  - - [25856, 1792, 1, 256]
+    - [105, 4795.47]
+  - - [35072, 1281, 1, 256]
+    - [104, 4679.31]
+  - - [22272, 256, 1, 256]
+    - [125, 4418.26]
+  - - [23296, 256, 1, 256]
+    - [132, 4438.16]
+  - - [42752, 2048, 1, 256]
+    - [112, 4820.42]
+  - - [30208, 9216, 1, 256]
+    - [112, 4835.5]
+  - - [9728, 6656, 1, 256]
+    - [112, 4789.0]
+  - - [36608, 1536, 1, 256]
+    - [112, 4785.71]
+  - - [44288, 1280, 1, 256]
+    - [105, 4803.49]
+  - - [12800, 513, 1, 256]
+    - [110, 4113.24]
+  - - [7680, 1792, 1, 256]
+    - [105, 4647.8]
+  - - [42496, 2305, 1, 256]
+    - [105, 4678.51]
+  - - [37376, 1536, 1, 256]
+    - [112, 4771.39]
+  - - [20224, 1792, 1, 256]
+    - [105, 4777.35]
+  - - [43520, 1536, 1, 256]
+    - [112, 4792.26]
+  - - [9216, 1536, 1, 256]
+    - [112, 4632.7]
+  - - [1536, 1281, 1, 256]
+    - [119, 3926.65]
+  - - [26368, 768, 1, 256]
+    - [105, 4716.3]
+  - - [18176, 3072, 1, 256]
+    - [112, 4787.97]
+  - - [24320, 12033, 1, 256]
+    - [105, 4817.3]
+  - - [17408, 9216, 1, 256]
+    - [112, 4828.91]
+  - - [36352, 1792, 1, 256]
+    - [105, 4811.75]
+  - - [24832, 768, 1, 256]
+    - [105, 4697.28]
+  - - [20992, 8705, 1, 256]
+    - [112, 4757.07]
+  - - [19712, 7424, 1, 256]
+    - [105, 4850.65]
+  - - [38144, 768, 1, 256]
+    - [105, 4767.71]
+  - - [24576, 1280, 1, 256]
+    - [112, 4771.11]
+  - - [33536, 1536, 1, 256]
+    - [112, 4785.91]
+  - - [7168, 1281, 1, 256]
+    - [110, 4463.48]
+  - - [10752, 1536, 1, 256]
+    - [112, 4648.86]
+  - - [29696, 1280, 1, 256]
+    - [105, 4791.79]
+  - - [17152, 9216, 1, 256]
+    - [112, 4827.32]
+  - - [4096, 3072, 1, 256]
+    - [110, 4557.23]
+  - - [18176, 2048, 1, 256]
+    - [112, 4744.71]
+  - - [29696, 17409, 1, 256]
+    - [112, 4788.39]
+  - - [5888, 2816, 1, 256]
+    - [105, 4656.86]
+  - - [34304, 256, 1, 256]
+    - [105, 4510.0]
+  - - [36352, 1280, 1, 256]
+    - [105, 4797.43]
+  - - [10240, 6913, 1, 256]
+    - [105, 4739.62]
+  - - [17408, 1536, 1, 256]
+    - [112, 4708.94]
+  - - [24832, 512, 1, 256]
+    - [112, 4593.0]
+  - - [18944, 1536, 1, 256]
+    - [112, 4728.26]
+  - - [38656, 26113, 1, 256]
+    - [112, 4804.27]
+  - - [37376, 25089, 1, 256]
+    - [112, 4797.76]
+  - - [38400, 1536, 1, 256]
+    - [112, 4779.83]
+  - - [22528, 512, 1, 256]
+    - [112, 4561.0]
+  - - [8448, 1792, 1, 256]
+    - [105, 4655.86]
+  - - [22272, 512, 1, 256]
+    - [112, 4568.44]
+  - - [13056, 769, 1, 256]
+    - [110, 4268.96]
+  - - [24320, 11777, 1, 256]
+    - [112, 4772.19]
+  - - [5376, 2048, 1, 256]
+    - [112, 4553.14]
+  - - [17664, 9216, 1, 256]
+    - [112, 4828.77]
+  - - [8192, 4865, 1, 256]
+    - [105, 4691.91]
+  - - [17920, 1792, 1, 256]
+    - [105, 4755.45]
+  - - [32000, 19713, 1, 256]
+    - [105, 4845.57]
+  - - [8960, 768, 1, 256]
+    - [112, 4451.65]
+  - - [31232, 3072, 1, 256]
+    - [112, 4817.52]
+  - - [6656, 1024, 1, 256]
+    - [130, 4494.67]
+  - - [23296, 1280, 1, 256]
+    - [112, 4749.88]
+  - - [30208, 512, 1, 256]
+    - [112, 4606.77]
+  - - [12544, 257, 1, 256]
+    - [110, 3622.89]
+  - - [43776, 3585, 1, 256]
+    - [112, 4720.09]
+  - - [11008, 1792, 1, 256]
+    - [105, 4684.2]
+  - - [27648, 1281, 1, 256]
+    - [108, 4665.8]
+  - - [27648, 1536, 1, 256]
+    - [112, 4762.58]
+  - - [9472, 1024, 1, 256]
+    - [112, 4532.4]
+  - - [29696, 17408, 1, 256]
+    - [112, 4855.03]
+  - - [44800, 2048, 1, 256]
+    - [112, 4809.31]
+  - - [2560, 1281, 1, 256]
+    - [110, 4153.56]
+  - - [25344, 1024, 1, 256]
+    - [112, 4716.72]
+  - - [4096, 768, 1, 256]
+    - [131, 4298.18]
+  - - [34560, 22272, 1, 256]
+    - [105, 4866.54]
+  - - [38656, 1281, 1, 256]
+    - [110, 4689.31]
+  - - [256, 2048, 1, 256]
+    - [119, 3615.78]
+  - - [32768, 20481, 1, 256]
+    - [112, 4792.43]
+  - - [14336, 3072, 1, 256]
+    - [112, 4768.35]
+  - - [2304, 2049, 1, 256]
+    - [132, 4213.33]
+  - - [19456, 7168, 1, 256]
+    - [112, 4813.92]
+  - - [38656, 512, 1, 256]
+    - [112, 4681.52]
+  - - [13312, 9216, 1, 256]
+    - [112, 4817.87]
+  - - [10496, 7424, 1, 256]
+    - [105, 4811.09]
+  - - [22272, 768, 1, 256]
+    - [105, 4693.3]
+  - - [24064, 1792, 1, 256]
+    - [105, 4799.49]
+  - - [16896, 1792, 1, 256]
+    - [105, 4765.43]
+  - - [27904, 15616, 1, 256]
+    - [105, 4860.86]
+  - - [37888, 3072, 1, 256]
+    - [112, 4826.13]
+  - - [512, 257, 1, 256]
+    - [122, 1380.55]
+  - - [36096, 1792, 1, 256]
+    - [105, 4826.77]
+  - - [13056, 513, 1, 256]
+    - [108, 4162.1]
+  - - [12544, 768, 1, 256]
+    - [105, 4539.56]
+  - - [36608, 24065, 1, 256]
+    - [112, 4793.08]
+  - - [40704, 3072, 1, 256]
+    - [112, 4819.3]
+  - - [28928, 16640, 1, 256]
+    - [105, 4868.2]
+  - - [24576, 12288, 1, 256]
+    - [112, 4838.38]
+  - - [13056, 1536, 1, 256]
+    - [112, 4687.23]
+  - - [2304, 1024, 1, 256]
+    - [105, 4301.86]
+  - - [33280, 9216, 1, 256]
+    - [112, 4840.44]
+  - - [18944, 1280, 1, 256]
+    - [105, 4740.48]
+  - - [17152, 3072, 1, 256]
+    - [112, 4776.45]
+  - - [17152, 4864, 1, 256]
+    - [105, 4836.15]
+  - - [6912, 1280, 1, 256]
+    - [132, 4547.31]
+  - - [34304, 768, 1, 256]
+    - [105, 4747.73]
+  - - [33280, 1024, 1, 256]
+    - [112, 4754.31]
+  - - [13568, 1280, 1, 256]
+    - [105, 4670.32]
+  - - [32768, 768, 1, 256]
+    - [112, 4735.84]
+  - - [42496, 9216, 1, 256]
+    - [112, 4844.37]
+  - - [2304, 1280, 1, 256]
+    - [119, 4168.37]
+  - - [30464, 2048, 1, 256]
+    - [112, 4796.37]
+  - - [32256, 768, 1, 256]
+    - [112, 4728.72]
+  - - [4352, 1792, 1, 256]
+    - [105, 4543.68]
+  - - [5632, 768, 1, 256]
+    - [132, 4338.26]
+  - - [40704, 513, 1, 256]
+    - [110, 4430.28]
+  - - [30464, 1280, 1, 256]
+    - [105, 4789.95]
+  - - [27392, 1281, 1, 256]
+    - [110, 4665.14]
+  - - [22016, 1281, 1, 256]
+    - [110, 4644.18]
+  - - [20736, 768, 1, 256]
+    - [105, 4673.8]
+  - - [19712, 768, 1, 256]
+    - [112, 4663.48]
+  - - [13312, 1024, 1, 256]
+    - [112, 4622.07]
+  - - [33536, 20993, 1, 256]
+    - [112, 4795.53]
+  - - [11520, 8448, 1, 256]
+    - [105, 4836.84]
+  - - [25088, 1792, 1, 256]
+    - [105, 4791.73]
+  - - [2816, 3072, 1, 256]
+    - [132, 4524.75]
+  - - [3584, 3072, 1, 256]
+    - [132, 4567.3]
+  - - [4608, 1537, 1, 256]
+    - [112, 4275.02]
+  - - [24832, 1280, 1, 256]
+    - [112, 4763.02]
+  - - [44032, 9216, 1, 256]
+    - [112, 4839.89]
+  - - [41216, 1024, 1, 256]
+    - [112, 4768.36]
+  - - [33792, 21249, 1, 256]
+    - [105, 4823.46]
+  - - [15360, 1792, 1, 256]
+    - [105, 4750.7]
+  - - [16384, 768, 1, 256]
+    - [110, 4600.7]
+  - - [29184, 1280, 1, 256]
+    - [105, 4781.7]
+  - - [32512, 20225, 1, 256]
+    - [105, 4824.05]
+  - - [6400, 1281, 1, 256]
+    - [110, 4367.02]
+  - - [38656, 9216, 1, 256]
+    - [112, 4841.72]
+  - - [17664, 5377, 1, 256]
+    - [105, 4767.55]
+  - - [7168, 512, 1, 256]
+    - [132, 4301.85]
+  - - [19456, 7169, 1, 256]
+    - [112, 4752.13]
+  - - [32000, 2048, 1, 256]
+    - [112, 4786.82]
+  - - [8448, 5121, 1, 256]
+    - [112, 4687.45]
+  - - [23040, 9216, 1, 256]
+    - [112, 4840.17]
+  - - [29440, 17152, 1, 256]
+    - [105, 4861.03]
+  - - [19968, 2048, 1, 256]
+    - [112, 4787.09]
+  - - [18688, 1281, 1, 256]
+    - [110, 4618.71]
+  - - [40448, 513, 1, 256]
+    - [110, 4421.03]
+  - - [6912, 256, 1, 256]
+    - [120, 4022.96]
+  - - [41472, 1792, 1, 256]
+    - [105, 4833.73]
+  - - [17920, 3072, 1, 256]
+    - [112, 4787.04]
+  - - [30976, 768, 1, 256]
+    - [105, 4728.36]
+  - - [43008, 9216, 1, 256]
+    - [112, 4844.15]
+  - - [6144, 3072, 1, 256]
+    - [112, 4674.95]
+  - - [35072, 9216, 1, 256]
+    - [112, 4837.7]
+  - - [34816, 22273, 1, 256]
+    - [105, 4818.09]
+  - - [37120, 768, 1, 256]
+    - [112, 4752.72]
+  - - [35072, 22785, 1, 256]
+    - [105, 4836.93]
+  - - [23296, 1281, 1, 256]
+    - [110, 4652.39]
+  - - [39168, 9216, 1, 256]
+    - [112, 4842.44]
+  - - [35840, 1536, 1, 256]
+    - [112, 4790.49]
+  - - [42752, 2817, 1, 256]
+    - [110, 4748.71]
+  - - [11776, 3072, 1, 256]
+    - [112, 4743.5]
+  - - [17152, 1536, 1, 256]
+    - [112, 4705.73]
+  - - [24832, 256, 1, 256]
+    - [125, 4404.06]
+  - - [10752, 256, 1, 256]
+    - [132, 4128.45]
+  - - [21504, 2048, 1, 256]
+    - [112, 4782.1]
+  - - [24832, 12289, 1, 256]
+    - [112, 4782.05]
+  - - [35328, 2048, 1, 256]
+    - [112, 4807.72]
+  - - [22272, 1281, 1, 256]
+    - [110, 4645.11]
+  - - [6656, 3329, 1, 256]
+    - [110, 4610.06]
+  - - [34560, 1024, 1, 256]
+    - [112, 4768.56]
+  - - [24576, 12033, 1, 256]
+    - [105, 4807.98]
+  - - [6400, 1536, 1, 256]
+    - [132, 4523.3]
+  - - [32512, 3072, 1, 256]
+    - [112, 4815.59]
+  - - [22528, 2048, 1, 256]
+    - [112, 4774.11]
+  - - [41216, 256, 1, 256]
+    - [112, 4610.7]
+  - - [25088, 1024, 1, 256]
+    - [112, 4715.54]
+  - - [37120, 1024, 1, 256]
+    - [112, 4757.12]
+  - - [13056, 1281, 1, 256]
+    - [110, 4572.14]
+  - - [30976, 3072, 1, 256]
+    - [112, 4800.63]
+  - - [22016, 9473, 1, 256]
+    - [105, 4789.78]
+  - - [19968, 1792, 1, 256]
+    - [105, 4778.09]
+  - - [29440, 3072, 1, 256]
+    - [112, 4818.67]
+  - - [15872, 1280, 1, 256]
+    - [105, 4704.35]
+  - - [27904, 1280, 1, 256]
+    - [105, 4778.01]
+  - - [3840, 256, 1, 256]
+    - [102, 3783.2]
+  - - [39936, 1024, 1, 256]
+    - [112, 4770.6]
+  - - [10752, 512, 1, 256]
+    - [132, 4384.84]
+  - - [43776, 3840, 1, 256]
+    - [105, 4858.66]
+  - - [41472, 768, 1, 256]
+    - [105, 4777.76]
+  - - [8192, 1792, 1, 256]
+    - [105, 4641.69]
+  - - [35840, 3072, 1, 256]
+    - [112, 4819.52]
+  - - [8704, 3072, 1, 256]
+    - [112, 4701.31]
+  - - [34048, 512, 1, 256]
+    - [112, 4652.56]
+  - - [36864, 1280, 1, 256]
+    - [105, 4807.23]
+  - - [9728, 1792, 1, 256]
+    - [112, 4665.02]
+  - - [15872, 512, 1, 256]
+    - [112, 4506.88]
+  - - [38144, 1281, 1, 256]
+    - [110, 4682.56]
+  - - [22272, 9729, 1, 256]
+    - [112, 4777.14]
+  - - [28928, 2048, 1, 256]
+    - [112, 4796.7]
+  - - [21504, 1281, 1, 256]
+    - [110, 4640.16]
+  - - [32768, 3072, 1, 256]
+    - [112, 4810.31]
+  - - [3072, 2048, 1, 256]
+    - [132, 4412.16]
+  - - [256, 256, 1, 256]
+    - [117, 635.501]
+  - - [43520, 27648, 1, 256]
+    - [112, 4850.68]
+  - - [36864, 24576, 1, 256]
+    - [112, 4846.4]
+  - - [31232, 1281, 1, 256]
+    - [110, 4668.49]
+  - - [14080, 768, 1, 256]
+    - [105, 4572.88]
+  - - [27648, 2048, 1, 256]
+    - [112, 4807.67]
+  - - [9984, 1536, 1, 256]
+    - [112, 4632.4]
+  - - [31232, 2048, 1, 256]
+    - [112, 4794.56]
+  - - [11520, 1792, 1, 256]
+    - [112, 4711.69]
+  - - [10752, 2048, 1, 256]
+    - [112, 4696.68]
+  - - [12032, 8961, 1, 256]
+    - [105, 4787.72]
+  - - [11776, 256, 1, 256]
+    - [122, 4152.78]
+  - - [1792, 256, 1, 256]
+    - [117, 3295.19]
+  - - [38144, 2048, 1, 256]
+    - [112, 4813.98]
+  - - [37632, 2048, 1, 256]
+    - [112, 4813.7]
+  - - [4352, 768, 1, 256]
+    - [132, 4300.56]
+  - - [38400, 25857, 1, 256]
+    - [105, 4832.21]
+  - - [38144, 1024, 1, 256]
+    - [112, 4755.55]
+  - - [20224, 7937, 1, 256]
+    - [105, 4797.82]
+  - - [10240, 2048, 1, 256]
+    - [112, 4667.31]
+  - - [34304, 21761, 1, 256]
+    - [105, 4825.04]
+  - - [30720, 18432, 1, 256]
+    - [112, 4852.56]
+  - - [31744, 9216, 1, 256]
+    - [112, 4835.26]
+  - - [26368, 2048, 1, 256]
+    - [112, 4790.5]
+  - - [35072, 2048, 1, 256]
+    - [112, 4803.06]
+  - - [27136, 14848, 1, 256]
+    - [112, 4842.57]
+  - - [36096, 512, 1, 256]
+    - [112, 4683.96]
+  - - [29952, 2048, 1, 256]
+    - [112, 4798.12]
+  - - [34048, 9216, 1, 256]
+    - [112, 4842.83]
+  - - [20992, 2048, 1, 256]
+    - [112, 4761.31]
+  - - [32256, 2048, 1, 256]
+    - [112, 4810.51]
+  - - [3584, 257, 1, 256]
+    - [99, 3502.65]
+  - - [19200, 2048, 1, 256]
+    - [112, 4761.21]
+  - - [18688, 6145, 1, 256]
+    - [112, 4735.09]
+  - - [24320, 1280, 1, 256]
+    - [105, 4765.8]
+  - - [36352, 256, 1, 256]
+    - [112, 4574.43]
+  - - [36096, 768, 1, 256]
+    - [105, 4757.95]
+  - - [7168, 1536, 1, 256]
+    - [132, 4567.01]
+  - - [25344, 9216, 1, 256]
+    - [112, 4847.3]
+  - - [39168, 512, 1, 256]
+    - [112, 4678.86]
+  - - [36608, 9216, 1, 256]
+    - [112, 4849.09]
+  - - [14848, 1792, 1, 256]
+    - [105, 4746.59]
+  - - [35584, 9216, 1, 256]
+    - [112, 4837.86]
+  - - [29952, 17664, 1, 256]
+    - [105, 4870.44]
+  - - [34816, 1792, 1, 256]
+    - [105, 4814.7]
+  - - [38912, 1280, 1, 256]
+    - [105, 4812.09]
+  - - [24064, 2048, 1, 256]
+    - [112, 4778.53]
+  - - [24064, 11776, 1, 256]
+    - [112, 4839.67]
+  - - [18176, 512, 1, 256]
+    - [112, 4534.38]
+  - - [11264, 1280, 1, 256]
+    - [105, 4655.17]
+  - - [34048, 1792, 1, 256]
+    - [105, 4823.18]
+  - - [5376, 1792, 1, 256]
+    - [105, 4564.43]
+  - - [36608, 512, 1, 256]
+    - [112, 4674.14]
+  - - [6656, 1281, 1, 256]
+    - [108, 4413.86]
+  - - [18432, 1024, 1, 256]
+    - [112, 4690.01]
+  - - [40448, 3072, 1, 256]
+    - [112, 4821.51]
+  - - [18688, 6401, 1, 256]
+    - [105, 4779.35]
+  - - [20480, 1536, 1, 256]
+    - [112, 4736.43]
+  - - [18432, 3072, 1, 256]
+    - [112, 4793.11]
+  - - [20224, 768, 1, 256]
+    - [105, 4665.15]
+  - - [32512, 9216, 1, 256]
+    - [112, 4841.95]
+  - - [14080, 1281, 1, 256]
+    - [104, 4580.87]
+  - - [3072, 1536, 1, 256]
+    - [130, 4406.69]
+  - - [26112, 512, 1, 256]
+    - [112, 4587.38]
+  - - [10496, 1281, 1, 256]
+    - [110, 4526.83]
+  - - [15616, 2048, 1, 256]
+    - [112, 4744.27]
+  - - [12800, 1024, 1, 256]
+    - [112, 4563.99]
+  - - [12544, 256, 1, 256]
+    - [125, 4112.89]
+  - - [25344, 768, 1, 256]
+    - [105, 4698.66]
+  - - [10240, 512, 1, 256]
+    - [130, 4395.97]
+  - - [8448, 2048, 1, 256]
+    - [112, 4669.38]
+  - - [36608, 24320, 1, 256]
+    - [105, 4865.85]
+  - - [34816, 9216, 1, 256]
+    - [112, 4830.36]
+  - - [14080, 512, 1, 256]
+    - [132, 4468.94]
+  - - [3072, 1792, 1, 256]
+    - [120, 4491.04]
+  - - [41216, 27648, 1, 256]
+    - [112, 4851.9]
+  - - [30464, 9216, 1, 256]
+    - [112, 4835.75]
+  - - [33024, 1281, 1, 256]
+    - [110, 4676.87]
+  - - [31488, 1536, 1, 256]
+    - [112, 4787.63]
+  - - [7424, 3072, 1, 256]
+    - [112, 4699.5]
+  - - [37888, 512, 1, 256]
+    - [112, 4672.97]
+  - - [20480, 1792, 1, 256]
+    - [105, 4781.1]
+  - - [41984, 1793, 1, 256]
+    - [110, 4663.84]
+  - - [18688, 1792, 1, 256]
+    - [105, 4754.41]
+  - - [13824, 1792, 1, 256]
+    - [105, 4736.35]
+  - - [15360, 1280, 1, 256]
+    - [105, 4703.89]
+  - - [38144, 3072, 1, 256]
+    - [112, 4829.95]
+  - - [33280, 3072, 1, 256]
+    - [112, 4815.26]
+  - - [35584, 23296, 1, 256]
+    - [105, 4864.83]
+  - - [43520, 768, 1, 256]
+    - [105, 4774.55]
+  - - [25856, 256, 1, 256]
+    - [112, 4491.83]
+  - - [40704, 1536, 1, 256]
+    - [112, 4793.61]
+  - - [29696, 3072, 1, 256]
+    - [112, 4805.72]
+  - - [32256, 19969, 1, 256]
+    - [112, 4804.26]
+  - - [39424, 1281, 1, 256]
+    - [108, 4687.72]
+  - - [40960, 9216, 1, 256]
+    - [112, 4840.74]
+  - - [16640, 2048, 1, 256]
+    - [112, 4750.17]
+  - - [37632, 9216, 1, 256]
+    - [112, 4838.04]
+  - - [37888, 1281, 1, 256]
+    - [110, 4681.76]
+  - - [26112, 256, 1, 256]
+    - [112, 4539.19]
+  - - [42240, 2305, 1, 256]
+    - [105, 4694.36]
+  - - [43008, 1024, 1, 256]
+    - [112, 4771.82]
+  - - [7424, 1024, 1, 256]
+    - [132, 4444.1]
+  - - [17920, 5377, 1, 256]
+    - [105, 4748.02]
+  - - [2816, 1281, 1, 256]
+    - [130, 4062.41]
+  - - [37376, 1280, 1, 256]
+    - [105, 4806.28]
+  - - [41984, 2048, 1, 256]
+    - [112, 4812.82]
+  - - [27904, 9216, 1, 256]
+    - [112, 4827.83]
+  - - [20736, 1024, 1, 256]
+    - [112, 4686.86]
+  - - [34304, 22016, 1, 256]
+    - [112, 4835.15]
+  - - [33792, 256, 1, 256]
+    - [105, 4501.57]
+  - - [13824, 2048, 1, 256]
+    - [112, 4724.25]
+  - - [11776, 8705, 1, 256]
+    - [112, 4745.32]
+  - - [22272, 1536, 1, 256]
+    - [112, 4755.59]
+  - - [25856, 9216, 1, 256]
+    - [112, 4832.94]
+  - - [19712, 3072, 1, 256]
+    - [112, 4800.56]
+  - - [20480, 1281, 1, 256]
+    - [110, 4626.71]
+  - - [17408, 1280, 1, 256]
+    - [105, 4724.88]
+  - - [40192, 2048, 1, 256]
+    - [112, 4808.23]
+  - - [41472, 9216, 1, 256]
+    - [112, 4841.51]
+  - - [40704, 2048, 1, 256]
+    - [112, 4804.63]
+  - - [35840, 256, 1, 256]
+    - [123, 4540.69]
+  - - [42496, 27648, 1, 256]
+    - [112, 4837.06]
+  - - [21248, 2048, 1, 256]
+    - [112, 4780.57]
+  - - [35072, 3072, 1, 256]
+    - [112, 4826.2]
+  - - [4608, 1281, 1, 256]
+    - [110, 4245.7]
+  - - [44288, 4352, 1, 256]
+    - [105, 4854.05]
+  - - [8192, 512, 1, 256]
+    - [132, 4396.26]
+  - - [38400, 256, 1, 256]
+    - [105, 4545.85]
+  - - [5888, 512, 1, 256]
+    - [132, 4165.33]
+  - - [41984, 1792, 1, 256]
+    - [105, 4823.55]
+  - - [42496, 2561, 1, 256]
+    - [112, 4666.84]
+  - - [9984, 6657, 1, 256]
+    - [112, 4729.24]
+  - - [43008, 3073, 1, 256]
+    - [112, 4690.13]
+  - - [4096, 2048, 1, 256]
+    - [132, 4526.74]
+  - - [36352, 24065, 1, 256]
+    - [112, 4792.81]
+  - - [4608, 2048, 1, 256]
+    - [130, 4546.33]
+  - - [24832, 3072, 1, 256]
+    - [112, 4805.24]
+  - - [25088, 1280, 1, 256]
+    - [105, 4771.79]
+  - - [29184, 16641, 1, 256]
+    - [105, 4818.9]
+  - - [1024, 2048, 1, 256]
+    - [120, 4178.64]
+  - - [37888, 1024, 1, 256]
+    - [112, 4751.84]
+  - - [768, 768, 1, 256]
+    - [94, 3218.14]
+  - - [24832, 2048, 1, 256]
+    - [112, 4775.63]
+  - - [42240, 27648, 1, 256]
+    - [112, 4847.28]
+  - - [8192, 5120, 1, 256]
+    - [112, 4752.0]
+  - - [31744, 1280, 1, 256]
+    - [105, 4784.06]
+  - - [9984, 1792, 1, 256]
+    - [105, 4691.65]
+  - - [13312, 1280, 1, 256]
+    - [112, 4658.94]
+  - - [44288, 3072, 1, 256]
+    - [112, 4819.65]
+  - - [18432, 6144, 1, 256]
+    - [112, 4822.03]
+  - - [23808, 1792, 1, 256]
+    - [105, 4797.15]
+  - - [32512, 1280, 1, 256]
+    - [105, 4791.03]
+  - - [11008, 768, 1, 256]
+    - [105, 4512.64]
+  - - [10752, 1280, 1, 256]
+    - [112, 4642.65]
+  - - [28672, 16129, 1, 256]
+    - [105, 4814.96]
+  - - [17920, 9216, 1, 256]
+    - [112, 4831.93]
+  - - [33536, 256, 1, 256]
+    - [112, 4556.0]
+  - - [25088, 12801, 1, 256]
+    - [112, 4782.81]
+  - - [19712, 9216, 1, 256]
+    - [112, 4830.57]
+  - - [40192, 256, 1, 256]
+    - [105, 4553.35]
+  - - [7680, 2048, 1, 256]
+    - [112, 4642.93]
+  - - [15616, 1281, 1, 256]
+    - [110, 4600.46]
+  - - [31744, 19457, 1, 256]
+    - [112, 4790.32]
+  - - [36864, 1792, 1, 256]
+    - [112, 4819.72]
+  - - [42496, 1792, 1, 256]
+    - [105, 4817.37]
+  - - [41216, 3072, 1, 256]
+    - [112, 4832.77]
+  - - [39936, 9216, 1, 256]
+    - [112, 4843.21]
+  - - [3840, 512, 1, 256]
+    - [131, 3986.99]
+  - - [8960, 1792, 1, 256]
+    - [105, 4677.31]
+  - - [44288, 2048, 1, 256]
+    - [112, 4816.12]
+  - - [13824, 1281, 1, 256]
+    - [110, 4548.67]
+  - - [6144, 2048, 1, 256]
+    - [112, 4613.09]
+  - - [7936, 4864, 1, 256]
+    - [105, 4776.76]
+  - - [5632, 2048, 1, 256]
+    - [112, 4558.19]
+  - - [27648, 1280, 1, 256]
+    - [105, 4774.49]
+  - - [18176, 256, 1, 256]
+    - [112, 4405.91]
+  - - [17664, 5121, 1, 256]
+    - [112, 4726.94]
+  - - [8704, 5632, 1, 256]
+    - [112, 4762.57]
+  - - [38144, 25601, 1, 256]
+    - [112, 4799.77]
+  - - [27136, 14849, 1, 256]
+    - [112, 4787.75]
+  - - [31744, 19456, 1, 256]
+    - [112, 4841.64]
+  - - [5376, 1280, 1, 256]
+    - [105, 4478.82]
+  - - [33024, 3072, 1, 256]
+    - [112, 4826.92]
+  - - [37888, 9216, 1, 256]
+    - [112, 4840.36]
+  - - [17664, 1792, 1, 256]
+    - [105, 4771.31]
+  - - [6912, 1792, 1, 256]
+    - [112, 4618.8]
+  - - [28672, 768, 1, 256]
+    - [105, 4723.92]
+  - - [32768, 1281, 1, 256]
+    - [110, 4672.58]
+  - - [39168, 1024, 1, 256]
+    - [112, 4760.33]
+  - - [11520, 1281, 1, 256]
+    - [108, 4544.59]
+  - - [42240, 2049, 1, 256]
+    - [108, 4655.95]
+  - - [34048, 3072, 1, 256]
+    - [112, 4830.19]
+  - - [10752, 7680, 1, 256]
+    - [112, 4809.94]
+  - - [37120, 9216, 1, 256]
+    - [112, 4840.86]
+  - - [14080, 9216, 1, 256]
+    - [112, 4819.75]
+  - - [38400, 1792, 1, 256]
+    - [105, 4829.76]
+  - - [43776, 9216, 1, 256]
+    - [112, 4846.38]
+  - - [26624, 768, 1, 256]
+    - [105, 4706.94]
+  - - [14336, 2049, 1, 256]
+    - [110, 4588.86]
+  - - [32512, 1281, 1, 256]
+    - [104, 4676.74]
+  - - [37120, 24577, 1, 256]
+    - [112, 4794.41]
+  - - [38400, 1024, 1, 256]
+    - [112, 4768.33]
+  - - [6144, 1281, 1, 256]
+    - [108, 4362.26]
+  - - [32768, 2048, 1, 256]
+    - [112, 4807.01]
+  - - [28672, 1280, 1, 256]
+    - [105, 4781.1]
+  - - [30976, 18433, 1, 256]
+    - [112, 4785.68]
+  - - [5632, 1024, 1, 256]
+    - [130, 4364.42]
+  - - [37632, 3072, 1, 256]
+    - [112, 4822.3]
+  - - [34560, 1792, 1, 256]
+    - [112, 4818.29]
+  - - [5120, 3072, 1, 256]
+    - [112, 4616.11]
+  - - [21760, 9217, 1, 256]
+    - [112, 4760.6]
+  - - [5120, 1280, 1, 256]
+    - [120, 4496.95]
+  - - [24064, 11521, 1, 256]
+    - [105, 4792.68]
+  - - [10496, 512, 1, 256]
+    - [130, 4389.14]
+  - - [35328, 1280, 1, 256]
+    - [105, 4810.22]
+  - - [7936, 3072, 1, 256]
+    - [112, 4697.38]
+  - - [30720, 1280, 1, 256]
+    - [105, 4793.4]
+  - - [21760, 9472, 1, 256]
+    - [105, 4850.7]
+  - - [9216, 6145, 1, 256]
+    - [112, 4715.37]
+  - - [37376, 2048, 1, 256]
+    - [112, 4807.6]
+  - - [8192, 1536, 1, 256]
+    - [112, 4594.66]
+  - - [39936, 27648, 1, 256]
+    - [112, 4842.17]
+  - - [21248, 9216, 1, 256]
+    - [112, 4827.26]
+  - - [5376, 2049, 1, 256]
+    - [110, 4438.63]
+  - - [35072, 22529, 1, 256]
+    - [112, 4800.07]
+  - - [13312, 769, 1, 256]
+    - [104, 4282.11]
+  - - [35840, 9216, 1, 256]
+    - [112, 4840.32]
+  - - [7936, 1024, 1, 256]
+    - [130, 4508.83]
+  - - [12544, 512, 1, 256]
+    - [132, 4441.77]
+  - - [27392, 1280, 1, 256]
+    - [105, 4773.66]
+  - - [39424, 27136, 1, 256]
+    - [112, 4851.49]
+  - - [26368, 9216, 1, 256]
+    - [112, 4831.01]
+  - - [34048, 21505, 1, 256]
+    - [112, 4795.22]
+  - - [23040, 1024, 1, 256]
+    - [112, 4724.65]
+  - - [29440, 1536, 1, 256]
+    - [112, 4773.96]
+  - - [38912, 768, 1, 256]
+    - [105, 4756.18]
+  - - [7680, 512, 1, 256]
+    - [132, 4335.2]
+  - - [4096, 512, 1, 256]
+    - [111, 4120.91]
+  - - [38400, 2048, 1, 256]
+    - [112, 4810.17]
+  - - [26112, 1792, 1, 256]
+    - [105, 4800.87]
+  - - [23296, 768, 1, 256]
+    - [105, 4687.62]
+  - - [3328, 3072, 1, 256]
+    - [132, 4546.99]
+  - - [3584, 1281, 1, 256]
+    - [97, 4290.76]
+  - - [43264, 27648, 1, 256]
+    - [112, 4839.73]
+  - - [40960, 256, 1, 256]
+    - [112, 4604.38]
+  - - [18432, 9216, 1, 256]
+    - [112, 4821.04]
+  - - [29952, 1280, 1, 256]
+    - [105, 4792.41]
+  - - [43264, 1281, 1, 256]
+    - [110, 4692.24]
+  - - [38912, 3072, 1, 256]
+    - [112, 4817.82]
+  - - [9216, 6144, 1, 256]
+    - [112, 4792.35]
+  - - [30464, 17921, 1, 256]
+    - [112, 4795.69]
+  - - [37376, 9216, 1, 256]
+    - [112, 4844.91]
+  - - [256, 3072, 1, 256]
+    - [118, 3821.69]
+  - - [34048, 2048, 1, 256]
+    - [112, 4794.73]
+  - - [9472, 3072, 1, 256]
+    - [112, 4723.46]
+  - - [26624, 1280, 1, 256]
+    - [105, 4778.16]
+  - - [35840, 23552, 1, 256]
+    - [112, 4842.03]
+  - - [8960, 3072, 1, 256]
+    - [112, 4709.05]
+  - - [27904, 2048, 1, 256]
+    - [112, 4787.03]
+  - - [22016, 256, 1, 256]
+    - [125, 4405.89]
+  - - [34816, 3072, 1, 256]
+    - [112, 4816.26]
+  - - [11008, 3072, 1, 256]
+    - [112, 4724.12]
+  - - [36864, 1536, 1, 256]
+    - [112, 4784.57]
+  - - [24064, 1281, 1, 256]
+    - [104, 4649.47]
+  - - [23552, 9216, 1, 256]
+    - [112, 4835.81]
+  - - [31232, 18945, 1, 256]
+    - [112, 4793.26]
+  - - [27136, 9216, 1, 256]
+    - [112, 4841.56]
+  - - [19968, 7681, 1, 256]
+    - [112, 4757.56]
+  - - [31488, 18945, 1, 256]
+    - [112, 4798.02]
+  - - [33280, 1792, 1, 256]
+    - [105, 4816.54]
+  - - [38912, 1281, 1, 256]
+    - [108, 4689.83]
+  - - [42240, 2048, 1, 256]
+    - [112, 4816.17]
+  - - [14592, 3072, 1, 256]
+    - [112, 4776.25]
+  - - [30976, 18689, 1, 256]
+    - [105, 4825.16]
+  - - [4096, 769, 1, 256]
+    - [105, 3955.83]
+  - - [31488, 3072, 1, 256]
+    - [112, 4817.4]
+  - - [28416, 1281, 1, 256]
+    - [110, 4668.65]
+  - - [22528, 1024, 1, 256]
+    - [112, 4709.54]
+  - - [3584, 256, 1, 256]
+    - [102, 3618.02]
+  - - [33024, 1792, 1, 256]
+    - [105, 4823.37]
+  - - [42752, 2816, 1, 256]
+    - [105, 4838.57]
+  - - [11520, 8449, 1, 256]
+    - [105, 4783.03]
+  - - [4864, 1281, 1, 256]
+    - [108, 4284.63]
+  - - [14592, 768, 1, 256]
+    - [105, 4605.57]
+  - - [7424, 1792, 1, 256]
+    - [105, 4656.77]
+  - - [44544, 4353, 1, 256]
+    - [105, 4762.08]
+  - - [37120, 3072, 1, 256]
+    - [112, 4814.81]
+  - - [18176, 5889, 1, 256]
+    - [105, 4767.63]
+  - - [5632, 2305, 1, 256]
+    - [108, 4478.65]
+  - - [39936, 27393, 1, 256]
+    - [105, 4823.81]
+  - - [10240, 7169, 1, 256]
+    - [112, 4715.91]
+  - - [39168, 26625, 1, 256]
+    - [112, 4800.56]
+  - - [10752, 7681, 1, 256]
+    - [112, 4734.51]
+  - - [13824, 1536, 1, 256]
+    - [112, 4691.55]
+  - - [21760, 1280, 1, 256]
+    - [105, 4748.73]
+  - - [20480, 768, 1, 256]
+    - [112, 4650.65]
+  - - [18688, 768, 1, 256]
+    - [105, 4660.57]
+  - - [14336, 9216, 1, 256]
+    - [112, 4820.44]
+  - - [40960, 768, 1, 256]
+    - [112, 4752.3]
+  - - [37632, 25345, 1, 256]
+    - [105, 4841.64]
+  - - [35840, 23553, 1, 256]
+    - [112, 4798.48]
+  - - [21760, 1024, 1, 256]
+    - [112, 4703.53]
+  - - [6656, 3584, 1, 256]
+    - [112, 4702.83]
+  - - [44544, 2048, 1, 256]
+    - [112, 4822.91]
+  - - [16640, 1281, 1, 256]
+    - [110, 4608.99]
+  - - [4608, 3072, 1, 256]
+    - [112, 4623.95]
+  - - [34816, 1024, 1, 256]
+    - [112, 4758.3]
+  - - [35840, 1280, 1, 256]
+    - [105, 4797.49]
+  - - [23552, 3072, 1, 256]
+    - [112, 4800.35]
+  - - [2048, 512, 1, 256]
+    - [100, 3949.92]
+  - - [39680, 2048, 1, 256]
+    - [112, 4812.61]
+  - - [41984, 1280, 1, 256]
+    - [105, 4807.76]
+  - - [19712, 7169, 1, 256]
+    - [112, 4749.37]
+  - - [8448, 768, 1, 256]
+    - [132, 4495.36]
+  - - [5888, 2561, 1, 256]
+    - [110, 4523.82]
+  - - [27136, 768, 1, 256]
+    - [112, 4705.05]
+  - - [22272, 1792, 1, 256]
+    - [105, 4792.73]
+  - - [11008, 1281, 1, 256]
+    - [108, 4541.24]
+  - - [12800, 9216, 1, 256]
+    - [112, 4817.75]
+  - - [15616, 1536, 1, 256]
+    - [112, 4701.88]
+  - - [6912, 1281, 1, 256]
+    - [108, 4439.62]
+  - - [7424, 256, 1, 256]
+    - [106, 4024.98]
+  - - [3840, 769, 1, 256]
+    - [109, 3926.65]
+  - - [42240, 2304, 1, 256]
+    - [112, 4829.67]
+  - - [38144, 1280, 1, 256]
+    - [105, 4796.18]
+  - - [13056, 1280, 1, 256]
+    - [105, 4684.83]
+  - - [24576, 3072, 1, 256]
+    - [112, 4804.98]
+  - - [12288, 768, 1, 256]
+    - [112, 4592.3]
+  - - [36864, 2048, 1, 256]
+    - [112, 4798.87]
+  - - [26880, 1024, 1, 256]
+    - [112, 4732.07]
+  - - [27136, 1536, 1, 256]
+    - [112, 4757.24]
+  - - [25344, 12801, 1, 256]
+    - [112, 4784.99]
+  - - [32512, 20224, 1, 256]
+    - [112, 4863.68]
+  - - [17664, 3072, 1, 256]
+    - [112, 4793.82]
+  - - [7168, 1280, 1, 256]
+    - [130, 4540.7]
+  - - [38656, 256, 1, 256]
+    - [132, 4530.65]
+  - - [43520, 3329, 1, 256]
+    - [105, 4730.25]
+  - - [28160, 15873, 1, 256]
+    - [112, 4784.3]
+  - - [31488, 1281, 1, 256]
+    - [110, 4672.08]
+  - - [40960, 3072, 1, 256]
+    - [112, 4827.6]
+  - - [43520, 1024, 1, 256]
+    - [112, 4777.03]
+  - - [14592, 9216, 1, 256]
+    - [112, 4830.16]
+  - - [43008, 1281, 1, 256]
+    - [110, 4685.42]
+  - - [9472, 1792, 1, 256]
+    - [112, 4658.94]
+  - - [22784, 10497, 1, 256]
+    - [105, 4820.66]
+  - - [22272, 3072, 1, 256]
+    - [112, 4808.33]
+  - - [9728, 1280, 1, 256]
+    - [105, 4616.6]
+  - - [28416, 512, 1, 256]
+    - [112, 4621.94]
+  - - [8704, 512, 1, 256]
+    - [130, 4326.65]
+  - - [39680, 27137, 1, 256]
+    - [112, 4795.51]
+  - - [20992, 8704, 1, 256]
+    - [112, 4828.92]
+  - - [42240, 256, 1, 256]
+    - [112, 4584.09]
+  - - [24320, 1536, 1, 256]
+    - [112, 4755.45]
+  - - [7936, 4865, 1, 256]
+    - [110, 4689.96]
+  - - [17664, 5376, 1, 256]
+    - [105, 4842.01]
+  - - [25344, 2048, 1, 256]
+    - [112, 4788.45]
+  - - [3584, 2048, 1, 256]
+    - [130, 4467.55]
+  - - [30464, 1281, 1, 256]
+    - [104, 4668.34]
+  - - [37888, 25345, 1, 256]
+    - [105, 4823.47]
+  - - [8192, 1024, 1, 256]
+    - [130, 4496.41]
+  - - [23296, 10753, 1, 256]
+    - [112, 4773.55]
+  - - [28416, 15873, 1, 256]
+    - [112, 4795.88]
+  - - [27648, 15361, 1, 256]
+    - [112, 4789.07]
+  - - [19200, 1281, 1, 256]
+    - [110, 4629.28]
+  - - [30208, 1280, 1, 256]
+    - [105, 4776.01]
+  - - [27136, 3072, 1, 256]
+    - [112, 4806.49]
+  - - [29952, 1792, 1, 256]
+    - [112, 4806.27]
+  - - [16128, 1281, 1, 256]
+    - [108, 4603.25]
+  - - [18432, 1280, 1, 256]
+    - [105, 4728.64]
+  - - [16896, 1280, 1, 256]
+    - [112, 4705.33]
+  - - [26112, 1280, 1, 256]
+    - [105, 4777.97]
+  - - [36608, 3072, 1, 256]
+    - [112, 4822.4]
+  - - [39424, 1536, 1, 256]
+    - [112, 4778.42]
+  - - [12032, 256, 1, 256]
+    - [105, 4231.21]
+  - - [3584, 512, 1, 256]
+    - [130, 4070.74]
+  - - [15104, 2817, 1, 256]
+    - [108, 4700.95]
+  - - [25344, 1792, 1, 256]
+    - [105, 4809.39]
+  - - [19456, 9216, 1, 256]
+    - [112, 4823.55]
+  - - [24064, 11777, 1, 256]
+    - [112, 4773.5]
+  - - [13824, 256, 1, 256]
+    - [105, 4348.93]
+  - - [29696, 1792, 1, 256]
+    - [112, 4811.3]
+  - - [24576, 768, 1, 256]
+    - [105, 4700.41]
+  - - [42496, 512, 1, 256]
+    - [112, 4669.71]
+  - - [27904, 256, 1, 256]
+    - [125, 4427.89]
+  - - [40448, 1536, 1, 256]
+    - [112, 4792.86]
+  - - [22784, 1280, 1, 256]
+    - [105, 4765.52]
+  - - [37376, 1024, 1, 256]
+    - [112, 4760.88]
+  - - [4864, 1280, 1, 256]
+    - [132, 4470.54]
+  - - [14336, 512, 1, 256]
+    - [132, 4504.38]
+  - - [512, 3072, 1, 256]
+    - [118, 4151.06]
+  - - [34560, 1280, 1, 256]
+    - [105, 4792.88]
+  - - [5632, 2560, 1, 256]
+    - [112, 4636.46]
+  - - [38912, 9216, 1, 256]
+    - [112, 4842.71]
+  - - [18688, 1024, 1, 256]
+    - [112, 4676.0]
+  - - [35584, 256, 1, 256]
+    - [125, 4537.74]
+  - - [5632, 256, 1, 256]
+    - [120, 3770.93]
+  - - [22016, 1024, 1, 256]
+    - [112, 4699.81]
+  - - [20480, 2048, 1, 256]
+    - [112, 4761.52]
+  - - [7680, 1281, 1, 256]
+    - [108, 4439.69]
+  - - [19456, 6913, 1, 256]
+    - [105, 4768.58]
+  - - [17408, 2048, 1, 256]
+    - [112, 4753.25]
+  - - [43776, 1024, 1, 256]
+    - [112, 4772.04]
+  - - [15104, 1281, 1, 256]
+    - [110, 4605.86]
+  - - [22272, 9216, 1, 256]
+    - [112, 4840.74]
+  - - [14848, 1281, 1, 256]
+    - [110, 4575.45]
+  - - [19968, 1280, 1, 256]
+    - [112, 4750.61]
+  - - [29440, 1792, 1, 256]
+    - [105, 4805.74]
+  - - [41984, 9216, 1, 256]
+    - [112, 4844.11]
+  - - [14080, 1793, 1, 256]
+    - [110, 4617.5]
+  - - [20992, 8449, 1, 256]
+    - [105, 4782.32]
+  - - [26880, 512, 1, 256]
+    - [112, 4605.99]
+  - - [17920, 768, 1, 256]
+    - [105, 4613.23]
+  - - [34304, 1280, 1, 256]
+    - [105, 4797.09]
+  - - [10496, 7169, 1, 256]
+    - [112, 4720.43]
+  - - [40704, 1280, 1, 256]
+    - [105, 4801.19]
+  - - [23552, 2048, 1, 256]
+    - [112, 4779.24]
+  - - [3328, 2048, 1, 256]
+    - [132, 4470.72]
+  - - [40704, 27648, 1, 256]
+    - [112, 4849.32]
+  - - [19968, 1024, 1, 256]
+    - [112, 4690.24]
+  - - [22784, 1281, 1, 256]
+    - [110, 4657.12]
+  - - [29440, 2048, 1, 256]
+    - [112, 4793.55]
+  - - [17152, 2048, 1, 256]
+    - [112, 4755.97]
+  - - [16384, 2048, 1, 256]
+    - [112, 4741.73]
+  - - [13568, 1025, 1, 256]
+    - [108, 4413.23]
+  - - [38144, 9216, 1, 256]
+    - [112, 4855.28]
+  - - [20992, 256, 1, 256]
+    - [112, 4400.93]
+  - - [24064, 1280, 1, 256]
+    - [105, 4759.24]
+  - - [2304, 768, 1, 256]
+    - [120, 4092.75]
+  - - [35328, 1024, 1, 256]
+    - [112, 4749.24]
+  - - [27392, 15104, 1, 256]
+    - [105, 4865.67]
+  - - [2304, 3072, 1, 256]
+    - [105, 4531.67]
+  - - [9472, 6401, 1, 256]
+    - [105, 4743.57]
+  - - [39424, 1792, 1, 256]
+    - [105, 4818.57]
+  - - [40960, 512, 1, 256]
+    - [112, 4695.23]
+  - - [41728, 768, 1, 256]
+    - [105, 4759.73]
+  - - [5376, 256, 1, 256]
+    - [107, 3650.24]
+  - - [8960, 1280, 1, 256]
+    - [132, 4578.08]
+  - - [26624, 256, 1, 256]
+    - [123, 4515.14]
+  - - [11264, 3072, 1, 256]
+    - [112, 4746.23]
+  - - [25344, 3072, 1, 256]
+    - [112, 4811.26]
+  - - [23296, 2048, 1, 256]
+    - [112, 4773.26]
+  - - [22784, 768, 1, 256]
+    - [105, 4683.92]
+  - - [35584, 512, 1, 256]
+    - [112, 4662.39]
+  - - [24576, 1792, 1, 256]
+    - [105, 4802.15]
+  - - [27392, 14849, 1, 256]
+    - [112, 4792.41]
+  - - [14848, 2561, 1, 256]
+    - [110, 4625.03]
+  - - [28160, 3072, 1, 256]
+    - [112, 4811.86]
+  - - [4864, 1792, 1, 256]
+    - [120, 4498.01]
+  - - [20736, 1281, 1, 256]
+    - [110, 4638.4]
+  - - [23552, 11009, 1, 256]
+    - [105, 4810.56]
+  - - [11776, 8449, 1, 256]
+    - [105, 4761.83]
+  - - [16640, 1792, 1, 256]
+    - [105, 4757.82]
+  - - [24576, 12289, 1, 256]
+    - [112, 4779.09]
+  - - [38656, 26369, 1, 256]
+    - [105, 4832.16]
+  - - [25088, 512, 1, 256]
+    - [112, 4617.67]
+  - - [5376, 2304, 1, 256]
+    - [105, 4601.1]
+  - - [30720, 1024, 1, 256]
+    - [112, 4737.32]
+  - - [13824, 9216, 1, 256]
+    - [112, 4821.32]
+  - - [28928, 1792, 1, 256]
+    - [105, 4818.66]
+  - - [36864, 1281, 1, 256]
+    - [108, 4681.9]
+  - - [25600, 1280, 1, 256]
+    - [105, 4762.47]
+  - - [27904, 15361, 1, 256]
+    - [112, 4788.63]
+  - - [34816, 512, 1, 256]
+    - [112, 4653.87]
+  - - [3840, 1792, 1, 256]
+    - [105, 4471.09]
+  - - [14848, 3072, 1, 256]
+    - [112, 4763.46]
+  - - [14848, 1280, 1, 256]
+    - [105, 4691.8]
+  - - [27904, 1536, 1, 256]
+    - [112, 4763.11]
+  - - [39936, 1536, 1, 256]
+    - [112, 4796.07]
+  - - [34816, 1536, 1, 256]
+    - [112, 4780.5]
+  - - [14592, 2305, 1, 256]
+    - [105, 4629.37]
+  - - [22528, 9985, 1, 256]
+    - [105, 4794.67]
+  - - [22784, 3072, 1, 256]
+    - [112, 4801.45]
+  - - [26368, 13825, 1, 256]
+    - [112, 4784.71]
+  - - [4096, 1792, 1, 256]
+    - [120, 4530.02]
+  - - [17152, 1280, 1, 256]
+    - [112, 4707.81]
+  - - [30720, 18177, 1, 256]
+    - [105, 4823.02]
+  - - [37120, 24833, 1, 256]
+    - [105, 4835.96]
+  - - [3840, 768, 1, 256]
+    - [131, 4140.94]
+  - - [1792, 1537, 1, 256]
+    - [130, 4079.51]
+  - - [16128, 2048, 1, 256]
+    - [112, 4755.75]
+  - - [6656, 2048, 1, 256]
+    - [112, 4620.6]
+  - - [15360, 2048, 1, 256]
+    - [112, 4740.89]
+  - - [24320, 3072, 1, 256]
+    - [112, 4803.27]
+  - - [17664, 1280, 1, 256]
+    - [105, 4724.55]
+  - - [12800, 1280, 1, 256]
+    - [105, 4661.37]
+  - - [4352, 1536, 1, 256]
+    - [130, 4441.19]
+  - - [41472, 1024, 1, 256]
+    - [112, 4769.68]
+  - - [9984, 256, 1, 256]
+    - [125, 4200.77]
+  - - [14592, 1281, 1, 256]
+    - [108, 4587.61]
+  - - [21248, 1281, 1, 256]
+    - [110, 4643.22]
+  - - [2560, 1536, 1, 256]
+    - [120, 4354.71]
+  - - [8960, 2048, 1, 256]
+    - [112, 4662.0]
+  - - [44032, 4097, 1, 256]
+    - [112, 4730.54]
+  - - [256, 257, 1, 256]
+    - [126, 718.547]
+  - - [34048, 1281, 1, 256]
+    - [108, 4674.52]
+  - - [44544, 27648, 1, 256]
+    - [112, 4849.49]
+  - - [34048, 21761, 1, 256]
+    - [105, 4838.63]
+  - - [26368, 1280, 1, 256]
+    - [105, 4768.99]
+  - - [24064, 1536, 1, 256]
+    - [112, 4743.41]
+  - - [24832, 12545, 1, 256]
+    - [105, 4817.29]
+  - - [44032, 3841, 1, 256]
+    - [105, 4748.09]
+  - - [22528, 9216, 1, 256]
+    - [112, 4826.54]
+  - - [40448, 257, 1, 256]
+    - [110, 4046.03]
+  - - [14592, 1280, 1, 256]
+    - [112, 4697.52]
+  - - [26624, 14337, 1, 256]
+    - [112, 4778.76]
+  - - [26368, 512, 1, 256]
+    - [112, 4599.07]
+  - - [19456, 1280, 1, 256]
+    - [105, 4728.64]
+  - - [8192, 5121, 1, 256]
+    - [110, 4674.48]
+  - - [26880, 3072, 1, 256]
+    - [112, 4818.31]
+  - - [25600, 1281, 1, 256]
+    - [110, 4651.68]
+  - - [42240, 1536, 1, 256]
+    - [112, 4790.45]
+  - - [5888, 2817, 1, 256]
+    - [110, 4602.37]
+  - - [8704, 2048, 1, 256]
+    - [112, 4661.1]
+  - - [6144, 1792, 1, 256]
+    - [105, 4576.2]
+  - - [16384, 1792, 1, 256]
+    - [105, 4748.43]
+  - - [8704, 1024, 1, 256]
+    - [132, 4534.75]
+  - - [26880, 256, 1, 256]
+    - [112, 4467.91]
+  - - [35584, 23297, 1, 256]
+    - [105, 4844.49]
+  - - [36352, 24064, 1, 256]
+    - [112, 4841.19]
+  - - [38400, 512, 1, 256]
+    - [112, 4679.05]
+  - - [23040, 1536, 1, 256]
+    - [112, 4738.34]
+  - - [28160, 512, 1, 256]
+    - [112, 4616.04]
+  - - [8704, 1536, 1, 256]
+    - [110, 4573.65]
+  - - [18432, 6145, 1, 256]
+    - [112, 4744.26]
+  - - [19456, 256, 1, 256]
+    - [132, 4405.29]
+  - - [23040, 1281, 1, 256]
+    - [110, 4650.66]
+  - - [12032, 3072, 1, 256]
+    - [112, 4743.89]
+  - - [36096, 1024, 1, 256]
+    - [112, 4768.85]
+  - - [4864, 3072, 1, 256]
+    - [112, 4615.36]
+  - - [42752, 1280, 1, 256]
+    - [105, 4809.19]
+  - - [15104, 1024, 1, 256]
+    - [112, 4648.96]
+  - - [1536, 1536, 1, 256]
+    - [105, 4333.95]
+  - - [28416, 2048, 1, 256]
+    - [112, 4792.07]
+  - - [39168, 3072, 1, 256]
+    - [112, 4824.85]
+  - - [7680, 256, 1, 256]
+    - [106, 4109.38]
+  - - [24576, 1281, 1, 256]
+    - [108, 4655.9]
+  - - [43520, 1281, 1, 256]
+    - [110, 4697.82]
+  - - [28160, 1536, 1, 256]
+    - [112, 4765.84]
+  - - [41728, 27648, 1, 256]
+    - [112, 4845.4]
+  - - [28416, 1792, 1, 256]
+    - [112, 4814.13]
+  - - [42240, 1792, 1, 256]
+    - [105, 4834.12]
+  - - [4864, 1536, 1, 256]
+    - [132, 4478.33]
+  - - [26368, 3072, 1, 256]
+    - [112, 4803.31]
+  - - [41728, 1536, 1, 256]
+    - [112, 4803.37]
+  - - [2048, 768, 1, 256]
+    - [120, 4147.64]
+  - - [24320, 12032, 1, 256]
+    - [105, 4859.94]
+  - - [28928, 16385, 1, 256]
+    - [112, 4792.95]
+  - - [34816, 22528, 1, 256]
+    - [112, 4842.42]
+  - - [26368, 1792, 1, 256]
+    - [105, 4798.55]
+  - - [34816, 1281, 1, 256]
+    - [110, 4677.35]
+  - - [25856, 13569, 1, 256]
+    - [105, 4821.02]
+  - - [4608, 1536, 1, 256]
+    - [132, 4481.45]
+  - - [22784, 256, 1, 256]
+    - [112, 4487.77]
+  - - [25600, 13312, 1, 256]
+    - [112, 4838.25]
+  - - [31232, 18689, 1, 256]
+    - [105, 4821.72]
+  - - [20736, 9216, 1, 256]
+    - [112, 4830.01]
+  - - [34304, 9216, 1, 256]
+    - [112, 4839.54]
+  - - [41472, 512, 1, 256]
+    - [112, 4699.66]
+  - - [12288, 1024, 1, 256]
+    - [112, 4618.64]
+  - - [7680, 1280, 1, 256]
+    - [112, 4556.39]
+  - - [14080, 1280, 1, 256]
+    - [105, 4716.75]
+  - - [29696, 1536, 1, 256]
+    - [112, 4778.27]
+  - - [43264, 3073, 1, 256]
+    - [112, 4697.14]
+  - - [17408, 1281, 1, 256]
+    - [108, 4606.62]
+  - - [7424, 2048, 1, 256]
+    - [112, 4627.54]
+  - - [37120, 1281, 1, 256]
+    - [103, 4674.08]
+  - - [12800, 512, 1, 256]
+    - [130, 4442.18]
+  - - [6912, 2048, 1, 256]
+    - [112, 4600.47]
+  - - [36864, 512, 1, 256]
+    - [112, 4680.2]
+  - - [8704, 5633, 1, 256]
+    - [110, 4674.85]
+  - - [4864, 1793, 1, 256]
+    - [110, 4424.88]
+  - - [15872, 256, 1, 256]
+    - [132, 4282.72]
+  - - [41984, 3072, 1, 256]
+    - [112, 4824.96]
+  - - [13824, 1280, 1, 256]
+    - [105, 4688.31]
+  - - [34560, 256, 1, 256]
+    - [112, 4542.2]
+  - - [20992, 3072, 1, 256]
+    - [112, 4797.56]
+  - - [40192, 1281, 1, 256]
+    - [108, 4689.73]
+  - - [9728, 6401, 1, 256]
+    - [105, 4734.78]
+  - - [36608, 1024, 1, 256]
+    - [112, 4759.73]
+  - - [17152, 1281, 1, 256]
+    - [104, 4605.02]
+  - - [16640, 4097, 1, 256]
+    - [112, 4690.24]
+  - - [38400, 9216, 1, 256]
+    - [112, 4853.68]
+  - - [15616, 256, 1, 256]
+    - [124, 4228.27]
+  - - [33024, 768, 1, 256]
+    - [105, 4744.8]
+  - - [38656, 1536, 1, 256]
+    - [112, 4791.74]
+  - - [1536, 3072, 1, 256]
+    - [105, 4457.42]
+  - - [12544, 1792, 1, 256]
+    - [105, 4706.38]
+  - - [37632, 1792, 1, 256]
+    - [105, 4832.65]
+  - - [17152, 4609, 1, 256]
+    - [112, 4708.64]
+  - - [18944, 6656, 1, 256]
+    - [112, 4819.54]
+  - - [34560, 22017, 1, 256]
+    - [112, 4801.94]
+  - - [23296, 11008, 1, 256]
+    - [105, 4855.67]
+  - - [41472, 1281, 1, 256]
+    - [108, 4660.14]
+  - - [14848, 768, 1, 256]
+    - [105, 4568.73]
+  - - [38656, 1792, 1, 256]
+    - [105, 4816.53]
+  - - [7424, 4352, 1, 256]
+    - [105, 4756.28]
+  - - [8448, 5377, 1, 256]
+    - [105, 4726.61]
+  - - [37120, 1280, 1, 256]
+    - [105, 4808.08]
+  - - [29696, 1281, 1, 256]
+    - [110, 4667.56]
+  - - [36608, 2048, 1, 256]
+    - [112, 4799.63]
+  - - [14080, 256, 1, 256]
+    - [130, 4268.81]
+  - - [29952, 17665, 1, 256]
+    - [105, 4833.28]
+  - - [16128, 3072, 1, 256]
+    - [112, 4782.65]
+  - - [19456, 2048, 1, 256]
+    - [112, 4761.36]
+  - - [2304, 2304, 1, 256]
+    - [105, 4385.43]
+  - - [33792, 21504, 1, 256]
+    - [112, 4848.87]
+  - - [37376, 512, 1, 256]
+    - [112, 4665.84]
+  - - [27136, 512, 1, 256]
+    - [112, 4614.15]
+  - - [24576, 1536, 1, 256]
+    - [112, 4760.15]
+  - - [6400, 1024, 1, 256]
+    - [132, 4454.44]
+  - - [7424, 1281, 1, 256]
+    - [110, 4464.53]
+  - - [35840, 2048, 1, 256]
+    - [112, 4806.83]
+  - - [3072, 1280, 1, 256]
+    - [120, 4407.33]
+  - - [23808, 256, 1, 256]
+    - [112, 4400.61]
+  - - [11520, 1024, 1, 256]
+    - [112, 4568.68]
+  - - [37376, 1792, 1, 256]
+    - [105, 4819.25]
+  - - [42752, 768, 1, 256]
+    - [105, 4770.58]
+  - - [4096, 1025, 1, 256]
+    - [114, 4161.34]
+  - - [35840, 768, 1, 256]
+    - [105, 4731.94]
+  - - [2304, 2305, 1, 256]
+    - [105, 4328.11]
+  - - [19200, 3072, 1, 256]
+    - [112, 4794.46]
+  - - [43264, 768, 1, 256]
+    - [105, 4770.85]
+  - - [33536, 1792, 1, 256]
+    - [105, 4825.09]
+  - - [36864, 9216, 1, 256]
+    - [112, 4837.49]
+  - - [38656, 26368, 1, 256]
+    - [105, 4867.44]
+  - - [22016, 1280, 1, 256]
+    - [105, 4760.59]
+  - - [8448, 5376, 1, 256]
+    - [105, 4804.55]
+  - - [17920, 1281, 1, 256]
+    - [108, 4617.66]
+  - - [2048, 1281, 1, 256]
+    - [132, 3960.92]
+  - - [41472, 3072, 1, 256]
+    - [112, 4822.04]
+  - - [3328, 512, 1, 256]
+    - [132, 3919.91]
+  - - [4608, 1024, 1, 256]
+    - [112, 4428.65]
+  - - [44288, 9216, 1, 256]
+    - [112, 4839.56]
+  - - [37888, 2048, 1, 256]
+    - [112, 4806.11]
+  - - [15104, 1792, 1, 256]
+    - [112, 4755.4]
+  - - [36096, 256, 1, 256]
+    - [112, 4548.86]
+  - - [44288, 4097, 1, 256]
+    - [112, 4724.48]
+  - - [26112, 3072, 1, 256]
+    - [112, 4804.21]
+  - - [512, 768, 1, 256]
+    - [119, 2946.82]
+  - - [36096, 3072, 1, 256]
+    - [112, 4820.65]
+  - - [4864, 1537, 1, 256]
+    - [132, 4300.79]
+  - - [43264, 3329, 1, 256]
+    - [105, 4745.23]
+  - - [9984, 2048, 1, 256]
+    - [112, 4681.01]
+  - - [33792, 1536, 1, 256]
+    - [112, 4784.17]
+  - - [13568, 2048, 1, 256]
+    - [112, 4725.47]
+  - - [31232, 18944, 1, 256]
+    - [112, 4845.2]
+  - - [44288, 1792, 1, 256]
+    - [105, 4827.68]
+  - - [25344, 1536, 1, 256]
+    - [112, 4773.29]
+  - - [7936, 1281, 1, 256]
+    - [108, 4455.73]
+  - - [38656, 2048, 1, 256]
+    - [112, 4798.62]
+  - - [30976, 2048, 1, 256]
+    - [112, 4792.42]
+  - - [20224, 7681, 1, 256]
+    - [112, 4752.82]
+  - - [26112, 9216, 1, 256]
+    - [112, 4841.32]
+  - - [7936, 1280, 1, 256]
+    - [105, 4595.12]
+  - - [31488, 2048, 1, 256]
+    - [112, 4795.77]
+  - - [6912, 512, 1, 256]
+    - [112, 4357.3]
+  - - [20224, 1280, 1, 256]
+    - [105, 4751.63]
+  - - [8960, 5888, 1, 256]
+    - [105, 4797.07]
+  - - [32000, 1792, 1, 256]
+    - [105, 4809.73]
+  - - [37888, 1792, 1, 256]
+    - [105, 4823.34]
+  - - [21504, 3072, 1, 256]
+    - [112, 4813.74]
+  - - [43264, 2048, 1, 256]
+    - [112, 4809.14]
+  - - [40448, 1281, 1, 256]
+    - [110, 4692.42]
+  - - [12544, 3072, 1, 256]
+    - [112, 4748.82]
+  - - [32256, 19713, 1, 256]
+    - [105, 4824.97]
+  - - [40704, 1792, 1, 256]
+    - [105, 4826.47]
+  - - [7936, 256, 1, 256]
+    - [124, 4049.31]
+  - - [18176, 5888, 1, 256]
+    - [105, 4832.37]
+  - - [33792, 9216, 1, 256]
+    - [112, 4846.67]
+  - - [35584, 1536, 1, 256]
+    - [112, 4788.57]
+  - - [26624, 14336, 1, 256]
+    - [112, 4839.8]
+  - - [38912, 1792, 1, 256]
+    - [105, 4823.59]
+  - - [7936, 1792, 1, 256]
+    - [112, 4627.4]
+  - - [28672, 16385, 1, 256]
+    - [112, 4782.0]
+  - - [18944, 3072, 1, 256]
+    - [112, 4787.7]
+  - - [33280, 20993, 1, 256]
+    - [112, 4800.41]
+  - - [5888, 3072, 1, 256]
+    - [112, 4646.68]
+  - - [37120, 24832, 1, 256]
+    - [105, 4864.61]
+  - - [6400, 3329, 1, 256]
+    - [110, 4627.57]
+  - - [43520, 1792, 1, 256]
+    - [112, 4827.19]
+  - - [29184, 3072, 1, 256]
+    - [112, 4809.08]
+  - - [16896, 4609, 1, 256]
+    - [112, 4716.94]
+  - - [29440, 1024, 1, 256]
+    - [112, 4738.16]
+  - - [43776, 1280, 1, 256]
+    - [105, 4815.67]
+  - - [37632, 1536, 1, 256]
+    - [112, 4791.63]
+  - - [14336, 768, 1, 256]
+    - [132, 4572.93]
+  - - [41984, 1281, 1, 256]
+    - [110, 4683.46]
+  - - [41472, 1536, 1, 256]
+    - [112, 4790.62]
+  - - [26624, 1281, 1, 256]
+    - [110, 4659.1]
+  - - [39936, 768, 1, 256]
+    - [112, 4763.59]
+  - - [23296, 11009, 1, 256]
+    - [105, 4810.24]
+  - - [42496, 256, 1, 256]
+    - [112, 4606.08]
+  - - [21504, 512, 1, 256]
+    - [132, 4571.45]
+  - - [16128, 512, 1, 256]
+    - [112, 4555.88]
+  - - [29952, 1281, 1, 256]
+    - [110, 4668.59]
+  - - [26624, 9216, 1, 256]
+    - [112, 4837.24]
+  - - [29184, 9216, 1, 256]
+    - [112, 4838.52]
+  - - [5120, 1281, 1, 256]
+    - [108, 4346.23]
+  - - [36352, 9216, 1, 256]
+    - [112, 4845.41]
+  - - [37632, 25344, 1, 256]
+    - [105, 4874.79]
+  - - [1280, 256, 1, 256]
+    - [119, 2505.56]
+  - - [37888, 25600, 1, 256]
+    - [112, 4847.13]
+  - - [34560, 1281, 1, 256]
+    - [110, 4685.19]
+  - - [16640, 9216, 1, 256]
+    - [112, 4824.31]
+  - - [1792, 1281, 1, 256]
+    - [97, 4195.19]
+  - - [44544, 9216, 1, 256]
+    - [112, 4847.99]
+  - - [14080, 1792, 1, 256]
+    - [112, 4729.82]
+  - - [33536, 21249, 1, 256]
+    - [105, 4829.71]
+  - - [32256, 1281, 1, 256]
+    - [110, 4670.9]
+  - - [23552, 1280, 1, 256]
+    - [105, 4762.72]
+  - - [18432, 2048, 1, 256]
+    - [112, 4764.09]
+  - - [34048, 21760, 1, 256]
+    - [105, 4864.94]
+  - - [9984, 768, 1, 256]
+    - [105, 4498.43]
+  - - [40192, 1536, 1, 256]
+    - [112, 4793.2]
+  - - [11520, 256, 1, 256]
+    - [105, 4148.21]
+  - - [4608, 1280, 1, 256]
+    - [105, 4473.67]
+  - - [41728, 3072, 1, 256]
+    - [112, 4824.27]
+  - - [35328, 9216, 1, 256]
+    - [112, 4841.16]
+  - - [11264, 1536, 1, 256]
+    - [112, 4639.45]
+  - - [6912, 3072, 1, 256]
+    - [112, 4677.67]
+  - - [32512, 768, 1, 256]
+    - [105, 4736.31]
+  - - [14592, 2049, 1, 256]
+    - [110, 4602.28]
+  - - [14848, 9216, 1, 256]
+    - [112, 4822.39]
+  - - [36352, 512, 1, 256]
+    - [112, 4654.15]
+  - - [23808, 3072, 1, 256]
+    - [112, 4806.58]
+  - - [13568, 9216, 1, 256]
+    - [112, 4822.61]
+  - - [1024, 769, 1, 256]
+    - [93, 3276.81]
+  - - [42496, 2560, 1, 256]
+    - [112, 4816.7]
+  - - [18176, 1024, 1, 256]
+    - [112, 4667.64]
+  - - [42752, 3072, 1, 256]
+    - [112, 4821.04]
+  - - [39680, 27392, 1, 256]
+    - [105, 4871.2]
+  - - [14592, 1792, 1, 256]
+    - [105, 4746.65]
+  - - [25600, 13313, 1, 256]
+    - [112, 4779.49]
+  - - [26624, 1792, 1, 256]
+    - [112, 4793.11]
+  - - [20480, 8193, 1, 256]
+    - [112, 4760.77]
+  - - [36096, 23808, 1, 256]
+    - [105, 4870.28]
+  - - [20736, 2048, 1, 256]
+    - [112, 4784.71]
+  - - [28672, 2048, 1, 256]
+    - [112, 4797.96]
+  - - [15104, 2561, 1, 256]
+    - [110, 4624.88]
+  - - [11776, 1281, 1, 256]
+    - [110, 4559.14]
+  - - [43520, 3072, 1, 256]
+    - [112, 4834.77]
+  - - [1280, 2048, 1, 256]
+    - [120, 4316.24]
+  - - [33280, 1280, 1, 256]
+    - [105, 4785.41]
+  - - [43008, 1792, 1, 256]
+    - [105, 4825.47]
+  - - [19712, 512, 1, 256]
+    - [112, 4553.24]
+  - - [18688, 3072, 1, 256]
+    - [112, 4792.87]
+  - - [35328, 23040, 1, 256]
+    - [112, 4853.32]
+  - - [18944, 6401, 1, 256]
+    - [105, 4766.21]
+  - - [16640, 768, 1, 256]
+    - [112, 4620.84]
+  - - [16128, 3585, 1, 256]
+    - [112, 4678.5]
+  - - [4352, 2048, 1, 256]
+    - [112, 4514.65]
+  - - [24064, 256, 1, 256]
+    - [125, 4421.49]
+  - - [29952, 1536, 1, 256]
+    - [112, 4778.09]
+  - - [7936, 512, 1, 256]
+    - [130, 4291.91]
+  - - [24320, 512, 1, 256]
+    - [112, 4613.13]
+  - - [17408, 5121, 1, 256]
+    - [112, 4718.11]
+  - - [44032, 1536, 1, 256]
+    - [112, 4797.37]
+  - - [4608, 1792, 1, 256]
+    - [112, 4553.53]
+  - - [36608, 1792, 1, 256]
+    - [105, 4831.97]
+  - - [13056, 768, 1, 256]
+    - [105, 4570.07]
+  - - [35328, 1792, 1, 256]
+    - [105, 4824.66]
+  - - [40960, 1280, 1, 256]
+    - [112, 4807.23]
+  - - [1280, 1280, 1, 256]
+    - [120, 3838.13]
+  - - [26112, 13824, 1, 256]
+    - [112, 4846.7]
+  - - [6400, 1280, 1, 256]
+    - [105, 4557.84]
+  - - [43520, 3585, 1, 256]
+    - [110, 4717.45]
+  - - [40704, 9216, 1, 256]
+    - [112, 4832.38]
+  - - [20224, 1024, 1, 256]
+    - [112, 4691.18]
+  - - [2816, 2817, 1, 256]
+    - [132, 4424.33]
+  - - [27904, 15617, 1, 256]
+    - [105, 4825.27]
+  - - [21248, 3072, 1, 256]
+    - [112, 4801.15]
+  - - [32768, 512, 1, 256]
+    - [112, 4661.35]
+  - - [19712, 1280, 1, 256]
+    - [105, 4736.75]
+  - - [38912, 1536, 1, 256]
+    - [112, 4792.17]
+  - - [20480, 1280, 1, 256]
+    - [105, 4759.09]
+  - - [8960, 1536, 1, 256]
+    - [112, 4599.5]
+  - - [28672, 1792, 1, 256]
+    - [112, 4803.08]
+  - - [14592, 2048, 1, 256]
+    - [112, 4731.47]
+  - - [18432, 1792, 1, 256]
+    - [105, 4778.75]
+  - - [39680, 1280, 1, 256]
+    - [105, 4810.27]
+  - - [29952, 9216, 1, 256]
+    - [112, 4845.1]
+  - - [4352, 1025, 1, 256]
+    - [108, 4187.32]
+  - - [35328, 1281, 1, 256]
+    - [110, 4675.72]
+  - - [23808, 2048, 1, 256]
+    - [112, 4778.15]
+  - - [25600, 1792, 1, 256]
+    - [112, 4803.14]
+  - - [19712, 256, 1, 256]
+    - [112, 4354.93]
+  - - [34304, 22017, 1, 256]
+    - [112, 4795.42]
+  - - [21760, 256, 1, 256]
+    - [132, 4359.45]
+  - - [39168, 1281, 1, 256]
+    - [110, 4683.91]
+  - - [42752, 512, 1, 256]
+    - [112, 4685.9]
+  - - [24064, 512, 1, 256]
+    - [132, 4573.04]
+  - - [28160, 15617, 1, 256]
+    - [105, 4813.45]
+  - - [20224, 512, 1, 256]
+    - [132, 4550.26]
+  - - [17408, 256, 1, 256]
+    - [132, 4325.34]
+  - - [1536, 256, 1, 256]
+    - [119, 2939.93]
+  - - [11776, 8704, 1, 256]
+    - [112, 4803.35]
+  - - [19968, 9216, 1, 256]
+    - [112, 4830.17]
+  - - [5376, 512, 1, 256]
+    - [130, 4150.83]
+  - - [26624, 1024, 1, 256]
+    - [112, 4711.17]
+  - - [7424, 4353, 1, 256]
+    - [110, 4703.28]
+  - - [19200, 1792, 1, 256]
+    - [105, 4777.84]
+  - - [27648, 15360, 1, 256]
+    - [112, 4847.1]
+  - - [26624, 3072, 1, 256]
+    - [112, 4808.11]
+  - - [21248, 1536, 1, 256]
+    - [112, 4738.68]
+  - - [16640, 1280, 1, 256]
+    - [105, 4710.75]
+  - - [23040, 10497, 1, 256]
+    - [105, 4809.84]
+  - - [21248, 8961, 1, 256]
+    - [105, 4807.92]
+  - - [32256, 1792, 1, 256]
+    - [105, 4813.07]
+  - - [28928, 1024, 1, 256]
+    - [112, 4729.63]
+  - - [26112, 13569, 1, 256]
+    - [105, 4816.2]
+  - - [20992, 1024, 1, 256]
+    - [112, 4677.61]
+  - - [3840, 2048, 1, 256]
+    - [132, 4531.53]
+  - - [25856, 1024, 1, 256]
+    - [112, 4716.77]
+  - - [12288, 8961, 1, 256]
+    - [105, 4781.28]
+  - - [16896, 3072, 1, 256]
+    - [112, 4786.38]
+  - - [6656, 3585, 1, 256]
+    - [108, 4593.77]
+  - - [19968, 7425, 1, 256]
+    - [105, 4775.77]
+  - - [40960, 1281, 1, 256]
+    - [110, 4682.71]
+  - - [9472, 768, 1, 256]
+    - [132, 4507.38]
+  - - [29440, 1281, 1, 256]
+    - [110, 4671.83]
+  - - [33792, 3072, 1, 256]
+    - [112, 4816.6]
+  - - [15616, 3072, 1, 256]
+    - [112, 4789.45]
+  - - [26624, 2048, 1, 256]
+    - [112, 4796.45]
+  - - [16384, 1024, 1, 256]
+    - [112, 4647.23]
+  - - [8704, 5377, 1, 256]
+    - [105, 4702.85]
+  - - [26880, 2048, 1, 256]
+    - [112, 4803.69]
+  - - [11520, 3072, 1, 256]
+    - [112, 4768.46]
+  - - [41216, 2048, 1, 256]
+    - [112, 4804.96]
+  - - [3584, 1280, 1, 256]
+    - [132, 4367.12]
+  - - [33536, 2048, 1, 256]
+    - [112, 4807.38]
+  - - [25856, 1536, 1, 256]
+    - [112, 4756.8]
+  - - [15872, 1281, 1, 256]
+    - [110, 4610.44]
+  - - [33792, 2048, 1, 256]
+    - [112, 4809.42]
+  - - [42496, 1281, 1, 256]
+    - [110, 4697.18]
+  - - [35840, 1792, 1, 256]
+    - [105, 4821.72]
+  - - [28416, 768, 1, 256]
+    - [105, 4722.1]
+  - - [12800, 2048, 1, 256]
+    - [112, 4713.63]
+  - - [21248, 512, 1, 256]
+    - [112, 4575.2]
+  - - [2048, 1793, 1, 256]
+    - [132, 4115.09]
+  - - [13056, 1024, 1, 256]
+    - [112, 4608.63]
+  - - [9728, 2048, 1, 256]
+    - [112, 4683.96]
+  - - [34816, 2048, 1, 256]
+    - [112, 4798.38]
+  - - [32256, 3072, 1, 256]
+    - [112, 4820.82]
+  - - [18688, 1280, 1, 256]
+    - [105, 4718.37]
+  - - [20736, 1536, 1, 256]
+    - [112, 4753.25]
+  - - [25856, 1281, 1, 256]
+    - [108, 4658.55]
+  - - [36864, 1024, 1, 256]
+    - [112, 4749.76]
+  - - [22784, 10241, 1, 256]
+    - [112, 4766.34]
+  - - [36608, 24321, 1, 256]
+    - [105, 4841.32]
+  - - [36096, 9216, 1, 256]
+    - [112, 4842.5]
+  - - [10752, 768, 1, 256]
+    - [105, 4571.25]
+  - - [38400, 26112, 1, 256]
+    - [112, 4852.19]
+  - - [9216, 5889, 1, 256]
+    - [105, 4732.77]
+  - - [28160, 256, 1, 256]
+    - [130, 4454.7]
+  - - [9472, 256, 1, 256]
+    - [130, 4000.75]
+  - - [39168, 2048, 1, 256]
+    - [112, 4809.93]
+  - - [30976, 1281, 1, 256]
+    - [110, 4677.98]
+  - - [41472, 27648, 1, 256]
+    - [112, 4845.65]
+  - - [38144, 25856, 1, 256]
+    - [105, 4870.9]
+  - - [12288, 256, 1, 256]
+    - [112, 4347.37]
+  - - [32256, 1280, 1, 256]
+    - [105, 4798.19]
+  - - [8960, 256, 1, 256]
+    - [105, 4190.71]
+  - - [11008, 1536, 1, 256]
+    - [112, 4632.41]
+  - - [15360, 3073, 1, 256]
+    - [112, 4654.96]
+  - - [24576, 1024, 1, 256]
+    - [112, 4707.74]
+  - - [29184, 16896, 1, 256]
+    - [112, 4849.14]
+  - - [3072, 1281, 1, 256]
+    - [130, 4141.68]
+  - - [21760, 512, 1, 256]
+    - [112, 4551.46]
+  - - [15872, 2048, 1, 256]
+    - [112, 4741.7]
+  - - [16128, 1792, 1, 256]
+    - [105, 4763.68]
+  - - [32768, 20225, 1, 256]
+    - [105, 4827.47]
+  - - [26624, 512, 1, 256]
+    - [112, 4617.91]
+  - - [23040, 10752, 1, 256]
+    - [112, 4837.81]
+  - - [28160, 1280, 1, 256]
+    - [105, 4780.48]
+  - - [15872, 3585, 1, 256]
+    - [110, 4671.51]
+  - - [11008, 7681, 1, 256]
+    - [112, 4723.19]
+  - - [15360, 9216, 1, 256]
+    - [112, 4830.01]
+  - - [2048, 1280, 1, 256]
+    - [120, 4327.37]
+  - - [9728, 1024, 1, 256]
+    - [132, 4558.38]
+  - - [28672, 512, 1, 256]
+    - [112, 4627.06]
+  - - [44032, 1281, 1, 256]
+    - [110, 4697.54]
+  - - [512, 512, 1, 256]
+    - [124, 2613.27]
+  - - [28416, 16128, 1, 256]
+    - [105, 4864.98]
+  - - [12288, 9216, 1, 256]
+    - [112, 4827.01]
+  - - [30208, 1792, 1, 256]
+    - [105, 4808.33]
+  - - [13056, 2048, 1, 256]
+    - [112, 4730.42]
+  - - [41728, 1792, 1, 256]
+    - [105, 4819.63]
+  - - [32256, 19968, 1, 256]
+    - [112, 4846.26]
+  - - [15360, 1281, 1, 256]
+    - [110, 4600.09]
+  - - [34304, 1024, 1, 256]
+    - [112, 4738.63]
+  - - [27904, 1792, 1, 256]
+    - [105, 4801.44]
+  - - [23552, 1024, 1, 256]
+    - [112, 4703.37]
+  - - [10240, 7168, 1, 256]
+    - [112, 4790.56]
+  - - [18944, 1792, 1, 256]
+    - [105, 4773.59]
+  - - [19200, 1536, 1, 256]
+    - [112, 4748.39]
+  - - [33024, 1024, 1, 256]
+    - [112, 4756.93]
+  - - [10240, 1280, 1, 256]
+    - [105, 4617.25]
+  - - [40192, 1792, 1, 256]
+    - [105, 4835.2]
+  - - [41728, 1793, 1, 256]
+    - [110, 4686.21]
+  - - [9984, 6912, 1, 256]
+    - [105, 4819.36]
+  - - [12544, 1281, 1, 256]
+    - [110, 4547.05]
+  - - [31488, 19201, 1, 256]
+    - [105, 4834.57]
+  - - [40192, 257, 1, 256]
+    - [110, 4073.19]
+  - - [14336, 2048, 1, 256]
+    - [112, 4726.33]
+  - - [31488, 1280, 1, 256]
+    - [112, 4792.56]
+  - - [42752, 27648, 1, 256]
+    - [112, 4839.56]
+  - - [3328, 1280, 1, 256]
+    - [112, 4332.28]
+  - - [2560, 1024, 1, 256]
+    - [118, 4217.51]
+  - - [17920, 512, 1, 256]
+    - [132, 4538.24]
+  - - [40704, 768, 1, 256]
+    - [105, 4763.53]
+  - - [25088, 12545, 1, 256]
+    - [105, 4811.89]
+  - - [28928, 1280, 1, 256]
+    - [105, 4777.11]
+  - - [24576, 9216, 1, 256]
+    - [112, 4840.83]
+  - - [37376, 1281, 1, 256]
+    - [104, 4679.51]
+  - - [33024, 20737, 1, 256]
+    - [105, 4834.87]
+  - - [29696, 9216, 1, 256]
+    - [112, 4834.63]
+  - - [768, 769, 1, 256]
+    - [94, 3184.32]
+  - - [31232, 1536, 1, 256]
+    - [112, 4767.44]
+  - - [25600, 1024, 1, 256]
+    - [112, 4716.15]
+  - - [30208, 17920, 1, 256]
+    - [112, 4846.65]
+  - - [9216, 1792, 1, 256]
+    - [105, 4686.17]
+  - - [8448, 1280, 1, 256]
+    - [105, 4586.52]
+  - - [44544, 4609, 1, 256]
+    - [112, 4733.05]
+  - - [43520, 1280, 1, 256]
+    - [112, 4808.62]
+  - - [22016, 9728, 1, 256]
+    - [112, 4832.58]
+  - - [24320, 256, 1, 256]
+    - [132, 4458.53]
+  - - [9472, 6400, 1, 256]
+    - [105, 4801.95]
+  - - [16640, 3072, 1, 256]
+    - [112, 4780.32]
+  - - [20480, 1024, 1, 256]
+    - [112, 4688.01]
+  - - [30208, 17921, 1, 256]
+    - [112, 4794.21]
+  - - [6656, 256, 1, 256]
+    - [125, 3921.32]
+  - - [5376, 1281, 1, 256]
+    - [110, 4400.42]
+  - - [19200, 6657, 1, 256]
+    - [112, 4751.22]
+  - - [6400, 2048, 1, 256]
+    - [112, 4580.19]
+  - - [32768, 1024, 1, 256]
+    - [112, 4749.81]
+  - - [34560, 512, 1, 256]
+    - [112, 4653.44]
+  - - [22016, 9729, 1, 256]
+    - [112, 4762.39]
+  - - [18176, 768, 1, 256]
+    - [105, 4635.91]
+  - - [7168, 1792, 1, 256]
+    - [105, 4634.59]
+  - - [39424, 512, 1, 256]
+    - [112, 4678.23]
+  - - [21760, 1792, 1, 256]
+    - [105, 4780.13]
+  - - [19968, 512, 1, 256]
+    - [132, 4558.39]
+  - - [37120, 2048, 1, 256]
+    - [112, 4801.72]
+  - - [29184, 1792, 1, 256]
+    - [112, 4811.34]
+  - - [12288, 1792, 1, 256]
+    - [105, 4733.12]
+  - - [17664, 512, 1, 256]
+    - [132, 4513.87]
+  - - [15616, 3328, 1, 256]
+    - [105, 4802.18]
+  - - [22528, 1536, 1, 256]
+    - [112, 4750.71]
+  - - [14848, 2305, 1, 256]
+    - [105, 4615.21]
+  - - [41216, 1025, 1, 256]
+    - [110, 4537.29]
+  - - [10496, 2048, 1, 256]
+    - [112, 4700.63]
+  - - [41984, 1024, 1, 256]
+    - [112, 4769.89]
+  - - [25088, 256, 1, 256]
+    - [125, 4424.09]
+  - - [8192, 3072, 1, 256]
+    - [112, 4696.08]
+  - - [18432, 512, 1, 256]
+    - [112, 4560.06]
+  - - [5888, 1792, 1, 256]
+    - [105, 4595.33]
+  - - [21760, 3072, 1, 256]
+    - [112, 4796.5]
+  - - [22272, 9985, 1, 256]
+    - [105, 4816.07]
+  - - [29184, 1536, 1, 256]
+    - [112, 4769.74]
+  - - [19456, 1536, 1, 256]
+    - [112, 4732.06]
+  - - [34304, 512, 1, 256]
+    - [112, 4676.24]
+  - - [9728, 512, 1, 256]
+    - [132, 4339.92]
+  - - [26112, 1281, 1, 256]
+    - [110, 4663.67]
+  - - [18944, 1281, 1, 256]
+    - [110, 4614.23]
+  - - [22016, 3072, 1, 256]
+    - [112, 4799.6]
+  - - [30720, 9216, 1, 256]
+    - [112, 4851.44]
+  - - [13824, 512, 1, 256]
+    - [112, 4463.34]
+  - - [39168, 768, 1, 256]
+    - [105, 4762.84]
+  - - [39424, 1280, 1, 256]
+    - [105, 4805.12]
+  - - [39680, 1792, 1, 256]
+    - [105, 4820.68]
+  - - [28928, 1281, 1, 256]
+    - [110, 4661.69]
+  - - [12288, 2048, 1, 256]
+    - [112, 4709.95]
+  - - [9728, 1536, 1, 256]
+    - [112, 4617.14]
+  - - [5120, 1792, 1, 256]
+    - [120, 4542.46]
+  - - [30208, 256, 1, 256]
+    - [105, 4500.57]
+  - - [34560, 9216, 1, 256]
+    - [112, 4848.67]
+  - - [33536, 1281, 1, 256]
+    - [110, 4673.17]
+  - - [12032, 8705, 1, 256]
+    - [112, 4745.31]
+  - - [10752, 7425, 1, 256]
+    - [105, 4762.81]
+  - - [12288, 512, 1, 256]
+    - [132, 4448.72]
+  - - [44032, 1792, 1, 256]
+    - [105, 4829.11]
+  - - [18688, 1536, 1, 256]
+    - [112, 4729.2]
+  - - [16128, 3840, 1, 256]
+    - [112, 4812.32]
+  - - [38656, 768, 1, 256]
+    - [105, 4753.85]
+  - - [27136, 1024, 1, 256]
+    - [112, 4729.24]
+  - - [21248, 1792, 1, 256]
+    - [105, 4792.88]
+  - - [36352, 3072, 1, 256]
+    - [112, 4809.94]
+  - - [16896, 1281, 1, 256]
+    - [108, 4608.58]
+  - - [19968, 7680, 1, 256]
+    - [112, 4825.83]
+  - - [14848, 1536, 1, 256]
+    - [112, 4674.22]
+  - - [3840, 513, 1, 256]
+    - [110, 3652.23]
+  - - [21248, 256, 1, 256]
+    - [105, 4427.97]
+  - - [3584, 1792, 1, 256]
+    - [132, 4459.13]
+  - - [12032, 512, 1, 256]
+    - [130, 4430.44]
+  - - [38400, 3072, 1, 256]
+    - [112, 4825.23]
+  - - [5376, 768, 1, 256]
+    - [131, 4338.22]
+  - - [37888, 1280, 1, 256]
+    - [105, 4799.27]
+  - - [5888, 2048, 1, 256]
+    - [112, 4597.05]
+  - - [20224, 9216, 1, 256]
+    - [112, 4834.93]
+  - - [17408, 5120, 1, 256]
+    - [112, 4812.9]
+  - - [28928, 9216, 1, 256]
+    - [112, 4834.26]
+  - - [19456, 1792, 1, 256]
+    - [105, 4782.7]
+  - - [8192, 2048, 1, 256]
+    - [112, 4635.99]
+  - - [40960, 2048, 1, 256]
+    - [112, 4809.85]
+  - - [10752, 3072, 1, 256]
+    - [112, 4766.58]
+  - - [35072, 1792, 1, 256]
+    - [105, 4821.73]
+  - - [28672, 1281, 1, 256]
+    - [110, 4664.35]
+  - - [7168, 2048, 1, 256]
+    - [112, 4611.62]
+  - - [31488, 19200, 1, 256]
+    - [105, 4859.12]
+  - - [11008, 7937, 1, 256]
+    - [105, 4756.64]
+  - - [21248, 8705, 1, 256]
+    - [112, 4769.8]
+  - - [13568, 3072, 1, 256]
+    - [112, 4753.18]
+  - - [29696, 2048, 1, 256]
+    - [112, 4794.67]
+  - - [3328, 256, 1, 256]
+    - [93, 3470.79]
+  - - [28416, 1280, 1, 256]
+    - [105, 4784.67]
+  - - [39168, 1280, 1, 256]
+    - [105, 4812.29]
+  - - [15616, 3329, 1, 256]
+    - [110, 4713.45]
+  - - [36864, 3072, 1, 256]
+    - [112, 4822.1]
+  - - [34560, 22273, 1, 256]
+    - [105, 4831.11]
+  - - [11520, 1280, 1, 256]
+    - [112, 4650.01]
+  - - [34048, 768, 1, 256]
+    - [105, 4751.5]
+  - - [40448, 27648, 1, 256]
+    - [112, 4842.87]
+  - - [28416, 16129, 1, 256]
+    - [105, 4834.06]
+  - - [8960, 512, 1, 256]
+    - [130, 4349.65]
+  - - [34816, 22529, 1, 256]
+    - [112, 4796.61]
+  - - [22528, 3072, 1, 256]
+    - [112, 4799.36]
+  - - [27136, 14593, 1, 256]
+    - [105, 4814.16]
+  - - [5888, 256, 1, 256]
+    - [125, 3927.89]
+  - - [35584, 3072, 1, 256]
+    - [112, 4820.51]
+  - - [43008, 3072, 1, 256]
+    - [112, 4821.42]
+  - - [30208, 2048, 1, 256]
+    - [112, 4798.95]
+  - - [10496, 1024, 1, 256]
+    - [132, 4568.72]
+  - - [30464, 1792, 1, 256]
+    - [105, 4806.51]
+  - - [16384, 4097, 1, 256]
+    - [112, 4692.23]
+  - - [20992, 9216, 1, 256]
+    - [112, 4831.63]
+  - - [43776, 1536, 1, 256]
+    - [112, 4798.57]
+  - - [4864, 256, 1, 256]
+    - [119, 3857.3]
+  - - [14848, 2048, 1, 256]
+    - [112, 4732.41]
+  - - [9728, 256, 1, 256]
+    - [132, 4066.94]
+  - - [3072, 2817, 1, 256]
+    - [108, 4424.74]
+  - - [31488, 1792, 1, 256]
+    - [112, 4812.17]
+  - - [31488, 9216, 1, 256]
+    - [112, 4844.13]
+  - - [26368, 1281, 1, 256]
+    - [103, 4658.45]
+  - - [22272, 9984, 1, 256]
+    - [112, 4859.96]
+  - - [41728, 1537, 1, 256]
+    - [112, 4579.76]
+  - - [34560, 768, 1, 256]
+    - [112, 4738.73]
+  - - [26880, 1792, 1, 256]
+    - [105, 4804.51]
+  - - [30464, 768, 1, 256]
+    - [105, 4732.06]
+  - - [8448, 1281, 1, 256]
+    - [110, 4490.7]
+  - - [40704, 1281, 1, 256]
+    - [110, 4685.52]
+  - - [22784, 9216, 1, 256]
+    - [112, 4842.37]
+  - - [24320, 1281, 1, 256]
+    - [110, 4657.44]
+  - - [30720, 1281, 1, 256]
+    - [110, 4673.67]
+  - - [17920, 1280, 1, 256]
+    - [112, 4730.01]
+  - - [7936, 2048, 1, 256]
+    - [112, 4626.35]
+  - - [37632, 1281, 1, 256]
+    - [110, 4687.29]
+  - - [3328, 1792, 1, 256]
+    - [132, 4466.73]
+  - - [2816, 1792, 1, 256]
+    - [119, 4367.3]
+  - - [41472, 1537, 1, 256]
+    - [112, 4581.41]
+  - - [16896, 1024, 1, 256]
+    - [112, 4661.71]
+  - - [33536, 1280, 1, 256]
+    - [105, 4794.62]
+  - - [30720, 512, 1, 256]
+    - [112, 4645.71]
+  - - [28672, 1024, 1, 256]
+    - [112, 4715.54]
+  - - [43008, 27648, 1, 256]
+    - [112, 4841.98]
+  - - [39424, 27137, 1, 256]
+    - [112, 4798.88]
+  - - [24320, 1792, 1, 256]
+    - [105, 4790.98]
+  - - [34816, 1280, 1, 256]
+    - [105, 4790.99]
+  - - [21504, 256, 1, 256]
+    - [125, 4444.02]
+  - - [32000, 3072, 1, 256]
+    - [112, 4828.33]
+  - - [6144, 768, 1, 256]
+    - [112, 4422.82]
+  - - [12800, 1792, 1, 256]
+    - [105, 4714.06]
+  - - [41728, 1280, 1, 256]
+    - [112, 4797.09]
+  - - [15872, 3072, 1, 256]
+    - [112, 4772.96]
+  - - [23296, 512, 1, 256]
+    - [112, 4574.32]
+  - - [30720, 768, 1, 256]
+    - [105, 4728.49]
+  - - [43776, 27648, 1, 256]
+    - [112, 4848.96]
+  - - [33792, 1281, 1, 256]
+    - [110, 4679.89]
+  - - [22016, 2048, 1, 256]
+    - [112, 4766.18]
+  - - [15872, 1792, 1, 256]
+    - [105, 4740.56]
+  - - [36608, 1280, 1, 256]
+    - [105, 4804.05]
+  - - [39936, 1792, 1, 256]
+    - [105, 4819.82]
+  - - [10496, 7425, 1, 256]
+    - [105, 4759.17]
+  - - [16896, 4608, 1, 256]
+    - [112, 4804.26]
+  - - [9984, 6913, 1, 256]
+    - [105, 4769.47]
+  - - [21248, 8960, 1, 256]
+    - [105, 4849.79]
+  - - [37376, 256, 1, 256]
+    - [112, 4538.75]
+  - - [27392, 1536, 1, 256]
+    - [112, 4770.56]
+  - - [14336, 1792, 1, 256]
+    - [112, 4720.55]
+  - - [9472, 1280, 1, 256]
+    - [112, 4623.96]
+  - - [24832, 12544, 1, 256]
+    - [105, 4860.23]
+  - - [30464, 18176, 1, 256]
+    - [105, 4860.12]
+  - - [36096, 1280, 1, 256]
+    - [105, 4797.26]
+  - - [5632, 512, 1, 256]
+    - [132, 4254.25]
+  - - [31744, 19201, 1, 256]
+    - [105, 4822.46]
+  - - [11008, 1280, 1, 256]
+    - [105, 4639.24]
+  - - [27648, 1024, 1, 256]
+    - [112, 4740.07]
+  - - [41216, 768, 1, 256]
+    - [105, 4760.1]
+  - - [1792, 768, 1, 256]
+    - [120, 3724.33]
+  - - [26112, 2048, 1, 256]
+    - [112, 4783.17]
+  - - [20992, 1280, 1, 256]
+    - [112, 4746.91]
+  - - [41216, 1281, 1, 256]
+    - [110, 4688.7]
+  - - [35584, 2048, 1, 256]
+    - [112, 4796.84]
+  - - [23040, 1280, 1, 256]
+    - [105, 4765.53]
+  - - [33792, 1792, 1, 256]
+    - [105, 4824.64]
+  - - [9216, 1024, 1, 256]
+    - [112, 4553.19]
+  - - [16896, 9216, 1, 256]
+    - [112, 4839.61]
+  - - [1536, 2048, 1, 256]
+    - [120, 4324.02]
+  - - [31744, 256, 1, 256]
+    - [105, 4520.2]
+  - - [43264, 3328, 1, 256]
+    - [112, 4840.79]
+  - - [40192, 3072, 1, 256]
+    - [112, 4823.69]
+  - - [32000, 512, 1, 256]
+    - [112, 4651.04]
+  - - [42240, 3072, 1, 256]
+    - [112, 4824.32]
+  - - [7168, 256, 1, 256]
+    - [120, 4080.63]
+  - - [32256, 9216, 1, 256]
+    - [112, 4837.82]
+  - - [29952, 256, 1, 256]
+    - [112, 4498.84]
+  - - [41984, 2049, 1, 256]
+    - [110, 4668.15]
+  - - [6656, 1792, 1, 256]
+    - [105, 4589.18]
+  - - [13824, 1537, 1, 256]
+    - [108, 4494.89]
+  - - [20736, 3072, 1, 256]
+    - [112, 4807.34]
+  - - [8192, 768, 1, 256]
+    - [130, 4489.89]
+  - - [43008, 768, 1, 256]
+    - [105, 4777.46]
+  - - [8448, 1024, 1, 256]
+    - [132, 4533.27]
+  - - [36096, 23809, 1, 256]
+    - [105, 4837.14]
+  - - [41728, 9216, 1, 256]
+    - [112, 4836.84]
+  - - [28160, 1281, 1, 256]
+    - [110, 4670.68]
+  - - [25600, 768, 1, 256]
+    - [112, 4685.5]
+  - - [9216, 1281, 1, 256]
+    - [110, 4506.53]
+  - - [43776, 2048, 1, 256]
+    - [112, 4818.69]
+  - - [23040, 256, 1, 256]
+    - [105, 4513.24]
+  - - [44032, 4096, 1, 256]
+    - [112, 4827.33]
+  - - [37632, 768, 1, 256]
+    - [105, 4761.47]
+  - - [43008, 256, 1, 256]
+    - [105, 4581.26]
+  - - [34304, 2048, 1, 256]
+    - [112, 4806.09]
+  - - [10496, 256, 1, 256]
+    - [132, 4061.56]
+  - - [25600, 9216, 1, 256]
+    - [112, 4829.57]
+  - - [19968, 3072, 1, 256]
+    - [112, 4793.72]
+  - - [40448, 256, 1, 256]
+    - [112, 4561.54]
+  - - [18176, 1280, 1, 256]
+    - [105, 4714.19]
+  - - [15616, 9216, 1, 256]
+    - [112, 4815.92]
+  - - [29184, 16897, 1, 256]
+    - [112, 4796.73]
+  - - [7168, 3841, 1, 256]
+    - [110, 4620.85]
+  - - [40704, 769, 1, 256]
+    - [110, 4442.57]
+  - - [39936, 1281, 1, 256]
+    - [110, 4694.61]
+  - - [6144, 3073, 1, 256]
+    - [112, 4545.93]
+  - - [9984, 1281, 1, 256]
+    - [108, 4535.54]
+  - - [8192, 1281, 1, 256]
+    - [110, 4502.33]
+  - - [41728, 2048, 1, 256]
+    - [112, 4809.51]
+  - - [34304, 1792, 1, 256]
+    - [105, 4816.97]
+  - - [39936, 1280, 1, 256]
+    - [105, 4805.6]
+  - - [28160, 2048, 1, 256]
+    - [112, 4789.07]
+  - - [43520, 9216, 1, 256]
+    - [112, 4839.39]
+  - - [18688, 6400, 1, 256]
+    - [112, 4838.81]
+  - - [35840, 512, 1, 256]
+    - [112, 4674.62]
+  - - [39680, 512, 1, 256]
+    - [112, 4676.6]
+  - - [20992, 1536, 1, 256]
+    - [112, 4739.11]
+  - - [2816, 1280, 1, 256]
+    - [118, 4347.66]
+  - - [7680, 4608, 1, 256]
+    - [112, 4754.55]
+  - - [14592, 512, 1, 256]
+    - [130, 4454.96]
+  - - [21760, 768, 1, 256]
+    - [112, 4680.32]
+  - - [1536, 1280, 1, 256]
+    - [117, 4006.02]
+  - - [43264, 3072, 1, 256]
+    - [112, 4828.1]
+  - - [21760, 9216, 1, 256]
+    - [112, 4829.37]
+  - - [18432, 768, 1, 256]
+    - [112, 4650.53]
+  - - [9216, 512, 1, 256]
+    - [130, 4403.47]
+  - - [11264, 768, 1, 256]
+    - [132, 4547.42]
+  - - [42496, 3072, 1, 256]
+    - [112, 4816.57]
+  - - [19712, 2048, 1, 256]
+    - [112, 4774.18]
+  - - [34048, 1280, 1, 256]
+    - [105, 4794.27]
+  - - [43520, 2048, 1, 256]
+    - [112, 4804.39]
+  - - [12800, 1281, 1, 256]
+    - [110, 4547.76]
+  - - [15104, 1536, 1, 256]
+    - [112, 4697.79]
+  - - [30208, 17665, 1, 256]
+    - [105, 4818.99]
+  - - [27392, 15105, 1, 256]
+    - [105, 4833.34]
+  - - [512, 513, 1, 256]
+    - [116, 2052.52]
+  - - [17920, 256, 1, 256]
+    - [112, 4368.42]
+  - - [1792, 512, 1, 256]
+    - [94, 3651.76]
+  - - [13312, 1536, 1, 256]
+    - [112, 4668.32]
+  - - [29952, 17409, 1, 256]
+    - [112, 4793.55]
+  - - [9472, 2048, 1, 256]
+    - [112, 4657.02]
+  - - [43264, 1280, 1, 256]
+    - [112, 4807.96]
+  - - [44032, 3072, 1, 256]
+    - [112, 4826.52]
+  - - [28416, 256, 1, 256]
+    - [125, 4490.86]
+  - - [3840, 1280, 1, 256]
+    - [132, 4423.13]
+  - - [32768, 9216, 1, 256]
+    - [112, 4852.41]
+  - - [37632, 512, 1, 256]
+    - [112, 4687.62]
+  - - [41216, 9216, 1, 256]
+    - [112, 4837.71]
+  - - [8448, 1536, 1, 256]
+    - [112, 4611.17]
+  - - [41216, 512, 1, 256]
+    - [112, 4697.62]
+  - - [36352, 768, 1, 256]
+    - [105, 4750.79]
+  - - [2560, 2560, 1, 256]
+    - [120, 4464.88]
+  - - [12288, 1280, 1, 256]
+    - [105, 4670.28]
+  - - [768, 513, 1, 256]
+    - [119, 2925.17]
+  - - [36352, 2048, 1, 256]
+    - [112, 4801.17]
+  - - [23552, 768, 1, 256]
+    - [105, 4680.5]
+  - - [11264, 1281, 1, 256]
+    - [110, 4531.02]
+  - - [4096, 1281, 1, 256]
+    - [103, 4236.77]
+  - - [7168, 3072, 1, 256]
+    - [112, 4672.39]
+  - - [19712, 1792, 1, 256]
+    - [105, 4777.84]
+  - - [23040, 2048, 1, 256]
+    - [112, 4778.02]
+  - - [27136, 1281, 1, 256]
+    - [108, 4662.12]
+  - - [6144, 1024, 1, 256]
+    - [132, 4398.18]
+  - - [44288, 4353, 1, 256]
+    - [103, 4773.42]
+  - - [43776, 1281, 1, 256]
+    - [110, 4695.1]
+  - - [36608, 768, 1, 256]
+    - [112, 4754.04]
+  - - [34816, 768, 1, 256]
+    - [105, 4744.45]
+  - - [15616, 3073, 1, 256]
+    - [112, 4650.77]
+  - - [37376, 24833, 1, 256]
+    - [105, 4830.05]
+  - - [38144, 25857, 1, 256]
+    - [105, 4844.84]
+  - - [26880, 14592, 1, 256]
+    - [105, 4865.07]
+  - - [6144, 2817, 1, 256]
+    - [105, 4561.4]
+  - - [35584, 1280, 1, 256]
+    - [105, 4808.79]
+  - - [23808, 768, 1, 256]
+    - [105, 4693.99]
+  - - [33280, 1281, 1, 256]
+    - [110, 4674.37]
+  - - [29184, 2048, 1, 256]
+    - [112, 4798.6]
+  - - [35072, 1024, 1, 256]
+    - [112, 4749.41]
+  - - [39168, 26881, 1, 256]
+    - [105, 4847.51]
+  - - [20736, 1280, 1, 256]
+    - [105, 4758.78]
+  - - [5120, 1793, 1, 256]
+    - [110, 4432.19]
+  - - [32512, 19969, 1, 256]
+    - [112, 4799.86]
+  - - [17664, 1281, 1, 256]
+    - [110, 4624.21]
+  - - [3072, 256, 1, 256]
+    - [121, 3847.99]
+  - - [32512, 512, 1, 256]
+    - [112, 4637.01]
+  - - [5632, 1281, 1, 256]
+    - [110, 4383.27]
+  - - [25088, 9216, 1, 256]
+    - [112, 4844.72]
+  - - [42240, 1280, 1, 256]
+    - [105, 4803.3]
+  - - [43008, 2817, 1, 256]
+    - [110, 4732.96]
+  - - [26112, 13825, 1, 256]
+    - [112, 4787.24]
+  - - [38912, 512, 1, 256]
+    - [112, 4686.55]
+  - - [1024, 1024, 1, 256]
+    - [101, 3959.24]
+  - - [31744, 2048, 1, 256]
+    - [112, 4789.52]
+  - - [22272, 1024, 1, 256]
+    - [112, 4712.85]
+  - - [4352, 3072, 1, 256]
+    - [132, 4595.02]
+  - - [14336, 1280, 1, 256]
+    - [105, 4700.82]
+  - - [33536, 3072, 1, 256]
+    - [112, 4818.29]
+  - - [9728, 6657, 1, 256]
+    - [112, 4709.61]
+  - - [2048, 3072, 1, 256]
+    - [120, 4489.89]
+  - - [40448, 512, 1, 256]
+    - [112, 4692.18]
+  - - [24832, 9216, 1, 256]
+    - [112, 4831.55]
+  - - [37888, 1536, 1, 256]
+    - [112, 4790.35]
+  - - [5632, 2561, 1, 256]
+    - [110, 4506.04]
+  - - [41472, 1280, 1, 256]
+    - [112, 4801.35]
+  - - [3072, 3072, 1, 256]
+    - [112, 4565.24]
+  - - [29184, 1281, 1, 256]
+    - [110, 4672.36]
+  - - [33280, 20992, 1, 256]
+    - [112, 4848.72]
+  - - [25344, 1281, 1, 256]
+    - [110, 4653.43]
+  - - [4096, 1280, 1, 256]
+    - [120, 4448.42]
+  - - [20224, 7936, 1, 256]
+    - [105, 4850.38]
+  - - [4352, 1024, 1, 256]
+    - [132, 4383.17]
+  - - [28928, 512, 1, 256]
+    - [112, 4637.54]
+  - - [28672, 16384, 1, 256]
+    - [112, 4858.25]
+  - - [28416, 9216, 1, 256]
+    - [112, 4844.95]
+  - - [37120, 256, 1, 256]
+    - [112, 4530.84]
+  - - [7936, 768, 1, 256]
+    - [130, 4398.13]
+  - - [38912, 2048, 1, 256]
+    - [112, 4817.31]
+  - - [23552, 11265, 1, 256]
+    - [112, 4775.79]
+  - - [25088, 3072, 1, 256]
+    - [112, 4800.44]
+  - - [32000, 19457, 1, 256]
+    - [112, 4794.68]
+  - - [44800, 3072, 1, 256]
+    - [112, 4829.58]
+  - - [37120, 1792, 1, 256]
+    - [105, 4817.17]
+  - - [32512, 256, 1, 256]
+    - [125, 4519.57]
+  - - [30464, 18177, 1, 256]
+    - [105, 4829.14]
+  - - [4864, 2048, 1, 256]
+    - [132, 4531.49]
+  - - [44544, 4608, 1, 256]
+    - [112, 4828.69]
+  - - [29440, 1280, 1, 256]
+    - [105, 4774.75]
+  - - [7168, 768, 1, 256]
+    - [132, 4410.64]
+  - - [11008, 1024, 1, 256]
+    - [112, 4572.9]
+  - - [18944, 9216, 1, 256]
+    - [112, 4824.77]
+  - - [11776, 2048, 1, 256]
+    - [112, 4701.36]
+  - - [33280, 20737, 1, 256]
+    - [105, 4819.91]
+  - - [1536, 512, 1, 256]
+    - [127, 3850.95]
+  - - [25856, 3072, 1, 256]
+    - [112, 4807.36]
+  - - [9472, 1281, 1, 256]
+    - [108, 4494.46]
+  - - [8192, 1280, 1, 256]
+    - [105, 4566.47]
+  - - [24320, 768, 1, 256]
+    - [105, 4700.29]
+  - - [43008, 2048, 1, 256]
+    - [112, 4816.67]
+  - - [27648, 9216, 1, 256]
+    - [112, 4845.69]
+  - - [39168, 256, 1, 256]
+    - [112, 4555.79]
+  - - [42752, 9216, 1, 256]
+    - [112, 4838.33]
+  - - [5120, 2049, 1, 256]
+    - [110, 4447.65]
+  - - [28160, 9216, 1, 256]
+    - [112, 4833.58]
+  - - [37632, 25089, 1, 256]
+    - [112, 4800.13]
+  - - [28928, 768, 1, 256]
+    - [105, 4725.39]
+  - - [22016, 1792, 1, 256]
+    - [105, 4788.49]
+  - - [16384, 9216, 1, 256]
+    - [112, 4826.53]
+  - - [23040, 512, 1, 256]
+    - [130, 4549.68]
+  - - [21504, 9217, 1, 256]
+    - [112, 4768.26]
+  - - [20480, 7937, 1, 256]
+    - [105, 4791.78]
+  - - [33536, 21248, 1, 256]
+    - [105, 4868.92]
+  - - [41728, 1281, 1, 256]
+    - [110, 4684.42]
+  - - [12800, 768, 1, 256]
+    - [105, 4508.71]
+  - - [28672, 9216, 1, 256]
+    - [112, 4836.98]
+  - - [6144, 1280, 1, 256]
+    - [105, 4537.25]
+  - - [30976, 1280, 1, 256]
+    - [105, 4780.53]
+  - - [14592, 1024, 1, 256]
+    - [112, 4635.04]
+  - - [32000, 9216, 1, 256]
+    - [112, 4838.76]
+  - - [40448, 1280, 1, 256]
+    - [105, 4805.24]
+  - - [16384, 4096, 1, 256]
+    - [112, 4800.08]
+  - - [44544, 3072, 1, 256]
+    - [112, 4822.47]
+  - - [5376, 3072, 1, 256]
+    - [110, 4626.28]
+  - - [39680, 1024, 1, 256]
+    - [112, 4764.07]
+  - - [35584, 1792, 1, 256]
+    - [105, 4817.97]
+  - - [26368, 256, 1, 256]
+    - [125, 4437.73]
+  - - [35840, 23297, 1, 256]
+    - [105, 4828.72]
+  - - [23808, 11521, 1, 256]
+    - [105, 4820.27]
+  - - [13312, 1025, 1, 256]
+    - [110, 4404.21]
+  - - [18176, 9216, 1, 256]
+    - [112, 4829.68]
+  - - [17920, 5633, 1, 256]
+    - [112, 4723.19]
+  - - [23808, 1281, 1, 256]
+    - [110, 4648.21]
+  - - [33024, 1280, 1, 256]
+    - [105, 4798.46]
+  - - [27648, 3072, 1, 256]
+    - [112, 4812.55]
+  - - [27392, 1024, 1, 256]
+    - [112, 4728.59]
+  - - [1024, 3072, 1, 256]
+    - [118, 4333.33]
+  - - [22016, 9216, 1, 256]
+    - [112, 4829.86]
+  - - [20992, 1281, 1, 256]
+    - [110, 4636.71]
+  - - [3840, 1281, 1, 256]
+    - [110, 4247.42]
+  - - [21760, 9473, 1, 256]
+    - [105, 4803.36]
+  - - [10240, 256, 1, 256]
+    - [129, 4141.5]
+  - - [6144, 1536, 1, 256]
+    - [112, 4509.34]
+  - - [16896, 1536, 1, 256]
+    - [112, 4702.56]
+  - - [19968, 768, 1, 256]
+    - [112, 4667.21]
+  - - [23552, 11264, 1, 256]
+    - [112, 4836.92]
+  - - [27904, 3072, 1, 256]
+    - [112, 4815.88]
+  - - [19712, 7425, 1, 256]
+    - [105, 4790.2]
+  - - [26624, 14081, 1, 256]
+    - [105, 4813.04]
+  - - [31232, 1280, 1, 256]
+    - [105, 4783.36]
+  - - [3328, 257, 1, 256]
+    - [98, 3323.57]
+  - - [24320, 9216, 1, 256]
+    - [112, 4835.7]
+  - - [14080, 3072, 1, 256]
+    - [112, 4766.91]
+  - - [17408, 3072, 1, 256]
+    - [112, 4781.17]
+  - - [21504, 9216, 1, 256]
+    - [112, 4830.07]
+  - - [30976, 1024, 1, 256]
+    - [112, 4738.66]
+  - - [10752, 1281, 1, 256]
+    - [110, 4531.16]
+  - - [14848, 2560, 1, 256]
+    - [112, 4735.08]
+  - - [41728, 1024, 1, 256]
+    - [112, 4762.69]
+  - - [34304, 3072, 1, 256]
+    - [112, 4820.66]
+  - - [15104, 9216, 1, 256]
+    - [112, 4819.55]
+  - - [10496, 768, 1, 256]
+    - [132, 4528.21]
+  - - [17152, 4865, 1, 256]
+    - [105, 4751.79]
+  - - [41472, 2048, 1, 256]
+    - [112, 4807.23]
+  - - [38912, 26625, 1, 256]
+    - [112, 4798.65]
+  - - [25600, 2048, 1, 256]
+    - [112, 4782.63]
+  - - [44288, 1281, 1, 256]
+    - [110, 4686.98]
+  - - [41216, 1792, 1, 256]
+    - [105, 4823.45]
+  - - [39424, 3072, 1, 256]
+    - [112, 4813.38]
+  - - [30720, 18433, 1, 256]
+    - [112, 4794.7]
+  - - [14848, 1024, 1, 256]
+    - [112, 4643.88]
+  - - [39424, 2048, 1, 256]
+    - [112, 4803.38]
+  - - [21760, 2048, 1, 256]
+    - [112, 4771.44]
+  - - [18944, 6657, 1, 256]
+    - [112, 4742.77]
+  - - [5632, 1792, 1, 256]
+    - [105, 4570.32]
+  - - [24064, 1024, 1, 256]
+    - [112, 4699.64]
+  - - [2304, 1281, 1, 256]
+    - [96, 4111.7]
+  - - [18176, 1792, 1, 256]
+    - [105, 4777.73]
+  - - [31232, 9216, 1, 256]
+    - [112, 4838.26]
+  - - [31744, 1536, 1, 256]
+    - [112, 4784.08]
+  - - [42752, 2561, 1, 256]
+    - [112, 4668.78]
+  - - [18688, 9216, 1, 256]
+    - [112, 4823.61]
+  - - [13568, 256, 1, 256]
+    - [112, 4329.92]
+  - - [19968, 256, 1, 256]
+    - [130, 4365.57]
+  - - [12032, 2048, 1, 256]
+    - [112, 4705.39]
+  - - [10240, 1024, 1, 256]
+    - [112, 4558.1]
+  - - [18944, 2048, 1, 256]
+    - [112, 4767.99]
+  - - [43776, 1792, 1, 256]
+    - [105, 4825.72]
+  - - [25344, 1280, 1, 256]
+    - [105, 4776.67]
+  - - [10240, 1792, 1, 256]
+    - [105, 4701.95]
+  - - [33792, 21505, 1, 256]
+    - [112, 4800.35]
+  - - [35072, 1536, 1, 256]
+    - [112, 4780.99]
+  - - [43008, 512, 1, 256]
+    - [112, 4688.24]
+  - - [25856, 13313, 1, 256]
+    - [112, 4786.85]
+  - - [32000, 1280, 1, 256]
+    - [105, 4779.55]
+  - - [29952, 3072, 1, 256]
+    - [112, 4822.38]
+  - - [23296, 1536, 1, 256]
+    - [112, 4759.52]
+  - - [5888, 768, 1, 256]
+    - [110, 4338.94]
+  - - [20480, 9216, 1, 256]
+    - [112, 4832.17]
+  - - [21504, 1536, 1, 256]
+    - [112, 4748.38]
+  - - [7424, 1280, 1, 256]
+    - [132, 4510.34]
+  - - [33024, 2048, 1, 256]
+    - [112, 4806.53]
+  - - [19200, 1280, 1, 256]
+    - [105, 4744.12]
+  - - [11008, 7936, 1, 256]
+    - [105, 4826.24]
+  - - [17152, 1792, 1, 256]
+    - [105, 4765.22]
+  - - [38656, 1280, 1, 256]
+    - [105, 4801.96]
+  - - [22528, 768, 1, 256]
+    - [105, 4679.64]
+  - - [23040, 10753, 1, 256]
+    - [112, 4786.57]
+  - - [8960, 5889, 1, 256]
+    - [110, 4739.3]
+  - - [21504, 1280, 1, 256]
+    - [112, 4758.53]
+  - - [11008, 512, 1, 256]
+    - [132, 4418.3]
+  - - [16640, 4352, 1, 256]
+    - [105, 4830.74]
+  - - [30464, 3072, 1, 256]
+    - [112, 4809.35]
+  - - [7424, 512, 1, 256]
+    - [132, 4275.39]
+  - - [13312, 1281, 1, 256]
+    - [108, 4571.38]
+  - - [8960, 1281, 1, 256]
+    - [110, 4500.81]
+  - - [16128, 9216, 1, 256]
+    - [112, 4827.99]
+  - - [26880, 1281, 1, 256]
+    - [110, 4661.51]
+  - - [5632, 1280, 1, 256]
+    - [130, 4447.4]
+  - - [43008, 1280, 1, 256]
+    - [105, 4815.18]
+  - - [22528, 1280, 1, 256]
+    - [105, 4750.67]
+  - - [21504, 1792, 1, 256]
+    - [105, 4801.52]
+  - - [11776, 512, 1, 256]
+    - [132, 4403.97]
+  - - [6400, 768, 1, 256]
+    - [132, 4420.64]
+  - - [39680, 1536, 1, 256]
+    - [112, 4793.79]
+  - - [40704, 256, 1, 256]
+    - [112, 4582.84]
+  - - [25344, 13057, 1, 256]
+    - [105, 4829.06]
+  - - [16128, 256, 1, 256]
+    - [132, 4311.33]
+  - - [39424, 9216, 1, 256]
+    - [112, 4835.89]
+  - - [27648, 1792, 1, 256]
+    - [105, 4810.94]
+  - - [25600, 3072, 1, 256]
+    - [112, 4801.63]
+  - - [23808, 1024, 1, 256]
+    - [112, 4716.69]
+  - - [32000, 256, 1, 256]
+    - [112, 4542.83]
+  - - [28416, 3072, 1, 256]
+    - [112, 4821.08]
+  - - [24832, 1281, 1, 256]
+    - [110, 4648.86]
+  - - [12032, 8960, 1, 256]
+    - [105, 4831.47]
+  - - [25088, 1281, 1, 256]
+    - [110, 4657.43]
+  - - [12800, 257, 1, 256]
+    - [128, 3633.04]
+  - - [43264, 1792, 1, 256]
+    - [105, 4828.92]
+  - - [40192, 1280, 1, 256]
+    - [105, 4805.49]
+  - - [20736, 8193, 1, 256]
+    - [112, 4761.56]
+  - - [22272, 2048, 1, 256]
+    - [112, 4786.89]
+  - - [30976, 9216, 1, 256]
+    - [112, 4834.66]
+  - - [1280, 1281, 1, 256]
+    - [118, 3804.92]
+  - - [24320, 2048, 1, 256]
+    - [112, 4785.79]
+  - - [3840, 1024, 1, 256]
+    - [130, 4355.46]
+  - - [23552, 1536, 1, 256]
+    - [112, 4759.4]
+  - - [16384, 3072, 1, 256]
+    - [112, 4779.55]
+  - - [25856, 1280, 1, 256]
+    - [105, 4769.58]
+  - - [40192, 27648, 1, 256]
+    - [112, 4849.22]
+  - - [18688, 2048, 1, 256]
+    - [112, 4751.28]
+  - - [31232, 1792, 1, 256]
+    - [105, 4808.55]
+  - - [36352, 23809, 1, 256]
+    - [105, 4817.56]
+  - - [23552, 1281, 1, 256]
+    - [110, 4641.11]
+  - - [25344, 512, 1, 256]
+    - [112, 4621.95]
+  - - [15872, 3329, 1, 256]
+    - [105, 4694.35]
+  - - [1792, 1792, 1, 256]
+    - [117, 4190.89]
+  - - [31744, 1792, 1, 256]
+    - [105, 4809.58]
+  - - [14336, 1281, 1, 256]
+    - [110, 4596.85]
+  - - [9984, 3072, 1, 256]
+    - [112, 4742.88]
+  - - [11776, 1792, 1, 256]
+    - [105, 4711.72]
+  - - [7680, 1024, 1, 256]
+    - [112, 4540.52]
+  - - [37120, 1536, 1, 256]
+    - [112, 4790.72]
+  - - [14592, 2304, 1, 256]
+    - [105, 4778.43]
+  - - [16384, 1281, 1, 256]
+    - [110, 4605.14]
+  - - [7424, 768, 1, 256]
+    - [132, 4466.94]
+  - - [10240, 1536, 1, 256]
+    - [112, 4625.43]
+  - - [2816, 2561, 1, 256]
+    - [108, 4356.75]
+  - - [16896, 2048, 1, 256]
+    - [112, 4751.84]
+  - - [35072, 1280, 1, 256]
+    - [112, 4788.82]
+  - - [27392, 9216, 1, 256]
+    - [112, 4846.42]
+  - - [15104, 1280, 1, 256]
+    - [105, 4695.53]
+  - - [15104, 3072, 1, 256]
+    - [112, 4772.92]
+  - - [19200, 9216, 1, 256]
+    - [112, 4849.38]
+  - - [12544, 1024, 1, 256]
+    - [112, 4591.36]
+  - - [6656, 1280, 1, 256]
+    - [105, 4530.62]
+  - - [32256, 256, 1, 256]
+    - [112, 4583.94]
+  - - [36096, 23553, 1, 256]
+    - [112, 4806.18]
+  - - [14336, 256, 1, 256]
+    - [130, 4315.29]
+  - - [1024, 1025, 1, 256]
+    - [97, 3814.56]
+  - - [9216, 1280, 1, 256]
+    - [112, 4591.75]
+  - - [16128, 3841, 1, 256]
+    - [105, 4722.75]
+  - - [18432, 5889, 1, 256]
+    - [105, 4767.36]
+  - - [42496, 1280, 1, 256]
+    - [105, 4808.39]
+  - - [43776, 3841, 1, 256]
+    - [105, 4758.56]
+  - - [22528, 10241, 1, 256]
+    - [112, 4767.75]
+  - - [20224, 3072, 1, 256]
+    - [112, 4793.32]
+  - - [29184, 1024, 1, 256]
+    - [112, 4725.63]
+  - - [39680, 3072, 1, 256]
+    - [112, 4819.07]
+  - - [20736, 8449, 1, 256]
+    - [105, 4798.62]
+  - - [15104, 2816, 1, 256]
+    - [105, 4789.82]
+  - - [25088, 1536, 1, 256]
+    - [112, 4750.1]
+  - - [30720, 1792, 1, 256]
+    - [105, 4815.24]
+  - - [36864, 24321, 1, 256]
+    - [105, 4826.54]
+  - - [12288, 1281, 1, 256]
+    - [110, 4561.97]
+  - - [22784, 1536, 1, 256]
+    - [112, 4750.38]
+  - - [35584, 1281, 1, 256]
+    - [110, 4680.97]
+  - - [7424, 4097, 1, 256]
+    - [110, 4620.54]
+  - - [20224, 1281, 1, 256]
+    - [108, 4629.99]
+  - - [7680, 4609, 1, 256]
+    - [112, 4654.26]
+  - - [9216, 2048, 1, 256]
+    - [112, 4677.48]
+  - - [12032, 768, 1, 256]
+    - [105, 4552.36]
+  - - [1792, 3072, 1, 256]
+    - [120, 4480.76]
+  - - [6400, 3073, 1, 256]
+    - [110, 4559.69]
+  - - [29440, 17153, 1, 256]
+    - [105, 4826.92]
+  - - [8704, 1792, 1, 256]
+    - [105, 4671.24]
+  - - [20224, 2048, 1, 256]
+    - [112, 4753.01]
+  - - [30720, 3072, 1, 256]
+    - [112, 4821.54]
+  - - [37632, 256, 1, 256]
+    - [105, 4565.44]
+  - - [16384, 512, 1, 256]
+    - [132, 4521.4]
+  - - [38912, 256, 1, 256]
+    - [125, 4540.52]
+  - - [5120, 512, 1, 256]
+    - [130, 4269.02]
+  - - [17920, 2048, 1, 256]
+    - [112, 4758.63]
+  - - [30464, 256, 1, 256]
+    - [105, 4545.33]
+  - - [8704, 256, 1, 256]
+    - [105, 4128.73]
+  - - [16384, 3841, 1, 256]
+    - [105, 4711.23]
+  - - [40192, 9216, 1, 256]
+    - [112, 4832.45]
+  - - [15616, 1792, 1, 256]
+    - [105, 4738.14]
+  - - [32512, 1024, 1, 256]
+    - [112, 4751.37]
+  - - [23040, 1792, 1, 256]
+    - [105, 4800.63]
+  - - [42240, 1281, 1, 256]
+    - [103, 4690.19]
+  - - [6912, 1536, 1, 256]
+    - [112, 4573.14]
+  - - [37888, 25601, 1, 256]
+    - [112, 4790.28]
+  - - [26368, 14080, 1, 256]
+    - [105, 4857.23]
+  - - [37632, 1280, 1, 256]
+    - [105, 4802.71]
+  - - [30208, 3072, 1, 256]
+    - [112, 4811.28]
+  - - [36608, 1281, 1, 256]
+    - [104, 4682.02]
+  - - [30464, 512, 1, 256]
+    - [112, 4650.35]
+  - - [26880, 768, 1, 256]
+    - [105, 4722.64]
+  - - [33024, 20736, 1, 256]
+    - [105, 4866.97]
+  - - [35072, 22784, 1, 256]
+    - [105, 4871.82]
+  - - [9472, 6145, 1, 256]
+    - [112, 4705.49]
+  - - [22784, 1792, 1, 256]
+    - [105, 4794.68]
+  - - [22272, 1280, 1, 256]
+    - [105, 4761.78]
+  - - [13568, 1281, 1, 256]
+    - [110, 4582.51]
+  - - [5120, 1536, 1, 256]
+    - [132, 4498.32]
+  - - [25088, 2048, 1, 256]
+    - [112, 4779.56]
+  - - [6656, 3072, 1, 256]
+    - [112, 4667.99]
+  - - [32768, 1280, 1, 256]
+    - [105, 4791.44]
+  - - [768, 2048, 1, 256]
+    - [120, 4134.03]
+  - - [4352, 1281, 1, 256]
+    - [105, 4253.13]
+  - - [27904, 1281, 1, 256]
+    - [110, 4670.36]
+  - - [15104, 2048, 1, 256]
+    - [112, 4734.57]
+  - - [9728, 1281, 1, 256]
+    - [108, 4499.02]
+  - - [30720, 2048, 1, 256]
+    - [112, 4798.86]
+  - - [1024, 1280, 1, 256]
+    - [119, 4056.39]
+  - - [10496, 1280, 1, 256]
+    - [112, 4609.87]
+  - - [6400, 3328, 1, 256]
+    - [105, 4702.95]
+  - - [36352, 1024, 1, 256]
+    - [112, 4739.61]
+  - - [12544, 1280, 1, 256]
+    - [105, 4649.79]
+  - - [40704, 512, 1, 256]
+    - [112, 4686.7]
+  - - [10240, 1281, 1, 256]
+    - [108, 4527.65]
+  - - [8704, 1281, 1, 256]
+    - [110, 4492.22]
+  - - [40192, 1024, 1, 256]
+    - [112, 4770.48]
+  - - [13312, 1792, 1, 256]
+    - [112, 4730.81]
+  - - [41984, 27648, 1, 256]
+    - [112, 4850.9]
+  - - [33024, 20481, 1, 256]
+    - [112, 4799.31]
+  - - [33280, 1536, 1, 256]
+    - [112, 4781.02]
+  - - [9216, 3072, 1, 256]
+    - [112, 4724.13]
+  - - [2816, 1536, 1, 256]
+    - [130, 4328.77]
+  - - [22528, 1792, 1, 256]
+    - [105, 4788.16]
+  - - [25088, 768, 1, 256]
+    - [105, 4695.12]
 - null


### PR DESCRIPTION
Passed full rocblas-test on both Vega 10 and Vega 20 overnight.