### PR TITLE
remove C++14 constexpr for C++11 compatibility

### DIFF
--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -62,10 +62,10 @@ struct rocblas_bfloat16
     __host__ __device__ rocblas_bfloat16() {}
 
     // round upper 16 bits of IEEE float to convert to bfloat16
-    explicit __host__ __device__ constexpr rocblas_bfloat16(float f) : data(float_to_bfloat16(f)) {}
+    explicit __host__ __device__ rocblas_bfloat16(float f) : data(float_to_bfloat16(f)) {}
 
     // zero extend lower 16 bits of bfloat16 to convert to IEEE float
-    explicit __host__ __device__ constexpr operator float() const
+    explicit __host__ __device__ operator float() const
     {
         union
         {
@@ -76,7 +76,7 @@ struct rocblas_bfloat16
     }
 
     private:
-    static __host__ __device__ constexpr uint16_t float_to_bfloat16(float f)
+    static __host__ __device__ uint16_t float_to_bfloat16(float f)
     {
         union
         {


### PR DESCRIPTION
- remove C++14 from external include file rocblas_bfloat16.h
