### PR TITLE
Fix typo and simplify compatibility logic in rocblas_bfloat16.h; parallelize header file checking

### DIFF
--- a/header_compilation_tests.sh
+++ b/header_compilation_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+
 exec >&2
 
 if [[ ! -e build/release/include/rocblas-export.h ]]; then
@@ -10,26 +11,6 @@ fi
 
 script=$(realpath "$0")
 
-echocmd()
-{
-    cat <<EOF
--------------------------------------------------------------------------------
-$@
-EOF
-    "$@"
-}
-
-hip_warning()
-{
-    cat <<EOF
-
-<hip/hip_runtime.h> and (sometimes due to bugs) <hip/hip_runtime_api.h> are
-incompatible with C, so they should only be included in the rocBLAS internal
-C++ implemenation, not in the public headers, which must be compatible with C.
-
-EOF
-}
-
 # Returns whether the output file is up to date.
 # Prints the output file.
 # The first argument is the source header file name.
@@ -38,9 +19,9 @@ EOF
 out_uptodate()
 {
     local file="$1_$2"
-    local out="build/compilation_tests/$file.o"
+    local out=$(realpath "build/compilation_tests/$file.o")
+    echo "$out"
     mkdir -p $(dirname "$out")
-    realpath "$out"
     [[ -n "$3" && "$out" -nt "$script" ]] || return
     find library clients \( -iname \*.hpp -o -iname \*.h \) -print0 \
         | while read -r -d $'\0' file; do
@@ -61,24 +42,50 @@ C99="$HCC -xc-header -std=c99"
 CPP11="$HCC -xc++-header -std=c++11"
 CPP14="$HCC -xc++-header -std=c++14"
 
+if [[ -e /.dockerenv ]]; then
+    NP=4   # limit parallelism to 4
+else
+    NP=0   # unlimited
+fi
+
+# xargs commands to perform parallel builds
+xargs_coproc()
+{
+    { coproc { xargs -P$NP -0 -n1 /bin/bash -xc --; } 4>&1 >&3 2>&1; } 3>&1
+    XARGS_PID=$!
+    exec {XARGS_OUT}<&${COPROC[0]}- {XARGS_IN}>&${COPROC[1]}-
+    echo -ne "true\0" >&$XARGS_IN  # At least one command is necessary
+}
+
+xargs_wait()
+{
+    XARGS_OUTPUT=""
+    exec {XARGS_IN}<&-
+    if ! wait $XARGS_PID; then
+        read -t 0.1 -u $XARGS_OUT XARGS_OUTPUT
+        return 1
+    fi
+}
+
 # Every header file must compile on its own, by including all of its
 # dependencies. This avoids creating dependencies on the order of
-# included files. We define _ROCBLAS_INTERNAL_BFLOAT16_ to enable the
-# internal rocblas_bfloat16 code. testing_trmm.hpp is excluded for now.
+# testing_trmm.hpp is excluded for now.
 #
+xargs_coproc
 find library clients \( -iname \*.hpp -o -iname \*.h \) \
      \! -name testing_trmm.hpp -print0 | while read -r -d $'\0' file; do
-    if ! out=$(out_uptodate $file cpp14 true) && \
-            ! echocmd $CPP14 -c -o "$out" -D_ROCBLAS_INTERNAL_BFLOAT16_ \
-              $HCC_OPTS $GPU_OPTS "$file"; then
-        rm -f "$out"
+    out=$(out_uptodate "$file" cpp14 true) || \
+        echo -ne "$CPP14 -c -o \"$out\" $HCC_OPTS $GPU_OPTS \"$file\" || (rm -f \"$out\"; echo \"$file\" >&4; exit 255)\0" >&$XARGS_IN
+done
+
+if ! xargs_wait; then
         cat <<EOF
 
-The header file $file cannot be compiled by itself,
+The header file $XARGS_OUTPUT cannot be compiled by itself,
 probably because of unmet dependencies on other header files.
 
-Add the necessary #include files at the top of $file
-so that $file can be used in any context, without
+Add the necessary #include files at the top of $XARGS_OUTPUT
+so that $XARGS_OUTPUT can be used in any context, without
 depending on other files being #included before it is #included.
 
 This allows clang-format to reorder #include directives in a canonical order
@@ -88,58 +95,75 @@ file will not matter.
 
 EOF
         exit 1
-    fi
-done
+fi
 
 # The headers in library/include must compile with clang host, C99 or C++11,
 # for client code.
 #
+if [[ -x "$CLANG" ]]; then
+    xargs_coproc
+    for file in library/include/*.{h,in}; do
+        out=$(out_uptodate $file clang) || \
+             echo -ne "$CLANG $CLANG_OPTS -c -o \"$out\" $HCC_OPTS \"$file\" || (rm -f \"$out\"; echo \"$file\" >&4; exit 255)\0" >&$XARGS_IN
+    done
+
+    if ! xargs_wait; then
+        cat <<EOF
+
+The public header file $XARGS_OUTPUT cannot be compiled with
+clang host-only compiler. rocBLAS public header files need to be compatible
+with host-only compilers.
+
+<hip/hip_runtime.h> and (sometimes due to bugs) <hip/hip_runtime_api.h> are
+incompatible with C, so they should only be included in the rocBLAS internal
+C++ implemenation, not in the public headers, which must be compatible with C.
+EOF
+        exit 1
+    fi
+fi
+
+xargs_coproc
 for file in library/include/*.{h,in}; do
-    if [[ -x "$CLANG" ]]; then
-        if ! out=$(out_uptodate $file clang) && \
-                ! echocmd $CLANG $CLANG_OPTS -c -o "$out" $HCC_OPTS $file; then
-            rm -f "$out"
-            cat <<EOF
-
-The public header $file cannot be compiled with clang host-only
-compiler. rocBLAS public headers need to be compatible with host-only
-compilers.
-EOF
-            hip_warning
-            exit 1
-        fi
-    fi
-    if ! out=$(out_uptodate $file c99) && \
-            ! echocmd $C99 -c -o "$out" $HCC_OPTS $GPU_OPTS $file; then
-        rm -f "$out"
-        cat <<EOF
-
-The public header $file cannot be compiled with a C compiler.
-rocBLAS public headers need to be compatible with C99.
-EOF
-        hip_warning
-        exit 1
-    elif ! out=$(out_uptodate $file cpp11) && \
-            ! echocmd $CPP11 -c -o "$out" $HCC_OPTS $GPU_OPTS $file; then
-        rm -f "$out"
-        cat <<EOF
-
-The public header $file cannot be compiled with -std=c++11.
-rocBLAS public headers need to be compatible with C++11.
-
-EOF
-        exit 1
-    fi
+    out=$(out_uptodate $file c99) || \
+        echo -ne "$C99 -c -o \"$out\" $HCC_OPTS $GPU_OPTS \"$file\" || (rm -f \"$out\"; echo \"$file\" >&4; exit 255)\0" >&$XARGS_IN
 done
+
+if ! xargs_wait; then
+    cat <<EOF
+
+The public header file $XARGS_OUTPUT cannot be compiled with a C compiler.
+rocBLAS public headers need to be compatible with C99.
+
+<hip/hip_runtime.h> and (sometimes due to bugs) <hip/hip_runtime_api.h> are
+incompatible with C, so they should only be included in the rocBLAS internal
+C++ implemenation, not in the public headers, which must be compatible with C.
+EOF
+        exit 1
+fi
+
+xargs_coproc
+for file in library/include/*.{h,in}; do
+    out=$(out_uptodate $file cpp11) ||
+        echo -ne "$CPP11 -c -o \"$out\" $HCC_OPTS $GPU_OPTS \"$file\" || (rm -f \"$out\"; echo \"$file\" >&4; exit 255)\0" >&$XARGS_IN
+done
+
+if ! xargs_wait; then
+        cat <<EOF
+
+The public header file $XARGS_OUTPUT cannot be compiled with
+-std=c++11. rocBLAS public headers need to be compatible with C++11.
+
+EOF
+        exit 1
+fi
 
 cat <<EOF
 -------------------------------------------------------------------------------
-All header compilation tests passed.
+All header file compilation tests passed.
 
-Public headers can compile with host-only Clang, -std=c99, and -std=c++11.
+Public header files can compile with host-only Clang, -std=c99, and -std=c++11.
 
 All public and internal implementation header files can compile on their own,
 without depending on #include file order.
 
 EOF
-exit 0

--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -30,21 +30,24 @@
 #ifndef _ROCBLAS_BFLOAT16_H_
 #define _ROCBLAS_BFLOAT16_H_
 
-#ifndef _ROCBLAS_INTERNAL_BFLOAT16_
+#if __cplusplus < 201402L || !defined(__HCC__)
+
+// If this is a C compiler, C++ compiler below C++14, or a host-only compiler, we only
+// include a minimal definition of rocblas_bfloat16
 
 #include <stdint.h>
 typedef struct
 {
     uint16_t data;
-} rocblas_bloat16;
+} rocblas_bfloat16;
 
-#else
+#else // __cplusplus < 201402L || !defined(__HCC__)
 
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <hip/hip_runtime.h>
-#include <iostream>
+#include <ostream>
 #include <type_traits>
 
 struct rocblas_bfloat16
@@ -246,5 +249,6 @@ inline rocblas_bfloat16 cos(rocblas_bfloat16 a)
     return rocblas_bfloat16(cosf(float(a)));
 }
 
-#endif // _ROCBLAS_INTERNAL_BFLOAT16_
+#endif // __cplusplus < 201402L || !defined(__HCC__)
+
 #endif // _ROCBLAS_BFLOAT16_H_

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -23,8 +23,6 @@ endfunction( )
 # package_targets is used as a list of install target
 set( package_targets rocblas )
 
-add_definitions(-D_ROCBLAS_INTERNAL_BFLOAT16_)
-
 # Set up Tensile  Dependency
 if( BUILD_WITH_TENSILE )
   # If we want to build a shared rocblas lib, force Tensile to build as a static lib to absorb into rocblas


### PR DESCRIPTION
Use a simpler method to ensure C/C++11/C++14 compatibility in `rocblas_bfloat16.h`.

Only if C++14 and HCC are detected enabled, does it include the `__device__` and `constexpr` code. Otherwise it uses a plain old C `struct`.

Fit a typo in the `struct`.

Parallelize the `header_compilation_tests.sh` header file validation script, reducing build times.
