### PR TITLE
use c++14 compile flag for rocblas_bfloat16.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@
 # The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
 cmake_minimum_required( VERSION 3.5 )
 
+# We use C++14 features, this will add compile option: -std=c++14
+set( CMAKE_CXX_STANDARD 14 )
+
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
 if( WIN32 )

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -5,9 +5,6 @@
 # The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
 cmake_minimum_required( VERSION 3.5 )
 
-# We use C++14 features
-set( CMAKE_CXX_STANDARD 14 )
-
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
 if( WIN32 )


### PR DESCRIPTION
- set( CMAKE_CXX_STANDARD 14 ) in CMakeLists.txt because rocblas_bfloat16.h uses C++14
- this will be passed to clients/CMakeLists.txt, so the setting in clients/CMakeLists.txt becomes redundant and can be removed
- without this setting, there are compiler warnings
