### PR TITLE
Simplify and fix error handling of version string function

### DIFF
--- a/library/src/buildinfo.cpp
+++ b/library/src/buildinfo.cpp
@@ -27,15 +27,11 @@
  ******************************************************************************/
 extern "C" rocblas_status rocblas_get_version_string(char* buf, size_t len)
 {
-    std::string v(VERSION_STRING);
-    strcpy(buf, v.c_str());
-
-    if(buf == NULL)
-        return rocblas_status_internal_error;
-
-    size_t count = std::min(len - 1, v.length());
-    memcpy(buf, v.c_str(), count);
-    *(buf + count) = '\0';
-
+    static constexpr char v[] = VERSION_STRING;
+    if(!buf)
+        return rocblas_status_invalid_pointer;
+    if(len < sizeof(v))
+        return rocblas_status_invalid_size;
+    memcpy(buf, v, sizeof(v));
     return rocblas_status_success;
 }


### PR DESCRIPTION
Current code unnecessarily uses `std::string` while plain C-style `char` array is sufficient (`std::string` requires allocation and deallocation from the heap, while C-style `char` array can be stored in `.text` as read-only memory).

Current code calls `strcpy` before checking whether the destination is `NULL`, which can cause crash instead of detecting the `NULL`. Also, status code should be `rocblas_status_invalid_pointer` instead of `rocblas_status_internal_error`.

Current code is overly complicated with respect to copying the string to the destination, copying it twice.

The new code checks whether destination is large enough, and if it is, calls `memcpy` to copy the known-length string (including the trailing `'\0'`); otherwise, it returns `rocblas_status_invalid_size`.