### PR TITLE
Following DR2387, explicitly declare const[expr] variable templates static

### DIFF
--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -24,10 +24,10 @@ constexpr double sqrthalf = 0.7071067811865475244;
 // Sum error tolerance for large sums. Multiplied by the number of items
 // in the sum to get an expected absolute error bound.
 template <class T>
-constexpr double sum_error_tolerance = 0.0;
+static constexpr double sum_error_tolerance = 0.0;
 
 template <>
-constexpr double sum_error_tolerance<rocblas_half> = 1 / 900.0;
+static constexpr double sum_error_tolerance<rocblas_half> = 1 / 900.0;
 
 #ifndef GOOGLE_TEST
 #define NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, err, NEAR_ASSERT)

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -33,17 +33,17 @@ rocblas_status (*rocblas_scal)(
     rocblas_handle handle, rocblas_int n, const T* alpha, T* x, rocblas_int incx);
 
 template <>
-constexpr auto rocblas_scal<float> = rocblas_sscal;
+static constexpr auto rocblas_scal<float> = rocblas_sscal;
 
 template <>
-constexpr auto rocblas_scal<double> = rocblas_dscal;
+static constexpr auto rocblas_scal<double> = rocblas_dscal;
 
 /* not implemented
 template <>
-constexpr auto rocblas_scal<rocblas_float_complex> = rocblas_cscal;
+static constexpr auto rocblas_scal<rocblas_float_complex> = rocblas_cscal;
 
 template <>
-constexpr auto rocblas_scal<rocblas_double_complex> = rocblas_zscal;
+static constexpr auto rocblas_scal<rocblas_double_complex> = rocblas_zscal;
 */
 
 // copy
@@ -52,17 +52,17 @@ rocblas_status (*rocblas_copy)(
     rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, T* y, rocblas_int incy);
 
 template <>
-constexpr auto rocblas_copy<float> = rocblas_scopy;
+static constexpr auto rocblas_copy<float> = rocblas_scopy;
 
 template <>
-constexpr auto rocblas_copy<double> = rocblas_dcopy;
+static constexpr auto rocblas_copy<double> = rocblas_dcopy;
 
 /* not implemented
 template <>
-constexpr auto rocblas_copy<rocblas_float_complex> = rocblas_ccopy;
+static constexpr auto rocblas_copy<rocblas_float_complex> = rocblas_ccopy;
 
 template <>
-constexpr auto rocblas_copy<rocblas_double_complex> = rocblas_zcopy;
+static constexpr auto rocblas_copy<rocblas_double_complex> = rocblas_zcopy;
 }
 */
 
@@ -72,18 +72,18 @@ rocblas_status (*rocblas_swap)(
     rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy);
 
 template <>
-constexpr auto rocblas_swap<float> = rocblas_sswap;
+static constexpr auto rocblas_swap<float> = rocblas_sswap;
 
 template <>
-constexpr auto rocblas_swap<double> = rocblas_dswap;
+static constexpr auto rocblas_swap<double> = rocblas_dswap;
 
 /* not implemented
 
 template <>
-constexpr auto rocblas_swap<rocblas_float_complex> = rocblas_cswap;
+static constexpr auto rocblas_swap<rocblas_float_complex> = rocblas_cswap;
 
 template <>
-constexpr auto rocblas_swap<rocblas_double_complex> = rocblas_zswap;
+static constexpr auto rocblas_swap<rocblas_double_complex> = rocblas_zswap;
 
 */
 
@@ -98,17 +98,17 @@ rocblas_status (*rocblas_dot)(rocblas_handle handle,
                               T* result);
 
 template <>
-constexpr auto rocblas_dot<float> = rocblas_sdot;
+static constexpr auto rocblas_dot<float> = rocblas_sdot;
 
 template <>
-constexpr auto rocblas_dot<double> = rocblas_ddot;
+static constexpr auto rocblas_dot<double> = rocblas_ddot;
 
 /* not implemented
 template <>
-constexpr auto rocblas_dot<rocblas_float_complex> = rocblas_cdotu;
+static constexpr auto rocblas_dot<rocblas_float_complex> = rocblas_cdotu;
 
 template <>
-constexpr auto rocblas_dot<rocblas_double_complex> = rocblas_zdotu;
+static constexpr auto rocblas_dot<rocblas_double_complex> = rocblas_zdotu;
 */
 
 // asum
@@ -117,17 +117,17 @@ rocblas_status (*rocblas_asum)(
     rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, T2* result);
 
 template <>
-constexpr auto rocblas_asum<float, float> = rocblas_sasum;
+static constexpr auto rocblas_asum<float, float> = rocblas_sasum;
 
 template <>
-constexpr auto rocblas_asum<double, double> = rocblas_dasum;
+static constexpr auto rocblas_asum<double, double> = rocblas_dasum;
 
 /* not implemented
 template<>
-constexpr auto rocblas_asum<rocblas_float_complex, float> = rocblas_scasum;
+static constexpr auto rocblas_asum<rocblas_float_complex, float> = rocblas_scasum;
 
 template<>
-constexpr auto rocblas_asum<rocblas_double_complex, double> = rocblas_dzasum;
+static constexpr auto rocblas_asum<rocblas_double_complex, double> = rocblas_dzasum;
 */
 
 // nrm2
@@ -136,17 +136,17 @@ rocblas_status (*rocblas_nrm2)(
     rocblas_handle handle, rocblas_int n, const T1* x, rocblas_int incx, T2* result);
 
 template <>
-constexpr auto rocblas_nrm2<float, float> = rocblas_snrm2;
+static constexpr auto rocblas_nrm2<float, float> = rocblas_snrm2;
 
 template <>
-constexpr auto rocblas_nrm2<double, double> = rocblas_dnrm2;
+static constexpr auto rocblas_nrm2<double, double> = rocblas_dnrm2;
 
 /* not implemented
 template <>
-constexpr auto rocblas_nrm2<rocblas_float_complex, float> = rocblas_scnrm2;
+static constexpr auto rocblas_nrm2<rocblas_float_complex, float> = rocblas_scnrm2;
 
 template <>
-constexpr auto rocblas_nrm2<rocblas_double_complex, double> = rocblas_dznrm2;
+static constexpr auto rocblas_nrm2<rocblas_double_complex, double> = rocblas_dznrm2;
 */
 
 // iamax and iamin need to be full functions rather than references, in order
@@ -201,20 +201,20 @@ rocblas_status (*rocblas_axpy)(rocblas_handle handle,
                                rocblas_int incy);
 
 template <>
-constexpr auto rocblas_axpy<rocblas_half> = rocblas_haxpy;
+static constexpr auto rocblas_axpy<rocblas_half> = rocblas_haxpy;
 
 template <>
-constexpr auto rocblas_axpy<float> = rocblas_saxpy;
+static constexpr auto rocblas_axpy<float> = rocblas_saxpy;
 
 template <>
-constexpr auto rocblas_axpy<double> = rocblas_daxpy;
+static constexpr auto rocblas_axpy<double> = rocblas_daxpy;
 
 /* not implemented
 template <>
-constexpr auto rocblas_axpy<rocblas_float_complex> = rocblas_caxpy;
+static constexpr auto rocblas_axpy<rocblas_float_complex> = rocblas_caxpy;
 
 template <>
-constexpr auto rocblas_axpy<rocblas_double_complex> = rocblas_zaxpy;
+static constexpr auto rocblas_axpy<rocblas_double_complex> = rocblas_zaxpy;
 */
 
 /*
@@ -237,10 +237,10 @@ rocblas_status (*rocblas_ger)(rocblas_handle handle,
                               rocblas_int lda);
 
 template <>
-constexpr auto rocblas_ger<float> = rocblas_sger;
+static constexpr auto rocblas_ger<float> = rocblas_sger;
 
 template <>
-constexpr auto rocblas_ger<double> = rocblas_dger;
+static constexpr auto rocblas_ger<double> = rocblas_dger;
 
 // syr
 template <typename T>
@@ -254,10 +254,10 @@ rocblas_status (*rocblas_syr)(rocblas_handle handle,
                               rocblas_int lda);
 
 template <>
-constexpr auto rocblas_syr<float> = rocblas_ssyr;
+static constexpr auto rocblas_syr<float> = rocblas_ssyr;
 
 template <>
-constexpr auto rocblas_syr<double> = rocblas_dsyr;
+static constexpr auto rocblas_syr<double> = rocblas_dsyr;
 
 // gemv
 template <typename T>
@@ -275,10 +275,10 @@ rocblas_status (*rocblas_gemv)(rocblas_handle handle,
                                rocblas_int incy);
 
 template <>
-constexpr auto rocblas_gemv<float> = rocblas_sgemv;
+static constexpr auto rocblas_gemv<float> = rocblas_sgemv;
 
 template <>
-constexpr auto rocblas_gemv<double> = rocblas_dgemv;
+static constexpr auto rocblas_gemv<double> = rocblas_dgemv;
 
 // trsv
 template <typename T>
@@ -293,10 +293,10 @@ rocblas_status (*rocblas_trsv)(rocblas_handle handle,
                                rocblas_int incx);
 
 template <>
-constexpr auto rocblas_trsv<float> = rocblas_strsv;
+static constexpr auto rocblas_trsv<float> = rocblas_strsv;
 
 template <>
-constexpr auto rocblas_trsv<double> = rocblas_dtrsv;
+static constexpr auto rocblas_trsv<double> = rocblas_dtrsv;
 
 // symv
 template <typename T>
@@ -314,10 +314,10 @@ rocblas_status (*rocblas_symv)(rocblas_handle handle,
 
 /* not implemented
 template <>
-constexpr auto rocblas_symv<float> = rocblas_ssymv;
+static constexpr auto rocblas_symv<float> = rocblas_ssymv;
 
 template <>
-constexpr auto rocblas_symv<double> = rocblas_dsymv;
+static constexpr auto rocblas_symv<double> = rocblas_dsymv;
 */
 
 /*
@@ -343,10 +343,10 @@ rocblas_status (*rocblas_geam)(rocblas_handle handle,
                                rocblas_int ldc);
 
 template <>
-constexpr auto rocblas_geam<float> = rocblas_sgeam;
+static constexpr auto rocblas_geam<float> = rocblas_sgeam;
 
 template <>
-constexpr auto rocblas_geam<double> = rocblas_dgeam;
+static constexpr auto rocblas_geam<double> = rocblas_dgeam;
 
 // gemm
 template <typename T>
@@ -366,13 +366,13 @@ rocblas_status (*rocblas_gemm)(rocblas_handle handle,
                                rocblas_int ldc);
 
 template <>
-constexpr auto rocblas_gemm<rocblas_half> = rocblas_hgemm;
+static constexpr auto rocblas_gemm<rocblas_half> = rocblas_hgemm;
 
 template <>
-constexpr auto rocblas_gemm<float> = rocblas_sgemm;
+static constexpr auto rocblas_gemm<float> = rocblas_sgemm;
 
 template <>
-constexpr auto rocblas_gemm<double> = rocblas_dgemm;
+static constexpr auto rocblas_gemm<double> = rocblas_dgemm;
 
 // gemm_strided_batched
 template <typename T>
@@ -396,13 +396,13 @@ rocblas_status (*rocblas_gemm_strided_batched)(rocblas_handle handle,
                                                rocblas_int batch_count);
 
 template <>
-constexpr auto rocblas_gemm_strided_batched<rocblas_half> = rocblas_hgemm_strided_batched;
+static constexpr auto rocblas_gemm_strided_batched<rocblas_half> = rocblas_hgemm_strided_batched;
 
 template <>
-constexpr auto rocblas_gemm_strided_batched<float> = rocblas_sgemm_strided_batched;
+static constexpr auto rocblas_gemm_strided_batched<float> = rocblas_sgemm_strided_batched;
 
 template <>
-constexpr auto rocblas_gemm_strided_batched<double> = rocblas_dgemm_strided_batched;
+static constexpr auto rocblas_gemm_strided_batched<double> = rocblas_dgemm_strided_batched;
 
 // trsm
 template <typename T>
@@ -420,10 +420,10 @@ rocblas_status (*rocblas_trsm)(rocblas_handle handle,
                                rocblas_int ldb);
 
 template <>
-constexpr auto rocblas_trsm<float> = rocblas_strsm;
+static constexpr auto rocblas_trsm<float> = rocblas_strsm;
 
 template <>
-constexpr auto rocblas_trsm<double> = rocblas_dtrsm;
+static constexpr auto rocblas_trsm<double> = rocblas_dtrsm;
 
 // trtri
 template <typename T>
@@ -437,10 +437,10 @@ rocblas_status (*rocblas_trtri)(rocblas_handle handle,
                                 rocblas_int ldinvA);
 
 template <>
-constexpr auto rocblas_trtri<float> = rocblas_strtri;
+static constexpr auto rocblas_trtri<float> = rocblas_strtri;
 
 template <>
-constexpr auto rocblas_trtri<double> = rocblas_dtrtri;
+static constexpr auto rocblas_trtri<double> = rocblas_dtrtri;
 
 // trtri_batched
 template <typename T>
@@ -457,9 +457,9 @@ rocblas_status (*rocblas_trtri_batched)(rocblas_handle handle,
                                         rocblas_int batch_count);
 
 template <>
-constexpr auto rocblas_trtri_batched<float> = rocblas_strtri_batched;
+static constexpr auto rocblas_trtri_batched<float> = rocblas_strtri_batched;
 
 template <>
-constexpr auto rocblas_trtri_batched<double> = rocblas_dtrtri_batched;
+static constexpr auto rocblas_trtri_batched<double> = rocblas_dtrtri_batched;
 
 #endif // _ROCBLAS_HPP_

--- a/clients/include/rocblas_math.hpp
+++ b/clients/include/rocblas_math.hpp
@@ -35,13 +35,13 @@ inline bool rocblas_isnan(rocblas_half arg)
 /*! \brief is_complex<T> returns true iff T is complex */
 
 template <typename>
-constexpr bool is_complex = false;
+static constexpr bool is_complex = false;
 
 template <>
-constexpr bool is_complex<rocblas_double_complex> = true;
+static constexpr bool is_complex<rocblas_double_complex> = true;
 
 template <>
-constexpr bool is_complex<rocblas_float_complex> = true;
+static constexpr bool is_complex<rocblas_float_complex> = true;
 
 /* ============================================================================================ */
 /*! \brief negate a value */

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -17,17 +17,17 @@
 #include "../../library/src/include/utility.h"
 
 template <typename T>
-char precision_letter;
+static constexpr auto precision_letter = "*";
 template <>
-constexpr auto precision_letter<rocblas_half> = "h";
+static constexpr auto precision_letter<rocblas_half> = "h";
 template <>
-constexpr auto precision_letter<float> = "s";
+static constexpr auto precision_letter<float> = "s";
 template <>
-constexpr auto precision_letter<double> = "d";
+static constexpr auto precision_letter<double> = "d";
 template <>
-constexpr auto precision_letter<rocblas_float_complex> = "c";
+static constexpr auto precision_letter<rocblas_float_complex> = "c";
 template <>
-constexpr auto precision_letter<rocblas_double_complex> = "z";
+static constexpr auto precision_letter<rocblas_double_complex> = "z";
 
 // replaces X in string with s, d, c, z or h depending on typename T
 template <typename T>

--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -98,15 +98,16 @@ struct rocblas_finalize_amax_amin
 };
 
 template <typename>
-constexpr char rocblas_iamaxmin_name[] = "unknown";
+static constexpr char rocblas_iamaxmin_name[] = "unknown";
 template <>
-constexpr char rocblas_iamaxmin_name<float>[] = "rocblas_isa" QUOTE(MAX_MIN);
+static constexpr char rocblas_iamaxmin_name<float>[] = "rocblas_isa" QUOTE(MAX_MIN);
 template <>
-constexpr char rocblas_iamaxmin_name<double>[] = "rocblas_ida" QUOTE(MAX_MIN);
+static constexpr char rocblas_iamaxmin_name<double>[] = "rocblas_ida" QUOTE(MAX_MIN);
 template <>
-constexpr char rocblas_iamaxmin_name<rocblas_float_complex>[] = "rocblas_ica" QUOTE(MAX_MIN);
+static constexpr char rocblas_iamaxmin_name<rocblas_float_complex>[] = "rocblas_ica" QUOTE(MAX_MIN);
 template <>
-constexpr char rocblas_iamaxmin_name<rocblas_double_complex>[] = "rocblas_iza" QUOTE(MAX_MIN);
+static constexpr char
+    rocblas_iamaxmin_name<rocblas_double_complex>[] = "rocblas_iza" QUOTE(MAX_MIN);
 
 // allocate workspace inside this API
 template <typename To, typename Ti>

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -26,15 +26,15 @@ struct rocblas_fetch_asum
 };
 
 template <typename>
-constexpr char rocblas_asum_name[] = "unknown";
+static constexpr char rocblas_asum_name[] = "unknown";
 template <>
-constexpr char rocblas_asum_name<float>[] = "rocblas_sasum";
+static constexpr char rocblas_asum_name<float>[] = "rocblas_sasum";
 template <>
-constexpr char rocblas_asum_name<double>[] = "rocblas_dasum";
+static constexpr char rocblas_asum_name<double>[] = "rocblas_dasum";
 template <>
-constexpr char rocblas_asum_name<rocblas_float_complex>[] = "rocblas_scasum";
+static constexpr char rocblas_asum_name<rocblas_float_complex>[] = "rocblas_scasum";
 template <>
-constexpr char rocblas_asum_name<rocblas_double_complex>[] = "rocblas_dzasum";
+static constexpr char rocblas_asum_name<rocblas_double_complex>[] = "rocblas_dzasum";
 
 // allocate workspace inside this API
 template <typename Ti, typename To>

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -12,17 +12,17 @@ namespace {
 constexpr int NB = 256;
 
 template <typename>
-constexpr char rocblas_axpy_name[] = "unknown";
+static constexpr char rocblas_axpy_name[] = "unknown";
 template <>
-constexpr char rocblas_axpy_name<float>[] = "rocblas_saxpy";
+static constexpr char rocblas_axpy_name<float>[] = "rocblas_saxpy";
 template <>
-constexpr char rocblas_axpy_name<double>[] = "rocblas_daxpy";
+static constexpr char rocblas_axpy_name<double>[] = "rocblas_daxpy";
 template <>
-constexpr char rocblas_axpy_name<rocblas_half>[] = "rocblas_haxpy";
+static constexpr char rocblas_axpy_name<rocblas_half>[] = "rocblas_haxpy";
 template <>
-constexpr char rocblas_axpy_name<rocblas_float_complex>[] = "rocblas_caxpy";
+static constexpr char rocblas_axpy_name<rocblas_float_complex>[] = "rocblas_caxpy";
 template <>
-constexpr char rocblas_axpy_name<rocblas_double_complex>[] = "rocblas_zaxpy";
+static constexpr char rocblas_axpy_name<rocblas_double_complex>[] = "rocblas_zaxpy";
 
 template <typename T>
 void rocblas_axpy_log(rocblas_handle handle,

--- a/library/src/blas1/rocblas_copy.cpp
+++ b/library/src/blas1/rocblas_copy.cpp
@@ -23,17 +23,17 @@ __global__ void copy_kernel(rocblas_int n, const T* x, rocblas_int incx, T* y, r
 }
 
 template <typename>
-constexpr char rocblas_copy_name[] = "unknown";
+static constexpr char rocblas_copy_name[] = "unknown";
 template <>
-constexpr char rocblas_copy_name<float>[] = "rocblas_scopy";
+static constexpr char rocblas_copy_name<float>[] = "rocblas_scopy";
 template <>
-constexpr char rocblas_copy_name<double>[] = "rocblas_dcopy";
+static constexpr char rocblas_copy_name<double>[] = "rocblas_dcopy";
 template <>
-constexpr char rocblas_copy_name<rocblas_half>[] = "rocblas_hcopy";
+static constexpr char rocblas_copy_name<rocblas_half>[] = "rocblas_hcopy";
 template <>
-constexpr char rocblas_copy_name<rocblas_float_complex>[] = "rocblas_ccopy";
+static constexpr char rocblas_copy_name<rocblas_float_complex>[] = "rocblas_ccopy";
 template <>
-constexpr char rocblas_copy_name<rocblas_double_complex>[] = "rocblas_zcopy";
+static constexpr char rocblas_copy_name<rocblas_double_complex>[] = "rocblas_zcopy";
 
 template <class T>
 rocblas_status rocblas_copy_template(

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -84,15 +84,15 @@ rocblas_status rocblas_dot_workspace(rocblas_handle __restrict__ handle,
 }
 
 template <typename>
-constexpr char rocblas_dot_name[] = "unknown";
+static constexpr char rocblas_dot_name[] = "unknown";
 template <>
-constexpr char rocblas_dot_name<float>[] = "rocblas_sdot";
+static constexpr char rocblas_dot_name<float>[] = "rocblas_sdot";
 template <>
-constexpr char rocblas_dot_name<double>[] = "rocblas_ddot";
+static constexpr char rocblas_dot_name<double>[] = "rocblas_ddot";
 template <>
-constexpr char rocblas_dot_name<rocblas_float_complex>[] = "rocblas_cdot";
+static constexpr char rocblas_dot_name<rocblas_float_complex>[] = "rocblas_cdot";
 template <>
-constexpr char rocblas_dot_name<rocblas_double_complex>[] = "rocblas_zdot";
+static constexpr char rocblas_dot_name<rocblas_double_complex>[] = "rocblas_zdot";
 
 // allocate workspace inside this API
 template <typename T>

--- a/library/src/blas1/rocblas_nrm2.cpp
+++ b/library/src/blas1/rocblas_nrm2.cpp
@@ -35,17 +35,17 @@ struct rocblas_finalize_nrm2
 };
 
 template <typename>
-constexpr char rocblas_nrm2_name[] = "unknown";
+static constexpr char rocblas_nrm2_name[] = "unknown";
 template <>
-constexpr char rocblas_nrm2_name<float>[] = "rocblas_snrm2";
+static constexpr char rocblas_nrm2_name<float>[] = "rocblas_snrm2";
 template <>
-constexpr char rocblas_nrm2_name<double>[] = "rocblas_dnrm2";
+static constexpr char rocblas_nrm2_name<double>[] = "rocblas_dnrm2";
 template <>
-constexpr char rocblas_nrm2_name<rocblas_half>[] = "rocblas_hnrm2";
+static constexpr char rocblas_nrm2_name<rocblas_half>[] = "rocblas_hnrm2";
 template <>
-constexpr char rocblas_nrm2_name<rocblas_float_complex>[] = "rocblas_scnrm2";
+static constexpr char rocblas_nrm2_name<rocblas_float_complex>[] = "rocblas_scnrm2";
 template <>
-constexpr char rocblas_nrm2_name<rocblas_double_complex>[] = "rocblas_dznrm2";
+static constexpr char rocblas_nrm2_name<rocblas_double_complex>[] = "rocblas_dznrm2";
 
 // allocate workspace inside this API
 template <typename Ti, typename To>

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -26,15 +26,15 @@ __global__ void scal_kernel(rocblas_int n, U alpha_device_host, T* x, rocblas_in
 }
 
 template <typename>
-constexpr char rocblas_scal_name[] = "unknown";
+static constexpr char rocblas_scal_name[] = "unknown";
 template <>
-constexpr char rocblas_scal_name<float>[] = "rocblas_sscal";
+static constexpr char rocblas_scal_name<float>[] = "rocblas_sscal";
 template <>
-constexpr char rocblas_scal_name<double>[] = "rocblas_dscal";
+static constexpr char rocblas_scal_name<double>[] = "rocblas_dscal";
 template <>
-constexpr char rocblas_scal_name<rocblas_float_complex>[] = "rocblas_cscal";
+static constexpr char rocblas_scal_name<rocblas_float_complex>[] = "rocblas_cscal";
 template <>
-constexpr char rocblas_scal_name<rocblas_double_complex>[] = "rocblas_zscal";
+static constexpr char rocblas_scal_name<rocblas_double_complex>[] = "rocblas_zscal";
 
 template <class T>
 rocblas_status

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -26,17 +26,17 @@ __global__ void swap_kernel(rocblas_int n, T* x, rocblas_int incx, T* y, rocblas
 }
 
 template <typename>
-constexpr char rocblas_swap_name[] = "unknown";
+static constexpr char rocblas_swap_name[] = "unknown";
 template <>
-constexpr char rocblas_swap_name<float>[] = "rocblas_sswap";
+static constexpr char rocblas_swap_name<float>[] = "rocblas_sswap";
 template <>
-constexpr char rocblas_swap_name<double>[] = "rocblas_dswap";
+static constexpr char rocblas_swap_name<double>[] = "rocblas_dswap";
 template <>
-constexpr char rocblas_swap_name<rocblas_half>[] = "rocblas_hswap";
+static constexpr char rocblas_swap_name<rocblas_half>[] = "rocblas_hswap";
 template <>
-constexpr char rocblas_swap_name<rocblas_float_complex>[] = "rocblas_cswap";
+static constexpr char rocblas_swap_name<rocblas_float_complex>[] = "rocblas_cswap";
 template <>
-constexpr char rocblas_swap_name<rocblas_double_complex>[] = "rocblas_zswap";
+static constexpr char rocblas_swap_name<rocblas_double_complex>[] = "rocblas_zswap";
 
 template <class T>
 rocblas_status

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -232,11 +232,11 @@ __global__ void gemvc_kernel(rocblas_int m,
 }
 
 template <typename>
-constexpr char rocblas_gemv_name[] = "unknown";
+static constexpr char rocblas_gemv_name[] = "unknown";
 template <>
-constexpr char rocblas_gemv_name<float>[] = "rocblas_sgemv";
+static constexpr char rocblas_gemv_name<float>[] = "rocblas_sgemv";
 template <>
-constexpr char rocblas_gemv_name<double>[] = "rocblas_dgemv";
+static constexpr char rocblas_gemv_name<double>[] = "rocblas_dgemv";
 
 template <typename T>
 rocblas_status rocblas_gemv(rocblas_handle handle,

--- a/library/src/blas2/rocblas_ger.cpp
+++ b/library/src/blas2/rocblas_ger.cpp
@@ -32,11 +32,11 @@ __global__ void ger_kernel(rocblas_int m,
 }
 
 template <typename>
-constexpr char rocblas_ger_name[] = "unknown";
+static constexpr char rocblas_ger_name[] = "unknown";
 template <>
-constexpr char rocblas_ger_name<float>[] = "rocblas_sger";
+static constexpr char rocblas_ger_name<float>[] = "rocblas_sger";
 template <>
-constexpr char rocblas_ger_name<double>[] = "rocblas_dger";
+static constexpr char rocblas_ger_name<double>[] = "rocblas_dger";
 
 template <typename T>
 rocblas_status rocblas_ger(rocblas_handle handle,

--- a/library/src/blas2/rocblas_syr.cpp
+++ b/library/src/blas2/rocblas_syr.cpp
@@ -30,11 +30,11 @@ __global__ void syr_kernel(rocblas_fill uplo,
 }
 
 template <typename>
-constexpr char rocblas_syr_name[] = "unknown";
+static constexpr char rocblas_syr_name[] = "unknown";
 template <>
-constexpr char rocblas_syr_name<float>[] = "rocblas_ssyr";
+static constexpr char rocblas_syr_name<float>[] = "rocblas_ssyr";
 template <>
-constexpr char rocblas_syr_name<double>[] = "rocblas_dsyr";
+static constexpr char rocblas_syr_name<double>[] = "rocblas_dsyr";
 
 template <typename T>
 rocblas_status rocblas_syr(rocblas_handle handle,

--- a/library/src/blas2/rocblas_trsv.cpp
+++ b/library/src/blas2/rocblas_trsv.cpp
@@ -48,11 +48,11 @@ void strided_vector_copy(
 }
 
 template <typename>
-constexpr char rocblas_trsv_name[] = "unknown";
+static constexpr char rocblas_trsv_name[] = "unknown";
 template <>
-constexpr char rocblas_trsv_name<float>[] = "rocblas_strsv";
+static constexpr char rocblas_trsv_name<float>[] = "rocblas_strsv";
 template <>
-constexpr char rocblas_trsv_name<double>[] = "rocblas_dtrsv";
+static constexpr char rocblas_trsv_name<double>[] = "rocblas_dtrsv";
 
 template <rocblas_int BLOCK, typename T>
 rocblas_status rocblas_trsv(rocblas_handle handle,

--- a/library/src/blas3/Tensile/gemm.cpp
+++ b/library/src/blas3/Tensile/gemm.cpp
@@ -205,13 +205,13 @@ hipError_t callTensile(const T* alpha,
 }
 
 template <typename>
-constexpr char rocblas_gemm_name[] = "unknown";
+static constexpr char rocblas_gemm_name[] = "unknown";
 template <>
-constexpr char rocblas_gemm_name<rocblas_half>[] = "rocblas_hgemm";
+static constexpr char rocblas_gemm_name<rocblas_half>[] = "rocblas_hgemm";
 template <>
-constexpr char rocblas_gemm_name<float>[] = "rocblas_sgemm";
+static constexpr char rocblas_gemm_name<float>[] = "rocblas_sgemm";
 template <>
-constexpr char rocblas_gemm_name<double>[] = "rocblas_dgemm";
+static constexpr char rocblas_gemm_name<double>[] = "rocblas_dgemm";
 
 /*******************************************************************************
  * GEMM implementation
@@ -376,13 +376,14 @@ rocblas_status rocblas_gemm_impl(rocblas_handle handle,
 }
 
 template <typename>
-constexpr char rocblas_gemm_strided_batched_name[] = "unknown";
+static constexpr char rocblas_gemm_strided_batched_name[] = "unknown";
 template <>
-constexpr char rocblas_gemm_strided_batched_name<rocblas_half>[] = "rocblas_hgemm_strided_batched";
+static constexpr char rocblas_gemm_strided_batched_name<rocblas_half>[] =
+    "rocblas_hgemm_strided_batched";
 template <>
-constexpr char rocblas_gemm_strided_batched_name<float>[] = "rocblas_sgemm_strided_batched";
+static constexpr char rocblas_gemm_strided_batched_name<float>[] = "rocblas_sgemm_strided_batched";
 template <>
-constexpr char rocblas_gemm_strided_batched_name<double>[] = "rocblas_dgemm_strided_batched";
+static constexpr char rocblas_gemm_strided_batched_name<double>[] = "rocblas_dgemm_strided_batched";
 
 /*******************************************************************************
  * Strided / Batched GEMM implementation

--- a/library/src/blas3/rocblas_geam.cpp
+++ b/library/src/blas3/rocblas_geam.cpp
@@ -154,11 +154,11 @@ __global__ void geam_inplace_kernel_device_pointer(rocblas_operation transB,
 /* ============================================================================================ */
 
 template <typename>
-constexpr char rocblas_geam_name[] = "unknown";
+static constexpr char rocblas_geam_name[] = "unknown";
 template <>
-constexpr char rocblas_geam_name<float>[] = "rocblas_sgeam";
+static constexpr char rocblas_geam_name<float>[] = "rocblas_sgeam";
 template <>
-constexpr char rocblas_geam_name<double>[] = "rocblas_dgeam";
+static constexpr char rocblas_geam_name<double>[] = "rocblas_dgeam";
 
 /*
  * ===========================================================================

--- a/library/src/blas3/rocblas_trmm.cpp
+++ b/library/src/blas3/rocblas_trmm.cpp
@@ -177,11 +177,11 @@ __global__ void trmm_left_lower_nontrans_MX096_NX096_KX16(rocblas_fill uplo,
 }
 
 template <typename>
-constexpr char rocblas_trmm_name[] = "unknown";
+static constexpr char rocblas_trmm_name[] = "unknown";
 template <>
-constexpr char rocblas_trmm_name<float>[] = "rocblas_strmm";
+static constexpr char rocblas_trmm_name<float>[] = "rocblas_strmm";
 template <>
-constexpr char rocblas_trmm_name<double>[] = "rocblas_dtrmm";
+static constexpr char rocblas_trmm_name<double>[] = "rocblas_dtrmm";
 
 /*! \brief BLAS Level 3 API
 

--- a/library/src/blas3/rocblas_trsm.cpp
+++ b/library/src/blas3/rocblas_trsm.cpp
@@ -944,11 +944,11 @@ rocblas_status special_trsm_template(rocblas_handle handle,
 } // namespace
 
 template <typename>
-constexpr char rocblas_trsm_name[] = "unknown";
+static constexpr char rocblas_trsm_name[] = "unknown";
 template <>
-constexpr char rocblas_trsm_name<float>[] = "rocblas_strsm";
+static constexpr char rocblas_trsm_name<float>[] = "rocblas_strsm";
 template <>
-constexpr char rocblas_trsm_name<double>[] = "rocblas_dtrsm";
+static constexpr char rocblas_trsm_name<double>[] = "rocblas_dtrsm";
 
 template <rocblas_int BLOCK, typename T>
 rocblas_status rocblas_trsm_ex_template(rocblas_handle handle,

--- a/library/src/blas3/rocblas_trtri_batched.cpp
+++ b/library/src/blas3/rocblas_trtri_batched.cpp
@@ -446,11 +446,11 @@ rocblas_status rocblas_trtri_large_batched(rocblas_handle handle,
 }
 
 template <typename>
-constexpr char rocblas_trtri_name[] = "unknown";
+static constexpr char rocblas_trtri_name[] = "unknown";
 template <>
-constexpr char rocblas_trtri_name<float>[] = "rocblas_strtri";
+static constexpr char rocblas_trtri_name<float>[] = "rocblas_strtri";
 template <>
-constexpr char rocblas_trtri_name<double>[] = "rocblas_dtrtri";
+static constexpr char rocblas_trtri_name<double>[] = "rocblas_dtrtri";
 
 template <typename T>
 rocblas_status rocblas_trtri_batched_template(rocblas_handle handle,

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -112,22 +112,22 @@ constexpr auto rocblas_datatype_string(rocblas_datatype type)
 }
 
 // return precision string for data type
-template <typename> constexpr char rocblas_precision_string                [] = "invalid";
-template <> constexpr char rocblas_precision_string<rocblas_half          >[] = "f16_r";
-template <> constexpr char rocblas_precision_string<float                 >[] = "f32_r";
-template <> constexpr char rocblas_precision_string<double                >[] = "f64_r";
-template <> constexpr char rocblas_precision_string<int8_t                >[] = "i8_r";
-template <> constexpr char rocblas_precision_string<uint8_t               >[] = "u8_r";
-template <> constexpr char rocblas_precision_string<int32_t               >[] = "i32_r";
-template <> constexpr char rocblas_precision_string<uint32_t              >[] = "u32_r";
-template <> constexpr char rocblas_precision_string<rocblas_float_complex >[] = "f32_c";
-template <> constexpr char rocblas_precision_string<rocblas_double_complex>[] = "f64_c";
+template <typename> static constexpr char rocblas_precision_string                [] = "invalid";
+template <> static constexpr char rocblas_precision_string<rocblas_half          >[] = "f16_r";
+template <> static constexpr char rocblas_precision_string<float                 >[] = "f32_r";
+template <> static constexpr char rocblas_precision_string<double                >[] = "f64_r";
+template <> static constexpr char rocblas_precision_string<int8_t                >[] = "i8_r";
+template <> static constexpr char rocblas_precision_string<uint8_t               >[] = "u8_r";
+template <> static constexpr char rocblas_precision_string<int32_t               >[] = "i32_r";
+template <> static constexpr char rocblas_precision_string<uint32_t              >[] = "u32_r";
+template <> static constexpr char rocblas_precision_string<rocblas_float_complex >[] = "f32_c";
+template <> static constexpr char rocblas_precision_string<rocblas_double_complex>[] = "f64_c";
 #if 0 // Not implemented
-template <> constexpr char rocblas_precision_string<rocblas_half_complex  >[] = "f16_c";
-template <> constexpr char rocblas_precision_string<rocblas_i8_complex    >[] = "i8_c";
-template <> constexpr char rocblas_precision_string<rocblas_u8_complex    >[] = "u8_c";
-template <> constexpr char rocblas_precision_string<rocblas_i32_complex   >[] = "i32_c";
-template <> constexpr char rocblas_precision_string<rocblas_u32_complex   >[] = "u32_c";
+template <> static constexpr char rocblas_precision_string<rocblas_half_complex  >[] = "f16_c";
+template <> static constexpr char rocblas_precision_string<rocblas_i8_complex    >[] = "i8_c";
+template <> static constexpr char rocblas_precision_string<rocblas_u8_complex    >[] = "u8_c";
+template <> static constexpr char rocblas_precision_string<rocblas_i32_complex   >[] = "i32_c";
+template <> static constexpr char rocblas_precision_string<rocblas_u32_complex   >[] = "u32_c";
 #endif
 
 // clang-format on


### PR DESCRIPTION
Resolves: SWDEV-188303

In [DR2387](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1359r0.html#2387), it was recently decided that unlike regular `const`-qualified variables, `const`-qualified **_variable templates_** do not have internal linkage by default.

Most compilers up to now have made `const`-qualified variable templates have internal linkage by default, all the way back to C++14. The standard was unclear.

This change declares _all_ `const`-qualified variable templates in rocBLAS as `static`.

[Recent changes to clang for DR2387](https://github.com/llvm/llvm-project/search?q=DR2387&type=Commits), which change the default linkage of `const`-qualified variable templates from internal to external.

[Detailed history / context of the problem](https://github.com/ROCmSoftwarePlatform/rocBLAS/pull/549#issuecomment-489879395)
