### PR TITLE
New clang-format for rocm2.5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -75,7 +75,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-#SpaceBeforeCpp11BracedList: false
+SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]

--- a/.clang-format
+++ b/.clang-format
@@ -23,12 +23,14 @@ DisableFormat:   false
 Standard: Cpp11
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: true
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
@@ -46,6 +48,7 @@ BinPackParameters: false
 BreakBeforeBraces: Custom
 # Control of individual brace wrapping cases
 BraceWrapping: {
+    AfterCaseLabel: 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -72,11 +75,12 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-SpaceBeforeCpp11BracedList: false
+#SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IndentCaseLabels: false
+IndentPPDirectives: None
 #FixNamespaceComments: true
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -116,5 +120,4 @@ SortIncludes: true
 ReflowComments: false
 
 #IncludeBlocks: Preserve
-#IndentPPDirectives: AfterHash
 ---

--- a/library/src/blas1/reduction.h
+++ b/library/src/blas1/reduction.h
@@ -162,8 +162,8 @@ template <rocblas_int NB,
 __global__ void
     rocblas_reduction_kernel_part1(rocblas_int n, const Ti* x, rocblas_int incx, To* workspace)
 {
-    ssize_t    tx  = hipThreadIdx_x;
-    ssize_t    tid = hipBlockIdx_x * hipBlockDim_x + tx;
+    ssize_t       tx  = hipThreadIdx_x;
+    ssize_t       tid = hipBlockIdx_x * hipBlockDim_x + tx;
     __shared__ To tmp[NB];
 
     // bound
@@ -187,7 +187,7 @@ template <rocblas_int NB,
           typename Tr>
 __global__ void rocblas_reduction_kernel_part2(rocblas_int nblocks, To* workspace, Tr* result)
 {
-    rocblas_int tx = hipThreadIdx_x;
+    rocblas_int   tx = hipThreadIdx_x;
     __shared__ To tmp[NB];
 
     if(tx < nblocks)


### PR DESCRIPTION
- Additional options are now available in clang-format, and they need to be applied to Jenkins after I upgraded CI from rocm2.4 to rocm2.5
