### PR TITLE
fix pointer declaration in bfloat16 sample

### DIFF
--- a/clients/samples/example_bf16_r_gemm_ex.cpp
+++ b/clients/samples/example_bf16_r_gemm_ex.cpp
@@ -449,7 +449,7 @@ int main(int argc, char* argv[])
     }
 
     // allocate memory on device
-    float *da, *db, *dc, *dd;
+    rocblas_bfloat16 *da, *db, *dc, *dd;
     CHECK_HIP_ERROR(hipMalloc(&da, size_a * sizeof(rocblas_bfloat16)));
     CHECK_HIP_ERROR(hipMalloc(&db, size_b * sizeof(rocblas_bfloat16)));
     CHECK_HIP_ERROR(hipMalloc(&dc, size_c * sizeof(rocblas_bfloat16)));


### PR DESCRIPTION
- correct pointer declaration changing from float* to rocblas_bfloat16*
