### PR TITLE
Simplify and tune rocblas_bfloat16.h

### DIFF
--- a/clients/include/rocblas_random.hpp
+++ b/clients/include/rocblas_random.hpp
@@ -28,8 +28,9 @@ class rocblas_nan_rng
     static T random_nan_data()
     {
         static_assert(sizeof(UINT_T) == sizeof(T), "Type sizes do not match");
-        union
+        union u_t
         {
+            u_t() {}
             UINT_T u;
             T fp;
         } x;
@@ -60,11 +61,8 @@ class rocblas_nan_rng
     // Random NaN bfloat16
     explicit operator rocblas_bfloat16()
     {
-        return rocblas_bfloat16::float_to_bfloat16(random_nan_data<float, uint32_t, 23, 8>());
+        return random_nan_data<rocblas_bfloat16, uint16_t, 7, 8>();
     }
-    // TODO: fix below
-    //  explicit operator rocblas_bfloat16() { return random_nan_data<rocblas_bfloat16, uint16_t, 7,
-    //  8>(); }
 };
 
 /* ============================================================================================ */
@@ -90,7 +88,7 @@ inline rocblas_half random_generator<rocblas_half>()
 template <>
 inline rocblas_bfloat16 random_generator<rocblas_bfloat16>()
 {
-    return static_cast<rocblas_bfloat16>((std::uniform_int_distribution<int>(-2, 2)(rocblas_rng)));
+    return rocblas_bfloat16(std::uniform_int_distribution<int>(-2, 2)(rocblas_rng));
 };
 
 /*! \brief  generate a random number in range [1,2,3] */

--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -6,19 +6,20 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
- * ies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
- * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
- * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 /*!\file
@@ -29,199 +30,155 @@
 #ifndef _ROCBLAS_BFLOAT16_H_
 #define _ROCBLAS_BFLOAT16_H_
 
-#include <cmath>
-#include <cinttypes>
-#include <iostream>
+#ifndef __cplusplus
 
-#ifndef __BYTE_ORDER__
-#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
-#endif
+#include <inttypes.h>
 
-#define BFLOAT16_Q_NAN_VALUE 0xFFC1
-
-typedef struct rocblas_bfloat16
+typedef struct
 {
-    rocblas_bfloat16() : data(BFLOAT16_ZERO_VALUE) {}
+    uint16_t data;
+} rocblas_bfloat16;
+
+#else // __cplusplus
+
+#include <cinttypes>
+#include <cmath>
+#include <iostream>
+#include <type_traits>
+
+struct rocblas_bfloat16
+{
+    uint16_t data;
+
+    constexpr rocblas_bfloat16() : data(0) {}
+
+    // round upper 16 bits of IEEE float to convert to bfloat16
+    explicit constexpr rocblas_bfloat16(float f) : data(float_to_bfloat16(f)) {}
+
     // zero extend lower 16 bits of bfloat16 to convert to IEEE float
-    static float bfloat16_to_float(const rocblas_bfloat16 v)
+    explicit constexpr operator float() const
     {
         union
         {
-            float fp32 = 0;
-            uint16_t q[2];
-        };
-
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        q[0] = v.data;
-#else
-        q[1]      = v.data;
-#endif
-        return fp32;
+            uint32_t int32;
+            float fp32;
+        } u = {uint32_t(data) << 16};
+        return u.fp32;
     }
 
-    // truncate lower 16 bits of IEEE float to convert to bfloat16
-    static rocblas_bfloat16 float_to_bfloat16(const float v)
+    private:
+    static constexpr uint16_t float_to_bfloat16(float f)
     {
-        rocblas_bfloat16 bf16;
-        if(std::isnan(v))
-        {
-            bf16.data = BFLOAT16_Q_NAN_VALUE;
-            return bf16;
-        }
         union
         {
             float fp32;
-            uint16_t p[2];
-        };
-        fp32 = v;
-
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        bf16.data = p[0];
-#else
-        bf16.data = p[1];
-#endif
-        return bf16;
+            uint32_t int32;
+        } u = {f};
+        if(~u.int32 & 0x7f800000)
+        {
+            // When the exponent bits are not all 1s, then the value is zero, normal,
+            // or subnormal. We round the bfloat16 mantissa up by adding 0x7FFF, plus
+            // 1 if the least significant bit of the bfloat16 mantissa is 1 (odd).
+            // This causes the bfloat16's mantissa to be incremented by 1 if the 16
+            // least significant bits of the float mantissa are greater than 0x8000,
+            // or if they are equal to 0x8000 and the least significant bit of the
+            // bfloat16 mantissa is 1 (odd). This causes it to be rounded to even when
+            // the lower 16 bits are exactly 0x8000. If the bfloat16 mantissa already
+            // has the value 0x7f, then incrementing it causes it to become 0x00 and
+            // the exponent is incremented by one, which is the next higher FP value
+            // to the unrounded bfloat16 value. When the bfloat16 value is subnormal
+            // with an exponent of 0x00 and a mantissa of 0x7F, it may be rounded up
+            // to a normal value with an exponent of 0x01 and a mantissa of 0x00.
+            // When the bfloat16 value has an exponent of 0xFE and a mantissa of 0x7F,
+            // incrementing it causes it to become an exponent of 0xFF and a mantissa
+            // of 0x00, which is Inf, the next higher value to the unrounded value.
+            u.int32 += 0x7fff + ((u.int32 >> 16) & 1); // Round to nearest, round to even
+        }
+        else if(u.int32 & 0xffff)
+        {
+            // When all of the exponent bits are 1, the value is Inf or NaN.
+            // Inf is indicated by a zero mantissa. NaN is indicated by any nonzero
+            // mantissa bit. Quiet NaN is indicated by the most significant mantissa
+            // bit being 1. Signaling NaN is indicated by the most significant
+            // mantissa bit being 0 but some other bit(s) being 1. If any of the
+            // lower 16 bits of the mantissa are 1, we set the least significant bit
+            // of the bfloat16 mantissa, in order to preserve signaling NaN in case
+            // the bloat16's mantissa bits are all 0.
+            u.int32 |= 0x10000; // Preserve signaling NaN
+        }
+        return uint16_t(u.int32 >> 16);
     }
+};
 
-    explicit rocblas_bfloat16(const float v) { data = float_to_bfloat16(v).data; }
+static_assert(std::is_standard_layout<rocblas_bfloat16>{},
+              "rocblas_bfloat16 is not a standard layout type, and thus is "
+              "incompatible with C.");
 
-    explicit rocblas_bfloat16(const double v)
-    {
-        data = float_to_bfloat16(static_cast<float>(v)).data;
-    }
-    explicit rocblas_bfloat16(const int v) { data = float_to_bfloat16(static_cast<float>(v)).data; }
-
-    explicit rocblas_bfloat16(const uint32_t v)
-    {
-        data = float_to_bfloat16(static_cast<float>(v)).data;
-    }
-
-    explicit rocblas_bfloat16(const uint16_t v)
-    {
-        data = float_to_bfloat16(static_cast<float>(v)).data;
-    }
-
-    explicit operator float() const { return bfloat16_to_float(*this); }
-
-    explicit operator double() const { return static_cast<double>(float(*this)); }
-
-    explicit operator int() const { return static_cast<int>(float(*this)); }
-
-    explicit operator uint32_t() const { return static_cast<uint32_t>(float(*this)); }
-
-    explicit operator uint16_t() const { return static_cast<uint16_t>(float(*this)); }
-
-    uint16_t data;
-
-    private:
-    static const int16_t BFLOAT16_ZERO_VALUE = 0x00;
-
-} rocblas_bfloat16;
+static_assert(std::is_trivially_copyable<rocblas_bfloat16>{},
+              "rocblas_bfloat16 is not trivially copyable, and thus is "
+              "incompatible with C.");
 
 inline std::ostream& operator<<(std::ostream& os, const rocblas_bfloat16& bf16)
 {
-    os << static_cast<float>(bf16);
-    return os;
+    return os << float(bf16);
 }
-
+inline rocblas_bfloat16 operator+(rocblas_bfloat16 a) { return a; }
+inline rocblas_bfloat16 operator-(rocblas_bfloat16 a)
+{
+    a.data ^= 0x8000;
+    return a;
+}
 inline rocblas_bfloat16 operator+(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
-    return static_cast<rocblas_bfloat16>(static_cast<float>(a) + static_cast<float>(b));
-}
-inline rocblas_bfloat16 operator+(int a, rocblas_bfloat16 b)
-{
-    return static_cast<rocblas_bfloat16>(static_cast<float>(a) + static_cast<float>(b));
-}
-inline rocblas_bfloat16 operator+(rocblas_bfloat16 a, int b)
-{
-    return static_cast<rocblas_bfloat16>(static_cast<float>(a) + static_cast<float>(b));
+    return rocblas_bfloat16(float(a) + float(b));
 }
 inline rocblas_bfloat16 operator-(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
-    return static_cast<rocblas_bfloat16>(static_cast<float>(a) - static_cast<float>(b));
+    return rocblas_bfloat16(float(a) - float(b));
 }
 inline rocblas_bfloat16 operator*(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
-    return static_cast<rocblas_bfloat16>(static_cast<float>(a) * static_cast<float>(b));
+    return rocblas_bfloat16(float(a) * float(b));
 }
 inline rocblas_bfloat16 operator/(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
-    return static_cast<rocblas_bfloat16>(static_cast<float>(a) / static_cast<float>(b));
+    return rocblas_bfloat16(float(a) / float(b));
 }
-
-inline bool operator<(rocblas_bfloat16 a, rocblas_bfloat16 b)
-{
-    return static_cast<float>(a) < static_cast<float>(b);
-}
-inline bool operator<=(rocblas_bfloat16 a, rocblas_bfloat16 b)
-{
-    return static_cast<float>(a) <= static_cast<float>(b);
-}
-inline bool operator==(rocblas_bfloat16 a, rocblas_bfloat16 b)
-{
-    return static_cast<float>(a) == static_cast<float>(b);
-}
-inline bool operator!=(rocblas_bfloat16 a, rocblas_bfloat16 b)
-{
-    return static_cast<float>(a) != static_cast<float>(b);
-}
-inline bool operator>(rocblas_bfloat16 a, rocblas_bfloat16 b)
-{
-    return static_cast<float>(a) > static_cast<float>(b);
-}
-inline bool operator>=(rocblas_bfloat16 a, rocblas_bfloat16 b)
-{
-    return static_cast<float>(a) >= static_cast<float>(b);
-}
-
-inline rocblas_bfloat16& operator+=(rocblas_bfloat16& a, rocblas_bfloat16 b)
-{
-    a = a + b;
-    return a;
-}
-inline rocblas_bfloat16& operator-=(rocblas_bfloat16& a, rocblas_bfloat16 b)
-{
-    a = a - b;
-    return a;
-}
-inline rocblas_bfloat16& operator*=(rocblas_bfloat16& a, rocblas_bfloat16 b)
-{
-    a = a * b;
-    return a;
-}
-inline rocblas_bfloat16& operator/=(rocblas_bfloat16& a, rocblas_bfloat16 b)
-{
-    a = a / b;
-    return a;
-}
-
-inline rocblas_bfloat16 operator++(rocblas_bfloat16& a)
-{
-    a += rocblas_bfloat16(1);
-    return a;
-}
+inline bool operator<(rocblas_bfloat16 a, rocblas_bfloat16 b) { return float(a) < float(b); }
+inline bool operator==(rocblas_bfloat16 a, rocblas_bfloat16 b) { return float(a) == float(b); }
+inline bool operator>(rocblas_bfloat16 a, rocblas_bfloat16 b) { return b < a; }
+inline bool operator<=(rocblas_bfloat16 a, rocblas_bfloat16 b) { return !(a > b); }
+inline bool operator!=(rocblas_bfloat16 a, rocblas_bfloat16 b) { return !(a == b); }
+inline bool operator>=(rocblas_bfloat16 a, rocblas_bfloat16 b) { return !(a < b); }
+inline rocblas_bfloat16& operator+=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a + b; }
+inline rocblas_bfloat16& operator-=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a - b; }
+inline rocblas_bfloat16& operator*=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a * b; }
+inline rocblas_bfloat16& operator/=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a / b; }
+inline rocblas_bfloat16& operator++(rocblas_bfloat16& a) { return a += rocblas_bfloat16(1.0f); }
+inline rocblas_bfloat16& operator--(rocblas_bfloat16& a) { return a -= rocblas_bfloat16(1.0f); }
 inline rocblas_bfloat16 operator++(rocblas_bfloat16& a, int)
 {
-    rocblas_bfloat16 original_value = a;
+    rocblas_bfloat16 orig = a;
     ++a;
-    return original_value;
+    return orig;
 }
+inline rocblas_bfloat16 operator--(rocblas_bfloat16& a, int)
+{
+    rocblas_bfloat16 orig = a;
+    --a;
+    return orig;
+}
+inline bool isinf(rocblas_bfloat16 a) { return !(~a.data & 0x7f80) && !(a.data & 0x7f); }
+inline bool isnan(rocblas_bfloat16 a) { return !(~a.data & 0x7f80) && +(a.data & 0x7f); }
+inline bool iszero(rocblas_bfloat16 a) { return !(a.data & 0x7fff); }
+inline rocblas_bfloat16 abs(rocblas_bfloat16 a)
+{
+    a.data &= 0x7fff;
+    return a;
+}
+inline rocblas_bfloat16 sin(rocblas_bfloat16 a) { return rocblas_bfloat16(sinf(float(a))); }
+inline rocblas_bfloat16 cos(rocblas_bfloat16 a) { return rocblas_bfloat16(cosf(float(a))); }
 
-inline bool isinf(const rocblas_bfloat16& a) { return std::isinf(static_cast<float>(a)); }
-inline bool isnan(const rocblas_bfloat16& a) { return std::isnan(static_cast<float>(a)); }
-inline bool iszero(const rocblas_bfloat16& a) { return (a.data & 0x7FFF) == 0; }
-
-inline rocblas_bfloat16 abs(const rocblas_bfloat16& a)
-{
-    return static_cast<rocblas_bfloat16>(std::abs(static_cast<float>(a)));
-}
-inline rocblas_bfloat16 sin(const rocblas_bfloat16& a)
-{
-    return static_cast<rocblas_bfloat16>(std::sin(static_cast<float>(a)));
-}
-inline rocblas_bfloat16 cos(const rocblas_bfloat16& a)
-{
-    return static_cast<rocblas_bfloat16>(std::cos(static_cast<float>(a)));
-}
+#endif // __cplusplus
 
 #endif // _ROCBLAS_BFLOAT16_H_


### PR DESCRIPTION
Summary of proposed changes:
-  Uses bitwise operations to optimize conversion from `float` to `rocblas_bfloat16`, correctly handling rounding, `NaN` and `Inf` (see inline comments).
- Uses "type punning" between `float` and `uint32_t` instead of between `float` and `uint16_t [2]`, to simplify operations and remove dependence on endianness.
- Makes `rocblas_bfloat16.h` compatible with the C language, by only defining `typedef struct { uint16_t data; } rocblas_bfloat16;` when the C language is used.
- Uses `static_assert` to ensure that C++ definition of `rocblas_bfloat16` is compatible with the C language.
- Changes preincrement operator function to return lvalue references rather than values.
- Adds predecrement and postdecrement operators.
- Adds unary `+` and unary `-` operators.
- Rewrites `>`, `>=`, `<=`, and `!=` in terms of `<` and `==`.
- Simplifies operator-assignment functions to a single `return` statement, reducing lines of code.
- Uses `sinf()` and `cosf()` instead of `sin()` and `cos()` for computing `sin(rocblas_bfloat16)` and `cos(rocblas_bfloat16)`.
- Rewrites `isnan(rocblas_bfloat16)` and `isinf(rocblas_bfloat16)` in terms of bit operations, instead of converting to `float` and then using the standard math library.
-  Uses `float(x)` and `rocblas_bfloat16(x)` function-style casts instead of `static_cast<...>(...)` for brevity and readability.
-  Removes conversion from and addition between `int` and `rocblas_bfloat16`, since it is a narrowing conversion and may result in double-rounding or other unexpected results. If we need support for converting types besides `float` to `rocblas_bfloat16`, then separate conversion routines will be needed, since merely converting a type to `float` and then to `rocblas_bfloat16` may result in loss of data or double-rounding.
- Uses `constexpr` functions for the `rocblas_bfloat16` class, allowing compile-time `rocblas_bfloat16` constants and other optimizations.
- Fixes copyright message to reduce the number of hyphens and broken lines.

