### PR TITLE
Add HPL-like initialization to rocblas-bench

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -453,8 +453,8 @@ int main(int argc, char* argv[]) try
 
         ("initialization",
          value<std::string>(&initialization)->default_value("rand_int"),
-         "Intialize with random integers or trig functions sin and cos. "
-         "Options: rand_int, trig_float")
+         "Intialize with random integers, trig functions sin and cos, or hpl-like input. "
+         "Options: rand_int, trig_float, hpl")
 
         ("transposeA",
          value<char>(&arg.transA)->default_value('N'),

--- a/clients/include/rocblas_datatype2string.hpp
+++ b/clients/include/rocblas_datatype2string.hpp
@@ -10,6 +10,7 @@
 typedef enum rocblas_initialization_ {
     rocblas_initialization_random_int = 111,
     rocblas_initialization_trig_float = 222,
+    rocblas_initialization_hpl = 333,
 } rocblas_initialization;
 
 /* ============================================================================================ */
@@ -87,6 +88,7 @@ constexpr auto rocblas_initialization2string(rocblas_initialization init)
     {
     case rocblas_initialization_random_int: return "rand_int";
     case rocblas_initialization_trig_float: return "trig_float";
+    case rocblas_initialization_hpl: return "hpl";
     default: return "invalid";
     }
 }
@@ -150,6 +152,7 @@ inline rocblas_initialization string2rocblas_initialization(const std::string& v
     return
         value == "rand_int"   ? rocblas_initialization_random_int :
         value == "trig_float" ? rocblas_initialization_trig_float :
+        value == "hpl" ? rocblas_initialization_hpl :
         static_cast<rocblas_initialization>(-1);
     // clang-format on
 }

--- a/clients/include/rocblas_datatype2string.hpp
+++ b/clients/include/rocblas_datatype2string.hpp
@@ -10,7 +10,7 @@
 typedef enum rocblas_initialization_ {
     rocblas_initialization_random_int = 111,
     rocblas_initialization_trig_float = 222,
-    rocblas_initialization_hpl = 333,
+    rocblas_initialization_hpl        = 333,
 } rocblas_initialization;
 
 /* ============================================================================================ */

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -109,10 +109,9 @@ inline void rocblas_init_hpl(
 {
     for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
         for(size_t i = 0; i < M; ++i)
-            for(size_t j = 0; j < N; ++j)
+            for(size_t j                          = 0; j < N; ++j)
                 A[i + j * lda + i_batch * stride] = random_hpl_generator<T>();
 }
-
 
 /* ============================================================================================ */
 /*! \brief  Initialize an array with random data, with NaN where apppropriate */

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -102,6 +102,18 @@ inline void rocblas_init_hermitian(std::vector<T>& A, size_t N, size_t lda)
         }
 }
 
+// Initialize vector with HPL-like random values
+template <typename T>
+inline void rocblas_init_hpl(
+    std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)
+{
+    for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
+        for(size_t i = 0; i < M; ++i)
+            for(size_t j = 0; j < N; ++j)
+                A[i + j * lda + i_batch * stride] = random_hpl_generator<T>();
+}
+
+
 /* ============================================================================================ */
 /*! \brief  Initialize an array with random data, with NaN where apppropriate */
 

--- a/clients/include/rocblas_random.hpp
+++ b/clients/include/rocblas_random.hpp
@@ -83,4 +83,11 @@ inline int8_t random_generator<int8_t>()
     return std::uniform_int_distribution<int8_t>(1, 3)(rocblas_rng);
 };
 
+/*! \brief  generate a random number in HPL-like [-0.5,0.5] doubles  */
+template <typename T>
+inline T random_hpl_generator()
+{
+    return std::uniform_real_distribution<double>(-0.5, 0.5)(rocblas_rng);
+}
+
 #endif

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -258,6 +258,13 @@ void testing_gemm(const Arguments& arg)
         rocblas_init_cos<T>(hB, B_row, B_col, ldb);
         rocblas_init_sin<T>(hC_1, M, N, ldc);
     }
+    else if(arg.initialization == rocblas_initialization_hpl)
+    {
+        rocblas_seedrand();
+        rocblas_init_hpl<T>(hA, A_row, A_col, lda);
+        rocblas_init_hpl<T>(hB, B_row, B_col, ldb);
+        rocblas_init_hpl<T>(hC_1, M, N, ldc);        
+    }
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -263,7 +263,7 @@ void testing_gemm(const Arguments& arg)
         rocblas_seedrand();
         rocblas_init_hpl<T>(hA, A_row, A_col, lda);
         rocblas_init_hpl<T>(hB, B_row, B_col, ldb);
-        rocblas_init_hpl<T>(hC_1, M, N, ldc);        
+        rocblas_init_hpl<T>(hC_1, M, N, ldc);
     }
 
     hC_2    = hC_1;


### PR DESCRIPTION
HPL initializes data distribution across [-0.5, 0.5]. This change adds a new initialization parameter to rocblas-bench for HPL-like input.