### PR TITLE
avoid NaN propagation in gemv when beta==0

### DIFF
--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -149,7 +149,16 @@ __global__ void gemvn_kernel(rocblas_int m,
             sdata[thread_id] += sdata[thread_id + DIM_X * 4 * i];
 
         if(ind < m)
-            y[ind * incy] = alpha * sdata[thread_id] + beta * y[ind * incy];
+        {
+            if(beta != 0)
+            {
+                y[ind * incy] = alpha * sdata[thread_id] + beta * y[ind * incy];
+            }
+            else
+            {
+                y[ind * incy] = alpha * sdata[thread_id];
+            }
+        }
     }
 }
 
@@ -210,7 +219,16 @@ __global__ void gemvc_kernel(rocblas_int m,
     }
 
     if(tx == 0)
-        y[col * incy] = alpha * sdata[0] + beta * y[col * incy];
+    {
+        if(beta != 0)
+        {
+            y[col * incy] = alpha * sdata[0] + beta * y[col * incy];
+        }
+        else
+        {
+            y[col * incy] = alpha * sdata[0];
+        }
+    }
 }
 
 template <typename>


### PR DESCRIPTION
resolves swdev-178779

- make gemv comply with reference implementation by not allowing NaN in y vector to propagate when beta = 0
