### PR TITLE
add HIP-Clang support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ endif()
 
 if( CXX_VERSION_STRING MATCHES "clang" )
   message( STATUS "Use hip-clang to build for amdgpu backend" )
+# set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fallow-half-arguments-and-returns" )
+  set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_HCC_COMPAT_MODE__=1" )
 elseif( CXX_VERSION_STRING MATCHES "nvcc" )
   message( STATUS "HIPCC nvcc compiler detected; CUDA backend selected" )
 


### PR DESCRIPTION
When building rocBLAS with HIP-Clang, -D__HIP_HCC_COMPAT_MODE__=1 is needed to deal with Tensile-generated calls hc_get_group_id, hc_get_num_groups, hc_get_workitem_id and hc_get_workitem_absolute_id.

Full rocblas-test passed on gfx900 and gfx906 as well as a hip-clang build in docker.