### PR TITLE
add Radeon VII

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -60,7 +60,10 @@ if( BUILD_WITH_TENSILE )
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
     # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc)
+    target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc )
+    foreach( target ${AMDGPU_TARGETS} )
+      target_compile_options( Tensile PRIVATE --amdgpu-target=${target} )
+    endforeach( )
   endif( )
 
   if( ROCBLAS_SHARED_LIBS )
@@ -147,9 +150,8 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( rocblas PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc )
-
   foreach( target ${AMDGPU_TARGETS} )
-    target_link_libraries( rocblas PRIVATE --amdgpu-target=${target} )
+    target_compile_options( rocblas PRIVATE --amdgpu-target=${target} )
   endforeach( )
 endif( )
 

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.8.1}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7]
+- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false


### PR DESCRIPTION
- Add Radeon VII to all vega20 logic files.
- Make sure whenever -fno-gpu-rdc is used, --amdgpu-target= options are explicitly specified to have the appropriate fat code objects generated; it also ensures that rocBLAS can be built when GPU isn't present, such as in docker.