### PR TITLE
no deprecation warnings for hipHccModuleLaunchKernel

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -60,7 +60,7 @@ if( BUILD_WITH_TENSILE )
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
     # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc )
+    target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc -Wno-deprecated-declarations)
     foreach( target ${AMDGPU_TARGETS} )
       target_compile_options( Tensile PRIVATE --amdgpu-target=${target} )
     endforeach( )


### PR DESCRIPTION
- ROCm 2.3 changes from hipHccModuleLaunchKernel to hipExtModuleLaunchKernel. 
- Deprecate warning messages untill the following commit is merged: 

https://github.com/amcamd/Tensile/commit/f4809158d82a11eac3a03bf6413cbecad9bd4a56  

- This commit changes to hipExtModuleLaunchKernel, but it will only work on ROCm2.3 or later.