### PR TITLE
[hip] Add HIP support for `bfloat16`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ elseif( CXX_VERSION_STRING MATCHES "nvcc" )
   set( CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN "-Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}" )
 elseif( CXX_VERSION_STRING MATCHES "HCC" )
   message( STATUS "HCC compiler set; ROCm backend selected [ CXX=/opt/rocm/bin/hcc cmake ... ]" )
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -hc")
 endif( )
 
 # This finds the rocm-cmake project, and installs it if not found

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -53,6 +53,7 @@ target_include_directories( rocblas-bench
 target_include_directories( rocblas-bench
   SYSTEM PRIVATE
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${HCC_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -87,6 +87,7 @@ target_include_directories( rocblas-test
 target_include_directories( rocblas-test
   SYSTEM PRIVATE
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${HCC_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>

--- a/clients/include/rocblas_math.hpp
+++ b/clients/include/rocblas_math.hpp
@@ -5,16 +5,17 @@
 #ifndef ROCBLAS_MATH_H_
 #define ROCBLAS_MATH_H_
 
+#include <hip/hip_runtime.h>
 #include <cmath>
 #include <immintrin.h>
 #include "rocblas.h"
 
 /* ============================================================================================ */
 // Helper routine to convert floats into their half equivalent; uses F16C instructions
-inline rocblas_half float_to_half(float val) { return _cvtss_sh(val, 0); }
+inline __host__ rocblas_half float_to_half(float val) { return _cvtss_sh(val, 0); }
 
 // Helper routine to convert halfs into their floats equivalent; uses F16C instructions
-inline float half_to_float(rocblas_half val) { return _cvtsh_ss(val); }
+inline __host__ float half_to_float(rocblas_half val) { return _cvtsh_ss(val); }
 
 /* ============================================================================================ */
 /*! \brief  returns true if value is NaN */

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -28,6 +28,7 @@ foreach( exe ${sample_list} )
   target_include_directories( ${exe}
     SYSTEM PRIVATE
       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+      $<BUILD_INTERFACE:${HCC_INCLUDE_DIRS}>
       )
 
   if( CUDA_FOUND )

--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -46,6 +46,7 @@ typedef struct
 
 #else // __cplusplus
 
+#include <hip/hip_runtime.h>
 #include <cinttypes>
 #include <cmath>
 #include <iostream>
@@ -55,13 +56,16 @@ struct rocblas_bfloat16
 {
     uint16_t data;
 
-    constexpr rocblas_bfloat16() : data(0) {}
+    // Skip initializing `data` on purpose so that `bfloat16` could be used
+    // with `__share__`, which forbids any initializer, including the implicit
+    // one.
+    __host__ __device__ rocblas_bfloat16() {}
 
     // round upper 16 bits of IEEE float to convert to bfloat16
-    explicit constexpr rocblas_bfloat16(float f) : data(float_to_bfloat16(f)) {}
+    explicit __host__ __device__ constexpr rocblas_bfloat16(float f) : data(float_to_bfloat16(f)) {}
 
     // zero extend lower 16 bits of bfloat16 to convert to IEEE float
-    explicit constexpr operator float() const
+    explicit __host__ __device__ constexpr operator float() const
     {
         union
         {
@@ -72,7 +76,7 @@ struct rocblas_bfloat16
     }
 
     private:
-    static constexpr uint16_t float_to_bfloat16(float f)
+    static __host__ __device__ constexpr uint16_t float_to_bfloat16(float f)
     {
         union
         {
@@ -127,62 +131,107 @@ inline std::ostream& operator<<(std::ostream& os, const rocblas_bfloat16& bf16)
 {
     return os << float(bf16);
 }
-inline rocblas_bfloat16 operator+(rocblas_bfloat16 a) { return a; }
-inline rocblas_bfloat16 operator-(rocblas_bfloat16 a)
+inline __host__ __device__ rocblas_bfloat16 operator+(rocblas_bfloat16 a) { return a; }
+inline __host__ __device__ rocblas_bfloat16 operator-(rocblas_bfloat16 a)
 {
     a.data ^= 0x8000;
     return a;
 }
-inline rocblas_bfloat16 operator+(rocblas_bfloat16 a, rocblas_bfloat16 b)
+inline __host__ __device__ rocblas_bfloat16 operator+(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
     return rocblas_bfloat16(float(a) + float(b));
 }
-inline rocblas_bfloat16 operator-(rocblas_bfloat16 a, rocblas_bfloat16 b)
+inline __host__ __device__ rocblas_bfloat16 operator-(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
     return rocblas_bfloat16(float(a) - float(b));
 }
-inline rocblas_bfloat16 operator*(rocblas_bfloat16 a, rocblas_bfloat16 b)
+inline __host__ __device__ rocblas_bfloat16 operator*(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
     return rocblas_bfloat16(float(a) * float(b));
 }
-inline rocblas_bfloat16 operator/(rocblas_bfloat16 a, rocblas_bfloat16 b)
+inline __host__ __device__ rocblas_bfloat16 operator/(rocblas_bfloat16 a, rocblas_bfloat16 b)
 {
     return rocblas_bfloat16(float(a) / float(b));
 }
-inline bool operator<(rocblas_bfloat16 a, rocblas_bfloat16 b) { return float(a) < float(b); }
-inline bool operator==(rocblas_bfloat16 a, rocblas_bfloat16 b) { return float(a) == float(b); }
-inline bool operator>(rocblas_bfloat16 a, rocblas_bfloat16 b) { return b < a; }
-inline bool operator<=(rocblas_bfloat16 a, rocblas_bfloat16 b) { return !(a > b); }
-inline bool operator!=(rocblas_bfloat16 a, rocblas_bfloat16 b) { return !(a == b); }
-inline bool operator>=(rocblas_bfloat16 a, rocblas_bfloat16 b) { return !(a < b); }
-inline rocblas_bfloat16& operator+=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a + b; }
-inline rocblas_bfloat16& operator-=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a - b; }
-inline rocblas_bfloat16& operator*=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a * b; }
-inline rocblas_bfloat16& operator/=(rocblas_bfloat16& a, rocblas_bfloat16 b) { return a = a / b; }
-inline rocblas_bfloat16& operator++(rocblas_bfloat16& a) { return a += rocblas_bfloat16(1.0f); }
-inline rocblas_bfloat16& operator--(rocblas_bfloat16& a) { return a -= rocblas_bfloat16(1.0f); }
-inline rocblas_bfloat16 operator++(rocblas_bfloat16& a, int)
+inline __host__ __device__ bool operator<(rocblas_bfloat16 a, rocblas_bfloat16 b)
+{
+    return float(a) < float(b);
+}
+inline __host__ __device__ bool operator==(rocblas_bfloat16 a, rocblas_bfloat16 b)
+{
+    return float(a) == float(b);
+}
+inline __host__ __device__ bool operator>(rocblas_bfloat16 a, rocblas_bfloat16 b) { return b < a; }
+inline __host__ __device__ bool operator<=(rocblas_bfloat16 a, rocblas_bfloat16 b)
+{
+    return !(a > b);
+}
+inline __host__ __device__ bool operator!=(rocblas_bfloat16 a, rocblas_bfloat16 b)
+{
+    return !(a == b);
+}
+inline __host__ __device__ bool operator>=(rocblas_bfloat16 a, rocblas_bfloat16 b)
+{
+    return !(a < b);
+}
+inline __host__ __device__ rocblas_bfloat16& operator+=(rocblas_bfloat16& a, rocblas_bfloat16 b)
+{
+    return a = a + b;
+}
+inline __host__ __device__ rocblas_bfloat16& operator-=(rocblas_bfloat16& a, rocblas_bfloat16 b)
+{
+    return a = a - b;
+}
+inline __host__ __device__ rocblas_bfloat16& operator*=(rocblas_bfloat16& a, rocblas_bfloat16 b)
+{
+    return a = a * b;
+}
+inline __host__ __device__ rocblas_bfloat16& operator/=(rocblas_bfloat16& a, rocblas_bfloat16 b)
+{
+    return a = a / b;
+}
+inline __host__ __device__ rocblas_bfloat16& operator++(rocblas_bfloat16& a)
+{
+    return a += rocblas_bfloat16(1.0f);
+}
+inline __host__ __device__ rocblas_bfloat16& operator--(rocblas_bfloat16& a)
+{
+    return a -= rocblas_bfloat16(1.0f);
+}
+inline __host__ __device__ rocblas_bfloat16 operator++(rocblas_bfloat16& a, int)
 {
     rocblas_bfloat16 orig = a;
     ++a;
     return orig;
 }
-inline rocblas_bfloat16 operator--(rocblas_bfloat16& a, int)
+inline __host__ __device__ rocblas_bfloat16 operator--(rocblas_bfloat16& a, int)
 {
     rocblas_bfloat16 orig = a;
     --a;
     return orig;
 }
-inline bool isinf(rocblas_bfloat16 a) { return !(~a.data & 0x7f80) && !(a.data & 0x7f); }
-inline bool isnan(rocblas_bfloat16 a) { return !(~a.data & 0x7f80) && +(a.data & 0x7f); }
-inline bool iszero(rocblas_bfloat16 a) { return !(a.data & 0x7fff); }
-inline rocblas_bfloat16 abs(rocblas_bfloat16 a)
+inline __host__ __device__ bool isinf(rocblas_bfloat16 a)
+{
+    return !(~a.data & 0x7f80) && !(a.data & 0x7f);
+}
+inline __host__ __device__ bool isnan(rocblas_bfloat16 a)
+{
+    return !(~a.data & 0x7f80) && +(a.data & 0x7f);
+}
+inline __host__ __device__ bool iszero(rocblas_bfloat16 a) { return !(a.data & 0x7fff); }
+inline __host__ __device__ rocblas_bfloat16 abs(rocblas_bfloat16 a)
 {
     a.data &= 0x7fff;
     return a;
 }
-inline rocblas_bfloat16 sin(rocblas_bfloat16 a) { return rocblas_bfloat16(sinf(float(a))); }
-inline rocblas_bfloat16 cos(rocblas_bfloat16 a) { return rocblas_bfloat16(cosf(float(a))); }
+inline __host__ __device__ rocblas_bfloat16 sin(rocblas_bfloat16 a)
+{
+    return rocblas_bfloat16(sinf(float(a)));
+}
+inline __host__ __device__ rocblas_bfloat16 cos(rocblas_bfloat16 a)
+{
+    return rocblas_bfloat16(cosf(float(a)));
+}
 
 #endif // __cplusplus
 


### PR DESCRIPTION
resolves compilation with HIP/Clang

Summary of proposed changes:
-  Include HIP header
-  Add necessary __device__/__host__ attributes.
-  Remove default initializer so that `bfloat16` could be used with `__share__`, which forbids any initializer.
