### PR TITLE
Fix use of variable templates in header

### DIFF
--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -98,15 +98,16 @@ struct rocblas_finalize_amax_amin
 };
 
 template <typename>
-constexpr char rocblas_iamaxmin_name[] = "unknown";
+static constexpr char rocblas_iamaxmin_name[] = "unknown";
 template <>
-constexpr char rocblas_iamaxmin_name<float>[] = "rocblas_isa" QUOTE(MAX_MIN);
+static constexpr char rocblas_iamaxmin_name<float>[] = "rocblas_isa" QUOTE(MAX_MIN);
 template <>
-constexpr char rocblas_iamaxmin_name<double>[] = "rocblas_ida" QUOTE(MAX_MIN);
+static constexpr char rocblas_iamaxmin_name<double>[] = "rocblas_ida" QUOTE(MAX_MIN);
 template <>
-constexpr char rocblas_iamaxmin_name<rocblas_float_complex>[] = "rocblas_ica" QUOTE(MAX_MIN);
+static constexpr char rocblas_iamaxmin_name<rocblas_float_complex>[] = "rocblas_ica" QUOTE(MAX_MIN);
 template <>
-constexpr char rocblas_iamaxmin_name<rocblas_double_complex>[] = "rocblas_iza" QUOTE(MAX_MIN);
+static constexpr char
+    rocblas_iamaxmin_name<rocblas_double_complex>[] = "rocblas_iza" QUOTE(MAX_MIN);
 
 // allocate workspace inside this API
 template <typename To, typename Ti>

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -112,22 +112,22 @@ constexpr auto rocblas_datatype_string(rocblas_datatype type)
 }
 
 // return precision string for data type
-template <typename> constexpr char rocblas_precision_string                [] = "invalid";
-template <> constexpr char rocblas_precision_string<rocblas_half          >[] = "f16_r";
-template <> constexpr char rocblas_precision_string<float                 >[] = "f32_r";
-template <> constexpr char rocblas_precision_string<double                >[] = "f64_r";
-template <> constexpr char rocblas_precision_string<int8_t                >[] = "i8_r";
-template <> constexpr char rocblas_precision_string<uint8_t               >[] = "u8_r";
-template <> constexpr char rocblas_precision_string<int32_t               >[] = "i32_r";
-template <> constexpr char rocblas_precision_string<uint32_t              >[] = "u32_r";
-template <> constexpr char rocblas_precision_string<rocblas_float_complex >[] = "f32_c";
-template <> constexpr char rocblas_precision_string<rocblas_double_complex>[] = "f64_c";
+template <typename> static constexpr char rocblas_precision_string                [] = "invalid";
+template <> static constexpr char rocblas_precision_string<rocblas_half          >[] = "f16_r";
+template <> static constexpr char rocblas_precision_string<float                 >[] = "f32_r";
+template <> static constexpr char rocblas_precision_string<double                >[] = "f64_r";
+template <> static constexpr char rocblas_precision_string<int8_t                >[] = "i8_r";
+template <> static constexpr char rocblas_precision_string<uint8_t               >[] = "u8_r";
+template <> static constexpr char rocblas_precision_string<int32_t               >[] = "i32_r";
+template <> static constexpr char rocblas_precision_string<uint32_t              >[] = "u32_r";
+template <> static constexpr char rocblas_precision_string<rocblas_float_complex >[] = "f32_c";
+template <> static constexpr char rocblas_precision_string<rocblas_double_complex>[] = "f64_c";
 #if 0 // Not implemented
-template <> constexpr char rocblas_precision_string<rocblas_half_complex  >[] = "f16_c";
-template <> constexpr char rocblas_precision_string<rocblas_i8_complex    >[] = "i8_c";
-template <> constexpr char rocblas_precision_string<rocblas_u8_complex    >[] = "u8_c";
-template <> constexpr char rocblas_precision_string<rocblas_i32_complex   >[] = "i32_c";
-template <> constexpr char rocblas_precision_string<rocblas_u32_complex   >[] = "u32_c";
+template <> static constexpr char rocblas_precision_string<rocblas_half_complex  >[] = "f16_c";
+template <> static constexpr char rocblas_precision_string<rocblas_i8_complex    >[] = "i8_c";
+template <> static constexpr char rocblas_precision_string<rocblas_u8_complex    >[] = "u8_c";
+template <> static constexpr char rocblas_precision_string<rocblas_i32_complex   >[] = "i32_c";
+template <> static constexpr char rocblas_precision_string<rocblas_u32_complex   >[] = "u32_c";
 #endif
 
 // clang-format on


### PR DESCRIPTION
- Add necessary `static` specifier to avoid multiple definition.

resolves SWDEV-188303

Summary of proposed changes:
- when variable template is used in header, it's necessary to add `static` specifier to avoid multiple definition errors during link if that header is included/used in multiple sources.
-  
-  
-  
