### PR TITLE
Trsm Hip and Fill Source Kernels with Higher Priority

### DIFF
--- a/library/src/blas3/rocblas_trsm.cpp
+++ b/library/src/blas3/rocblas_trsm.cpp
@@ -646,7 +646,7 @@ __global__ void copy_void_ptr_matrix_trsm(rocblas_int rows,
                                           void* b,
                                           rocblas_int ldb)
 {
-    asm volatile ("s_setprio 2");
+    asm volatile("s_setprio 2");
 
     size_t tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     size_t ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;

--- a/library/src/blas3/rocblas_trsm.cpp
+++ b/library/src/blas3/rocblas_trsm.cpp
@@ -646,6 +646,8 @@ __global__ void copy_void_ptr_matrix_trsm(rocblas_int rows,
                                           void* b,
                                           rocblas_int ldb)
 {
+    asm volatile ("s_setprio 2");
+
     size_t tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     size_t ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
 

--- a/library/src/blas3/trtri_trsm.hpp
+++ b/library/src/blas3/trtri_trsm.hpp
@@ -52,7 +52,7 @@ __global__ void rocblas_tritri_batched_fill(rocblas_handle handle,
                                             T* A,
                                             rocblas_int batch_count)
 {
-    asm volatile ("s_setprio 2");
+    asm volatile("s_setprio 2");
     // if(!handle)
     //     return rocblas_status_invalid_handle;
 

--- a/library/src/blas3/trtri_trsm.hpp
+++ b/library/src/blas3/trtri_trsm.hpp
@@ -52,6 +52,7 @@ __global__ void rocblas_tritri_batched_fill(rocblas_handle handle,
                                             T* A,
                                             rocblas_int batch_count)
 {
+    asm volatile ("s_setprio 2");
     // if(!handle)
     //     return rocblas_status_invalid_handle;
 


### PR DESCRIPTION
Contributes towards #172044

Summary of proposed changes:
-  Adding assembly setPrio instruction to trsm kernels as an effort to improve parallelism