### PR TITLE
add 'Device 66af' for Radeon VII

### DIFF
--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.8.1}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Ailk_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/archive/vega20_Cijk_Alik_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.8.1}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Ailk_Bljk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_4xi8BH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_4xi8BH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_DB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.7.2}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_HBH.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega20_Cijk_Alik_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.6.0}
 - vega20
 - gfx906
-- [Device 66a0, Device 66a1, Device 66a7, Vega 20]
+- [Device 66a0, Device 66a1, Device 66a7, Device 66af, Vega 20]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false


### PR DESCRIPTION
Resolves SWDEV-190051
- when /usr/share/misc/pci.ids is missing on the system, Radeon VII presents itself as 'Device 66af', not 'Vega 20'.  This fix brings 'Device 66af' into the 'Vega 20' fold.