### PR TITLE
trsv implementation

### DIFF
--- a/library/src/blas2/gemv.hpp
+++ b/library/src/blas2/gemv.hpp
@@ -1,0 +1,61 @@
+/* ************************************************************************
+ * Copyright 2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+#ifndef _GEMV_HPP_
+#define _GEMV_HPP_
+
+#include <hip/hip_runtime.h>
+
+template <typename T>
+rocblas_status rocblas_gemv_template(rocblas_handle handle,
+                                     rocblas_operation transA,
+                                     rocblas_int m,
+                                     rocblas_int n,
+                                     const T* alpha,
+                                     const T* A,
+                                     rocblas_int lda,
+                                     const T* x,
+                                     rocblas_int incx,
+                                     const T* beta,
+                                     T* y,
+                                     rocblas_int incy);
+
+template <>
+rocblas_status rocblas_gemv_template(rocblas_handle handle,
+                                     rocblas_operation transA,
+                                     rocblas_int m,
+                                     rocblas_int n,
+                                     const float* alpha,
+                                     const float* A,
+                                     rocblas_int lda,
+                                     const float* x,
+                                     rocblas_int incx,
+                                     const float* beta,
+                                     float* y,
+                                     rocblas_int incy)
+
+{
+    return rocblas_sgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+template <>
+rocblas_status rocblas_gemv_template(rocblas_handle handle,
+                                     rocblas_operation transA,
+                                     rocblas_int m,
+                                     rocblas_int n,
+                                     const double* alpha,
+                                     const double* A,
+                                     rocblas_int lda,
+                                     const double* x,
+                                     rocblas_int incx,
+                                     const double* beta,
+                                     double* y,
+                                     rocblas_int incy)
+
+{
+    return rocblas_dgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+#endif // _GEMV_HPP_

--- a/library/src/blas2/rocblas_trsv.cpp
+++ b/library/src/blas2/rocblas_trsv.cpp
@@ -1,51 +1,499 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
+
+#include <hip/hip_runtime_api.h>
 #include <hip/hip_runtime.h>
 
+#include "rocblas_trsv.hpp"
 #include "rocblas.h"
-#include "rocblas_trsm.hpp"
 #include "status.h"
 #include "definitions.h"
+#include "gemv.hpp"
+#include "../blas3/trtri_trsm.hpp"
+#include "rocblas_unique_ptr.hpp"
 #include "handle.h"
 #include "logging.h"
 #include "utility.h"
-#include "rocblas_unique_ptr.hpp"
 
 namespace {
 
-template <bool to_temp, typename T>
-__global__ void strided_vector_copy_kernel(T* x, rocblas_int m, T* x_temp, rocblas_int incx)
+#define A(ii, jj) (A + (ii) + (jj)*lda)
+#define B(ii) (B + (ii))
+#define X(ii) (X + (ii))
+#define invA(ii) (invA + (ii)*BLOCK)
+
+template <typename T>
+__global__ void flip_vector_kernel(T* data, rocblas_int size)
 {
     ssize_t tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    ssize_t ty = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
-
-    ssize_t id_temp = ty * hipBlockDim_x * hipGridDim_x + tx;
-    ssize_t id_x    = incx * id_temp;
-
-    if(id_temp < m)
+    if(tx < (size / 2))
     {
-        if(to_temp)
-            x_temp[id_temp] = x[id_x];
-        else
-            x[id_x] = x_temp[id_temp];
+        T temp              = data[tx];
+        data[tx]            = data[size - tx - 1];
+        data[size - tx - 1] = temp;
     }
 }
 
-template <bool to_temp, typename T>
-void strided_vector_copy(
-    hipStream_t rocblas_stream, T* x, rocblas_int m, T* x_temp, rocblas_int incx)
+template <typename T>
+void flip_vector(hipStream_t rocblas_stream, T* data, rocblas_int size)
 {
-    static constexpr int NB_X = 128;
-    static constexpr int NB_Y = 8;
-    rocblas_int blocksX       = (m - 1) / NB_X + 1; // parameters for device kernel
-    rocblas_int blocksY       = (m - 1) / NB_Y + 1;
-    dim3 grid(blocksX, blocksY);
-    dim3 threads(NB_X, NB_Y);
+    static constexpr int NB_X = 1024;
+    rocblas_int blocksX       = (size / 2) / NB_X + 1;
+    dim3 grid(blocksX);
+    dim3 threads(NB_X);
 
-    hipLaunchKernelGGL(
-        strided_vector_copy_kernel<to_temp>, grid, threads, 0, rocblas_stream, x, m, x_temp, incx);
+    hipLaunchKernelGGL(flip_vector_kernel, grid, threads, 0, rocblas_stream, data, size);
 }
+
+template <typename T>
+__global__ void strided_vector_copy_kernel(
+    T* dst, rocblas_int dst_incx, const T* src, rocblas_int src_incx, rocblas_int size)
+{
+    ssize_t tx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if(tx < size)
+    {
+        dst[tx * dst_incx] = src[tx * src_incx];
+    }
+}
+
+template <typename T>
+void strided_vector_copy(hipStream_t rocblas_stream,
+                         T* dst,
+                         rocblas_int dst_incx,
+                         T* src,
+                         rocblas_int src_incx,
+                         rocblas_int size)
+{
+    static constexpr int NB_X = 1024;
+    rocblas_int blocksX       = (size - 1) / NB_X + 1;
+    dim3 grid(blocksX);
+    dim3 threads(NB_X);
+
+    hipLaunchKernelGGL(strided_vector_copy_kernel,
+                       grid,
+                       threads,
+                       0,
+                       rocblas_stream,
+                       dst,
+                       dst_incx,
+                       src,
+                       src_incx,
+                       size);
+}
+
+template <rocblas_int BLOCK, typename T>
+rocblas_status rocblas_trsv_left(rocblas_handle handle,
+                                 rocblas_fill uplo,
+                                 rocblas_operation transA,
+                                 rocblas_int m,
+                                 const T* A,
+                                 rocblas_int lda,
+                                 T* B,
+                                 rocblas_int incx,
+                                 const T* invA,
+                                 T* X)
+{
+    static constexpr T negative_one = -1;
+    static constexpr T one          = 1;
+    static constexpr T zero         = 0;
+
+    const T* p_one          = &one;
+    const T* p_zero         = &zero;
+    const T* p_negative_one = &negative_one;
+
+    if(handle->pointer_mode == rocblas_pointer_mode_device)
+    {
+        p_one          = reinterpret_cast<T*>(handle->get_trsv_one());
+        p_zero         = reinterpret_cast<T*>(handle->get_trsv_zero());
+        p_negative_one = reinterpret_cast<T*>(handle->get_trsv_negative_one());
+    }
+
+    rocblas_int i, jb;
+
+    // transB is always non-transpose
+    rocblas_operation transB = rocblas_operation_none;
+
+    if(transA == transB)
+    {
+        if(uplo == rocblas_fill_lower)
+        {
+            // left, lower no-transpose
+            jb = min(BLOCK, m);
+            rocblas_gemv_template<T>(
+                handle, transA, jb, jb, p_one, invA, BLOCK, B, incx, p_zero, X, 1);
+
+            if(BLOCK < m)
+            {
+                rocblas_gemv_template<T>(handle,
+                                         transA,
+                                         m - BLOCK,
+                                         BLOCK,
+                                         p_negative_one,
+                                         A(BLOCK, 0),
+                                         lda,
+                                         X,
+                                         1,
+                                         p_one,
+                                         B(BLOCK * incx),
+                                         incx);
+
+                // remaining blocks
+                for(i = BLOCK; i < m; i += BLOCK)
+                {
+                    jb = min(m - i, BLOCK);
+
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             jb,
+                                             jb,
+                                             p_one,
+                                             invA(i),
+                                             BLOCK,
+                                             B(i * incx),
+                                             incx,
+                                             p_zero,
+                                             X(i),
+                                             1);
+                    // this condition is not necessary at all and can be changed as if (i+BLOCK<m)
+                    if(i + BLOCK >= m)
+                        break;
+
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             m - i - BLOCK,
+                                             BLOCK,
+                                             p_negative_one,
+                                             A(i + BLOCK, i),
+                                             lda,
+                                             X(i),
+                                             1,
+                                             p_one,
+                                             B((i + BLOCK) * incx),
+                                             incx);
+                }
+            }
+        }
+        else
+        {
+            // left, upper no-transpose
+            jb = (m % BLOCK == 0) ? BLOCK : (m % BLOCK);
+            i  = m - jb;
+
+            // if m=n=35=lda=ldb, BLOCK =32, then jb = 3, i = 32; {3, 35, 3, 32, 35, 35}
+            rocblas_gemv_template<T>(
+                handle, transA, jb, jb, p_one, invA(i), BLOCK, B(i * incx), incx, p_zero, X(i), 1);
+
+            if(i - BLOCK >= 0)
+            {
+                rocblas_gemv_template<T>(
+                    handle, transA, i, jb, p_negative_one, A(0, i), lda, X(i), 1, p_one, B, incx);
+
+                // remaining blocks
+                for(i = m - jb - BLOCK; i >= 0; i -= BLOCK)
+                {
+                    //{32, 35, 32, 32, 35, 35}
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             BLOCK,
+                                             BLOCK,
+                                             p_one,
+                                             invA(i),
+                                             BLOCK,
+                                             B(i * incx),
+                                             incx,
+                                             p_zero,
+                                             X(i),
+                                             1);
+
+                    if(i - BLOCK < 0)
+                        break;
+
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             i,
+                                             BLOCK,
+                                             p_negative_one,
+                                             A(0, i),
+                                             lda,
+                                             X(i),
+                                             1,
+                                             p_one,
+                                             B,
+                                             incx);
+                }
+            }
+        }
+    }
+    else
+    { // transA == rocblas_operation_transpose || transA == rocblas_operation_conjugate_transpose
+        if(uplo == rocblas_fill_lower)
+        {
+            // left, lower transpose
+            jb = (m % BLOCK == 0) ? BLOCK : (m % BLOCK);
+            i  = m - jb;
+
+            rocblas_gemv_template<T>(
+                handle, transA, jb, jb, p_one, invA(i), BLOCK, B(i * incx), incx, p_zero, X(i), 1);
+
+            if(i - BLOCK >= 0)
+            {
+                rocblas_gemv_template<T>(
+                    handle, transA, jb, i, p_negative_one, A(i, 0), lda, X(i), 1, p_one, B, incx);
+
+                // remaining blocks
+                for(i = m - jb - BLOCK; i >= 0; i -= BLOCK)
+                {
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             BLOCK,
+                                             BLOCK,
+                                             p_one,
+                                             invA(i),
+                                             BLOCK,
+                                             B(i * incx),
+                                             incx,
+                                             p_zero,
+                                             X(i),
+                                             1);
+
+                    if(i - BLOCK < 0)
+                        break;
+
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             BLOCK,
+                                             i,
+                                             p_negative_one,
+                                             A(i, 0),
+                                             lda,
+                                             X(i),
+                                             1,
+                                             p_one,
+                                             B,
+                                             incx);
+                }
+            }
+        }
+        else
+        {
+            // left, upper transpose
+            jb = min(BLOCK, m);
+            rocblas_gemv_template<T>(
+                handle, transA, jb, jb, p_one, invA, BLOCK, B, incx, p_zero, X, 1);
+
+            if(BLOCK < m)
+            {
+                rocblas_gemv_template<T>(handle,
+                                         transA,
+                                         BLOCK,
+                                         m - BLOCK,
+                                         p_negative_one,
+                                         A(0, BLOCK),
+                                         lda,
+                                         X,
+                                         1,
+                                         p_one,
+                                         B(BLOCK * incx),
+                                         incx);
+
+                // remaining blocks
+                for(i = BLOCK; i < m; i += BLOCK)
+                {
+                    jb = min(m - i, BLOCK);
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             jb,
+                                             jb,
+                                             p_one,
+                                             invA(i),
+                                             BLOCK,
+                                             B(i * incx),
+                                             incx,
+                                             p_zero,
+                                             X(i),
+                                             1);
+
+                    if(i + BLOCK >= m)
+                        break;
+
+                    rocblas_gemv_template<T>(handle,
+                                             transA,
+                                             BLOCK,
+                                             m - i - BLOCK,
+                                             p_negative_one,
+                                             A(i, i + BLOCK),
+                                             lda,
+                                             X(i),
+                                             1,
+                                             p_one,
+                                             B((i + BLOCK) * incx),
+                                             incx);
+                }
+            }
+        }
+    } // transpose
+
+    return rocblas_status_success;
+}
+
+template <rocblas_int BLOCK, typename T>
+rocblas_status special_trsv_template(rocblas_handle handle,
+                                     rocblas_fill uplo,
+                                     rocblas_operation transA,
+                                     rocblas_diagonal diag,
+                                     rocblas_int m,
+                                     const T* A,
+                                     rocblas_int lda,
+                                     T* B,
+                                     rocblas_int incx,
+                                     const T* supplied_invA,
+                                     rocblas_int ldinvA,
+                                     const size_t* B_chunk,
+                                     T* x)
+{
+    hipStream_t rocblas_stream;
+    RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+
+    if(*B_chunk == 0)
+        return rocblas_status_invalid_size;
+
+    if(!x)
+    {
+        T* invA_temp = reinterpret_cast<T*>(handle->get_trsm_invA());
+        T* invA_C    = reinterpret_cast<T*>(handle->get_trsm_invA_C());
+
+        rocblas_trtri_trsm_template<T, BLOCK>(handle, invA_C, uplo, diag, m, A, lda, invA_temp);
+    }
+
+    T* x_temp     = x ? x : reinterpret_cast<T*>(handle->get_trsm_Y());
+    const T* invA = x ? supplied_invA : reinterpret_cast<T*>(handle->get_trsm_invA());
+
+    int R                = m / BLOCK;
+    const T zero         = 0;
+    const T one          = 1;
+    const T negative_one = -1;
+
+    const T* p_one          = &one;
+    const T* p_zero         = &zero;
+    const T* p_negative_one = &negative_one;
+
+    if(handle->pointer_mode == rocblas_pointer_mode_device)
+    {
+        p_one          = reinterpret_cast<T*>(handle->get_trsv_one());
+        p_zero         = reinterpret_cast<T*>(handle->get_trsv_zero());
+        p_negative_one = reinterpret_cast<T*>(handle->get_trsv_negative_one());
+    }
+
+    for(int r = 0; r < R; r++)
+    {
+        int q = R - 1 - r;
+
+        int j = (((uplo == rocblas_fill_lower) && (transA == rocblas_operation_none)) ||
+                 ((uplo == rocblas_fill_upper) && (transA == rocblas_operation_transpose)))
+                    ? r
+                    : q;
+
+        // copy a BLOCK*n piece we are solving at a time
+        strided_vector_copy<T>(rocblas_stream, x_temp, 1, B + j * BLOCK * incx, incx, BLOCK);
+
+        if(r > 0)
+        {
+            const T* A_current = nullptr;
+            T* B_current       = nullptr;
+
+            if((uplo == rocblas_fill_upper) && (transA == rocblas_operation_transpose))
+            {
+                A_current = A + r * BLOCK * lda;
+                B_current = B;
+            }
+            else if((uplo == rocblas_fill_lower) && (transA == rocblas_operation_none))
+            {
+                A_current = A + r * BLOCK;
+                B_current = B;
+            }
+            else if((uplo == rocblas_fill_lower) && (transA == rocblas_operation_transpose))
+            {
+                A_current = A + q * BLOCK * lda + (q + 1) * BLOCK;
+                B_current = B + (q + 1) * BLOCK * incx;
+            }
+            else // ((uplo == rocblas_fill_upper) && (transA == rocblas_operation_none))
+            {
+                A_current = A + (q + 1) * BLOCK * lda + q * BLOCK;
+                B_current = B + (q + 1) * BLOCK * incx;
+            }
+
+            rocblas_int M = (transA == rocblas_operation_none) ? BLOCK : r * BLOCK;
+            rocblas_int N = (transA == rocblas_operation_none) ? r * BLOCK : BLOCK;
+            rocblas_gemv_template(handle,
+                                  transA,
+                                  M,
+                                  N,
+                                  p_negative_one,
+                                  A_current,
+                                  lda,
+                                  B_current,
+                                  incx,
+                                  p_one,
+                                  (T*)x_temp,
+                                  1);
+        }
+
+        rocblas_gemv_template(handle,
+                              transA,
+                              BLOCK,
+                              BLOCK,
+                              p_one,
+                              ((T*)invA) + j * BLOCK * BLOCK,
+                              BLOCK,
+                              (T*)x_temp,
+                              1,
+                              p_zero,
+                              (T*)B + j * BLOCK * incx,
+                              incx);
+    }
+
+    return rocblas_status_success;
+}
+
+template <rocblas_int BLOCK, typename T>
+rocblas_status rocblas_trsv_impl(rocblas_handle handle,
+                                 rocblas_fill uplo,
+                                 rocblas_operation transA,
+                                 rocblas_diagonal diag,
+                                 rocblas_int m,
+                                 const T* A,
+                                 rocblas_int lda,
+                                 T* B,
+                                 rocblas_int incx,
+                                 const T* invA,
+                                 rocblas_int ldInvA,
+                                 const size_t* x_temp_size,
+                                 T* x_temp)
+{
+    if(m % BLOCK == 0 && m <= BLOCK * *(handle->get_trsm_A_blks()))
+    {
+        rocblas_operation trA = transA;
+        if(trA == rocblas_operation_conjugate_transpose)
+            trA = rocblas_operation_transpose;
+
+        return special_trsv_template<BLOCK>(
+            handle, uplo, trA, diag, m, A, lda, B, incx, invA, ldInvA, x_temp_size, x_temp);
+    }
+
+    hipStream_t rocblas_stream;
+    RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+
+    rocblas_status status =
+        rocblas_trsv_left<BLOCK>(handle, uplo, transA, m, A, lda, B, incx, invA, x_temp);
+
+    // copy solution X into B
+    strided_vector_copy(rocblas_stream, B, incx, x_temp, 1, m);
+
+    return status;
+}
+
+} // namespace
 
 template <typename>
 static constexpr char rocblas_trsv_name[] = "unknown";
@@ -55,23 +503,85 @@ template <>
 static constexpr char rocblas_trsv_name<double>[] = "rocblas_dtrsv";
 
 template <rocblas_int BLOCK, typename T>
-rocblas_status rocblas_trsv(rocblas_handle handle,
-                            rocblas_fill uplo,
-                            rocblas_operation transA,
-                            rocblas_diagonal diag,
-                            rocblas_int m,
-                            const T* A,
-                            rocblas_int lda,
-                            T* x,
-                            rocblas_int incx)
+rocblas_status rocblas_trsv_ex_template(rocblas_handle handle,
+                                        rocblas_fill uplo,
+                                        rocblas_operation transA,
+                                        rocblas_diagonal diag,
+                                        rocblas_int m,
+                                        const T* A,
+                                        rocblas_int lda,
+                                        T* B,
+                                        rocblas_int incx,
+                                        const T* invA,
+                                        rocblas_int ldInvA,
+                                        const size_t* x_temp_size,
+                                        T* x_temp)
+{
+    if(!m)
+        return rocblas_status_success;
+
+    if(!invA)
+        return rocblas_status_memory_error;
+
+    if(!x_temp_size || (*x_temp_size) < m)
+        return rocblas_status_invalid_size;
+
+    if(handle->pointer_mode == rocblas_pointer_mode_device)
+    {
+        static const T one{1};
+        static const T zero{0};
+        static const T negative_one{-1};
+
+        T* one_d = (T*)handle->get_trsv_one();
+        RETURN_IF_HIP_ERROR(hipMemcpy(one_d, &one, sizeof(T), hipMemcpyHostToDevice));
+        T* zero_d = (T*)handle->get_trsv_zero();
+        RETURN_IF_HIP_ERROR(hipMemcpy(zero_d, &zero, sizeof(T), hipMemcpyHostToDevice));
+        T* negative_one_d = (T*)handle->get_trsv_negative_one();
+        RETURN_IF_HIP_ERROR(
+            hipMemcpy(negative_one_d, &negative_one, sizeof(T), hipMemcpyHostToDevice));
+    }
+
+    hipStream_t rocblas_stream;
+    RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+
+    // TODO: workaround to fix negative incx issue
+    rocblas_int abs_incx = (incx > 0) ? incx : -incx;
+
+    if(incx < 0)
+    {
+        flip_vector(rocblas_stream, B, (m - 1) * abs_incx + 1);
+    }
+
+    rocblas_status status = rocblas_trsv_impl<BLOCK>(
+        handle, uplo, transA, diag, m, A, lda, B, abs_incx, invA, ldInvA, x_temp_size, x_temp);
+
+    if(incx < 0)
+    {
+        flip_vector(rocblas_stream, B, (m - 1) * abs_incx + 1);
+    }
+
+    return status;
+}
+
+template <rocblas_int BLOCK, typename T>
+rocblas_status rocblas_trsv_template(rocblas_handle handle,
+                                     rocblas_fill uplo,
+                                     rocblas_operation transA,
+                                     rocblas_diagonal diag,
+                                     rocblas_int m,
+                                     const T* A,
+                                     rocblas_int lda,
+                                     T* B,
+                                     rocblas_int incx)
 {
     if(!handle)
         return rocblas_status_invalid_handle;
 
     auto pointer_mode = handle->pointer_mode;
     auto layer_mode   = handle->layer_mode;
+
     if(layer_mode & rocblas_layer_mode_log_trace)
-        log_trace(handle, rocblas_trsv_name<T>, uplo, transA, diag, m, A, lda, x, incx);
+        log_trace(handle, rocblas_trsv_name<T>, uplo, transA, diag, m, A, lda, B, incx);
 
     if(layer_mode & (rocblas_layer_mode_log_bench | rocblas_layer_mode_log_profile))
     {
@@ -118,7 +628,7 @@ rocblas_status rocblas_trsv(rocblas_handle handle,
 
     if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
         return rocblas_status_not_implemented;
-    if(!A || !x)
+    if(!A || !B)
         return rocblas_status_invalid_pointer;
     if(m < 0 || lda < m || lda < 1 || !incx)
         return rocblas_status_invalid_size;
@@ -127,46 +637,113 @@ rocblas_status rocblas_trsv(rocblas_handle handle,
     if(!m)
         return rocblas_status_success;
 
-    // Calling TRSM for now
-    rocblas_status status;
-
-    static constexpr T alpha_h{1};
-    const T* alpha = &alpha_h;
-    if(pointer_mode == rocblas_pointer_mode_device)
+    if(handle->pointer_mode == rocblas_pointer_mode_device)
     {
-        T* alpha_d = (T*)handle->get_trsv_alpha();
-        RETURN_IF_HIP_ERROR(hipMemcpy(alpha_d, &alpha_h, sizeof(T), hipMemcpyHostToDevice));
-        alpha = alpha_d;
+        static const T one{1};
+        static const T zero{0};
+        static const T negative_one{-1};
+
+        T* one_d = (T*)handle->get_trsv_one();
+        RETURN_IF_HIP_ERROR(hipMemcpy(one_d, &one, sizeof(T), hipMemcpyHostToDevice));
+        T* zero_d = (T*)handle->get_trsv_zero();
+        RETURN_IF_HIP_ERROR(hipMemcpy(zero_d, &zero, sizeof(T), hipMemcpyHostToDevice));
+        T* negative_one_d = (T*)handle->get_trsv_negative_one();
+        RETURN_IF_HIP_ERROR(
+            hipMemcpy(negative_one_d, &negative_one, sizeof(T), hipMemcpyHostToDevice));
     }
 
-    if(incx == 1)
+    hipStream_t rocblas_stream;
+    RETURN_IF_ROCBLAS_ERROR(rocblas_get_stream(handle, &rocblas_stream));
+
+    // TODO: workaround to fix negative incx issue
+    rocblas_int abs_incx = (incx > 0) ? incx : -incx;
+
+    if(m % BLOCK == 0 && m <= BLOCK * *(handle->get_trsm_A_blks()))
     {
-        status = rocblas_trsm_template<BLOCK>(
-            handle, rocblas_side_left, uplo, transA, diag, m, 1, alpha, A, lda, x, m);
-    }
-    else
-    {
+        rocblas_operation trA = transA;
+        if(trA == rocblas_operation_conjugate_transpose)
+            trA = rocblas_operation_transpose;
+
         if(incx < 0)
-            x -= ssize_t(incx) * (m - 1);
+        {
+            flip_vector(rocblas_stream, B, (m - 1) * abs_incx + 1);
+        }
 
-        T* dx_mod = sizeof(T) * m <= *(handle->get_trsv_X_size())
-                        ? (T*)handle->get_trsv_x()
-                        : (T*)rocblas_unique_ptr(rocblas::device_malloc(sizeof(T) * m),
-                                                 rocblas::device_free)
-                              .get();
+        T* x_temp                 = nullptr;
+        const T* invA             = nullptr;
+        const size_t* x_temp_size = nullptr;
 
-        strided_vector_copy<true>(handle->rocblas_stream, x, m, dx_mod, incx);
+        rocblas_status status = special_trsv_template<BLOCK>(handle,
+                                                             uplo,
+                                                             trA,
+                                                             diag,
+                                                             m,
+                                                             A,
+                                                             lda,
+                                                             B,
+                                                             abs_incx,
+                                                             invA,
+                                                             0,
+                                                             (handle->get_trsm_B_chnk()),
+                                                             x_temp);
+        if(incx < 0)
+        {
+            flip_vector(rocblas_stream, B, (m - 1) * abs_incx + 1);
+        }
 
-        status = rocblas_trsm_template<BLOCK>(
-            handle, rocblas_side_left, uplo, transA, diag, m, 1, alpha, A, lda, dx_mod, m);
+        return status;
+    }
 
-        strided_vector_copy<false>(handle->rocblas_stream, x, m, dx_mod, incx);
+    // invA is of size BLOCK*k, BLOCK is the blocking size
+    // used unique_ptr to avoid memory leak
+    auto invA =
+        rocblas_unique_ptr{rocblas::device_malloc(BLOCK * m * sizeof(T)), rocblas::device_free};
+    if(!invA)
+        return rocblas_status_memory_error;
+
+    auto C_tmp = rocblas_unique_ptr{
+        rocblas::device_malloc(sizeof(T) * (BLOCK / 2) * (BLOCK / 2) * (m / BLOCK)),
+        rocblas::device_free};
+    if(!C_tmp && m >= BLOCK)
+        return rocblas_status_memory_error;
+
+    // X is size of packed B
+    auto X = rocblas_unique_ptr{rocblas::device_malloc(m * sizeof(T)), rocblas::device_free};
+    if(!X)
+        return rocblas_status_memory_error;
+
+    // batched trtri invert diagonal part (BLOCK*BLOCK) of A into invA
+    rocblas_status status = rocblas_trtri_trsm_template<T, BLOCK>(
+        handle, (T*)C_tmp.get(), uplo, diag, m, A, lda, (T*)invA.get());
+    if(status != rocblas_status_success)
+        return status;
+
+    if(incx < 0)
+    {
+        flip_vector(rocblas_stream, B, (m - 1) * abs_incx + 1);
+    }
+
+    status = rocblas_trsv_impl<BLOCK>(handle,
+                                      uplo,
+                                      transA,
+                                      diag,
+                                      m,
+                                      A,
+                                      lda,
+                                      B,
+                                      abs_incx,
+                                      (T*)invA.get(),
+                                      BLOCK,
+                                      (handle->get_trsm_B_chnk()),
+                                      (T*)X.get());
+
+    if(incx < 0)
+    {
+        flip_vector(rocblas_stream, B, (m - 1) * abs_incx + 1);
     }
 
     return status;
 }
-
-} // namespace
 
 /*
  * ===========================================================================
@@ -175,6 +752,44 @@ rocblas_status rocblas_trsv(rocblas_handle handle,
  */
 
 extern "C" {
+
+rocblas_status rocblas_strsv_ex(rocblas_handle handle,
+                                rocblas_fill uplo,
+                                rocblas_operation transA,
+                                rocblas_diagonal diag,
+                                rocblas_int m,
+                                const float* A,
+                                rocblas_int lda,
+                                float* x,
+                                rocblas_int incx,
+                                const float* invA,
+                                rocblas_int ldInvA,
+                                const size_t* x_temp_size,
+                                float* x_temp)
+{
+    static constexpr rocblas_int STRSV_BLOCK = 128;
+    return rocblas_trsv_ex_template<STRSV_BLOCK>(
+        handle, uplo, transA, diag, m, A, lda, x, incx, invA, ldInvA, x_temp_size, x_temp);
+}
+
+rocblas_status rocblas_dtrsv_ex(rocblas_handle handle,
+                                rocblas_fill uplo,
+                                rocblas_operation transA,
+                                rocblas_diagonal diag,
+                                rocblas_int m,
+                                const double* A,
+                                rocblas_int lda,
+                                double* x,
+                                rocblas_int incx,
+                                const double* invA,
+                                rocblas_int ldInvA,
+                                const size_t* x_temp_size,
+                                double* x_temp)
+{
+    static constexpr rocblas_int DTRSV_BLOCK = 128;
+    return rocblas_trsv_ex_template<DTRSV_BLOCK>(
+        handle, uplo, transA, diag, m, A, lda, x, incx, invA, ldInvA, x_temp_size, x_temp);
+}
 
 rocblas_status rocblas_strsv(rocblas_handle handle,
                              rocblas_fill uplo,
@@ -187,7 +802,7 @@ rocblas_status rocblas_strsv(rocblas_handle handle,
                              rocblas_int incx)
 {
     static constexpr rocblas_int STRSV_BLOCK = 128;
-    return rocblas_trsv<STRSV_BLOCK>(handle, uplo, transA, diag, m, A, lda, x, incx);
+    return rocblas_trsv_template<STRSV_BLOCK>(handle, uplo, transA, diag, m, A, lda, x, incx);
 }
 
 rocblas_status rocblas_dtrsv(rocblas_handle handle,
@@ -201,7 +816,7 @@ rocblas_status rocblas_dtrsv(rocblas_handle handle,
                              rocblas_int incx)
 {
     static constexpr rocblas_int DTRSV_BLOCK = 128;
-    return rocblas_trsv<DTRSV_BLOCK>(handle, uplo, transA, diag, m, A, lda, x, incx);
+    return rocblas_trsv_template<DTRSV_BLOCK>(handle, uplo, transA, diag, m, A, lda, x, incx);
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trsm.cpp
+++ b/library/src/blas3/rocblas_trsm.cpp
@@ -1,9 +1,11 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
+
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_runtime.h>
 
+#include "rocblas_trsm.hpp"
 #include "rocblas.h"
 #include "status.h"
 #include "definitions.h"

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 #include "handle.h"
 #include <cstdlib>
@@ -41,6 +41,9 @@ _rocblas_handle::_rocblas_handle()
     // allocate trsv temp buffers
     THROW_IF_HIP_ERROR(hipMalloc(&trsv_x, WORKBUF_TRSV_X_SZ));
     THROW_IF_HIP_ERROR(hipMalloc(&trsv_alpha, WORKBUF_TRSV_ALPHA_SZ));
+    THROW_IF_HIP_ERROR(hipMalloc(&trsv_one, WORKBUF_TRSV_CONSTANT_SZ));
+    THROW_IF_HIP_ERROR(hipMalloc(&trsv_zero, WORKBUF_TRSV_CONSTANT_SZ));
+    THROW_IF_HIP_ERROR(hipMalloc(&trsv_negative_one, WORKBUF_TRSV_CONSTANT_SZ));
 }
 
 /*******************************************************************************
@@ -58,6 +61,12 @@ _rocblas_handle::~_rocblas_handle()
         hipFree(trsv_x);
     if(trsv_alpha)
         hipFree(trsv_alpha);
+    if(trsv_one)
+        hipFree(trsv_one);
+    if(trsv_zero)
+        hipFree(trsv_zero);
+    if(trsv_negative_one)
+        hipFree(trsv_negative_one);
 }
 
 /*******************************************************************************

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #ifndef HANDLE_H
@@ -57,6 +57,9 @@ struct _rocblas_handle
     // trsv get pointers
     void* get_trsv_x() const { return trsv_x; }
     void* get_trsv_alpha() const { return trsv_alpha; }
+    void* get_trsv_one() const { return trsv_one; }
+    void* get_trsv_zero() const { return trsv_zero; }
+    void* get_trsv_negative_one() const { return trsv_negative_one; }
     const size_t* get_trsv_X_size() { return &WORKBUF_TRSV_X_SZ; }
 
     rocblas_int device;
@@ -74,8 +77,11 @@ struct _rocblas_handle
     void* trsm_invA_C = nullptr;
 
     // space allocated for trsv
-    void* trsv_x     = nullptr;
-    void* trsv_alpha = nullptr;
+    void* trsv_x            = nullptr;
+    void* trsv_alpha        = nullptr;
+    void* trsv_one          = nullptr;
+    void* trsv_zero         = nullptr;
+    void* trsv_negative_one = nullptr;
 
     // default logging_mode is no logging
     static rocblas_layer_mode layer_mode;
@@ -104,12 +110,13 @@ struct _rocblas_handle
     private:
     size_t WORKBUF_TRSM_B_CHNK;
     size_t WORKBUF_TRSM_Y_SZ;
-    const size_t WORKBUF_TRSM_A_BLKS     = 10;
-    const size_t WORKBUF_TRSM_B_MIN_CHNK = 1024;
-    const size_t WORKBUF_TRSM_INVA_SZ    = 128 * 128 * 10 * sizeof(double);
-    const size_t WORKBUF_TRSM_INVA_C_SZ  = 128 * 128 * 10 * sizeof(double) / 2;
-    const size_t WORKBUF_TRSV_X_SZ       = 131072 * sizeof(double);
-    const size_t WORKBUF_TRSV_ALPHA_SZ   = sizeof(double);
+    const size_t WORKBUF_TRSM_A_BLKS      = 10;
+    const size_t WORKBUF_TRSM_B_MIN_CHNK  = 1024;
+    const size_t WORKBUF_TRSM_INVA_SZ     = 128 * 128 * 10 * sizeof(double);
+    const size_t WORKBUF_TRSM_INVA_C_SZ   = 128 * 128 * 10 * sizeof(double) / 2;
+    const size_t WORKBUF_TRSV_X_SZ        = 131072 * sizeof(double);
+    const size_t WORKBUF_TRSV_ALPHA_SZ    = sizeof(double);
+    const size_t WORKBUF_TRSV_CONSTANT_SZ = sizeof(double);
     static int get_device_arch_id()
     {
         int deviceId;

--- a/library/src/include/rocblas_trsm.hpp
+++ b/library/src/include/rocblas_trsm.hpp
@@ -1,6 +1,10 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
+
+#ifndef _ROCBLAS_TRSM_HPP_
+#define _ROCBLAS_TRSM_HPP_
+
 #include "rocblas.h"
 #include "status.h"
 
@@ -112,3 +116,4 @@ rocblas_status rocblas_trsm_ex_template(rocblas_handle handle,
                                         rocblas_int ldInvA,
                                         const size_t* x_temp_size,
                                         T* x_temp);
+#endif // _ROCBLAS_TRSM_HPP_

--- a/library/src/include/rocblas_trsv.hpp
+++ b/library/src/include/rocblas_trsv.hpp
@@ -1,0 +1,91 @@
+/* ************************************************************************
+ * Copyright 2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#ifndef _ROCBLAS_TRSV_HPP_
+#define _ROCBLAS_TRSV_HPP_
+
+#include "rocblas.h"
+#include "status.h"
+
+/* ============================================================================================ */
+
+/*! \brief BLAS Level 2 API
+
+    \details
+    trsv solves
+
+         A*x = alpha*b or A**T*x = alpha*b,
+
+    where x and b are vectors and A is a triangular matrix.
+
+    The vector x is overwritten on b.
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+
+    @param[in]
+    uplo    rocblas_fill.
+            rocblas_fill_upper:  A is an upper triangular matrix.
+            rocblas_fill_lower:  A is a  lower triangular matrix.
+
+    @param[in]
+    transA     rocblas_operation
+
+    @param[in]
+    diag    rocblas_diagonal.
+            rocblas_diagonal_unit:     A is assumed to be unit triangular.
+            rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
+
+    @param[in]
+    m         rocblas_int
+              m specifies the number of rows of b. m >= 0.
+
+    @param[in]
+    alpha
+              specifies the scalar alpha.
+
+    @param[in]
+    A         pointer storing matrix A on the GPU,
+              of dimension ( lda, m )
+
+    @param[in]
+    lda       rocblas_int
+              specifies the leading dimension of A.
+              lda = max( 1, m ).
+
+    @param[in]
+    x         pointer storing vector x on the GPU.
+
+    @param[in]
+    incx      specifies the increment for the elements of x.
+
+    ********************************************************************/
+
+template <rocblas_int BLOCK, typename T>
+rocblas_status rocblas_trsv_template(rocblas_handle handle,
+                                     rocblas_fill uplo,
+                                     rocblas_operation transA,
+                                     rocblas_diagonal diag,
+                                     rocblas_int m,
+                                     const T* A,
+                                     rocblas_int lda,
+                                     T* x,
+                                     rocblas_int incx);
+
+template <rocblas_int BLOCK, typename T>
+rocblas_status rocblas_trsv_ex_template(rocblas_handle handle,
+                                        rocblas_fill uplo,
+                                        rocblas_operation transA,
+                                        rocblas_diagonal diag,
+                                        rocblas_int m,
+                                        const T* A,
+                                        rocblas_int lda,
+                                        T* x,
+                                        rocblas_int incx,
+                                        const T* invA,
+                                        rocblas_int ldInvA,
+                                        const size_t* x_temp_size,
+                                        T* x_temp);
+#endif // _ROCBLAS_TRSV_HPP_


### PR DESCRIPTION
1. use gemv to implement trsv
2. add trsv_ex function

resolves #___

Summary of proposed changes:
-  some of our users didn't accept to use trsm to implement trsv function.
-  We implement trsv function by using gemv function. We are reference to trsm function and replace gemm by gemv to achieve trsv function which has better performance.
-  We also implement trsv_ex and trsv_ex testcase, all implementation are reference to trsm implementation.
