### PR TITLE
Use git ls-files instead of find for clang-format

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ To format all files, run the following script in rocBLAS directory:
 
 ```
 #!/bin/bash
-git ls-files *.cc *.cpp *.h *.hpp *.cl *.h.in *.hpp.in *.cpp.in| xargs /opt/rocm/hcc/bin/clang-format  -style=file -i
+git ls-files -z *.cc *.cpp *.h *.hpp *.cl *.h.in *.hpp.in *.cpp.in | xargs -0 /opt/rocm/hcc/bin/clang-format  -style=file -i
 ```
 
 Also, githooks can be installed to format the code per-commit:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,11 +64,7 @@ To format all files, run the following script in rocBLAS directory:
 
 ```
 #!/bin/bash
-
-find . \( -name build -o -name \*.git \) -prune -o \( -type f \( -name \*.h \
-    -o -name \*.hpp -o -name \*.cpp -o -name \*.h.in -o -name \*.hpp.in -o \
-    -name \*.cpp.in -o -name \*.cl \) -print0 \) | \
-    xargs -0 /opt/rocm/hcc/bin/clang-format -i -style=file
+git ls-files *.cc *.cpp *.h *.hpp *.cl *.h.in *.hpp.in *.cpp.in| xargs -0 /opt/rocm/hcc/bin/clang-format  -style=file -i
 ```
 
 Also, githooks can be installed to format the code per-commit:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ To format all files, run the following script in rocBLAS directory:
 
 ```
 #!/bin/bash
-git ls-files *.cc *.cpp *.h *.hpp *.cl *.h.in *.hpp.in *.cpp.in| xargs -0 /opt/rocm/hcc/bin/clang-format  -style=file -i
+git ls-files *.cc *.cpp *.h *.hpp *.cl *.h.in *.hpp.in *.cpp.in| xargs /opt/rocm/hcc/bin/clang-format  -style=file -i
 ```
 
 Also, githooks can be installed to format the code per-commit:


### PR DESCRIPTION
Summary of proposed changes:
-  Change in documentation to use git ls-files instead of find