### PR TITLE
HotFix: include hip_runtime_api.h in place of hip_runtime.h

### DIFF
--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -46,7 +46,7 @@ typedef struct
 
 #else // __cplusplus
 
-#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
 #include <cinttypes>
 #include <cmath>
 #include <iostream>

--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -224,14 +224,8 @@ inline __host__ __device__ rocblas_bfloat16 abs(rocblas_bfloat16 a)
     a.data &= 0x7fff;
     return a;
 }
-inline __host__ __device__ rocblas_bfloat16 sin(rocblas_bfloat16 a)
-{
-    return rocblas_bfloat16(sinf(float(a)));
-}
-inline __host__ __device__ rocblas_bfloat16 cos(rocblas_bfloat16 a)
-{
-    return rocblas_bfloat16(cosf(float(a)));
-}
+inline rocblas_bfloat16 sin(rocblas_bfloat16 a) { return rocblas_bfloat16(sinf(float(a))); }
+inline rocblas_bfloat16 cos(rocblas_bfloat16 a) { return rocblas_bfloat16(cosf(float(a))); }
 
 #endif // __cplusplus
 


### PR DESCRIPTION
- in rocblas_bfloat16.h include hip/hip_runtime_api.h in place of hip/hip_runtime.h
- this enables compiling with gcc
