### PR TITLE
Adding CentOS CI support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ rocBLASCI:
     rocblas.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906'], rocblas)
+    def nodes = new dockerNodes(['gfx900', 'gfx906 && centos7'], rocblas)
 
     boolean formatCheck = true
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ rocBLASCI:
     rocblas.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900', 'gfx906'], rocblas)
+    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906'], rocblas)
 
     boolean formatCheck = true
 
@@ -58,24 +58,47 @@ rocBLASCI:
 
         def command
 
-        if(auxiliary.isJobStartedByTimer())
+        if(platform.jenkinsLabel.contains('centos'))
         {
-          command = """#!/usr/bin/env bash
-                set -x
-                cd ${project.paths.project_build_prefix}/build/release/clients/staging
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocblas-test --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
-            """
+            if(auxiliary.isJobStartedByTimer())
+            {
+                command = """#!/usr/bin/env bash
+                        set -x
+                        cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                        LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG sudo ./rocblas-test --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
+                    """
+            }
+            else
+            {
+                command = """#!/usr/bin/env bash
+                        set -x
+                        cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                        LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./example-sscal
+                        LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG sudo ./rocblas-test --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin*
+                    """
+            }
         }
         else
         {
-          command = """#!/usr/bin/env bash
-                set -x
-                cd ${project.paths.project_build_prefix}/build/release/clients/staging
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./example-sscal
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocblas-test --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin*
-            """
+            if(auxiliary.isJobStartedByTimer())
+            {
+                command = """#!/usr/bin/env bash
+                        set -x
+                        cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                        LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocblas-test --gtest_output=xml --gtest_color=yes --gtest_filter=*nightly*-*known_bug* #--gtest_filter=*nightly*
+                    """
+            }
+            else
+            {
+                command = """#!/usr/bin/env bash
+                        set -x
+                        cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                        LD_LIBRARY_PATH=/opt/rocm/hcc/lib ./example-sscal
+                        LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocblas-test --gtest_output=xml --gtest_color=yes  --gtest_filter=*quick*:*pre_checkin*-*known_bug* #--gtest_filter=*checkin*
+                    """
+            }
         }
-
+        
         platform.runCommand(this, command)
         junit "${project.paths.project_build_prefix}/build/release/clients/staging/*.xml"
     }
@@ -84,17 +107,36 @@ rocBLASCI:
     {
         platform, project->
 
-        def command = """
-                      set -x
-                      cd ${project.paths.project_build_prefix}/build/release
-                      make package
-                      rm -rf package && mkdir -p package
-                      mv *.deb package/
-                      dpkg -c package/*.deb
-                      """
+        def command 
+        
+        if(platform.jenkinsLabel.contains('centos'))
+        {
+            command = """
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release
+                    make package
+                    rm -rf package && mkdir -p package
+                    mv *.rpm package/
+                    rpm -qlp package/*.rpm
+                """
 
-        platform.runCommand(this, command)
-        platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.deb""")
+            platform.runCommand(this, command)
+            platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.rpm""")        
+        }
+        else
+        {
+            command = """
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release
+                    make package
+                    rm -rf package && mkdir -p package
+                    mv *.deb package/
+                    dpkg -c package/*.deb
+                """
+
+            platform.runCommand(this, command)
+            platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.deb""")
+        }
     }
 
     buildProject(rocblas, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -24,8 +24,11 @@ RUN yum install -y \
     gtest \
     pkgconfig \
     python27 \
-    python34 \
-    python-yaml \
+    python36 \
+    python36-devel \
+    python36-pip \
+    python36-pytest \
+    python36-setuptools \
     PyYAML \
     libcxx-devel \
     boost-devel \

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -1,0 +1,53 @@
+# Parameters related to building rocblas
+ARG base_image
+
+FROM ${base_image}
+LABEL maintainer="andrew.chapman@amd.com"
+
+ARG user_uid
+
+# Install dependent packages
+RUN yum install -y \
+    sudo \
+    rock-dkms \
+    centos-release
+    ca-certificates \
+    git \
+    cmake3 \
+    make \
+    clang \
+    clang-devel \
+    gcc-c++ \
+    gcc-gfortran \
+    gtest-devel \ 
+    gtest \
+    pkgconfig \
+    python27 \
+    python34 \
+    python-yaml \
+    PyYAML \
+    libcxx-devel \
+    boost-devel \
+    numactl-libs \
+    rpm-build
+
+RUN echo '#!/bin/bash' | tee /etc/profile.d/devtoolset7.sh && echo \
+    'source scl_source enable devtoolset-7' >>/etc/profile.d/devtoolset7.sh
+    
+# docker pipeline runs containers with particular uid
+# create a jenkins user with this specific uid so it can use sudo priviledges
+# Grant any member of sudo group password-less sudo privileges
+RUN useradd --create-home -u ${user_uid} -o -G video --shell /bin/bash jenkins && \
+    echo '%video ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
+    chmod 400 /etc/sudoers.d/sudo-nopasswd
+
+ARG ROCBLAS_SRC_ROOT=/usr/local/src/rocBLAS
+
+# Clone rocblas repo
+# Build client dependencies and install into /usr/local (LAPACK & GTEST)
+RUN mkdir -p ${ROCBLAS_SRC_ROOT} && cd ${ROCBLAS_SRC_ROOT} && \
+    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocBLAS . && \
+    mkdir -p build/deps && cd build/deps && \
+    cmake3 -DBUILD_BOOST=OFF ${ROCBLAS_SRC_ROOT}/deps && \
+    make -j $(nproc) install && \
+    rm -rf ${ROCBLAS_SRC_ROOT}

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -30,7 +30,8 @@ RUN yum install -y \
     libcxx-devel \
     boost-devel \
     numactl-libs \
-    rpm-build
+    rpm-build \ 
+    deltarpm
 
 RUN echo '#!/bin/bash' | tee /etc/profile.d/devtoolset7.sh && echo \
     'source scl_source enable devtoolset-7' >>/etc/profile.d/devtoolset7.sh

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -10,7 +10,8 @@ ARG user_uid
 RUN yum install -y \
     sudo \
     rock-dkms \
-    centos-release
+    centos-release-scl \
+    devtoolset-7 \
     ca-certificates \
     git \
     cmake3 \

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -35,6 +35,8 @@ RUN yum install -y \
 
 RUN echo '#!/bin/bash' | tee /etc/profile.d/devtoolset7.sh && echo \
     'source scl_source enable devtoolset-7' >>/etc/profile.d/devtoolset7.sh
+
+RUN pip3 install wheel && pip3 install tox pyyaml
     
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges

--- a/docker/dockerfile-install-centos
+++ b/docker/dockerfile-install-centos
@@ -1,0 +1,21 @@
+# Parameters related to building rocblas
+ARG base_image
+
+FROM ${base_image}
+LABEL maintainer="andrew.chapman@amd.com"
+
+# Copy the rpm package of rocblas into the container from host
+COPY *.rpm /tmp/
+
+# Install the rpm package, and print out contents of expected changed locations
+RUN yum -y update && yum install -y\
+    /tmp/rocblas-*.rpm \
+  && rm -f /tmp/*.rpm \
+  && yum -y clean all \
+  && rm -rf /var/lib/apt/lists/* \
+  && printf "ls -la /etc/ld.so.conf.d/\n" && ls -la /etc/ld.so.conf.d/ \
+  && printf "ls -la /opt/rocm/include\n" && ls -la /opt/rocm/include \
+  && printf "ls -la /opt/rocm/lib\n" && ls -la /opt/rocm/lib \
+  && printf "ls -la /opt/rocm/lib/cmake\n" && ls -la /opt/rocm/lib/cmake \
+  && printf "ls -la /opt/rocm/rocblas/include\n" && ls -la /opt/rocm/rocblas/include \
+  && printf "ls -la /opt/rocm/rocblas/lib\n" && ls -la /opt/rocm/rocblas/lib


### PR DESCRIPTION
Summary of proposed changes:
-	Idea is to run a CentOS instance of rocBLAS in CI
-	CentOS7 image is more barebones than the Ubuntu base image, so additional packages need to be installed to enable CentOS support
-	Some CentOS/rpm packages have slightly different names than Ubuntu/debian packages 
-	cmake3 must be specified for centOS7, as the default cmake is cmake2. 
-	sudo privileges for running tests must be added to the Jenkinsfile to run in CentOS w/o getting a permissions issue (not sure why this is happening, group and user permissions do appear to be the same as Ubuntu)

CentOS support in general:
-	All existing Jenkins nodes can run CentOS jobs because it's being ran in a docker container
-	Currently gfx900 is set to test CentOS7 base image, but this can be changed pretty easily
-	See [this link](https://github.com/ROCmSoftwarePlatform/rocJenkins/blob/master/README.md) for more informatioN