### PR TITLE
Adding level 1 complex and gemv complex

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -182,7 +182,7 @@ struct perf_blas<T, U, typename std::enable_if<std::is_same<T, rocblas_half>{}>:
     }
 };
 
-template <typename T>
+template <typename T, typename U>
 struct perf_blas<T,
                  U,
                  typename std::enable_if<std::is_same<T, rocblas_double_complex>{}

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -440,6 +440,9 @@ try
         ("alpha",
           value<double>(&arg.alpha)->default_value(1.0), "specifies the scalar alpha")
 
+        ("alphai",
+         value<double>(&arg.alphai)->default_value(0.0), "specifies the imaginary part of the scalar alpha")
+
         ("beta",
          value<double>(&arg.beta)->default_value(0.0), "specifies the scalar beta")
 

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -194,7 +194,9 @@ struct perf_blas<T,
     }
     void operator()(const Arguments& arg)
     {
-        if(!strcmp(arg.function, "axpy"))
+        if(!strcmp(arg.function, "asum"))
+            testing_asum<T>(arg);
+        else if(!strcmp(arg.function, "axpy"))
             testing_axpy<T>(arg);
         else if(!strcmp(arg.function, "copy"))
             testing_copy<T>(arg);
@@ -202,6 +204,8 @@ struct perf_blas<T,
             testing_dot<T>(arg);
         else if(!strcmp(arg.function, "dotc"))
             testing_dotc<T>(arg);
+        else if(!strcmp(arg.function, "nrm2"))
+            testing_nrm2<T>(arg);
         else if(!strcmp(arg.function, "swap"))
             testing_swap<T>(arg);
         else if(!strcmp(arg.function, "iamax"))
@@ -241,37 +245,6 @@ struct perf_blas_scal<
     {
         if(!strcmp(arg.function, "scal"))
             testing_scal<Ta, Tb>(arg);
-        else
-            throw std::invalid_argument("Invalid combination --function "s + arg.function
-                                        + " --a_type "s + rocblas_datatype2string(arg.a_type));
-    }
-};
-
-template <typename Ti, typename To = Ti, typename = void>
-struct perf_asum_nrm2 : rocblas_test_invalid
-{
-};
-
-template <typename Ti, typename To>
-struct perf_asum_nrm2<
-    Ti,
-    To,
-    typename std::enable_if<
-        (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})
-        || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
-        || (std::is_same<Ti, float>{} && std::is_same<Ti, To>{})
-        || (std::is_same<Ti, double>{} && std::is_same<Ti, To>{})>::type>
-{
-    explicit operator bool()
-    {
-        return true;
-    }
-    void operator()(const Arguments& arg)
-    {
-        if(!strcmp(arg.function, "asum"))
-            testing_asum<Ti, To>(arg);
-        else if(!strcmp(arg.function, "nrm2"))
-            testing_nrm2<Ti, To>(arg);
         else
             throw std::invalid_argument("Invalid combination --function "s + arg.function
                                         + " --a_type "s + rocblas_datatype2string(arg.a_type));
@@ -437,9 +410,7 @@ int run_bench_test(Arguments& arg)
     else
 #endif
     {
-        if(!strcmp(function, "nrm2") || !strcmp(function, "asum"))
-            rocblas_blas1_dispatch<perf_asum_nrm2>(arg);
-        else if(!strcmp(function, "scal"))
+        if(!strcmp(function, "scal"))
             rocblas_blas1_dispatch<perf_blas_scal>(arg);
         else
             rocblas_simple_dispatch<perf_blas>(arg);

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -96,14 +96,15 @@ struct perf_gemm_strided_batched_ex<
 
 #endif
 
-template <typename T, typename U=T, typename = void>
+template <typename T, typename U = T, typename = void>
 struct perf_blas : rocblas_test_invalid
 {
 };
 
 template <typename T, typename U>
 struct perf_blas<
-    T, U,
+    T,
+    U,
     typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
 {
     explicit operator bool()
@@ -183,6 +184,7 @@ struct perf_blas<T, U, typename std::enable_if<std::is_same<T, rocblas_half>{}>:
 
 template <typename T>
 struct perf_blas<T,
+                 U,
                  typename std::enable_if<std::is_same<T, rocblas_double_complex>{}
                                          || std::is_same<T, rocblas_float_complex>{}>::type>
 {
@@ -212,18 +214,22 @@ struct perf_blas<T,
     }
 };
 
-template <typename Ta, typename Tb=Ta, typename = void>
+template <typename Ta, typename Tb = Ta, typename = void>
 struct perf_blas_scal : rocblas_test_invalid
 {
 };
 
 template <typename Ta, typename Tb>
-struct perf_blas_scal<Ta, Tb, typename std::enable_if<(std::is_same<Ta, double>{} && std::is_same<Tb, rocblas_double_complex>{}) ||
-                                                      (std::is_same<Ta, float>{}  && std::is_same<Tb, rocblas_float_complex>{} ) ||
-                                                      (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{}                     ) ||
-                                                      (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{}                    ) ||
-                                                      (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_float_complex>{}     ) ||
-                                                      (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_double_complex>{}    )>::type>
+struct perf_blas_scal<
+    Ta,
+    Tb,
+    typename std::enable_if<
+        (std::is_same<Ta, double>{} && std::is_same<Tb, rocblas_double_complex>{})
+        || (std::is_same<Ta, float>{} && std::is_same<Tb, rocblas_float_complex>{})
+        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{})
+        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{})
+        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_float_complex>{})
+        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_double_complex>{})>::type>
 {
     explicit operator bool()
     {
@@ -245,10 +251,14 @@ struct perf_asum_nrm2 : rocblas_test_invalid
 };
 
 template <typename Ti, typename To>
-struct perf_asum_nrm2<Ti, To, typename std::enable_if<(std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{}) ||
-                                                      (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})   ||
-                                                      (std::is_same<Ti, float>{} && std::is_same<Ti, To>{} )                     ||
-                                                      (std::is_same<Ti, double>{} && std::is_same<Ti, To>{}) >::type>
+struct perf_asum_nrm2<
+    Ti,
+    To,
+    typename std::enable_if<
+        (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})
+        || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
+        || (std::is_same<Ti, float>{} && std::is_same<Ti, To>{})
+        || (std::is_same<Ti, double>{} && std::is_same<Ti, To>{})>::type>
 {
     explicit operator bool()
     {

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -208,6 +208,8 @@ struct perf_blas<T,
             testing_iamax<T>(arg);
         else if(!strcmp(arg.function, "iamin"))
             testing_iamin<T>(arg);
+        else if(!strcmp(arg.function, "gemv"))
+            testing_gemv<T>(arg);
         else
             throw std::invalid_argument("Invalid combination --function "s + arg.function
                                         + " --a_type "s + rocblas_datatype2string(arg.a_type));

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -278,7 +278,6 @@ struct perf_asum_nrm2<
 
 int run_bench_test(Arguments& arg)
 {
-    std::cout << "a_type: " << arg.a_type << "\n";
     // disable unit_check in client benchmark, it is only used in gtest unit test
     arg.unit_check = 0;
 
@@ -544,6 +543,9 @@ try
 
         ("beta",
          value<double>(&arg.beta)->default_value(0.0), "specifies the scalar beta")
+
+        ("betai",
+         value<double>(&arg.beta)->default_value(0.0), "specifies the imaginary part of the scalar beta")
 
         ("function,f",
          value<std::string>(&function),

--- a/clients/benchmarks/perf_script/blasPerformanceTesting.py
+++ b/clients/benchmarks/perf_script/blasPerformanceTesting.py
@@ -237,7 +237,7 @@ def decode_parameter_problemsize(problemsize):
     return problemsize
 
 def blas_table_header():
-    return 'm,n,k,lda,ldb,ldc,offa,offb,offc,alpha,alpha_imag,beta,transa,transb,side,uplo,diag,function,device,library,numQueues,label,GFLOPS'
+    return 'm,n,k,lda,ldb,ldc,offa,offb,offc,alpha,alphai,beta,betai,transa,transb,side,uplo,diag,function,device,library,numQueues,label,GFLOPS'
 
 class BlasTestCombination:
     def __init__(self,
@@ -259,7 +259,7 @@ class BlasTestCombination:
         self.offb = str(offb)
         self.offc = str(offc)
         self.alpha = str(alpha)
-        self.alpha_imag = str(alpha_imagi)
+        self.alphai = str(alphai)
         self.beta = str(beta)
         self.betai = str(betai)
         self.transa = transa

--- a/clients/benchmarks/perf_script/blasPerformanceTesting.py
+++ b/clients/benchmarks/perf_script/blasPerformanceTesting.py
@@ -237,14 +237,14 @@ def decode_parameter_problemsize(problemsize):
     return problemsize
 
 def blas_table_header():
-    return 'm,n,k,lda,ldb,ldc,offa,offb,offc,alpha,beta,transa,transb,side,uplo,diag,function,device,library,numQueues,label,GFLOPS'
+    return 'm,n,k,lda,ldb,ldc,offa,offb,offc,alpha,alpha_imag,beta,transa,transb,side,uplo,diag,function,device,library,numQueues,label,GFLOPS'
 
 class BlasTestCombination:
     def __init__(self,
                  sizem, sizen, sizek,
                  lda, ldb, ldc,
                  offa, offb, offc,
-                 alpha, beta,
+                 alpha, alpha_imag, beta,
                  transa, transb,
                  side, uplo, diag,
                  function, precision,
@@ -259,6 +259,7 @@ class BlasTestCombination:
         self.offb = str(offb)
         self.offc = str(offc)
         self.alpha = str(alpha)
+        self.alpha_imag = str(alpha_imagi)
         self.beta = str(beta)
         self.transa = transa
         self.transb = transb
@@ -272,7 +273,7 @@ class BlasTestCombination:
         self.label = label
 
     def __str__(self):
-        return self.sizem + 'x' + self.sizen + 'x' + self.sizek + ':' + self.lda + 'x' + self.ldb + 'x' + self.ldc + self.offa + 'x' + self.offb + 'x' + self.offc + ', ' + self.device + ', ' + self.precision + self.function + ', ' + self.library + ', alpha(' + self.alpha + '), beta(' + self.beta + '), transa(' + self.transa + '), transb(' + self.transb + '), side(' + self.side  + '), uplo(' + self.uplo + '), diag(' + self.diag + ') -- ' + self.label
+        return self.sizem + 'x' + self.sizen + 'x' + self.sizek + ':' + self.lda + 'x' + self.ldb + 'x' + self.ldc + self.offa + 'x' + self.offb + 'x' + self.offc + ', ' + self.device + ', ' + self.precision + self.function + ', ' + self.library + ', alpha(' + self.alpha + '), alpha_imag(' + self.alpha_imag + '), beta(' + self.beta + '), transa(' + self.transa + '), transb(' + self.transb + '), side(' + self.side  + '), uplo(' + self.uplo + '), diag(' + self.diag + ') -- ' + self.label
 
 class BlasGraphPoint:
     def __init__(self,

--- a/clients/benchmarks/perf_script/blasPerformanceTesting.py
+++ b/clients/benchmarks/perf_script/blasPerformanceTesting.py
@@ -244,7 +244,7 @@ class BlasTestCombination:
                  sizem, sizen, sizek,
                  lda, ldb, ldc,
                  offa, offb, offc,
-                 alpha, alpha_imag, beta,
+                 alpha, alphai, beta, betai,
                  transa, transb,
                  side, uplo, diag,
                  function, precision,
@@ -261,6 +261,7 @@ class BlasTestCombination:
         self.alpha = str(alpha)
         self.alpha_imag = str(alpha_imagi)
         self.beta = str(beta)
+        self.betai = str(betai)
         self.transa = transa
         self.transb = transb
         self.side = side
@@ -273,7 +274,7 @@ class BlasTestCombination:
         self.label = label
 
     def __str__(self):
-        return self.sizem + 'x' + self.sizen + 'x' + self.sizek + ':' + self.lda + 'x' + self.ldb + 'x' + self.ldc + self.offa + 'x' + self.offb + 'x' + self.offc + ', ' + self.device + ', ' + self.precision + self.function + ', ' + self.library + ', alpha(' + self.alpha + '), alpha_imag(' + self.alpha_imag + '), beta(' + self.beta + '), transa(' + self.transa + '), transb(' + self.transb + '), side(' + self.side  + '), uplo(' + self.uplo + '), diag(' + self.diag + ') -- ' + self.label
+        return self.sizem + 'x' + self.sizen + 'x' + self.sizek + ':' + self.lda + 'x' + self.ldb + 'x' + self.ldc + self.offa + 'x' + self.offb + 'x' + self.offc + ', ' + self.device + ', ' + self.precision + self.function + ', ' + self.library + ', alpha(' + self.alpha + '), alphai(' + self.alphai + '), beta(' + self.beta + '), betai(' + self.betai + ') transa(' + self.transa + '), transb(' + self.transb + '), side(' + self.side  + '), uplo(' + self.uplo + '), diag(' + self.diag + ') -- ' + self.label
 
 class BlasGraphPoint:
     def __init__(self,

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -69,9 +69,9 @@ void cblas_gemm<rocblas_bfloat16, rocblas_bfloat16, float>(rocblas_operation tra
     // cblas does not support rocblas_bfloat16, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
 
-    size_t sizeA = (transA == rocblas_operation_none ? k : m) * static_cast<size_t>(lda);
-    size_t sizeB = (transB == rocblas_operation_none ? n : k) * static_cast<size_t>(ldb);
-    size_t sizeC = n * static_cast<size_t>(ldc);
+    size_t sizeA = (transA == rocblas_operation_none ? k : m) * size_t(lda);
+    size_t sizeB = (transB == rocblas_operation_none ? n : k) * size_t(ldb);
+    size_t sizeC = n * size_t(ldc);
 
     host_vector<float> A_float(sizeA), B_float(sizeB), C_float(sizeC);
 
@@ -121,9 +121,9 @@ void cblas_gemm<rocblas_half, rocblas_half, float>(rocblas_operation transA,
     // cblas does not support rocblas_half, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
 
-    size_t sizeA = (transA == rocblas_operation_none ? k : m) * static_cast<size_t>(lda);
-    size_t sizeB = (transB == rocblas_operation_none ? n : k) * static_cast<size_t>(ldb);
-    size_t sizeC = n * static_cast<size_t>(ldc);
+    size_t sizeA = (transA == rocblas_operation_none ? k : m) * size_t(lda);
+    size_t sizeB = (transB == rocblas_operation_none ? n : k) * size_t(ldb);
+    size_t sizeC = n * size_t(ldc);
 
     host_vector<float> A_float(sizeA), B_float(sizeB), C_float(sizeC);
 
@@ -175,9 +175,9 @@ void cblas_gemm<rocblas_half, rocblas_half, rocblas_half>(rocblas_operation tran
     float alpha_float = half_to_float(alpha);
     float beta_float  = half_to_float(beta);
 
-    size_t sizeA = (transA == rocblas_operation_none ? k : m) * static_cast<size_t>(lda);
-    size_t sizeB = (transB == rocblas_operation_none ? n : k) * static_cast<size_t>(ldb);
-    size_t sizeC = n * static_cast<size_t>(ldc);
+    size_t sizeA = (transA == rocblas_operation_none ? k : m) * size_t(lda);
+    size_t sizeB = (transB == rocblas_operation_none ? n : k) * size_t(ldb);
+    size_t sizeC = n * size_t(ldc);
 
     host_vector<float> A_float(sizeA), B_float(sizeB), C_float(sizeC);
 
@@ -230,9 +230,9 @@ void cblas_gemm<int8_t, int32_t, int32_t>(rocblas_operation transA,
     // NOTE: This will not properly account for 32-bit integer overflow, however
     //       the result should be acceptable for testing.
 
-    size_t const sizeA = ((transA == rocblas_operation_none) ? k : m) * static_cast<size_t>(lda);
-    size_t const sizeB = ((transB == rocblas_operation_none) ? n : k) * static_cast<size_t>(ldb);
-    size_t const sizeC = n * static_cast<size_t>(ldc);
+    size_t const sizeA = ((transA == rocblas_operation_none) ? k : m) * size_t(lda);
+    size_t const sizeB = ((transB == rocblas_operation_none) ? n : k) * size_t(ldb);
+    size_t const sizeC = n * size_t(ldc);
 
     host_vector<double> A_double(sizeA);
     host_vector<double> B_double(sizeB);

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -71,8 +71,8 @@ double norm_check_general<rocblas_bfloat16>(char              norm_type,
     host_vector<float> hCPU_float(N * lda), hGPU_float(N * lda);
     for(rocblas_int i = 0; i < N * lda; i++)
     {
-        hCPU_float[i] = static_cast<float>(hCPU[i]);
-        hGPU_float[i] = static_cast<float>(hGPU[i]);
+        hCPU_float[i] = float(hCPU[i]);
+        hGPU_float[i] = float(hGPU[i]);
     }
 
     float       work;
@@ -84,7 +84,7 @@ double norm_check_general<rocblas_bfloat16>(char              norm_type,
     saxpy_(&size, &alpha, hCPU_float, &incx, hGPU_float, &incx);
 
     float error_float = slange_(&norm_type, &M, &N, hGPU_float, &lda, &work) / cpu_norm;
-    error_double      = static_cast<double>(error_float);
+    error_double      = double(error_float);
 
     return error_double;
 }
@@ -120,7 +120,7 @@ double norm_check_general<rocblas_half>(char          norm_type,
     saxpy_(&size, &alpha, hCPU_float, &incx, hGPU_float, &incx);
 
     float error_float = slange_(&norm_type, &M, &N, hGPU_float, &lda, &work) / cpu_norm;
-    error_double      = static_cast<double>(error_float);
+    error_double      = double(error_float);
 
     return error_double;
 }
@@ -178,8 +178,8 @@ double norm_check_general<int32_t>(
 
     for(int i = 0; i < M * N; i++)
     {
-        hCPU_double[i] = static_cast<double>(hCPU[i]);
-        hGPU_double[i] = static_cast<double>(hGPU[i]);
+        hCPU_double[i] = double(hCPU[i]);
+        hGPU_double[i] = double(hGPU[i]);
     }
     return norm_check_general<double>(norm_type, M, N, lda, hCPU_double, hGPU_double);
 }
@@ -262,8 +262,8 @@ double norm_check_general<rocblas_bfloat16>(char              norm_type,
         for(rocblas_int i = 0; i < N * lda; i++)
         {
             auto index        = i + i_batch * stride_a;
-            hCPU_float[index] = static_cast<float>(hCPU[index]);
-            hGPU_float[index] = static_cast<float>(hGPU[index]);
+            hCPU_float[index] = float(hCPU[index]);
+            hGPU_float[index] = float(hGPU[index]);
         }
     }
 

--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -292,9 +292,9 @@ def instantiate(test):
         for typename in enum_args:
             if COMPLEX_RE.match(test[typename]):
                 break
-        else:
-            test['alphai'] = 0.0
-            test['betai'] = 0.0
+            else:
+                test['alphai'] = 0.0
+                test['betai'] = 0.0
 
         # For enum arguments, replace name with value
         for typename in enum_args:

--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -22,6 +22,9 @@ INT_RANGE_RE = re.compile(r'\s*(-?\d+)\s*\.\.\s*(-?\d+)\s*(?:\.\.\s*(-?\d+)\s*)?
 # Regex for include: YAML extension
 INCLUDE_RE = re.compile(r'include\s*:\s*(.*)')
 
+# Regex for complex types
+COMPLEX_RE = re.compile(r'f\d+_c$')
+
 args = {}
 testcases = set()
 datatypes = {}
@@ -189,6 +192,8 @@ def get_arguments(doc):
 
 def setdefaults(test):
     """Set default values for parameters"""
+    # Do not put constant defaults here -- use rocblas_common.yaml for that.
+    # These are only for dynamic defaults
     # TODO: This should be ideally moved to YAML file, with eval'd expressions.
     if test['transA'] == '*' or test['transB'] == '*':
         test.setdefault('lda', 0)
@@ -252,15 +257,19 @@ def write_test(test):
     # scalars, we coerce the string/numeric value into ctype.
     arg = []
     for name, ctype in param['Arguments']._fields_:
-        if issubclass(ctype, ctypes.Array):
-            if issubclass(ctype._type_, ctypes.c_char):
+        try:
+            if issubclass(ctype, ctypes.Array):
+                if issubclass(ctype._type_, ctypes.c_char):
+                    arg.append(bytes(test[name], 'utf_8'))
+                else:
+                    arg.append(ctype(*test[name]))
+            elif issubclass(ctype, ctypes.c_char):
                 arg.append(bytes(test[name], 'utf_8'))
             else:
-                arg.append(ctype(*test[name]))
-        elif issubclass(ctype, ctypes.c_char):
-            arg.append(bytes(test[name], 'utf_8'))
-        else:
-            arg.append(ctype(test[name]))
+                arg.append(ctype(test[name]))
+        except TypeError as err:
+            sys.exit("TypeError: " + str(err) + " for " + name +
+                     ", which has type " + str(type(test[name])) + "\n")
 
     byt = bytes(param['Arguments'](*arg))
     if byt not in testcases:
@@ -273,11 +282,20 @@ def instantiate(test):
     """Instantiate a given test case"""
     test = test.copy()
 
-    # Any Arguments fields declared as enums
+    # Any Arguments fields declared as enums (a_type, b_type, etc.)
     enum_args = [decl[0] for decl in param['Arguments']._fields_
                  if decl[1].__module__ == '__main__']
     try:
         setdefaults(test)
+
+        # If no enum arguments are complex, clear alphai and betai
+        for typename in enum_args:
+            if COMPLEX_RE.match(test[typename]):
+                break
+        else:
+            test['alphai'] = 0.0
+            test['betai'] = 0.0
+
         # For enum arguments, replace name with value
         for typename in enum_args:
             test[typename] = datatypes[test[typename]]
@@ -330,9 +348,15 @@ def generate(test, function):
 
             # For a bare dictionary, wrap it in a list and apply it once
             for item in [ilist] if type(ilist) == dict else ilist:
-                case = test.copy()
-                case.update(item)
-                generate(case, function)  # original test merged with each item
+                try:
+                    case = test.copy()
+                    case.update(item)  # original test merged with each item
+                    generate(case, function)
+                except TypeError as err:
+                    sys.exit("TypeError: " + str(err) + " for " + argname +
+                             ", which has type " + str(type(item)) +
+                             "\nA name listed in \"Dictionary lists to expand\" "
+                             "must be a defined as a dictionary.\n")
             return
 
     for key in sorted(list(test)):

--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -292,9 +292,10 @@ def instantiate(test):
         for typename in enum_args:
             if COMPLEX_RE.match(test[typename]):
                 break
-            else:
-                test['alphai'] = 0.0
-                test['betai'] = 0.0
+        else:
+            for name in ('alphai', 'betai'):
+                if name in test:
+                    test[name] = 0.0
 
         # For enum arguments, replace name with value
         for typename in enum_args:

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -185,7 +185,7 @@ BLAS1_TESTING(axpy,  ARG1)
 BLAS1_TESTING(copy,  ARG1)
 BLAS1_TESTING(dot,   ARG1)
 BLAS1_TESTING(dotc,  ARG1)
-BLAS1_TESTING(scal,  ARG1)
+BLAS1_TESTING(scal,  ARG2)
 BLAS1_TESTING(swap,  ARG1)
 
     // clang-format on

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -7,7 +7,6 @@
 #include "testing_axpy.hpp"
 #include "testing_copy.hpp"
 #include "testing_dot.hpp"
-#include "testing_dotc.hpp"
 #include "testing_iamax_iamin.hpp"
 #include "testing_nrm2.hpp"
 #include "testing_scal.hpp"

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -7,6 +7,7 @@
 #include "testing_axpy.hpp"
 #include "testing_copy.hpp"
 #include "testing_dot.hpp"
+#include "testing_dotc.hpp"
 #include "testing_iamax_iamin.hpp"
 #include "testing_nrm2.hpp"
 #include "testing_scal.hpp"
@@ -25,6 +26,7 @@ namespace
         axpy,
         copy,
         dot,
+        dotc,
         scal,
         swap,
     };
@@ -70,12 +72,54 @@ namespace
 
     // This tells whether the BLAS1 tests are enabled
     template <blas1 BLAS1, typename Ti, typename To, typename Tc>
-    using blas1_enabled
-        = std::integral_constant<bool,
-                                 std::is_same<Ti, To>{} && std::is_same<To, Tc>{}
-                                     && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}
-                                         || (std::is_same<Ti, rocblas_half>{}
-                                             && BLAS1 == blas1::axpy))>;
+    using blas1_enabled = std::integral_constant<
+        bool,
+        (BLAS1 == blas1::asum && std::is_same<To, Tc>{}
+         && ((std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
+             || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})
+             || (std::is_same<Ti, To>{} && std::is_same<To, float>{})
+             || (std::is_same<Ti, To>{} && std::is_same<To, double>{})))
+
+            || (BLAS1 == blas1::axpy && std::is_same<Ti, To>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, rocblas_half>{} || std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
+                    || std::is_same<Ti, double>{}))
+
+            || (BLAS1 == blas1::dot && std::is_same<Ti, To>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
+                    || std::is_same<Ti, double>{}))
+
+            || (BLAS1 == blas1::dotc && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{}))
+
+            || (BLAS1 == blas1::nrm2 && std::is_same<To, Tc>{}
+                && ((std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
+                    || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})
+                    || (std::is_same<Ti, To>{} && std::is_same<To, float>{})
+                    || (std::is_same<Ti, To>{} && std::is_same<To, double>{})))
+
+            || (BLAS1 == blas1::scal && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
+                    || std::is_same<Ti, double>{}))
+
+            || (BLAS1 == blas1::iamax && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
+                    || std::is_same<Ti, double>{}))
+
+            || (BLAS1 == blas1::iamin && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
+                    || std::is_same<Ti, double>{}))
+
+            || (BLAS1 == blas1::copy && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}))
+
+            || (BLAS1 == blas1::swap && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function
@@ -134,6 +178,7 @@ BLAS1_TESTING(iamin, ARG1)
 BLAS1_TESTING(axpy,  ARG1)
 BLAS1_TESTING(copy,  ARG1)
 BLAS1_TESTING(dot,   ARG1)
+BLAS1_TESTING(dotc,  ARG1)
 BLAS1_TESTING(scal,  ARG1)
 BLAS1_TESTING(swap,  ARG1)
 

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -73,11 +73,9 @@ namespace
     template <blas1 BLAS1, typename Ti, typename To, typename Tc>
     using blas1_enabled = std::integral_constant<
         bool,
-        (BLAS1 == blas1::asum && std::is_same<To, Tc>{}
-         && ((std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
-             || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})
-             || (std::is_same<Ti, To>{} && std::is_same<To, float>{})
-             || (std::is_same<Ti, To>{} && std::is_same<To, double>{})))
+        (BLAS1 == blas1::asum && std::is_same<Ti, To>{} && std::is_same<To, Tc>{}
+         && (std::is_same<Ti, rocblas_float_complex>{} || std::is_same<Ti, rocblas_double_complex>{}
+             || std::is_same<Ti, float>{} || std::is_same<Ti, double>{}))
 
             || (BLAS1 == blas1::axpy && std::is_same<Ti, To>{} && std::is_same<To, Tc>{}
                 && (std::is_same<Ti, rocblas_half>{} || std::is_same<Ti, rocblas_float_complex>{}
@@ -93,11 +91,10 @@ namespace
                 && (std::is_same<Ti, rocblas_float_complex>{}
                     || std::is_same<Ti, rocblas_double_complex>{}))
 
-            || (BLAS1 == blas1::nrm2 && std::is_same<To, Tc>{}
-                && ((std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
-                    || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})
-                    || (std::is_same<Ti, To>{} && std::is_same<To, float>{})
-                    || (std::is_same<Ti, To>{} && std::is_same<To, double>{})))
+            || (BLAS1 == blas1::nrm2 && std::is_same<Ti, To>{} && std::is_same<To, Tc>{}
+                && (std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
+                    || std::is_same<Ti, double>{}))
 
             || (BLAS1 == blas1::scal && std::is_same<To, Tc>{}
                 && ((std::is_same<Ti, rocblas_float_complex>{} && std::is_same<Ti, To>{})
@@ -177,8 +174,8 @@ INSTANTIATE_TEST_CATEGORIES(NAME)
 #define ARG2(Ti, To, Tc) Ti, To
 #define ARG3(Ti, To, Tc) Ti, To, Tc
 
-BLAS1_TESTING(asum,  ARG2)
-BLAS1_TESTING(nrm2,  ARG2)
+BLAS1_TESTING(asum,  ARG1)
+BLAS1_TESTING(nrm2,  ARG1)
 BLAS1_TESTING(iamax, ARG1)
 BLAS1_TESTING(iamin, ARG1)
 BLAS1_TESTING(axpy,  ARG1)

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -101,8 +101,8 @@ namespace
                     || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<Ti, To>{})
                     || (std::is_same<Ti, float>{} && std::is_same<Ti, To>{})
                     || (std::is_same<Ti, double>{} && std::is_same<Ti, To>{})
-                    || (std::is_same<Ti, float>{} && std::is_same<To, rocblas_float_complex>{})
-                    || (std::is_same<Ti, double>{} && std::is_same<To, rocblas_double_complex>{})))
+                    || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
+                    || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})))
 
             || (BLAS1 == blas1::iamax && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
                 && (std::is_same<Ti, rocblas_float_complex>{}

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -52,13 +52,15 @@ namespace
             RocBLAS_TestName<blas1_test_template> name;
             name << rocblas_datatype2string(arg.a_type);
 
+            if(BLAS1 == blas1::scal && arg.a_type != arg.b_type)
+                name << rocblas_datatype2string(arg.b_type);
             if((BLAS1 == blas1::nrm2 || BLAS1 == blas1::asum) && arg.a_type != arg.d_type)
                 name << rocblas_datatype2string(arg.d_type);
 
             name << '_' << arg.N;
 
             if(BLAS1 == blas1::axpy || BLAS1 == blas1::scal)
-                name << '_' << arg.alpha;
+                name << '_' << arg.alpha << "-" << arg.alphai;
 
             name << '_' << arg.incx;
 
@@ -100,10 +102,13 @@ namespace
                     || (std::is_same<Ti, To>{} && std::is_same<To, float>{})
                     || (std::is_same<Ti, To>{} && std::is_same<To, double>{})))
 
-            || (BLAS1 == blas1::scal && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
-                && (std::is_same<Ti, rocblas_float_complex>{}
-                    || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
-                    || std::is_same<Ti, double>{}))
+            || (BLAS1 == blas1::scal && std::is_same<To, Tc>{}
+                && ((std::is_same<Ti, rocblas_float_complex>{} && std::is_same<Ti, To>{})
+                    || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<Ti, To>{})
+                    || (std::is_same<Ti, float>{} && std::is_same<Ti, To>{})
+                    || (std::is_same<Ti, double>{} && std::is_same<Ti, To>{})
+                    || (std::is_same<Ti, float>{} && std::is_same<To, rocblas_float_complex>{})
+                    || (std::is_same<Ti, double>{} && std::is_same<To, rocblas_double_complex>{})))
 
             || (BLAS1 == blas1::iamax && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
                 && (std::is_same<Ti, rocblas_float_complex>{}
@@ -116,10 +121,14 @@ namespace
                     || std::is_same<Ti, double>{}))
 
             || (BLAS1 == blas1::copy && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
-                && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}))
+                && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}
+                    || std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{}))
 
             || (BLAS1 == blas1::swap && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
-                && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}))>;
+                && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}
+                    || std::is_same<Ti, rocblas_float_complex>{}
+                    || std::is_same<Ti, rocblas_double_complex>{}))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -52,14 +52,12 @@ namespace
             name << rocblas_datatype2string(arg.a_type);
 
             if(BLAS1 == blas1::scal && arg.a_type != arg.b_type)
-                name << rocblas_datatype2string(arg.b_type);
-            if((BLAS1 == blas1::nrm2 || BLAS1 == blas1::asum) && arg.a_type != arg.d_type)
-                name << rocblas_datatype2string(arg.d_type);
+                name << '_' << rocblas_datatype2string(arg.b_type);
 
             name << '_' << arg.N;
 
             if(BLAS1 == blas1::axpy || BLAS1 == blas1::scal)
-                name << '_' << arg.alpha << "-" << arg.alphai;
+                name << '_' << arg.alpha << "_" << arg.alphai;
 
             name << '_' << arg.incx;
 

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -27,8 +27,8 @@ Tests:
   alpha_beta: *alpha_beta_range
   alphai: *alphai_range
   function:
-    - nrm2:  *single_double_real_joined
-    - asum:  *single_double_real_joined
+    - nrm2:  *single_double_real_complex_in_real_out
+    - asum:  *single_double_real_complex_in_real_out
     - iamax: *single_double_precisions_complex_real
 #   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
     - axpy:  *half_single_precisions_complex_real
@@ -46,8 +46,8 @@ Tests:
   alpha_beta: *alpha_beta_range
   alphai: *alphai_range
   function:
-    - nrm2:  *double_real_joined
-    - asum:  *double_real_joined
+    - nrm2:  *double_real_complex_in_real_out
+    - asum:  *double_real_complex_in_real_out
     - iamax: *single_double_precisions_complex_real
 #   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
     - axpy:  *half_single_precisions_complex_real
@@ -61,8 +61,8 @@ Tests:
 - name: blas1_bad_arg
   category: pre_checkin
   function:
-    - nrm2_bad_arg:  *single_double_real_joined
-    - asum_bad_arg:  *single_double_real_joined
+    - nrm2_bad_arg:  *single_real_complex_in_real_out
+    - asum_bad_arg:  *single_real_complex_in_real_out
     - iamax_bad_arg: *single_double_precisions_complex_real
     - iamin_bad_arg: *single_double_precisions_complex_real
     - axpy_bad_arg:  *half_single_precisions_complex_real

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -28,8 +28,8 @@ Tests:
   alpha_beta: *alpha_beta_range
   alphai_betai: *alphai_betai_range
   function:
-    - nrm2:  *single_double_real_complex_in_real_out
-    - asum:  *single_double_real_complex_in_real_out
+    - nrm2:  *single_double_precisions_complex_real
+    - asum:  *single_double_precisions_complex_real
     - iamax: *single_double_precisions_complex_real
 #   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
     - axpy:  *half_single_precisions_complex_real
@@ -47,8 +47,8 @@ Tests:
   alpha_beta: *alpha_beta_range
   alphai_betai: *alphai_betai_range
   function:
-    - nrm2:  *double_real_complex_in_real_out
-    - asum:  *double_real_complex_in_real_out
+    - nrm2:  *single_double_precisions_complex_real
+    - asum:  *single_double_precisions_complex_real
     - iamax: *single_double_precisions_complex_real
 #   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
     - axpy:  *half_single_precisions_complex_real
@@ -62,8 +62,8 @@ Tests:
 - name: blas1_bad_arg
   category: pre_checkin
   function:
-    - nrm2_bad_arg:  *single_real_complex_in_real_out
-    - asum_bad_arg:  *single_real_complex_in_real_out
+    - nrm2_bad_arg:  *single_double_precisions_complex_real
+    - asum_bad_arg:  *single_double_precisions_complex_real
     - iamax_bad_arg: *single_double_precisions_complex_real
     - iamin_bad_arg: *single_double_precisions_complex_real
     - axpy_bad_arg:  *half_single_precisions_complex_real

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -15,42 +15,49 @@ Definitions:
     - { alpha:  1.0, beta:  0.0 }
     - { alpha:  2.0, beta: -1.0 }
 
+  - &alphai_range
+    - {alphai: 0.5}
+    - {alphai: 0.8}
+    - {alphai: 1.5}
+
 Tests:
 - name: blas1
   category: quick
   N: [ -1, 0, 5, 10, 500, 1000, 1024, 1025, 7111, 10000, 33792 ]
   incx_incy: *incx_incy_range
   alpha_beta: *alpha_beta_range
+  alphai: *alphai_range
   function:
     - nrm2:  *single_double_real_joined
     - asum:  *single_double_real_joined
     - iamax: *single_double_precisions_complex_real
 #   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
     - axpy:  *half_single_precisions_complex_real
-    - copy:  *single_double_precisions
+    - copy:  *single_double_precisions_complex_real
     - dot:   *single_double_precisions_complex_real
     - dotc:  *single_double_precisions_complex
     - scal:  *single_double_precisions_complex_real
     - scalrc: *single_double_complex_real_in_complex_out
-    - swap:  *single_double_precisions
+    - swap:  *single_double_precisions_complex_real
 
 - name: blas1
   category: pre_checkin
   N: [ 1048576, 1049600, 4000000, 8000000 ]
   incx_incy: *incx_incy_range
   alpha_beta: *alpha_beta_range
+  alphai: *alphai_range
   function:
     - nrm2:  *double_real_joined
     - asum:  *double_real_joined
     - iamax: *single_double_precisions_complex_real
 #   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
     - axpy:  *half_single_precisions_complex_real
-    - copy:  *single_double_precisions
+    - copy:  *single_double_precisions_complex_real
     - dot:   *double_precision_complex_real
     - dotc:  *single_double_precisions_complex
     - scal:  *single_double_precisions_complex_real
     - scalrc: *single_double_complex_real_in_complex_out
-    - swap:  *single_double_precisions
+    - swap:  *single_double_precisions_complex_real
 
 - name: blas1_bad_arg
   category: pre_checkin
@@ -60,10 +67,10 @@ Tests:
     - iamax_bad_arg: *single_double_precisions_complex_real
     - iamin_bad_arg: *single_double_precisions_complex_real
     - axpy_bad_arg:  *half_single_precisions_complex_real
-    - copy_bad_arg:  *single_double_precisions
+    - copy_bad_arg:  *single_double_precisions_complex_real
     - dot_bad_arg:   *single_double_precisions_complex_real
     - dotc_bad_arg:  *single_double_precisions_complex
     - scal_bad_arg:  *single_double_precisions_complex_real
     - scalrc_bad_arg: *single_double_complex_real_in_complex_out
-    - swap_bad_arg:  *single_double_precisions
+    - swap_bad_arg:  *single_double_precisions_complex_real
 ...

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -17,8 +17,8 @@ Definitions:
 
   - &alphai_betai_range
     - { alphai: 0.0 }
-    - { alphai: 0.5 }
-    - { alphai: 1.5 }
+    - { alphai: 1.0}
+    - { alphai: 2.0 }
 
 Tests:
 - name: blas1
@@ -47,14 +47,14 @@ Tests:
   alpha_beta: *alpha_beta_range
   alphai_betai: *alphai_betai_range
   function:
-    - nrm2:  *single_double_precisions_complex_real
-    - asum:  *single_double_precisions_complex_real
+    - nrm2:  *double_precision_complex_real
+    - asum:  *double_precision_complex_real
     - iamax: *single_double_precisions_complex_real
 #   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
     - axpy:  *half_single_precisions_complex_real
     - copy:  *single_double_precisions_complex_real
     - dot:   *double_precision_complex_real
-    - dotc:  *single_double_precisions_complex
+    - dotc:  *double_precision_complex_real
     - scal:  *single_double_precisions_complex_real
     - scal:  *single_double_complex_real_in_complex_out
     - swap:  *single_double_precisions_complex_real

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -36,7 +36,7 @@ Tests:
     - dot:   *single_double_precisions_complex_real
     - dotc:  *single_double_precisions_complex
     - scal:  *single_double_precisions_complex_real
-    - scalrc: *single_double_complex_real_in_complex_out
+    - scal:  *single_double_complex_real_in_complex_out
     - swap:  *single_double_precisions_complex_real
 
 - name: blas1
@@ -55,7 +55,7 @@ Tests:
     - dot:   *double_precision_complex_real
     - dotc:  *single_double_precisions_complex
     - scal:  *single_double_precisions_complex_real
-    - scalrc: *single_double_complex_real_in_complex_out
+    - scal:  *single_double_complex_real_in_complex_out
     - swap:  *single_double_precisions_complex_real
 
 - name: blas1_bad_arg
@@ -70,6 +70,6 @@ Tests:
     - dot_bad_arg:   *single_double_precisions_complex_real
     - dotc_bad_arg:  *single_double_precisions_complex
     - scal_bad_arg:  *single_double_precisions_complex_real
-    - scalrc_bad_arg: *single_double_complex_real_in_complex_out
+    - scal_bad_arg:  *single_double_complex_real_in_complex_out
     - swap_bad_arg:  *single_double_precisions_complex_real
 ...

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -22,14 +22,16 @@ Tests:
   incx_incy: *incx_incy_range
   alpha_beta: *alpha_beta_range
   function:
-    - nrm2:  *single_double_precisions
-    - asum:  *single_double_precisions
-    - iamax: *single_double_precisions
-#   - iamin: *single_double_precisions
-    - axpy:  *half_single_double_precisions
+    - nrm2:  *single_double_real_joined
+    - asum:  *single_double_real_joined
+    - iamax: *single_double_precisions_complex_real
+#   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
+    - axpy:  *half_single_precisions_complex_real
     - copy:  *single_double_precisions
-    - dot:   *single_double_precisions
-    - scal:  *single_double_precisions
+    - dot:   *single_double_precisions_complex_real
+    - dotc:  *single_double_precisions_complex
+    - scal:  *single_double_precisions_complex_real
+    - scalrc: *single_double_complex_real_in_complex_out
     - swap:  *single_double_precisions
 
 - name: blas1
@@ -38,26 +40,30 @@ Tests:
   incx_incy: *incx_incy_range
   alpha_beta: *alpha_beta_range
   function:
-    - nrm2:  *double_precision
-    - asum:  *double_precision
-    - iamax: *single_double_precisions
-#   - iamin: *single_double_precisions
-    - axpy:  *half_single_double_precisions
+    - nrm2:  *double_real_joined
+    - asum:  *double_real_joined
+    - iamax: *single_double_precisions_complex_real
+#   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
+    - axpy:  *half_single_precisions_complex_real
     - copy:  *single_double_precisions
-    - dot:   *double_precision
-    - scal:  *single_double_precisions
+    - dot:   *double_precision_complex_real
+    - dotc:  *single_double_precisions_complex
+    - scal:  *single_double_precisions_complex_real
+    - scalrc: *single_double_complex_real_in_complex_out
     - swap:  *single_double_precisions
 
 - name: blas1_bad_arg
   category: pre_checkin
   function:
-    - nrm2_bad_arg:  *single_double_precisions
-    - asum_bad_arg:  *single_double_precisions
-    - iamax_bad_arg: *single_double_precisions
-    - iamin_bad_arg: *single_double_precisions
-    - axpy_bad_arg:  *half_single_double_precisions
+    - nrm2_bad_arg:  *single_double_real_joined
+    - asum_bad_arg:  *single_double_real_joined
+    - iamax_bad_arg: *single_double_precisions_complex_real
+    - iamin_bad_arg: *single_double_precisions_complex_real
+    - axpy_bad_arg:  *half_single_precisions_complex_real
     - copy_bad_arg:  *single_double_precisions
-    - dot_bad_arg:   *single_double_precisions
-    - scal_bad_arg:  *single_double_precisions
+    - dot_bad_arg:   *single_double_precisions_complex_real
+    - dotc_bad_arg:  *single_double_precisions_complex
+    - scal_bad_arg:  *single_double_precisions_complex_real
+    - scalrc_bad_arg: *single_double_complex_real_in_complex_out
     - swap_bad_arg:  *single_double_precisions
 ...

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -15,9 +15,10 @@ Definitions:
     - { alpha:  1.0, beta:  0.0 }
     - { alpha:  2.0, beta: -1.0 }
 
-  - &alphai_range
-    - {alphai: 0.5}
-    - {alphai: 1.5}
+  - &alphai_betai_range
+    - { alphai: 0.0 }
+    - { alphai: 0.5 }
+    - { alphai: 1.5 }
 
 Tests:
 - name: blas1
@@ -25,7 +26,7 @@ Tests:
   N: [ -1, 0, 5, 10, 500, 1000, 1024, 1025, 7111, 10000, 33792 ]
   incx_incy: *incx_incy_range
   alpha_beta: *alpha_beta_range
-  alphai: *alphai_range
+  alphai_betai: *alphai_betai_range
   function:
     - nrm2:  *single_double_real_complex_in_real_out
     - asum:  *single_double_real_complex_in_real_out
@@ -44,7 +45,7 @@ Tests:
   N: [ 1048576, 1049600, 4000000, 8000000 ]
   incx_incy: *incx_incy_range
   alpha_beta: *alpha_beta_range
-  alphai: *alphai_range
+  alphai_betai: *alphai_betai_range
   function:
     - nrm2:  *double_real_complex_in_real_out
     - asum:  *double_real_complex_in_real_out

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -17,7 +17,6 @@ Definitions:
 
   - &alphai_range
     - {alphai: 0.5}
-    - {alphai: 0.8}
     - {alphai: 1.5}
 
 Tests:

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -26,8 +26,8 @@ namespace
     struct gemv_testing<
         T,
         typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
-                                || std::is_same<T, rocblas_float_complex>{}>::
-            type> // || std::is_same<T, rocblas_double_complex>{}>::type>
+                                || std::is_same<T, rocblas_float_complex>{}
+                                || std::is_same<T, rocblas_double_complex>{}>::type>
     {
         explicit operator bool()
         {

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -25,7 +25,9 @@ namespace
     template <typename T>
     struct gemv_testing<
         T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
+                                || std::is_same<T, rocblas_float_complex>{}>::
+            type> // || std::is_same<T, rocblas_double_complex>{}>::type>
     {
         explicit operator bool()
         {
@@ -59,10 +61,11 @@ namespace
         // Google Test name suffix based on parameters
         static std::string name_suffix(const Arguments& arg)
         {
-            return RocBLAS_TestName<gemv>{} << rocblas_datatype2string(arg.a_type) << '_'
-                                            << (char)std::toupper(arg.transA) << '_' << arg.M << '_'
-                                            << arg.N << '_' << arg.alpha << '_' << arg.lda << '_'
-                                            << arg.incx << '_' << arg.beta << '_' << arg.incy;
+            return RocBLAS_TestName<gemv>{}
+                   << rocblas_datatype2string(arg.a_type) << '_' << (char)std::toupper(arg.transA)
+                   << '_' << arg.M << '_' << arg.N << '_' << arg.alpha << '_' << arg.alphai << '_'
+                   << arg.lda << '_' << arg.incx << '_' << arg.beta << '_' << arg.betai << '_'
+                   << arg.incy;
         }
     };
 

--- a/clients/gtest/gemv_gtest.yaml
+++ b/clients/gtest/gemv_gtest.yaml
@@ -36,10 +36,10 @@ Definitions:
     - { incx:  10, incy: 100 }
 
   - &alpha_beta_range
-    - { alpha:  2.0, beta:  0.0 }
-    - { alpha: -1.0, beta: -1.0 }
-    - { alpha:  2.0, beta:  1.0 }
-    - { alpha:  0.0, beta:  1.0 }
+    - { alpha:  2.0, beta:  0.0, alphai: 1.5, betai: 0.5 }
+    - { alpha: -1.0, beta: -1.0, alphai: 0.5, betai: 1.5 }
+    - { alpha:  2.0, beta:  1.0, alphai: -1.5, betai: 0.5 }
+    - { alpha:  0.0, beta:  1.0, alphai: -0.5, betai: 0 }
 
 Tests:
 - name: gemv_bad_arg
@@ -61,7 +61,7 @@ Tests:
 - name: gemv_small
   category: quick
   function: gemv
-  precision: *single_double_precisions
+  precision: *single_double_real_single_complex
   transA: [ N, T, C ]
   matrix_size: *small_matrix_size_range
   incx_incy: *incx_incy_range
@@ -70,7 +70,7 @@ Tests:
 - name: gemv_medium
   category: pre_checkin
   function: gemv
-  precision: *single_double_precisions
+  precision: *single_double_real_single_complex
   transA: [ N, T, C ]
   matrix_size: *medium_matrix_size_range
   incx_incy: *incx_incy_range
@@ -79,8 +79,8 @@ Tests:
 - name: gemv_large
   category: nightly
   function: gemv
-  precision: *single_double_precisions
-  transA: [ N, T, C ]
+  precision: *single_double_real_single_complex
+  transA: [  N, T, C ]
   matrix_size: *large_matrix_size_range
   incx_incy: *incx_incy_range
   alpha_beta: *alpha_beta_range

--- a/clients/gtest/gemv_gtest.yaml
+++ b/clients/gtest/gemv_gtest.yaml
@@ -61,7 +61,7 @@ Tests:
 - name: gemv_small
   category: quick
   function: gemv
-  precision: *single_double_real_single_complex
+  precision: *single_double_precisions_complex_real
   transA: [ N, T, C ]
   matrix_size: *small_matrix_size_range
   incx_incy: *incx_incy_range
@@ -70,7 +70,7 @@ Tests:
 - name: gemv_medium
   category: pre_checkin
   function: gemv
-  precision: *single_double_real_single_complex
+  precision: *single_double_precisions_complex_real
   transA: [ N, T, C ]
   matrix_size: *medium_matrix_size_range
   incx_incy: *incx_incy_range
@@ -79,7 +79,7 @@ Tests:
 - name: gemv_large
   category: nightly
   function: gemv
-  precision: *single_double_real_single_complex
+  precision: *single_double_precisions_complex_real
   transA: [  N, T, C ]
   matrix_size: *large_matrix_size_range
   incx_incy: *incx_incy_range

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -398,18 +398,8 @@ inline void cblas_gemv(rocblas_operation transA,
                        float*            y,
                        rocblas_int       incy)
 {
-    cblas_sgemv(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                m,
-                n,
-                alpha,
-                A,
-                lda,
-                x,
-                incx,
-                beta,
-                y,
-                incy);
+    cblas_sgemv(
+        CblasColMajor, CBLAS_TRANSPOSE(transA), m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
@@ -425,18 +415,8 @@ inline void cblas_gemv(rocblas_operation transA,
                        double*           y,
                        rocblas_int       incy)
 {
-    cblas_dgemv(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                m,
-                n,
-                alpha,
-                A,
-                lda,
-                x,
-                incx,
-                beta,
-                y,
-                incy);
+    cblas_dgemv(
+        CblasColMajor, CBLAS_TRANSPOSE(transA), m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
@@ -452,18 +432,8 @@ inline void cblas_gemv(rocblas_operation      transA,
                        rocblas_float_complex* y,
                        rocblas_int            incy)
 {
-    cblas_cgemv(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                m,
-                n,
-                &alpha,
-                A,
-                lda,
-                x,
-                incx,
-                &beta,
-                y,
-                incy);
+    cblas_cgemv(
+        CblasColMajor, CBLAS_TRANSPOSE(transA), m, n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 template <>
@@ -479,18 +449,8 @@ inline void cblas_gemv(rocblas_operation       transA,
                        rocblas_double_complex* y,
                        rocblas_int             incy)
 {
-    cblas_zgemv(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                m,
-                n,
-                &alpha,
-                A,
-                lda,
-                x,
-                incx,
-                &beta,
-                y,
-                incy);
+    cblas_zgemv(
+        CblasColMajor, CBLAS_TRANSPOSE(transA), m, n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 // trsv
@@ -515,9 +475,9 @@ inline void cblas_trsv(rocblas_fill      uplo,
                        rocblas_int       incx)
 {
     cblas_strsv(CblasColMajor,
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 A,
                 lda,
@@ -536,9 +496,9 @@ inline void cblas_trsv(rocblas_fill      uplo,
                        rocblas_int       incx)
 {
     cblas_dtrsv(CblasColMajor,
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 A,
                 lda,
@@ -568,9 +528,9 @@ inline void cblas_trmv(rocblas_fill      uplo,
                        rocblas_int       incx)
 {
     cblas_strmv(CblasColMajor,
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 A,
                 lda,
@@ -589,9 +549,9 @@ inline void cblas_trmv(rocblas_fill      uplo,
                        rocblas_int       incx)
 {
     cblas_dtrmv(CblasColMajor,
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 A,
                 lda,
@@ -624,8 +584,7 @@ inline void cblas_symv(rocblas_fill uplo,
                        float*       y,
                        rocblas_int  incy)
 {
-    cblas_ssymv(
-        CblasColMajor, static_cast<CBLAS_UPLO>(uplo), n, alpha, A, lda, x, incx, beta, y, incy);
+    cblas_ssymv(CblasColMajor, CBLAS_UPLO(uplo), n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
@@ -640,8 +599,7 @@ inline void cblas_symv(rocblas_fill uplo,
                        double*      y,
                        rocblas_int  incy)
 {
-    cblas_dsymv(
-        CblasColMajor, static_cast<CBLAS_UPLO>(uplo), n, alpha, A, lda, x, incx, beta, y, incy);
+    cblas_dsymv(CblasColMajor, CBLAS_UPLO(uplo), n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 // ger
@@ -698,7 +656,7 @@ inline void cblas_syr(rocblas_fill uplo,
                       float*       A,
                       rocblas_int  lda)
 {
-    cblas_ssyr(CblasColMajor, static_cast<CBLAS_UPLO>(uplo), n, alpha, x, incx, A, lda);
+    cblas_ssyr(CblasColMajor, CBLAS_UPLO(uplo), n, alpha, x, incx, A, lda);
 }
 
 template <>
@@ -710,7 +668,7 @@ inline void cblas_syr(rocblas_fill uplo,
                       double*      A,
                       rocblas_int  lda)
 {
-    cblas_dsyr(CblasColMajor, static_cast<CBLAS_UPLO>(uplo), n, alpha, x, incx, A, lda);
+    cblas_dsyr(CblasColMajor, CBLAS_UPLO(uplo), n, alpha, x, incx, A, lda);
 }
 
 // hemv
@@ -738,8 +696,7 @@ inline void cblas_hemv(rocblas_fill           uplo,
                        rocblas_float_complex* y,
                        rocblas_int            incy)
 {
-    cblas_chemv(
-        CblasColMajor, static_cast<CBLAS_UPLO>(uplo), n, &alpha, A, lda, x, incx, &beta, y, incy);
+    cblas_chemv(CblasColMajor, CBLAS_UPLO(uplo), n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 template <>
@@ -754,8 +711,7 @@ inline void cblas_hemv(rocblas_fill            uplo,
                        rocblas_double_complex* y,
                        rocblas_int             incy)
 {
-    cblas_zhemv(
-        CblasColMajor, static_cast<CBLAS_UPLO>(uplo), n, &alpha, A, lda, x, incx, &beta, y, incy);
+    cblas_zhemv(CblasColMajor, CBLAS_UPLO(uplo), n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 /*
@@ -798,8 +754,8 @@ inline void cblas_gemm(rocblas_operation transA,
     // just directly cast, since transA, transB are integers in the enum
     // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
     cblas_sgemm(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_TRANSPOSE>(transB),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_TRANSPOSE(transB),
                 m,
                 n,
                 k,
@@ -831,17 +787,17 @@ inline void cblas_gemm(rocblas_operation transA,
     // just directly cast, since transA, transB are integers in the enum
     // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
     cblas_sgemm(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_TRANSPOSE>(transB),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_TRANSPOSE(transB),
                 m,
                 n,
                 k,
-                static_cast<float>(alpha),
+                float(alpha),
                 A,
                 lda,
                 B,
                 ldb,
-                static_cast<float>(beta),
+                float(beta),
                 C,
                 ldc);
 }
@@ -862,8 +818,8 @@ inline void cblas_gemm(rocblas_operation transA,
                        rocblas_int       ldc)
 {
     cblas_dgemm(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_TRANSPOSE>(transB),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_TRANSPOSE(transB),
                 m,
                 n,
                 k,
@@ -894,8 +850,8 @@ inline void cblas_gemm(rocblas_operation      transA,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_cgemm(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_TRANSPOSE>(transB),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_TRANSPOSE(transB),
                 m,
                 n,
                 k,
@@ -925,8 +881,8 @@ inline void cblas_gemm(rocblas_operation       transA,
                        rocblas_int             ldc)
 {
     cblas_zgemm(CblasColMajor,
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_TRANSPOSE>(transB),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_TRANSPOSE(transB),
                 m,
                 n,
                 k,
@@ -969,10 +925,10 @@ inline void cblas_trsm(rocblas_side      side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_strsm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 alpha,
@@ -997,10 +953,10 @@ inline void cblas_trsm(rocblas_side      side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_dtrsm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 alpha,
@@ -1025,10 +981,10 @@ inline void cblas_trsm(rocblas_side                 side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_ctrsm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 &alpha,
@@ -1053,10 +1009,10 @@ inline void cblas_trsm(rocblas_side                  side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_ztrsm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 &alpha,
@@ -1119,10 +1075,10 @@ inline void cblas_trmm(rocblas_side      side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_strmm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 alpha,
@@ -1147,10 +1103,10 @@ inline void cblas_trmm(rocblas_side      side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_dtrmm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 alpha,
@@ -1175,10 +1131,10 @@ inline void cblas_trmm(rocblas_side                 side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_ctrmm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 &alpha,
@@ -1203,10 +1159,10 @@ inline void cblas_trmm(rocblas_side                  side,
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_ztrmm(CblasColMajor,
-                static_cast<CBLAS_SIDE>(side),
-                static_cast<CBLAS_UPLO>(uplo),
-                static_cast<CBLAS_TRANSPOSE>(transA),
-                static_cast<CBLAS_DIAG>(diag),
+                CBLAS_SIDE(side),
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
                 m,
                 n,
                 &alpha,

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -285,7 +285,7 @@ inline void
 
 // scal
 template <typename T, typename U>
-inline void cblas_scal(rocblas_int n, T alpha, U* x, rocblas_int incx);
+inline void cblas_scal(rocblas_int n, U alpha, T* x, rocblas_int incx);
 
 template <>
 inline void cblas_scal(rocblas_int n, float alpha, float* x, rocblas_int incx)

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -285,7 +285,7 @@ inline void
 
 // scal
 template <typename T, typename U>
-inline void cblas_scal(rocblas_int n, U alpha, T* x, rocblas_int incx);
+inline void cblas_scal(rocblas_int n, T alpha, U* x, rocblas_int incx);
 
 template <>
 inline void cblas_scal(rocblas_int n, float alpha, float* x, rocblas_int incx)

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -226,6 +226,33 @@ inline void cblas_dot(rocblas_int                   n,
     cblas_zdotu_sub(n, x, incx, y, incy, result);
 }
 
+// dotc
+template <typename T>
+void cblas_dotc(
+    rocblas_int n, const T* x, rocblas_int incx, const T* y, rocblas_int incy, T* result);
+
+template <>
+inline void cblas_dotc(rocblas_int                  n,
+                       const rocblas_float_complex* x,
+                       rocblas_int                  incx,
+                       const rocblas_float_complex* y,
+                       rocblas_int                  incy,
+                       rocblas_float_complex*       result)
+{
+    cblas_cdotc_sub(n, x, incx, y, incy, result);
+}
+
+template <>
+inline void cblas_dotc(rocblas_int                   n,
+                       const rocblas_double_complex* x,
+                       rocblas_int                   incx,
+                       const rocblas_double_complex* y,
+                       rocblas_int                   incy,
+                       rocblas_double_complex*       result)
+{
+    cblas_zdotc_sub(n, x, incx, y, incy, result);
+}
+
 // nrm2
 template <typename T1, typename T2>
 void cblas_nrm2(rocblas_int n, const T1* x, rocblas_int incx, T2* result);
@@ -257,8 +284,8 @@ inline void
 }
 
 // scal
-template <typename T>
-inline void cblas_scal(rocblas_int n, T alpha, T* x, rocblas_int incx);
+template <typename T, typename U>
+inline void cblas_scal(rocblas_int n, U alpha, T* x, rocblas_int incx);
 
 template <>
 inline void cblas_scal(rocblas_int n, float alpha, float* x, rocblas_int incx)
@@ -288,6 +315,18 @@ inline void cblas_scal(rocblas_int             n,
                        rocblas_int             incx)
 {
     cblas_zscal(n, &alpha, x, incx);
+}
+
+template <>
+inline void cblas_scal(rocblas_int n, float alpha, rocblas_float_complex* x, rocblas_int incx)
+{
+    cblas_csscal(n, alpha, x, incx);
+}
+
+template <>
+inline void cblas_scal(rocblas_int n, double alpha, rocblas_double_complex* x, rocblas_int incx)
+{
+    cblas_zdscal(n, alpha, x, incx);
 }
 
 // swap

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -323,6 +323,7 @@ inline void cblas_scal(rocblas_int n, float alpha, rocblas_float_complex* x, roc
     cblas_csscal(n, alpha, x, incx);
 }
 
+template <>
 inline void cblas_scal(rocblas_int n, double alpha, rocblas_double_complex* x, rocblas_int incx)
 {
     cblas_zdscal(n, alpha, x, incx);

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -323,7 +323,6 @@ inline void cblas_scal(rocblas_int n, float alpha, rocblas_float_complex* x, roc
     cblas_csscal(n, alpha, x, incx);
 }
 
-template <>
 inline void cblas_scal(rocblas_int n, double alpha, rocblas_double_complex* x, rocblas_int incx)
 {
     cblas_zdscal(n, alpha, x, incx);

--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -24,17 +24,20 @@ constexpr double sqrthalf = 0.7071067811865475244;
 // Sum error tolerance for large sums. Multiplied by the number of items
 // in the sum to get an expected absolute error bound.
 
-// TODO: should the tolerances not be a function of magnitude
-//       as well as number of items in the sum?
 template <class T>
 static constexpr double sum_error_tolerance = 0.0;
 
 template <>
 static constexpr double sum_error_tolerance<rocblas_half> = 1 / 900.0;
+
+// The complex tolerances are used as a function of the magnitude of
+// the expected result
+// 0.01%
 template <>
-static constexpr double sum_error_tolerance<rocblas_float_complex> = 1 / 5000.0;
+static constexpr double sum_error_tolerance<rocblas_float_complex> = 1 / 10000.0;
+// 0.0001%
 template <>
-static constexpr double sum_error_tolerance<rocblas_double_complex> = 1 / 10000.0;
+static constexpr double sum_error_tolerance<rocblas_double_complex> = 1 / 1000000.0;
 
 #ifndef GOOGLE_TEST
 #define NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, err, NEAR_ASSERT)

--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -23,6 +23,9 @@ constexpr double sqrthalf = 0.7071067811865475244;
 
 // Sum error tolerance for large sums. Multiplied by the number of items
 // in the sum to get an expected absolute error bound.
+
+// TODO: should the tolerances not be a function of magnitude
+//       as well as number of items in the sum?
 template <class T>
 static constexpr double sum_error_tolerance = 0.0;
 

--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -28,6 +28,10 @@ static constexpr double sum_error_tolerance = 0.0;
 
 template <>
 static constexpr double sum_error_tolerance<rocblas_half> = 1 / 900.0;
+template <>
+static constexpr double sum_error_tolerance<rocblas_float_complex> = 1 / 5000.0;
+template <>
+static constexpr double sum_error_tolerance<rocblas_double_complex> = 1 / 10000.0;
 
 #ifndef GOOGLE_TEST
 #define NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, err, NEAR_ASSERT)

--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -58,20 +58,12 @@ static constexpr double sum_error_tolerance<rocblas_double_complex> = 1 / 100000
 
 #define NEAR_ASSERT_HALF(a, b, err) ASSERT_NEAR(half_to_float(a), half_to_float(b), err)
 
-#define NEAR_ASSERT_FLOAT_COMPLEX(a, b, err) \
-    do                                       \
-    {                                        \
-        auto ta = (a), tb = (b);             \
-        ASSERT_NEAR(ta.x, tb.x, err);        \
-        ASSERT_NEAR(ta.y, tb.y, err);        \
-    } while(0)
-
-#define NEAR_ASSERT_DOUBLE_COMPLEX(a, b, err) \
-    do                                        \
-    {                                         \
-        auto ta = (a), tb = (b);              \
-        ASSERT_NEAR(ta.x, tb.x, err);         \
-        ASSERT_NEAR(ta.y, tb.y, err);         \
+#define NEAR_ASSERT_COMPLEX(a, b, err)                  \
+    do                                                  \
+    {                                                   \
+        auto ta = (a), tb = (b);                        \
+        ASSERT_NEAR(std::real(ta), std::real(tb), err); \
+        ASSERT_NEAR(std::imag(ta), std::imag(tb), err); \
     } while(0)
 
 template <typename T>
@@ -112,7 +104,7 @@ inline void near_check_general(rocblas_int            M,
                                double                 abs_error)
 {
     abs_error *= sqrthalf;
-    NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_FLOAT_COMPLEX);
+    NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
 }
 
 template <>
@@ -124,7 +116,7 @@ inline void near_check_general(rocblas_int             M,
                                double                  abs_error)
 {
     abs_error *= sqrthalf;
-    NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_DOUBLE_COMPLEX);
+    NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
 }
 
 template <typename T>
@@ -187,7 +179,7 @@ inline void near_check_general(rocblas_int            M,
                                double                 abs_error)
 {
     abs_error *= sqrthalf;
-    NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, abs_error, NEAR_ASSERT_FLOAT_COMPLEX);
+    NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
 }
 
 template <>
@@ -201,7 +193,7 @@ inline void near_check_general(rocblas_int             M,
                                double                  abs_error)
 {
     abs_error *= sqrthalf;
-    NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, abs_error, NEAR_ASSERT_DOUBLE_COMPLEX);
+    NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
 }
 
 #endif

--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -30,12 +30,9 @@ static constexpr double sum_error_tolerance = 0.0;
 template <>
 static constexpr double sum_error_tolerance<rocblas_half> = 1 / 900.0;
 
-// The complex tolerances are used as a function of the magnitude of
-// the expected result
-// 0.01%
 template <>
 static constexpr double sum_error_tolerance<rocblas_float_complex> = 1 / 10000.0;
-// 0.0001%
+
 template <>
 static constexpr double sum_error_tolerance<rocblas_double_complex> = 1 / 1000000.0;
 

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -33,13 +33,13 @@ rocblas_status (*rocblas_scal)(
     rocblas_handle handle, rocblas_int n, const U* alpha, T* x, rocblas_int incx);
 
 template <>
-static constexpr auto rocblas_scal<float> = rocblas_sscal;
+static constexpr auto rocblas_scal<float, float> = rocblas_sscal;
 
 template <>
-static constexpr auto rocblas_scal<double> = rocblas_dscal;
+static constexpr auto rocblas_scal<double, double> = rocblas_dscal;
 
 template <>
-static constexpr auto rocblas_scal<rocblas_float_complex> = rocblas_cscal;
+static constexpr auto rocblas_scal<rocblas_float_complex, rocblas_float_complex> = rocblas_cscal;
 
 template <>
 static constexpr auto rocblas_scal<rocblas_double_complex> = rocblas_zscal;

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -328,8 +328,8 @@ static constexpr auto rocblas_gemv<double> = rocblas_dgemv;
 template <>
 static constexpr auto rocblas_gemv<rocblas_float_complex> = rocblas_cgemv;
 
-// template <>
-// static constexpr auto rocblas_gemv<rocblas_double_complex> = rocblas_zgemv;
+template <>
+static constexpr auto rocblas_gemv<rocblas_double_complex> = rocblas_zgemv;
 
 // trsv
 template <typename T>

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -45,10 +45,10 @@ template <>
 static constexpr auto rocblas_scal<rocblas_double_complex> = rocblas_zscal;
 
 template <>
-static constexpr auto rocblas_scal<float, rocblas_float_complex> = rocblas_csscal;
+static constexpr auto rocblas_scal<rocblas_float_complex, float> = rocblas_csscal;
 
 template <>
-static constexpr auto rocblas_scal<double, rocblas_double_complex> = rocblas_zdscal;
+static constexpr auto rocblas_scal<rocblas_double_complex, double> = rocblas_zdscal;
 
 // copy
 template <typename T>

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -45,10 +45,10 @@ template <>
 static constexpr auto rocblas_scal<rocblas_double_complex> = rocblas_zscal;
 
 template <>
-static constexpr auto rocblas_scal<rocblas_float_complex, float> = rocblas_csscal;
+static constexpr auto rocblas_scal<float, rocblas_float_complex> = rocblas_csscal;
 
 template <>
-static constexpr auto rocblas_scal<rocblas_double_complex, double> = rocblas_zdscal;
+static constexpr auto rocblas_scal<double, rocblas_double_complex> = rocblas_zdscal;
 
 // copy
 template <typename T>

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -33,13 +33,13 @@ rocblas_status (*rocblas_scal)(
     rocblas_handle handle, rocblas_int n, const U* alpha, T* x, rocblas_int incx);
 
 template <>
-static constexpr auto rocblas_scal<float, float> = rocblas_sscal;
+static constexpr auto rocblas_scal<float> = rocblas_sscal;
 
 template <>
-static constexpr auto rocblas_scal<double, double> = rocblas_dscal;
+static constexpr auto rocblas_scal<double> = rocblas_dscal;
 
 template <>
-static constexpr auto rocblas_scal<rocblas_float_complex, rocblas_float_complex> = rocblas_cscal;
+static constexpr auto rocblas_scal<rocblas_float_complex> = rocblas_cscal;
 
 template <>
 static constexpr auto rocblas_scal<rocblas_double_complex> = rocblas_zscal;
@@ -324,6 +324,12 @@ static constexpr auto rocblas_gemv<float> = rocblas_sgemv;
 
 template <>
 static constexpr auto rocblas_gemv<double> = rocblas_dgemv;
+
+template <>
+static constexpr auto rocblas_gemv<rocblas_float_complex> = rocblas_cgemv;
+
+// template <>
+// static constexpr auto rocblas_gemv<rocblas_double_complex> = rocblas_zgemv;
 
 // trsv
 template <typename T>

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -28,9 +28,9 @@
  */
 
 // scal
-template <typename T>
+template <typename T, typename U = T>
 rocblas_status (*rocblas_scal)(
-    rocblas_handle handle, rocblas_int n, const T* alpha, T* x, rocblas_int incx);
+    rocblas_handle handle, rocblas_int n, const U* alpha, T* x, rocblas_int incx);
 
 template <>
 static constexpr auto rocblas_scal<float> = rocblas_sscal;
@@ -38,13 +38,17 @@ static constexpr auto rocblas_scal<float> = rocblas_sscal;
 template <>
 static constexpr auto rocblas_scal<double> = rocblas_dscal;
 
-/* not implemented
 template <>
 static constexpr auto rocblas_scal<rocblas_float_complex> = rocblas_cscal;
 
 template <>
 static constexpr auto rocblas_scal<rocblas_double_complex> = rocblas_zscal;
-*/
+
+template <>
+static constexpr auto rocblas_scal<rocblas_float_complex, float> = rocblas_csscal;
+
+template <>
+static constexpr auto rocblas_scal<rocblas_double_complex, double> = rocblas_zdscal;
 
 // copy
 template <typename T>
@@ -57,14 +61,11 @@ static constexpr auto rocblas_copy<float> = rocblas_scopy;
 template <>
 static constexpr auto rocblas_copy<double> = rocblas_dcopy;
 
-/* not implemented
 template <>
 static constexpr auto rocblas_copy<rocblas_float_complex> = rocblas_ccopy;
 
 template <>
 static constexpr auto rocblas_copy<rocblas_double_complex> = rocblas_zcopy;
-}
-*/
 
 // swap
 template <typename T>
@@ -77,15 +78,11 @@ static constexpr auto rocblas_swap<float> = rocblas_sswap;
 template <>
 static constexpr auto rocblas_swap<double> = rocblas_dswap;
 
-/* not implemented
-
 template <>
 static constexpr auto rocblas_swap<rocblas_float_complex> = rocblas_cswap;
 
 template <>
 static constexpr auto rocblas_swap<rocblas_double_complex> = rocblas_zswap;
-
-*/
 
 // dot
 template <typename T>
@@ -103,13 +100,27 @@ static constexpr auto rocblas_dot<float> = rocblas_sdot;
 template <>
 static constexpr auto rocblas_dot<double> = rocblas_ddot;
 
-/* not implemented
 template <>
 static constexpr auto rocblas_dot<rocblas_float_complex> = rocblas_cdotu;
 
 template <>
 static constexpr auto rocblas_dot<rocblas_double_complex> = rocblas_zdotu;
-*/
+
+// dotc
+template <typename T>
+rocblas_status (*rocblas_dotc)(rocblas_handle handle,
+                               rocblas_int    n,
+                               const T*       x,
+                               rocblas_int    incx,
+                               const T*       y,
+                               rocblas_int    incy,
+                               T*             result);
+
+template <>
+static constexpr auto rocblas_dotc<rocblas_float_complex> = rocblas_cdotc;
+
+template <>
+static constexpr auto rocblas_dotc<rocblas_double_complex> = rocblas_zdotc;
 
 // asum
 template <typename T1, typename T2>
@@ -122,13 +133,11 @@ static constexpr auto rocblas_asum<float, float> = rocblas_sasum;
 template <>
 static constexpr auto rocblas_asum<double, double> = rocblas_dasum;
 
-/* not implemented
-template<>
+template <>
 static constexpr auto rocblas_asum<rocblas_float_complex, float> = rocblas_scasum;
 
-template<>
+template <>
 static constexpr auto rocblas_asum<rocblas_double_complex, double> = rocblas_dzasum;
-*/
 
 // nrm2
 template <typename T1, typename T2>
@@ -141,13 +150,11 @@ static constexpr auto rocblas_nrm2<float, float> = rocblas_snrm2;
 template <>
 static constexpr auto rocblas_nrm2<double, double> = rocblas_dnrm2;
 
-/* not implemented
 template <>
 static constexpr auto rocblas_nrm2<rocblas_float_complex, float> = rocblas_scnrm2;
 
 template <>
 static constexpr auto rocblas_nrm2<rocblas_double_complex, double> = rocblas_dznrm2;
-*/
 
 // iamax and iamin need to be full functions rather than references, in order
 // to allow them to be passed as template arguments
@@ -171,6 +178,26 @@ inline rocblas_status rocblas_iamax(
     return rocblas_idamax(handle, n, x, incx, result);
 }
 
+template <>
+inline rocblas_status rocblas_iamax(rocblas_handle               handle,
+                                    rocblas_int                  n,
+                                    const rocblas_float_complex* x,
+                                    rocblas_int                  incx,
+                                    rocblas_int*                 result)
+{
+    return rocblas_icamax(handle, n, x, incx, result);
+}
+
+template <>
+inline rocblas_status rocblas_iamax(rocblas_handle                handle,
+                                    rocblas_int                   n,
+                                    const rocblas_double_complex* x,
+                                    rocblas_int                   incx,
+                                    rocblas_int*                  result)
+{
+    return rocblas_izamax(handle, n, x, incx, result);
+}
+
 // iamin
 template <typename T>
 rocblas_status rocblas_iamin(
@@ -188,6 +215,26 @@ inline rocblas_status rocblas_iamin(
     rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
 {
     return rocblas_idamin(handle, n, x, incx, result);
+}
+
+template <>
+inline rocblas_status rocblas_iamin(rocblas_handle               handle,
+                                    rocblas_int                  n,
+                                    const rocblas_float_complex* x,
+                                    rocblas_int                  incx,
+                                    rocblas_int*                 result)
+{
+    return rocblas_icamin(handle, n, x, incx, result);
+}
+
+template <>
+inline rocblas_status rocblas_iamin(rocblas_handle                handle,
+                                    rocblas_int                   n,
+                                    const rocblas_double_complex* x,
+                                    rocblas_int                   incx,
+                                    rocblas_int*                  result)
+{
+    return rocblas_izamin(handle, n, x, incx, result);
 }
 
 // axpy
@@ -209,13 +256,11 @@ static constexpr auto rocblas_axpy<float> = rocblas_saxpy;
 template <>
 static constexpr auto rocblas_axpy<double> = rocblas_daxpy;
 
-/* not implemented
 template <>
 static constexpr auto rocblas_axpy<rocblas_float_complex> = rocblas_caxpy;
 
 template <>
 static constexpr auto rocblas_axpy<rocblas_double_complex> = rocblas_zaxpy;
-*/
 
 /*
  * ===========================================================================

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -242,7 +242,9 @@ private:
         print("incd", arg.incd);
         print("incb", arg.incb);
         print("alpha", arg.alpha);
+        print("alphai", arg.alphai);
         print("beta", arg.beta);
+        print("betai", arg.betai);
         print("side", arg.side);
         print("uplo", arg.uplo);
         print("diag", arg.diag);

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -211,9 +211,9 @@ Single double real and joined: &single_double_real_complex_in_real_out
 #############################################
 Joined precisions: &complex_real_in_complex_out
   - &single_precision_complex_real_in_complex_out
-    { a_type: f32_c, b_type: f32_r, c_type: f32_r, d_type: f32_c, compute_type: f32_r }
+    { a_type: f32_r, b_type: f32_c, c_type: f32_r, d_type: f32_c, compute_type: f32_r }
   - &double_precision_complex_real_in_complex_out
-    { a_type: f64_c, b_type: f64_r, c_type: f64_r, d_type: f64_c, compute_type: f64_r }
+    { a_type: f64_r, b_type: f64_c, c_type: f64_r, d_type: f64_c, compute_type: f64_r }
 
 Single double joined: &single_double_complex_real_in_complex_out
   - *single_precision_complex_real_in_complex_out

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -308,6 +308,7 @@ Dictionary lists to expand:
   - arguments
   - transA_transB
   - alpha_beta
+  - alphai
   - incx_incy
   - matrix_size
   - precision

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -165,9 +165,9 @@ Simple precisions complex and real: &half_single_double_precisions_complex_real
 #############################################
 Joined precisions: &complex_real_in_complex_out
   - &single_precision_complex_real_in_complex_out
-    { a_type: f32_r, b_type: f32_c, c_type: f32_r, d_type: f32_c, compute_type: f32_r }
+    { a_type: f32_c, b_type: f32_r, c_type: f32_r, d_type: f32_c, compute_type: f32_r }
   - &double_precision_complex_real_in_complex_out
-    { a_type: f64_r, b_type: f64_c, c_type: f64_r, d_type: f64_c, compute_type: f64_r }
+    { a_type: f64_c, b_type: f64_r, c_type: f64_r, d_type: f64_c, compute_type: f64_r }
 
 Single double joined: &single_double_complex_real_in_complex_out
   - *single_precision_complex_real_in_complex_out

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -114,31 +114,6 @@ C precisions complex: &single_double_precisions_complex
   - *single_precision_complex
   - *double_precision_complex
 
-Short simple precisions complex: &half_single_precisions_complex
-  - *half_precision_complex
-  - *single_precision_complex
-
-Short precisions complex: &int8_half_single_precisions_complex
-  - *int8_precision_complex
-  - *half_precision_complex
-  - *single_precision_complex
-
-ML precisions complex: &hpa_half_single_precisions_complex
-  - *hpa_half_precision_complex
-  - *half_precision_complex
-  - *single_precision_complex
-
-Non-int precisions complex: &hpa_half_single_double_precisions_complex
-  - *hpa_half_precision_complex
-  - *half_precision_complex
-  - *single_precision_complex
-  - *double_precision_complex
-
-Simple precisions complex: &half_single_double_precisions_complex
-  - *half_precision_complex
-  - *single_precision_complex
-  - *double_precision_complex
-
 C precisions complex and real: &single_double_precisions_complex_real
   - *single_precision
   - *double_precision
@@ -184,27 +159,6 @@ Simple precisions complex and real: &half_single_double_precisions_complex_real
   - *half_precision_complex
   - *single_precision_complex
   - *double_precision_complex
-
-###########################################
-#          Used for asum and nrm2         #
-###########################################
-Complex in real out: &complex_in_real_out_precisions
-  - &single_precision_joined
-    { a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_r, compute_type: f32_r }
-  - &double_precision_joined
-    { a_type: f64_c, b_type: f64_c, c_type: f64_c, d_type: f64_r, compute_type: f64_r }
-
-Single real and joined: &single_real_complex_in_real_out
-  - *single_precision_joined
-  - *single_precision
-
-Double real and joined: &double_real_complex_in_real_out
-  - *double_precision_joined
-  - *double_precision
-
-Single double real and joined: &single_double_real_complex_in_real_out
-  - <<: *single_real_complex_in_real_out
-  - <<: *double_real_complex_in_real_out
 
 #############################################
 #               Used for Scal               #

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -194,19 +194,17 @@ Complex in real out: &complex_in_real_out_precisions
   - &double_precision_joined
     { a_type: f64_c, b_type: f64_c, c_type: f64_c, d_type: f64_r, compute_type: f64_r }
 
-Single double real and joined: &single_double_real_complex_in_real_out
+Single real and joined: &single_real_complex_in_real_out
   - *single_precision_joined
-  - *double_precision_joined
   - *single_precision
-  - *double_precision
 
 Double real and joined: &double_real_complex_in_real_out
   - *double_precision_joined
   - *double_precision
 
-Single real and joined: &single_real_complex_in_real_out
-  - *single_precision_joined
-  - *single_precision
+Single double real and joined: &single_double_real_complex_in_real_out
+  - <<: *single_real_complex_in_real_out
+  - <<: *double_real_complex_in_real_out
 
 #############################################
 #               Used for Scal               #
@@ -220,8 +218,6 @@ Joined precisions: &complex_real_in_complex_out
 Single double joined: &single_double_complex_real_in_complex_out
   - *single_precision_complex_real_in_complex_out
   - *double_precision_complex_real_in_complex_out
-
-
 
 # The Arguments struct passed directly to C++. See rocblas_arguments.hpp.
 # The order of the entries is significant, so it can't simply be a dictionary.
@@ -245,9 +241,9 @@ Arguments:
   - incd: rocblas_int
   - incb: rocblas_int
   - alpha: c_double
-  - alpha_imag: c_double
+  - alphai: c_double
   - beta: c_double
-  - beta_imag: c_double
+  - betai: c_double
   - transA: c_char
   - transB: c_char
   - side: c_char
@@ -292,6 +288,7 @@ Dictionary lists to expand:
   - arguments
   - transA_transB
   - alpha_beta
+  - alphai_betai
   - incx_incy
   - matrix_size
   - precision
@@ -313,15 +310,19 @@ Defaults:
   incd: 0
   incb: 0
   alpha: 1.0
-  alpha_imag: 0.0
+  alphai: 0.0
   beta: 0.0
-  beta_imag: 0.0
+  betai: 0.0
   transA: '*'
   transB: '*'
   side: '*'
   uplo: '*'
   diag: '*'
   batch_count: -1
+  stride_a: 0
+  stride_b: 0
+  stride_c: 0
+  stride_d: 0
   norm_check: 0
   unit_check: 1
   timing: 0

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -72,6 +72,173 @@ Simple precisions: &half_single_double_precisions
   - *single_precision
   - *double_precision
 
+Complex precisions: &complex_precisions
+  - &half_precision_complex
+    { a_type: f16_c, b_type: f16_c, c_type: f16_c, d_type: f16_c, compute_type: f16_c }
+  - &hpa_half_precision_complex
+    { a_type: f16_c, b_type: f16_c, c_type: f16_c, d_type: f16_c, compute_type: f32_c }
+  - &single_precision_complex
+    { a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_c, compute_type: f32_c }
+  - &double_precision_complex
+    { a_type: f64_c, b_type: f64_c, c_type: f64_c, d_type: f64_c, compute_type: f64_c }
+  - &int8_precision_complex
+    { a_type:  i8_c, b_type:  i8_c, c_type: i32_c, d_type: i32_c, compute_type: i32_c }
+  - &hpa_bf16_precision_complex
+    { a_type:  bf16_c, b_type:  bf16_c, c_type: bf16_c, d_type: bf16_c, compute_type: f32_c }
+
+Half Precision complex and real: &half_precision_complex_real
+  - *half_precision
+  - *half_precision_complex
+
+Hpa Half Precision complex and real: &hpa_half_precision_complex_real
+  - *hpa_half_precision
+  - *hpa_half_precision_complex
+
+Single Precision complex and real: &single_precision_complex_real
+  - *single_precision
+  - *single_precision_complex
+
+Double Precision complex and real: &double_precision_complex_real
+  - *double_precision
+  - *double_precision_complex
+
+int8 Precision complex and real: &int8_precision_complex_real
+  - *int8_precision
+  - *int8_precision_complex
+
+hpabf16 Precision complex and real: &hpa_bf16_precision_complex_real
+  - *hpa_bf16_precision
+  - *hpa_bf16_precision_complex
+
+C precisions complex: &single_double_precisions_complex
+  - *single_precision_complex
+  - *double_precision_complex
+
+Short simple precisions complex: &half_single_precisions_complex
+  - *half_precision_complex
+  - *single_precision_complex
+
+Short precisions complex: &int8_half_single_precisions_complex
+  - *int8_precision_complex
+  - *half_precision_complex
+  - *single_precision_complex
+
+ML precisions complex: &hpa_half_single_precisions_complex
+  - *hpa_half_precision_complex
+  - *half_precision_complex
+  - *single_precision_complex
+
+Non-int precisions complex: &hpa_half_single_double_precisions_complex
+  - *hpa_half_precision_complex
+  - *half_precision_complex
+  - *single_precision_complex
+  - *double_precision_complex
+
+Simple precisions complex: &half_single_double_precisions_complex
+  - *half_precision_complex
+  - *single_precision_complex
+  - *double_precision_complex
+
+C precisions complex and real: &single_double_precisions_complex_real
+  - *single_precision
+  - *double_precision
+  - *single_precision_complex
+  - *double_precision_complex
+
+Short simple precisions complex and real: &half_single_precisions_complex_real
+  - *half_precision
+  - *single_precision
+  - *half_precision_complex
+  - *single_precision_complex
+
+Short precisions complex and real: &int8_half_single_precisions_complex_real
+  - *int8_precision
+  - *half_precision
+  - *single_precision
+  - *int8_precision_complex
+  - *half_precision_complex
+  - *single_precision_complex
+
+ML precisions complex and real: &hpa_half_single_precisions_complex_real
+  - *hpa_half_precision
+  - *half_precision
+  - *single_precision
+  - *hpa_half_precision_complex
+  - *half_precision_complex
+  - *single_precision_complex
+
+Non-int precisions complex and real: &hpa_half_single_double_precisions_complex_real
+  - *hpa_half_precision
+  - *half_precision
+  - *single_precision
+  - *double_precision
+  - *hpa_half_precision_complex
+  - *half_precision_complex
+  - *single_precision_complex
+  - *double_precision_complex
+
+Simple precisions complex and real: &half_single_double_precisions_complex_real
+  - *half_precision
+  - *single_precision
+  - *double_precision
+  - *half_precision_complex
+  - *single_precision_complex
+  - *double_precision_complex
+
+###########################################
+# TODO: These are just for asum right now #
+###########################################
+Joined precisions: &joined_precisions
+  # - &half_precision_joined
+  #   { a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f16_r }
+  # - &hpa_half_precision_complex
+  #   { a_type: f16_c, b_type: f16_c, c_type: f16_c, d_type: f16_c, compute_type: f32_c }
+  - &single_precision_joined
+    { a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_r, compute_type: f32_r }
+  - &double_precision_joined
+    { a_type: f64_c, b_type: f64_c, c_type: f64_c, d_type: f64_r, compute_type: f64_r }
+  # - &int8_precision_complex
+  #   { a_type:  i8_c, b_type:  i8_c, c_type: i32_c, d_type: i32_c, compute_type: i32_c }
+  # - &hpa_bf16_precision_complex
+  #   { a_type:  bf16_c, b_type:  bf16_c, c_type: bf16_c, d_type: bf16_c, compute_type: f32_c }
+
+Singled double real and joined: &single_double_real_joined
+  - *single_precision_joined
+  - *double_precision_joined
+  - *single_precision
+  - *double_precision
+
+Double real and joined: &double_real_joined
+  - *double_precision_joined
+  - *double_precision
+
+Single real and joined: &single_real_joined
+  - *single_precision_joined
+  - *single_precision
+
+#############################################
+# TODO: These are just for scalrc right now #
+#############################################
+Joined precisions: &complex_real_in_complex_out
+  # - &half_prec_complex_real_in_complex_out
+  #   { a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f16_r }
+  # - &hpa_half_prec_complex_real_in_complex_out
+  #   { a_type: f16_c, b_type: f16_c, c_type: f16_c, d_type: f16_c, compute_type: f32_c }
+  - &single_precision_complex_real_in_complex_out
+    { a_type: f32_c, b_type: f32_r, c_type: f32_r, d_type: f32_c, compute_type: f32_r }
+  - &double_precision_complex_real_in_complex_out
+    { a_type: f64_c, b_type: f64_r, c_type: f64_r, d_type: f64_c, compute_type: f64_r }
+  # - &int8_precision_complex
+  #   { a_type:  i8_c, b_type:  i8_c, c_type: i32_c, d_type: i32_c, compute_type: i32_c }
+  # - &hpa_bf16_precision_complex
+  #   { a_type:  bf16_c, b_type:  bf16_c, c_type: bf16_c, d_type: bf16_c, compute_type: f32_c }
+
+Single double joined: &single_double_complex_real_in_complex_out
+  - *single_precision_complex_real_in_complex_out
+  - *double_precision_complex_real_in_complex_out
+###########################################
+
+
 # The Arguments struct passed directly to C++. See rocblas_arguments.hpp.
 # The order of the entries is significant, so it can't simply be a dictionary.
 # The types on the RHS are eval'd for Python-recognized types including ctypes
@@ -94,7 +261,9 @@ Arguments:
   - incd: rocblas_int
   - incb: rocblas_int
   - alpha: c_double
+  - alpha_imag: c_double
   - beta: c_double
+  - beta_imag: c_double
   - transA: c_char
   - transB: c_char
   - side: c_char
@@ -160,7 +329,9 @@ Defaults:
   incd: 0
   incb: 0
   alpha: 1.0
+  alpha_imag: 0.0
   beta: 0.0
+  beta_imag: 0.0
   transA: '*'
   transB: '*'
   side: '*'

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -189,20 +189,12 @@ Simple precisions complex and real: &half_single_double_precisions_complex_real
 #    These are just for asum right now    #
 ###########################################
 Joined precisions: &joined_precisions
-  # - &half_precision_joined
-  #   { a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f16_r }
-  # - &hpa_half_precision_complex
-  #   { a_type: f16_c, b_type: f16_c, c_type: f16_c, d_type: f16_c, compute_type: f32_c }
   - &single_precision_joined
     { a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_r, compute_type: f32_r }
   - &double_precision_joined
     { a_type: f64_c, b_type: f64_c, c_type: f64_c, d_type: f64_r, compute_type: f64_r }
-  # - &int8_precision_complex
-  #   { a_type:  i8_c, b_type:  i8_c, c_type: i32_c, d_type: i32_c, compute_type: i32_c }
-  # - &hpa_bf16_precision_complex
-  #   { a_type:  bf16_c, b_type:  bf16_c, c_type: bf16_c, d_type: bf16_c, compute_type: f32_c }
 
-Singled double real and joined: &single_double_real_joined
+Single double real and joined: &single_double_real_joined
   - *single_precision_joined
   - *double_precision_joined
   - *single_precision
@@ -220,23 +212,22 @@ Single real and joined: &single_real_joined
 #     These are just for scal right now     #
 #############################################
 Joined precisions: &complex_real_in_complex_out
-  # - &half_prec_complex_real_in_complex_out
-  #   { a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f16_r }
-  # - &hpa_half_prec_complex_real_in_complex_out
-  #   { a_type: f16_c, b_type: f16_c, c_type: f16_c, d_type: f16_c, compute_type: f32_c }
   - &single_precision_complex_real_in_complex_out
     { a_type: f32_c, b_type: f32_r, c_type: f32_r, d_type: f32_c, compute_type: f32_r }
   - &double_precision_complex_real_in_complex_out
     { a_type: f64_c, b_type: f64_r, c_type: f64_r, d_type: f64_c, compute_type: f64_r }
-  # - &int8_precision_complex
-  #   { a_type:  i8_c, b_type:  i8_c, c_type: i32_c, d_type: i32_c, compute_type: i32_c }
-  # - &hpa_bf16_precision_complex
-  #   { a_type:  bf16_c, b_type:  bf16_c, c_type: bf16_c, d_type: bf16_c, compute_type: f32_c }
 
 Single double joined: &single_double_complex_real_in_complex_out
   - *single_precision_complex_real_in_complex_out
   - *double_precision_complex_real_in_complex_out
-###########################################
+
+#############################################
+#     These are just for gemv right now     #
+#############################################
+Single double real single complex: &single_double_real_single_complex
+  - *single_precision
+  - *double_precision
+  - *single_precision_complex
 
 
 # The Arguments struct passed directly to C++. See rocblas_arguments.hpp.

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -186,7 +186,7 @@ Simple precisions complex and real: &half_single_double_precisions_complex_real
   - *double_precision_complex
 
 ###########################################
-# TODO: These are just for asum right now #
+#    These are just for asum right now    #
 ###########################################
 Joined precisions: &joined_precisions
   # - &half_precision_joined
@@ -217,7 +217,7 @@ Single real and joined: &single_real_joined
   - *single_precision
 
 #############################################
-# TODO: These are just for scalrc right now #
+#     These are just for scal right now     #
 #############################################
 Joined precisions: &complex_real_in_complex_out
   # - &half_prec_complex_real_in_complex_out
@@ -308,7 +308,6 @@ Dictionary lists to expand:
   - arguments
   - transA_transB
   - alpha_beta
-  - alphai
   - incx_incy
   - matrix_size
   - precision

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -186,30 +186,30 @@ Simple precisions complex and real: &half_single_double_precisions_complex_real
   - *double_precision_complex
 
 ###########################################
-#    These are just for asum right now    #
+#          Used for asum and nrm2         #
 ###########################################
-Joined precisions: &joined_precisions
+Complex in real out: &complex_in_real_out_precisions
   - &single_precision_joined
     { a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_r, compute_type: f32_r }
   - &double_precision_joined
     { a_type: f64_c, b_type: f64_c, c_type: f64_c, d_type: f64_r, compute_type: f64_r }
 
-Single double real and joined: &single_double_real_joined
+Single double real and joined: &single_double_real_complex_in_real_out
   - *single_precision_joined
   - *double_precision_joined
   - *single_precision
   - *double_precision
 
-Double real and joined: &double_real_joined
+Double real and joined: &double_real_complex_in_real_out
   - *double_precision_joined
   - *double_precision
 
-Single real and joined: &single_real_joined
+Single real and joined: &single_real_complex_in_real_out
   - *single_precision_joined
   - *single_precision
 
 #############################################
-#     These are just for scal right now     #
+#               Used for Scal               #
 #############################################
 Joined precisions: &complex_real_in_complex_out
   - &single_precision_complex_real_in_complex_out
@@ -221,13 +221,6 @@ Single double joined: &single_double_complex_real_in_complex_out
   - *single_precision_complex_real_in_complex_out
   - *double_precision_complex_real_in_complex_out
 
-#############################################
-#     These are just for gemv right now     #
-#############################################
-Single double real single complex: &single_double_real_single_complex
-  - *single_precision
-  - *double_precision
-  - *single_precision_complex
 
 
 # The Arguments struct passed directly to C++. See rocblas_arguments.hpp.

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -118,29 +118,7 @@ template <typename T>
 inline void rocblas_init_nan(T* A, size_t N)
 {
     for(size_t i = 0; i < N; ++i)
-        A[i] = static_cast<T>(rocblas_nan_rng());
-}
-
-template <>
-inline void rocblas_init_nan(rocblas_float_complex* A, size_t N)
-{
-    for(size_t i = 0; i < N; ++i)
-    {
-        float x = (float)rocblas_nan_rng();
-        float y = (float)rocblas_nan_rng();
-        A[i]    = rocblas_float_complex(x, y);
-    }
-}
-
-template <>
-inline void rocblas_init_nan(rocblas_double_complex* A, size_t N)
-{
-    for(size_t i = 0; i < N; ++i)
-    {
-        double x = (double)rocblas_nan_rng();
-        double y = (double)rocblas_nan_rng();
-        A[i]     = rocblas_double_complex(x, y);
-    }
+        A[i] = T(rocblas_nan_rng());
 }
 
 template <typename T>
@@ -150,7 +128,7 @@ inline void rocblas_init_nan(
     for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
         for(size_t i = 0; i < M; ++i)
             for(size_t j = 0; j < N; ++j)
-                A[i + j * lda + i_batch * stride] = static_cast<T>(rocblas_nan_rng());
+                A[i + j * lda + i_batch * stride] = T(rocblas_nan_rng());
 }
 
 /* ============================================================================================ */

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -121,23 +121,25 @@ inline void rocblas_init_nan(T* A, size_t N)
         A[i] = static_cast<T>(rocblas_nan_rng());
 }
 
-template<>
+template <>
 inline void rocblas_init_nan(rocblas_float_complex* A, size_t N)
 {
     for(size_t i = 0; i < N; ++i)
     {
-        float x = (float) rocblas_nan_rng(); float y = (float) rocblas_nan_rng();
-        A[i] = rocblas_float_complex(x, y);
+        float x = (float)rocblas_nan_rng();
+        float y = (float)rocblas_nan_rng();
+        A[i]    = rocblas_float_complex(x, y);
     }
 }
 
-template<>
+template <>
 inline void rocblas_init_nan(rocblas_double_complex* A, size_t N)
 {
     for(size_t i = 0; i < N; ++i)
     {
-        double x = (double) rocblas_nan_rng(); double y = (double) rocblas_nan_rng();
-        A[i] = rocblas_double_complex(x, y);
+        double x = (double)rocblas_nan_rng();
+        double y = (double)rocblas_nan_rng();
+        A[i]     = rocblas_double_complex(x, y);
     }
 }
 

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -121,6 +121,26 @@ inline void rocblas_init_nan(T* A, size_t N)
         A[i] = static_cast<T>(rocblas_nan_rng());
 }
 
+template<>
+inline void rocblas_init_nan(rocblas_float_complex* A, size_t N)
+{
+    for(size_t i = 0; i < N; ++i)
+    {
+        float x = (float) rocblas_nan_rng(); float y = (float) rocblas_nan_rng();
+        A[i] = rocblas_float_complex(x, y);
+    }
+}
+
+template<>
+inline void rocblas_init_nan(rocblas_double_complex* A, size_t N)
+{
+    for(size_t i = 0; i < N; ++i)
+    {
+        double x = (double) rocblas_nan_rng(); double y = (double) rocblas_nan_rng();
+        A[i] = rocblas_double_complex(x, y);
+    }
+}
+
 template <typename T>
 inline void rocblas_init_nan(
     std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)

--- a/clients/include/rocblas_random.hpp
+++ b/clients/include/rocblas_random.hpp
@@ -105,7 +105,7 @@ inline rocblas_float_complex random_generator<rocblas_float_complex>()
             std::uniform_real_distribution<float>(-1, 1)(rocblas_rng)};
 };
 
-// for rocblas_double_complex, generate two floats
+// for rocblas_double_complex, generate two doubles
 template <>
 inline rocblas_double_complex random_generator<rocblas_double_complex>()
 {

--- a/clients/include/rocblas_random.hpp
+++ b/clients/include/rocblas_random.hpp
@@ -75,6 +75,16 @@ public:
     {
         return random_nan_data<rocblas_bfloat16, uint16_t, 7, 8>();
     }
+
+    explicit operator rocblas_float_complex()
+    {
+        return {float(*this), float(*this)};
+    }
+
+    explicit operator rocblas_double_complex()
+    {
+        return {double(*this), double(*this)};
+    }
 };
 
 /* ============================================================================================ */
@@ -86,6 +96,22 @@ inline T random_generator()
 {
     return std::uniform_int_distribution<int>(1, 10)(rocblas_rng);
 }
+
+// for rocblas_float_complex, generate two floats
+template <>
+inline rocblas_float_complex random_generator<rocblas_float_complex>()
+{
+    return {std::uniform_real_distribution<float>(-1, 1)(rocblas_rng),
+            std::uniform_real_distribution<float>(-1, 1)(rocblas_rng)};
+};
+
+// for rocblas_double_complex, generate two floats
+template <>
+inline rocblas_double_complex random_generator<rocblas_double_complex>()
+{
+    return {std::uniform_real_distribution<double>(-2, 2)(rocblas_rng),
+            std::uniform_real_distribution<double>(-2, 2)(rocblas_rng)};
+};
 
 // for rocblas_half, generate float, and convert to rocblas_half
 /*! \brief  generate a random number in range [-2,-1,0,1,2] */

--- a/clients/include/rocblas_random.hpp
+++ b/clients/include/rocblas_random.hpp
@@ -97,20 +97,20 @@ inline T random_generator()
     return std::uniform_int_distribution<int>(1, 10)(rocblas_rng);
 }
 
-// for rocblas_float_complex, generate two floats
+// for rocblas_float_complex, generate two random ints (same behaviour as for floats)
 template <>
 inline rocblas_float_complex random_generator<rocblas_float_complex>()
 {
-    return {std::uniform_real_distribution<float>(-1, 1)(rocblas_rng),
-            std::uniform_real_distribution<float>(-1, 1)(rocblas_rng)};
+    return {float(std::uniform_int_distribution<int>(1, 10)(rocblas_rng)),
+            float(std::uniform_int_distribution<int>(1, 10)(rocblas_rng))};
 };
 
-// for rocblas_double_complex, generate two doubles
+// for rocblas_double_complex, generate two random ints (same behaviour as for doubles)
 template <>
 inline rocblas_double_complex random_generator<rocblas_double_complex>()
 {
-    return {std::uniform_real_distribution<double>(-2, 2)(rocblas_rng),
-            std::uniform_real_distribution<double>(-2, 2)(rocblas_rng)};
+    return {double(std::uniform_int_distribution<int>(1, 10)(rocblas_rng)),
+            double(std::uniform_int_distribution<int>(1, 10)(rocblas_rng))};
 };
 
 // for rocblas_half, generate float, and convert to rocblas_half

--- a/clients/include/rocblas_template.yaml
+++ b/clients/include/rocblas_template.yaml
@@ -28,6 +28,8 @@ Functions:
   rocblas_dsyr:  { function: syr, <<: *double_precision  }
   rocblas_sgemv: { function: gemv, <<: *single_precision }
   rocblas_dgemv: { function: gemv, <<: *double_precision }
+  rocblas_cgemv: { function: gemv, <<: *single_precision_complex }
+  # rocblas_zgemv: { function: gemv, <<: *double_precision_complex } 
   rocblas_strsv: { function: trsv, <<: *single_precision }
   rocblas_dtrsv: { function: trsv, <<: *double_precision }
   rocblas_ssymv: { function: symv, <<: *single_precision }

--- a/clients/include/rocblas_template.yaml
+++ b/clients/include/rocblas_template.yaml
@@ -13,11 +13,15 @@ Functions:
   rocblas_ddot:  { function: dot, <<: *double_precision  }
   rocblas_sasum: { function: asum, <<: *single_precision }
   rocblas_dasum: { function: asum, <<: *double_precision }
+  rocblas_scasum: { function: asum, <<: *single_precision_complex }
+  rocblas_dzasum: { funciton: asum, <<: *double_precision_complex }
   rocblas_snrm2: { function: nrm2, <<: *single_precision }
   rocblas_dnrm2: { function: nrm2, <<: *double_precision }
   rocblas_haxpy: { function: axpy, <<: *half_precision   }
   rocblas_saxpy: { function: axpy, <<: *single_precision }
   rocblas_daxpy: { function: axpy, <<: *double_precision }
+  rocblas_caxpy: { function: axpy, <<: *single_precision_complex }
+  rocblas_zaxpy: { function: axpy, <<: *double_precision_complex }
   rocblas_sger:  { function: ger, <<: *single_precision  }
   rocblas_dger:  { function: ger, <<: *double_precision  }
   rocblas_ssyr:  { function: syr, <<: *single_precision  }

--- a/clients/include/rocblas_template.yaml
+++ b/clients/include/rocblas_template.yaml
@@ -29,7 +29,7 @@ Functions:
   rocblas_sgemv: { function: gemv, <<: *single_precision }
   rocblas_dgemv: { function: gemv, <<: *double_precision }
   rocblas_cgemv: { function: gemv, <<: *single_precision_complex }
-  # rocblas_zgemv: { function: gemv, <<: *double_precision_complex } 
+  rocblas_zgemv: { function: gemv, <<: *double_precision_complex } 
   rocblas_strsv: { function: trsv, <<: *single_precision }
   rocblas_dtrsv: { function: trsv, <<: *double_precision }
   rocblas_ssymv: { function: symv, <<: *single_precision }

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -102,7 +102,7 @@ void testing_asum_template(const Arguments& arg)
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         CHECK_ROCBLAS_ERROR((rocblas_asum<T1, T2>(handle, N, dx, incx, d_rocblas_result_2)));
         CHECK_HIP_ERROR(
-            hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T1), hipMemcpyDeviceToHost));
+            hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T2), hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -111,19 +111,8 @@ void testing_asum_template(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            // Do unit checks if not concerned about error propogation for complex numbers, always for real numbers
-            if(!is_complex<T1>)
-            {
-                unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1);
-                unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2);
-            }
-            else
-            {
-                // tolerance calculated as a measurement of the expected result
-                double tol = sum_error_tolerance<T1> * std::abs(cpu_result);
-                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
-                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
-            }
+            unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1);
+            unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2);
         }
 
         if(arg.norm_check)

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -111,20 +111,18 @@ void testing_asum(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            if(std::is_same<T1, rocblas_float_complex>::value
-               || std::is_same<T1, rocblas_double_complex>::value)
-            {
-                double tol
-                    = sum_error_tolerance<
-                          T1> * cpu_result; // tolerance calculated as a measurement of the expected result (?)
-
-                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
-                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
-            }
-            else
+            // Do unit checks if not concerned about error propogation for complex numbers, always for real numbers
+            if(!is_complex<T1>)
             {
                 unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1);
                 unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2);
+            }
+            else
+            {
+                // tolerance calculated as a measurement of the expected result (?)
+                double tol = sum_error_tolerance<T1> * N;
+                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
+                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
             }
         }
 

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -68,7 +68,7 @@ void testing_asum(const Arguments& arg)
         return;
     }
 
-    size_t size_x = N * static_cast<size_t>(incx);
+    size_t size_x = N * size_t(incx);
 
     // allocate memory on device
     device_vector<T1> dx(size_x);
@@ -120,7 +120,7 @@ void testing_asum(const Arguments& arg)
             else
             {
                 // tolerance calculated as a measurement of the expected result
-                double tol = sum_error_tolerance<T1> * getMagnitude(cpu_result);
+                double tol = sum_error_tolerance<T1> * std::abs(cpu_result);
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
             }
@@ -132,8 +132,8 @@ void testing_asum(const Arguments& arg)
                       << ", gpu_host_ptr=" << rocblas_result_1
                       << ", gpu_dev_ptr=" << rocblas_result_2 << "\n";
 
-            rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
-            rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);
+            rocblas_error_1 = std::abs((cpu_result - rocblas_result_1) / cpu_result);
+            rocblas_error_2 = std::abs((cpu_result - rocblas_result_2) / cpu_result);
         }
     }
 

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -119,8 +119,8 @@ void testing_asum(const Arguments& arg)
             }
             else
             {
-                // tolerance calculated as a measurement of the expected result (?)
-                double tol = sum_error_tolerance<T1> * N;
+                // tolerance calculated as a measurement of the expected result
+                double tol = sum_error_tolerance<T1> * getMagnitude(cpu_result);
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
             }

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -3,6 +3,7 @@
  * ************************************************************************ */
 
 #include "cblas_interface.hpp"
+#include "near.hpp"
 #include "rocblas.hpp"
 #include "rocblas_init.hpp"
 #include "rocblas_math.hpp"
@@ -110,8 +111,19 @@ void testing_asum(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1);
-            unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2);
+            if(std::is_same<T1, rocblas_float_complex>::value
+               || std::is_same<T1, rocblas_double_complex>::value)
+            {
+                double tol = 0.001 * cpu_result; // 0.1% of expected result (?)
+
+                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
+                near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
+            }
+            else
+            {
+                unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1);
+                unit_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2);
+            }
         }
 
         if(arg.norm_check)
@@ -120,6 +132,7 @@ void testing_asum(const Arguments& arg)
                    cpu_result,
                    rocblas_result_1,
                    rocblas_result_2);
+
             rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
             rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);
         }

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -114,7 +114,7 @@ void testing_asum(const Arguments& arg)
             if(std::is_same<T1, rocblas_float_complex>::value
                || std::is_same<T1, rocblas_double_complex>::value)
             {
-                double tol = 0.001 * cpu_result; // 0.1% of expected result (?)
+                double tol = sum_error_tolerance<T1> * cpu_result; // tolerance calculated as a measurement of the expected result (?)
 
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -128,10 +128,7 @@ void testing_asum(const Arguments& arg)
 
         if(arg.norm_check)
         {
-            printf("cpu=%e, gpu_host_ptr,=%e, gup_dev_ptr=%e\n",
-                   cpu_result,
-                   rocblas_result_1,
-                   rocblas_result_2);
+            std::cout << "cpu=" << std::scientific << cpu_result << ", gpu_host_ptr=" << rocblas_result_1 << ", gpu_dev_ptr=" << rocblas_result_2 << "\n";
 
             rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
             rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -114,7 +114,9 @@ void testing_asum(const Arguments& arg)
             if(std::is_same<T1, rocblas_float_complex>::value
                || std::is_same<T1, rocblas_double_complex>::value)
             {
-                double tol = sum_error_tolerance<T1> * cpu_result; // tolerance calculated as a measurement of the expected result (?)
+                double tol
+                    = sum_error_tolerance<
+                          T1> * cpu_result; // tolerance calculated as a measurement of the expected result (?)
 
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
@@ -128,7 +130,9 @@ void testing_asum(const Arguments& arg)
 
         if(arg.norm_check)
         {
-            std::cout << "cpu=" << std::scientific << cpu_result << ", gpu_host_ptr=" << rocblas_result_1 << ", gpu_dev_ptr=" << rocblas_result_2 << "\n";
+            std::cout << "cpu=" << std::scientific << cpu_result
+                      << ", gpu_host_ptr=" << rocblas_result_1
+                      << ", gpu_dev_ptr=" << rocblas_result_2 << "\n";
 
             rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
             rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -14,7 +14,7 @@
 #include "utility.hpp"
 
 template <typename T1, typename T2 = T1>
-void testing_asum_bad_arg(const Arguments& arg)
+void testing_asum_bad_arg_template(const Arguments& arg)
 {
     rocblas_int         N                = 100;
     rocblas_int         incx             = 1;
@@ -39,7 +39,7 @@ void testing_asum_bad_arg(const Arguments& arg)
 }
 
 template <typename T1, typename T2 = T1>
-void testing_asum(const Arguments& arg)
+void testing_asum_template(const Arguments& arg)
 {
     rocblas_int N    = arg.N;
     rocblas_int incx = arg.incx;
@@ -170,4 +170,40 @@ void testing_asum(const Arguments& arg)
 
         std::cout << std::endl;
     }
+}
+
+template <typename T>
+void testing_asum_bad_arg(const Arguments& arg)
+{
+    testing_asum_bad_arg_template<T>(arg);
+}
+
+template <>
+void testing_asum_bad_arg<rocblas_float_complex>(const Arguments& arg)
+{
+    testing_asum_bad_arg_template<rocblas_float_complex, float>(arg);
+}
+
+template <>
+void testing_asum_bad_arg<rocblas_double_complex>(const Arguments& arg)
+{
+    testing_asum_bad_arg_template<rocblas_double_complex, double>(arg);
+}
+
+template <typename T>
+void testing_asum(const Arguments& arg)
+{
+    return testing_asum_template<T>(arg);
+}
+
+template <>
+void testing_asum<rocblas_float_complex>(const Arguments& arg)
+{
+    return testing_asum_template<rocblas_float_complex, float>(arg);
+}
+
+template <>
+void testing_asum<rocblas_double_complex>(const Arguments& arg)
+{
+    return testing_asum_template<rocblas_double_complex, double>(arg);
 }

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -52,14 +52,10 @@ void testing_axpy_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_axpy(const Arguments& arg)
 {
-    rocblas_int N    = arg.N;
-    rocblas_int incx = arg.incx;
-    rocblas_int incy = arg.incy;
-    T           h_alpha = arg.get_alpha<T>();
-    rocblas_int N       = arg.N;
-    rocblas_int incx    = arg.incx;
-    rocblas_int incy    = arg.incy;
-
+    rocblas_int          N       = arg.N;
+    rocblas_int          incx    = arg.incx;
+    rocblas_int          incy    = arg.incy;
+    T                    h_alpha = arg.get_alpha<T>();
     rocblas_local_handle handle;
 
     // argument sanity check before allocating invalid memory
@@ -81,8 +77,8 @@ void testing_axpy(const Arguments& arg)
 
     rocblas_int abs_incx = incx > 0 ? incx : -incx;
     rocblas_int abs_incy = incy > 0 ? incy : -incy;
-    size_t      size_x   = N * static_cast<size_t>(abs_incx);
-    size_t      size_y   = N * static_cast<size_t>(abs_incy);
+    size_t      size_x   = N * size_t(abs_incx);
+    size_t      size_y   = N * size_t(abs_incy);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(size_x);

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -55,11 +55,10 @@ void testing_axpy(const Arguments& arg)
     rocblas_int N    = arg.N;
     rocblas_int incx = arg.incx;
     rocblas_int incy = arg.incy;
-    T           h_alpha;
-    if(std::is_same<T, rocblas_half>{})
-        h_alpha = float_to_half(arg.alpha);
-    else
-        h_alpha = arg.alpha;
+    T           h_alpha = arg.get_alpha<T>();
+    rocblas_int N       = arg.N;
+    rocblas_int incx    = arg.incx;
+    rocblas_int incy    = arg.incy;
 
     rocblas_local_handle handle;
 
@@ -92,6 +91,7 @@ void testing_axpy(const Arguments& arg)
     host_vector<T> hy_gold(size_y);
 
     // Initial Data on CPU
+    // TODO: add NaN testing when roblas_isnan(arg.alpha) returns true.
     rocblas_seedrand();
     rocblas_init<T>(hx, 1, N, abs_incx);
     rocblas_init<T>(hy_1, 1, N, abs_incy);

--- a/clients/include/testing_bandwidth.hpp
+++ b/clients/include/testing_bandwidth.hpp
@@ -21,7 +21,7 @@ void testing_bandwidth(const Arguments& arg)
 {
     rocblas_int N      = 25 * 1e7;
     rocblas_int incx   = 1;
-    size_t      size_X = N * static_cast<size_t>(incx);
+    size_t      size_X = N * size_t(incx);
     T           alpha  = 2.0;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
@@ -87,7 +87,7 @@ void testing_bandwidth(const Arguments& arg)
         // check error with CPU result
         for(size_t i = 0; i < size; i++)
         {
-            T error = fabs(hz[i] - hx[i]);
+            T error = std::abs(hz[i] - hx[i]);
             if(error > 0)
             {
                 printf("error is %f, CPU=%f, GPU=%f, at elment %zu", error, hz[i], hx[i], i);

--- a/clients/include/testing_copy.hpp
+++ b/clients/include/testing_copy.hpp
@@ -64,8 +64,8 @@ void testing_copy(const Arguments& arg)
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    size_t      size_x   = N * static_cast<size_t>(abs_incx);
-    size_t      size_y   = N * static_cast<size_t>(abs_incy);
+    size_t      size_x   = N * size_t(abs_incx);
+    size_t      size_y   = N * size_t(abs_incy);
 
     // allocate memory on device
     device_vector<T> dx(size_x);

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -147,20 +147,8 @@ void testing_dot(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            // Do unit checks if not concerned about error propogation for complex numbers, always for real numbers
-            if(!is_complex<T>)
-            {
-                unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1);
-                unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2);
-            }
-            else
-            {
-                // tolerance calculated as a measurement of the expected result (?)
-                double tol = sum_error_tolerance<T> * std::abs(cpu_result);
-
-                near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
-                near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
-            }
+            unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1);
+            unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2);
         }
 
         if(arg.norm_check)

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -132,10 +132,8 @@ void testing_dot(const Arguments& arg)
             if(std::is_same<T, rocblas_float_complex>::value
                || std::is_same<T, rocblas_double_complex>::value)
             {
-                double max
-                    = std::abs((std::abs(cpu_result.x) > std::abs(cpu_result.y)) ? cpu_result.x
-                                                                                 : cpu_result.y);
-                double tol = 0.001 * max; // 0.1% of max part of expected result (?)
+                double max = std::abs( (std::abs(cpu_result.x) > std::abs(cpu_result.y)) ? cpu_result.x : cpu_result.y);
+                double tol = sum_error_tolerance<T> * max; // tolerance calculated as a measurement of the expected result (?)
 
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -138,7 +138,7 @@ void testing_dot(const Arguments& arg)
             else
             {
                 // tolerance calculated as a measurement of the expected result (?)
-                double tol = sum_error_tolerance<rocblas_float_complex> * N;
+                double tol = sum_error_tolerance<T> * getMagnitude(cpu_result);
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
             }
@@ -149,8 +149,8 @@ void testing_dot(const Arguments& arg)
             std::cout << "cpu=" << cpu_result << ", gpu_host_ptr=" << rocblas_result_1
                       << ", gpu_device_ptr=" << rocblas_result_2 << "\n";
 
-            rocblas_error_1 = getAbsError<T>((cpu_result - rocblas_result_1) / cpu_result);
-            rocblas_error_2 = getAbsError<T>((cpu_result - rocblas_result_2) / cpu_result);
+            rocblas_error_1 = getMagnitude<T>((cpu_result - rocblas_result_1) / cpu_result);
+            rocblas_error_2 = getMagnitude<T>((cpu_result - rocblas_result_2) / cpu_result);
         }
     }
 

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -15,7 +15,7 @@
 #include "unit.hpp"
 #include "utility.hpp"
 
-template <typename T>
+template <typename T, bool CONJ = false>
 void testing_dot_bad_arg(const Arguments& arg)
 {
     rocblas_int         N         = 100;
@@ -35,17 +35,29 @@ void testing_dot_bad_arg(const Arguments& arg)
 
     CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
-    EXPECT_ROCBLAS_STATUS(rocblas_dot<T>(handle, N, nullptr, incx, dy, incy, d_rocblas_result),
-                          rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocblas_dot<T>(handle, N, dx, incx, nullptr, incy, d_rocblas_result),
-                          rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocblas_dot<T>(handle, N, dx, incx, dy, incy, nullptr),
-                          rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocblas_dot<T>(nullptr, N, dx, incx, dy, incy, d_rocblas_result),
-                          rocblas_status_invalid_handle);
+    EXPECT_ROCBLAS_STATUS(
+        (CONJ ? rocblas_dotc<T>
+              : rocblas_dot<T>)(handle, N, nullptr, incx, dy, incy, d_rocblas_result),
+        rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(
+        (CONJ ? rocblas_dotc<T>
+              : rocblas_dot<T>)(handle, N, dx, incx, nullptr, incy, d_rocblas_result),
+        rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(
+        (CONJ ? rocblas_dotc<T> : rocblas_dot<T>)(handle, N, dx, incx, dy, incy, nullptr),
+        rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(
+        (CONJ ? rocblas_dotc<T> : rocblas_dot<T>)(nullptr, N, dx, incx, dy, incy, d_rocblas_result),
+        rocblas_status_invalid_handle);
 }
 
 template <typename T>
+void testing_dotc_bad_arg(const Arguments& arg)
+{
+    testing_dot_bad_arg<T, true>(arg);
+}
+
+template <typename T, bool CONJ = false>
 void testing_dot(const Arguments& arg)
 {
     rocblas_int N    = arg.N;
@@ -74,14 +86,16 @@ void testing_dot(const Arguments& arg)
         }
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(rocblas_dot<T>(handle, N, dx, incx, dy, incy, d_rocblas_result));
+        CHECK_ROCBLAS_ERROR(
+            (CONJ ? rocblas_dotc<T>
+                  : rocblas_dot<T>)(handle, N, dx, incx, dy, incy, d_rocblas_result));
         return;
     }
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    size_t      size_x   = N * static_cast<size_t>(abs_incx);
-    size_t      size_y   = N * static_cast<size_t>(abs_incy);
+    size_t      size_x   = N * size_t(abs_incx);
+    size_t      size_y   = N * size_t(abs_incy);
 
     // allocate memory on device
     device_vector<T> dx(size_x);
@@ -113,19 +127,23 @@ void testing_dot(const Arguments& arg)
     {
         // GPU BLAS, rocblas_pointer_mode_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_dot<T>(handle, N, dx, incx, dy, incy, &rocblas_result_1));
+        CHECK_ROCBLAS_ERROR(
+            (CONJ ? rocblas_dotc<T>
+                  : rocblas_dot<T>)(handle, N, dx, incx, dy, incy, &rocblas_result_1));
 
         // GPU BLAS, rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(rocblas_dot<T>(handle, N, dx, incx, dy, incy, d_rocblas_result_2));
+        CHECK_ROCBLAS_ERROR(
+            (CONJ ? rocblas_dotc<T>
+                  : rocblas_dot<T>)(handle, N, dx, incx, dy, incy, d_rocblas_result_2));
         CHECK_HIP_ERROR(
             hipMemcpy(&rocblas_result_2, d_rocblas_result_2, sizeof(T), hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
-        cblas_dot<T>(N, hx, incx, hy, incy, &cpu_result);
+        (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx, incx, hy, incy, &cpu_result);
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops  = axpy_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = dot_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
@@ -138,7 +156,8 @@ void testing_dot(const Arguments& arg)
             else
             {
                 // tolerance calculated as a measurement of the expected result (?)
-                double tol = sum_error_tolerance<T> * getMagnitude(cpu_result);
+                double tol = sum_error_tolerance<T> * std::abs(cpu_result);
+
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
             }
@@ -149,8 +168,8 @@ void testing_dot(const Arguments& arg)
             std::cout << "cpu=" << cpu_result << ", gpu_host_ptr=" << rocblas_result_1
                       << ", gpu_device_ptr=" << rocblas_result_2 << "\n";
 
-            rocblas_error_1 = getMagnitude<T>((cpu_result - rocblas_result_1) / cpu_result);
-            rocblas_error_2 = getMagnitude<T>((cpu_result - rocblas_result_2) / cpu_result);
+            rocblas_error_1 = std::abs((cpu_result - rocblas_result_1) / cpu_result);
+            rocblas_error_2 = std::abs((cpu_result - rocblas_result_2) / cpu_result);
         }
     }
 
@@ -162,14 +181,16 @@ void testing_dot(const Arguments& arg)
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {
-            rocblas_dot<T>(handle, N, dx, incx, dy, incy, &rocblas_result_1);
+            (CONJ ? rocblas_dotc<T>
+                  : rocblas_dot<T>)(handle, N, dx, incx, dy, incy, &rocblas_result_1);
         }
 
         gpu_time_used = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_hot_calls; iter++)
         {
-            rocblas_dot<T>(handle, N, dx, incx, dy, incy, &rocblas_result_1);
+            (CONJ ? rocblas_dotc<T>
+                  : rocblas_dot<T>)(handle, N, dx, incx, dy, incy, &rocblas_result_1);
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
@@ -190,4 +211,10 @@ void testing_dot(const Arguments& arg)
 
         std::cout << std::endl;
     }
+}
+
+template <typename T>
+void testing_dotc(const Arguments& arg)
+{
+    testing_dot<T, true>(arg);
 }

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -4,6 +4,7 @@
 
 #include "cblas_interface.hpp"
 #include "flops.hpp"
+#include "near.hpp"
 #include "norm.hpp"
 #include "rocblas.hpp"
 #include "rocblas_init.hpp"
@@ -128,18 +129,42 @@ void testing_dot(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1);
-            unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2);
+            if(std::is_same<T, rocblas_float_complex>::value
+               || std::is_same<T, rocblas_double_complex>::value)
+            {
+                double max
+                    = std::abs((std::abs(cpu_result.x) > std::abs(cpu_result.y)) ? cpu_result.x
+                                                                                 : cpu_result.y);
+                double tol = 0.001 * max; // 0.1% of max part of expected result (?)
+
+                near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
+                near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);
+            }
+            else
+            {
+                unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1);
+                unit_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2);
+            }
         }
 
         if(arg.norm_check)
         {
-            printf("cpu=%f, gpu_host_ptr=%f, gpu_device_ptr=%f\n",
-                   cpu_result,
-                   rocblas_result_1,
-                   rocblas_result_2);
-            rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
-            rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);
+            std::cout << "cpu=" << cpu_result << ", gpu_host_ptr=" << rocblas_result_1
+                      << ", gpu_device_ptr=" << rocblas_result_2 << "\n";
+
+            if(std::is_same<T, rocblas_float_complex>::value
+               || std::is_same<T, rocblas_double_complex>::value)
+            {
+                auto err        = (cpu_result - rocblas_result_1) / cpu_result;
+                rocblas_error_1 = std::abs(err);
+                err             = (cpu_result - rocblas_result_2) / cpu_result;
+                rocblas_error_2 = std::abs(err);
+            }
+            else
+            {
+                rocblas_error_1 = std::abs((cpu_result - rocblas_result_1) / cpu_result);
+                rocblas_error_2 = std::abs((cpu_result - rocblas_result_2) / cpu_result);
+            }
         }
     }
 

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -132,8 +132,12 @@ void testing_dot(const Arguments& arg)
             if(std::is_same<T, rocblas_float_complex>::value
                || std::is_same<T, rocblas_double_complex>::value)
             {
-                double max = std::abs( (std::abs(cpu_result.x) > std::abs(cpu_result.y)) ? cpu_result.x : cpu_result.y);
-                double tol = sum_error_tolerance<T> * max; // tolerance calculated as a measurement of the expected result (?)
+                double max
+                    = std::abs((std::abs(cpu_result.x) > std::abs(cpu_result.y)) ? cpu_result.x
+                                                                                 : cpu_result.y);
+                double tol
+                    = sum_error_tolerance<
+                          T> * max; // tolerance calculated as a measurement of the expected result (?)
 
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_1, tol);
                 near_check_general<T>(1, 1, 1, &cpu_result, &rocblas_result_2, tol);

--- a/clients/include/testing_geam.hpp
+++ b/clients/include/testing_geam.hpp
@@ -34,9 +34,9 @@ void testing_geam_bad_arg(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    size_t size_A = N * static_cast<size_t>(lda);
-    size_t size_B = N * static_cast<size_t>(ldb);
-    size_t size_C = N * static_cast<size_t>(ldc);
+    size_t size_A = N * size_t(lda);
+    size_t size_B = N * size_t(ldb);
+    size_t size_C = N * size_t(ldc);
 
     host_vector<T> hA(size_A);
     host_vector<T> hB(size_B);
@@ -150,9 +150,9 @@ void testing_geam(const Arguments& arg)
         inc2_B = 1;
     }
 
-    size_t size_A = lda * static_cast<size_t>(A_col);
-    size_t size_B = ldb * static_cast<size_t>(B_col);
-    size_t size_C = ldc * static_cast<size_t>(N);
+    size_t size_A = lda * size_t(A_col);
+    size_t size_B = ldb * size_t(B_col);
+    size_t size_C = ldc * size_t(N);
 
     // check here to prevent undefined memory allocation error
     if(M <= 0 || N <= 0 || lda < A_row || ldb < B_row || ldc < M)

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -134,9 +134,9 @@ void testing_gemm(const Arguments& arg)
         return;
     }
 
-    const auto size_A = static_cast<size_t>(lda) * static_cast<size_t>(A_col);
-    const auto size_B = static_cast<size_t>(ldb) * static_cast<size_t>(B_col);
-    const auto size_C = static_cast<size_t>(ldc) * static_cast<size_t>(N);
+    const auto size_A = size_t(lda) * size_t(A_col);
+    const auto size_B = size_t(ldb) * size_t(B_col);
+    const auto size_C = size_t(ldc) * size_t(N);
 
     // allocate memory on device
     device_vector<T> dA(size_A);
@@ -246,8 +246,8 @@ void testing_gemm(const Arguments& arg)
 
         if(arg.norm_check)
         {
-            auto err1     = fabs(norm_check_general<T>('F', M, N, ldc, hC_gold, hC_1));
-            auto err2     = fabs(norm_check_general<T>('F', M, N, ldc, hC_gold, hC_2));
+            auto err1     = std::abs(norm_check_general<T>('F', M, N, ldc, hC_gold, hC_1));
+            auto err2     = std::abs(norm_check_general<T>('F', M, N, ldc, hC_gold, hC_2));
             rocblas_error = err1 > err2 ? err1 : err2;
         }
     }

--- a/clients/include/testing_gemm_parallel.hpp
+++ b/clients/include/testing_gemm_parallel.hpp
@@ -82,9 +82,9 @@ void testing_gemm_parallel(const Arguments& arg,
         return;
     }
 
-    const auto size_A = static_cast<size_t>(lda) * static_cast<size_t>(A_col);
-    const auto size_B = static_cast<size_t>(ldb) * static_cast<size_t>(B_col);
-    const auto size_C = static_cast<size_t>(ldc) * static_cast<size_t>(N);
+    const auto size_A = size_t(lda) * size_t(A_col);
+    const auto size_B = size_t(ldb) * size_t(B_col);
+    const auto size_C = size_t(ldc) * size_t(N);
 
     // allocate memory on device
     device_vector<T> dA(size_A);
@@ -166,9 +166,9 @@ void testing_gemm_parallel(const Arguments& arg,
     if(arg.norm_check)
     {
         double error_hst_ptr
-            = fabs(norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data()));
+            = std::abs(norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_1.data()));
         double error_dev_ptr
-            = fabs(norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_2.data()));
+            = std::abs(norm_check_general<T>('F', M, N, ldc, hC_gold.data(), hC_2.data()));
         rocblas_error = error_hst_ptr > error_dev_ptr ? error_hst_ptr : error_dev_ptr;
     }
 }

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -98,20 +98,15 @@ void testing_gemm_strided_batched(const Arguments& arg)
 
     double rocblas_error = 0.0;
 
-    size_t size_one_a = transA == rocblas_operation_none
-                            ? static_cast<size_t>(K) * static_cast<size_t>(lda)
-                            : static_cast<size_t>(M) * static_cast<size_t>(lda);
-    size_t size_one_b = transB == rocblas_operation_none
-                            ? static_cast<size_t>(N) * static_cast<size_t>(ldb)
-                            : static_cast<size_t>(K) * static_cast<size_t>(ldb);
+    size_t size_one_a
+        = transA == rocblas_operation_none ? size_t(K) * size_t(lda) : size_t(M) * size_t(lda);
+    size_t size_one_b
+        = transB == rocblas_operation_none ? size_t(N) * size_t(ldb) : size_t(K) * size_t(ldb);
     size_t size_one_c = N * ldc;
 
-    size_t size_a
-        = size_one_a + static_cast<size_t>(stride_a) * static_cast<size_t>(batch_count - 1);
-    size_t size_b
-        = size_one_b + static_cast<size_t>(stride_b) * static_cast<size_t>(batch_count - 1);
-    size_t size_c
-        = size_one_c + static_cast<size_t>(stride_c) * static_cast<size_t>(batch_count - 1);
+    size_t size_a = size_one_a + size_t(stride_a) * size_t(batch_count - 1);
+    size_t size_b = size_one_b + size_t(stride_b) * size_t(batch_count - 1);
+    size_t size_c = size_one_c + size_t(stride_c) * size_t(batch_count - 1);
 
     // allocate memory on device
     device_vector<T> dA(size_a);
@@ -246,9 +241,9 @@ void testing_gemm_strided_batched(const Arguments& arg)
         if(arg.norm_check)
         {
             double error_hst_ptr
-                = fabs(norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_1));
+                = std::abs(norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_1));
             double error_dev_ptr
-                = fabs(norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_2));
+                = std::abs(norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_2));
             rocblas_error = error_hst_ptr > error_dev_ptr ? error_hst_ptr : error_dev_ptr;
         }
     }

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -240,10 +240,10 @@ void testing_gemm_strided_batched(const Arguments& arg)
 
         if(arg.norm_check)
         {
-            double error_hst_ptr
-                = std::abs(norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_1));
-            double error_dev_ptr
-                = std::abs(norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_2));
+            double error_hst_ptr = std::abs(
+                norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_1));
+            double error_dev_ptr = std::abs(
+                norm_check_general<T>('F', M, N, ldc, stride_c, batch_count, hC_gold, hC_2));
             rocblas_error = error_hst_ptr > error_dev_ptr ? error_hst_ptr : error_dev_ptr;
         }
     }

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -33,9 +33,9 @@ void testing_gemv_bad_arg(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    size_t size_A = lda * static_cast<size_t>(N);
-    size_t size_x = N * static_cast<size_t>(incx);
-    size_t size_y = M * static_cast<size_t>(incy);
+    size_t size_A = lda * size_t(N);
+    size_t size_x = N * size_t(incx);
+    size_t size_y = M * size_t(incy);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(size_A);
@@ -96,8 +96,8 @@ void testing_gemv(const Arguments& arg)
     rocblas_int       lda     = arg.lda;
     rocblas_int       incx    = arg.incx;
     rocblas_int       incy    = arg.incy;
-    T                 h_alpha = arg.getAlphaBeta<T>();
-    T                 h_beta  = arg.getAlphaBeta<T>(false);
+    T                 h_alpha = arg.get_alpha<T>();
+    T                 h_beta  = arg.get_beta<T>();
     rocblas_operation transA  = char2rocblas_operation(arg.transA);
 
     rocblas_local_handle handle;
@@ -123,7 +123,7 @@ void testing_gemv(const Arguments& arg)
         return;
     }
 
-    size_t size_A = lda * static_cast<size_t>(N);
+    size_t size_A = lda * size_t(N);
     size_t size_x, dim_x, abs_incx;
     size_t size_y, dim_y, abs_incy;
 
@@ -231,7 +231,7 @@ void testing_gemv(const Arguments& arg)
                 // tolerance calculated as a measurement of the expected result
                 // TODO: this isn't a great way to get a tolerance, should we
                 //       calculate a new tolerance for each element being compared?
-                double tol = sum_error_tolerance<T> * (dim_y > 0 ? hy_gold[0] : 0);
+                double tol = sum_error_tolerance<T> * (dim_y > 0 ? std::abs(hy_gold[0]) : 0);
                 near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_1, tol);
                 near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_2, tol);
             }

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -112,7 +112,6 @@ void testing_gemv(const Arguments& arg)
         h_alpha.y = arg.alphai;
         h_beta.x  = rocblas_isnan(arg.beta) ? 0 : arg.beta;
         h_beta.y  = rocblas_isnan(arg.betai) ? 0 : arg.betai;
-        std::cout << "alpha: " << h_alpha << "beta: " << h_beta << "\n";
     }
     else
     {
@@ -242,8 +241,7 @@ void testing_gemv(const Arguments& arg)
         {
             if constexpr(is_complex<T>)
             {
-                double tol = sum_error_tolerance<
-                    T>; // * 10;// * hy_gold; // tolerance calculated as a measurement of the expected result (?)
+                double tol = sum_error_tolerance<T>;
 
                 near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_1, tol);
                 near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_2, tol);

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -220,21 +220,8 @@ void testing_gemv(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            // Do unit checks if not concerned about error propogation for complex numbers, always for real numbers
-            if(!is_complex<T>)
-            {
-                unit_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_1);
-                unit_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_2);
-            }
-            else
-            {
-                // tolerance calculated as a measurement of the expected result
-                // TODO: this isn't a great way to get a tolerance, should we
-                //       calculate a new tolerance for each element being compared?
-                double tol = sum_error_tolerance<T> * (dim_y > 0 ? std::abs(hy_gold[0]) : 0);
-                near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_1, tol);
-                near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_2, tol);
-            }
+            unit_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_1);
+            unit_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_2);
         }
 
         if(arg.norm_check)

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -228,8 +228,10 @@ void testing_gemv(const Arguments& arg)
             }
             else
             {
-                // tolerance calculated as a measurement of the expected result (?)
-                double tol = sum_error_tolerance<T>; // * M or N?
+                // tolerance calculated as a measurement of the expected result
+                // TODO: this isn't a great way to get a tolerance, should we
+                //       calculate a new tolerance for each element being compared?
+                double tol = sum_error_tolerance<T> * (dim_y > 0 ? hy_gold[0] : 0);
                 near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_1, tol);
                 near_check_general<T>(1, dim_y, abs_incy, hy_gold, hy_2, tol);
             }

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -28,9 +28,9 @@ void testing_ger_bad_arg(const Arguments& arg)
 
     rocblas_int abs_incx = incx >= 0 ? incx : -incx;
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
-    size_t      size_A   = lda * static_cast<size_t>(N);
-    size_t      size_x   = M * static_cast<size_t>(abs_incx);
-    size_t      size_y   = N * static_cast<size_t>(abs_incy);
+    size_t      size_A   = lda * size_t(N);
+    size_t      size_x   = M * size_t(abs_incx);
+    size_t      size_y   = N * size_t(abs_incy);
 
     // allocate memory on device
     device_vector<T> dA_1(size_A);

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -84,7 +84,7 @@ void testing_iamax_iamin(const Arguments& arg)
         return;
     }
 
-    size_t size_x = static_cast<size_t>(N) * incx;
+    size_t size_x = size_t(N) * incx;
 
     // allocate memory on device
     device_vector<T>           dx(size_x);
@@ -179,26 +179,15 @@ void testing_iamax_iamin(const Arguments& arg)
 // CBLAS does not have a cblas_iamin function, so we write our own version of it
 namespace rocblas_cblas
 {
-
     template <typename T>
-    T aabs(T x)
+    T asum(T x)
     {
-        return std::abs(x);
+        return x < 0 ? -x : x;
     }
 
-    rocblas_half aabs(rocblas_half x)
+    rocblas_half asum(rocblas_half x)
     {
         return x & 0x7fff;
-    }
-
-    double aabs(rocblas_double_complex x)
-    {
-        return aabs(x.x) + aabs(x.y);
-    }
-
-    float aabs(rocblas_float_complex x)
-    {
-        return aabs(x.x) + aabs(x.y);
     }
 
     template <typename T>
@@ -218,11 +207,11 @@ namespace rocblas_cblas
         rocblas_int minpos = -1;
         if(N > 0 && incx > 0)
         {
-            auto min = aabs(X[0]);
+            auto min = asum(X[0]);
             minpos   = 0;
             for(size_t i = 1; i < N; ++i)
             {
-                auto a = aabs(X[i * incx]);
+                auto a = asum(X[i * incx]);
                 if(lessthan(a, min))
                 {
                     min    = a;

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -211,14 +211,14 @@ void testing_logging()
         // BLAS_EX
         if(BUILD_WITH_TENSILE)
         {
-            void*             alpha          = 0;
-            void*             beta           = 0;
-            float             alpha_float    = 1.0;
-            float             beta_float     = 1.0;
-            rocblas_half      alpha_half     = float_to_half(alpha_float);
-            rocblas_half      beta_half      = float_to_half(beta_float);
-            double            alpha_double   = static_cast<double>(alpha_float);
-            double            beta_double    = static_cast<double>(beta_float);
+            void*             alpha       = 0;
+            void*             beta        = 0;
+            float             alpha_float = 1.0;
+            float             beta_float  = 1.0;
+            rocblas_half      alpha_half  = float_to_half(alpha_float);
+            rocblas_half      beta_half   = float_to_half(beta_float);
+            double            alpha_double(alpha_float);
+            double            beta_double(beta_float);
             rocblas_gemm_algo algo           = rocblas_gemm_algo_standard;
             int32_t           solution_index = 0;
             uint32_t          flags          = 0;
@@ -235,8 +235,8 @@ void testing_logging()
                 c_type       = rocblas_datatype_f16_r;
                 d_type       = rocblas_datatype_f16_r;
                 compute_type = rocblas_datatype_f16_r;
-                alpha        = static_cast<void*>(&alpha_half);
-                beta         = static_cast<void*>(&beta_half);
+                alpha        = &alpha_half;
+                beta         = &beta_half;
             }
             else if(std::is_same<T, float>{})
             {
@@ -245,8 +245,8 @@ void testing_logging()
                 c_type       = rocblas_datatype_f32_r;
                 d_type       = rocblas_datatype_f32_r;
                 compute_type = rocblas_datatype_f32_r;
-                alpha        = static_cast<void*>(&alpha_float);
-                beta         = static_cast<void*>(&beta_float);
+                alpha        = &alpha_float;
+                beta         = &beta_float;
             }
             else if(std::is_same<T, double>{})
             {
@@ -255,8 +255,8 @@ void testing_logging()
                 c_type       = rocblas_datatype_f64_r;
                 d_type       = rocblas_datatype_f64_r;
                 compute_type = rocblas_datatype_f64_r;
-                alpha        = static_cast<void*>(&alpha_double);
-                beta         = static_cast<void*>(&beta_double);
+                alpha        = &alpha_double;
+                beta         = &beta_double;
             }
 
             rocblas_gemm_ex(handle,

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -399,8 +399,10 @@ void testing_logging()
     {
         trace_ofs2 << replaceX<T>("rocblas_Xscal") << "," << n << "," << alpha << "," << (void*)dx
                    << "," << incx << '\n';
-        bench_ofs2 << "./rocblas-bench -f scal -r " << rocblas_precision_string<T> << " -n " << n
-                   << " --incx " << incx << " --alpha " << alpha << '\n';
+        bench_ofs2 << "./rocblas-bench -f scal --a_type "
+                   << rocblas_precision_string<T> << " --b_type "
+                   << rocblas_precision_string<T> << " -n " << n << " --incx " << incx
+                   << " --alpha " << alpha << '\n';
     }
     else
     {

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -3,7 +3,6 @@
  * ************************************************************************ */
 
 #include "../../library/src/include/handle.h"
-#include "../../library/src/include/utility.h"
 #include "cblas_interface.hpp"
 #include "rocblas.hpp"
 #include "rocblas_math.hpp"

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -12,7 +12,6 @@
 #include "rocblas_test.hpp"
 #include "rocblas_vector.hpp"
 #include "unit.hpp"
-#include "near.hpp"
 #include "utility.hpp"
 
 template <typename T1, typename T2 = T1>

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -12,6 +12,7 @@
 #include "rocblas_test.hpp"
 #include "rocblas_vector.hpp"
 #include "unit.hpp"
+#include "near.hpp"
 #include "utility.hpp"
 
 template <typename T1, typename T2 = T1>
@@ -122,8 +123,8 @@ void testing_nrm2(const Arguments& arg)
         abs_error *= tolerance;
         if(arg.unit_check)
         {
-            near_check_general<T1>(1, 1, 1, &cpu_result, &rocblas_result_1, abs_error);
-            near_check_general<T1>(1, 1, 1, &cpu_result, &rocblas_result_2, abs_error);
+            near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_1, abs_error);
+            near_check_general<T2>(1, 1, 1, &cpu_result, &rocblas_result_2, abs_error);
         }
 
         if(arg.norm_check)

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -15,7 +15,7 @@
 #include "utility.hpp"
 
 template <typename T1, typename T2 = T1>
-void testing_nrm2_bad_arg(const Arguments& arg)
+void testing_nrm2_bad_arg_template(const Arguments& arg)
 {
     rocblas_int         N         = 100;
     rocblas_int         incx      = 1;
@@ -42,7 +42,7 @@ void testing_nrm2_bad_arg(const Arguments& arg)
 }
 
 template <typename T1, typename T2 = T1>
-void testing_nrm2(const Arguments& arg)
+void testing_nrm2_template(const Arguments& arg)
 {
     rocblas_int N    = arg.N;
     rocblas_int incx = arg.incx;
@@ -170,4 +170,40 @@ void testing_nrm2(const Arguments& arg)
 
         std::cout << std::endl;
     }
+}
+
+template <typename T>
+void testing_nrm2_bad_arg(const Arguments& arg)
+{
+    testing_nrm2_bad_arg_template<T>(arg);
+}
+
+template <>
+void testing_nrm2_bad_arg<rocblas_float_complex>(const Arguments& arg)
+{
+    testing_nrm2_bad_arg_template<rocblas_float_complex, float>(arg);
+}
+
+template <>
+void testing_nrm2_bad_arg<rocblas_double_complex>(const Arguments& arg)
+{
+    testing_nrm2_bad_arg_template<rocblas_double_complex, double>(arg);
+}
+
+template <typename T>
+void testing_nrm2(const Arguments& arg)
+{
+    testing_nrm2_template<T>(arg);
+}
+
+template <>
+void testing_nrm2<rocblas_float_complex>(const Arguments& arg)
+{
+    testing_nrm2_template<rocblas_float_complex, float>(arg);
+}
+
+template <>
+void testing_nrm2<rocblas_double_complex>(const Arguments& arg)
+{
+    testing_nrm2_template<rocblas_double_complex, double>(arg);
 }

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -73,7 +73,7 @@ void testing_nrm2(const Arguments& arg)
         return;
     }
 
-    size_t size_x = N * static_cast<size_t>(incx);
+    size_t size_x = N * size_t(incx);
 
     // allocate memory on device
     device_vector<T1> dx(size_x);
@@ -132,8 +132,8 @@ void testing_nrm2(const Arguments& arg)
                    cpu_result,
                    rocblas_result_1,
                    rocblas_result_2);
-            rocblas_error_1 = fabs((cpu_result - rocblas_result_1) / cpu_result);
-            rocblas_error_2 = fabs((cpu_result - rocblas_result_2) / cpu_result);
+            rocblas_error_1 = std::abs((cpu_result - rocblas_result_1) / cpu_result);
+            rocblas_error_2 = std::abs((cpu_result - rocblas_result_2) / cpu_result);
         }
     }
 

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -14,13 +14,13 @@
 #include "unit.hpp"
 #include "utility.hpp"
 
-template <typename T>
+template <typename T, typename U=T>
 void testing_scal_bad_arg(const Arguments& arg)
 {
     rocblas_int N     = 100;
     rocblas_int incx  = 1;
-    T alpha;
-    if constexpr(is_complex<T>)
+    U alpha;
+    if constexpr(is_complex<U>)
         alpha = T(0.5, 1.0);
     else
         alpha = 0.6;
@@ -30,22 +30,22 @@ void testing_scal_bad_arg(const Arguments& arg)
     size_t size_x = N * static_cast<size_t>(incx);
 
     // allocate memory on device
-    device_vector<T> dx(size_x);
+    device_vector<U> dx(size_x);
     if(!dx)
     {
         CHECK_HIP_ERROR(hipErrorOutOfMemory);
         return;
     }
 
-    EXPECT_ROCBLAS_STATUS(rocblas_scal<T>(handle, N, &alpha, nullptr, incx),
+    EXPECT_ROCBLAS_STATUS((rocblas_scal<T, U>(handle, N, &alpha, nullptr, incx)),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocblas_scal<T>(handle, N, nullptr, dx, incx),
+    EXPECT_ROCBLAS_STATUS((rocblas_scal<T, U>(handle, N, nullptr, dx, incx)),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(rocblas_scal<T>(nullptr, N, &alpha, dx, incx),
+    EXPECT_ROCBLAS_STATUS((rocblas_scal<T, U>(nullptr, N, &alpha, dx, incx)),
                           rocblas_status_invalid_handle);
 }
 
-template <typename T>
+template <typename T, typename U=T>
 void testing_scal(const Arguments& arg)
 {
     rocblas_int N       = arg.N;
@@ -62,7 +62,7 @@ void testing_scal(const Arguments& arg)
     if(N <= 0 || incx <= 0)
     {
         static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dx(safe_size);
+        device_vector<U>    dx(safe_size);
         if(!dx)
         {
             CHECK_HIP_ERROR(hipErrorOutOfMemory);
@@ -70,20 +70,20 @@ void testing_scal(const Arguments& arg)
         }
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_scal<T>(handle, N, &h_alpha, dx, incx));
+        CHECK_ROCBLAS_ERROR((rocblas_scal<T, U>(handle, N, &h_alpha, dx, incx)));
         return;
     }
 
     size_t size_x = N * static_cast<size_t>(incx);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<T> hx_1(size_x);
-    host_vector<T> hx_2(size_x);
-    host_vector<T> hy_gold(size_x);
+    host_vector<U> hx_1(size_x);
+    host_vector<U> hx_2(size_x);
+    host_vector<U> hy_gold(size_x);
 
     // Initial Data on CPU
     rocblas_seedrand();
-    rocblas_init<T>(hx_1, 1, N, incx);
+    rocblas_init<U>(hx_1, 1, N, incx);
 
     // copy vector is easy in STL; hy_gold = hx: save a copy in hy_gold which will be output of CPU
     // BLAS
@@ -91,8 +91,8 @@ void testing_scal(const Arguments& arg)
     hy_gold = hx_1;
 
     // allocate memory on device
-    device_vector<T> dx_1(size_x);
-    device_vector<T> dx_2(size_x);
+    device_vector<U> dx_1(size_x);
+    device_vector<U> dx_2(size_x);
     device_vector<T> d_alpha(1);
     if(!dx_1 || !dx_2 || !d_alpha)
     {
@@ -101,48 +101,48 @@ void testing_scal(const Arguments& arg)
     }
 
     // copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1, sizeof(T) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1, sizeof(U) * size_x, hipMemcpyHostToDevice));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
     double rocblas_error_1 = 0.0;
     double rocblas_error_2 = 0.0;
 
-    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1, sizeof(T) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1, sizeof(U) * size_x, hipMemcpyHostToDevice));
 
     if(arg.unit_check || arg.norm_check)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dx_2, hx_2, sizeof(T) * size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dx_2, hx_2, sizeof(U) * size_x, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
         // GPU BLAS, rocblas_pointer_mode_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_scal<T>(handle, N, &h_alpha, dx_1, incx));
+        CHECK_ROCBLAS_ERROR((rocblas_scal<T, U>(handle, N, &h_alpha, dx_1, incx)));
 
         // GPU BLAS, rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(rocblas_scal<T>(handle, N, d_alpha, dx_2, incx));
+        CHECK_ROCBLAS_ERROR((rocblas_scal<T, U>(handle, N, d_alpha, dx_2, incx)));
 
         // copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hx_1, dx_1, sizeof(T) * N * incx, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hx_2, dx_2, sizeof(T) * N * incx, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hx_1, dx_1, sizeof(U) * N * incx, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hx_2, dx_2, sizeof(U) * N * incx, hipMemcpyDeviceToHost));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
-        cblas_scal<T>(N, h_alpha, hy_gold, incx);
+        cblas_scal<T, U>(N, h_alpha, hy_gold, incx);
         cpu_time_used = get_time_us() - cpu_time_used;
         cblas_gflops  = axpy_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
-            unit_check_general<T>(1, N, incx, hy_gold, hx_1);
-            unit_check_general<T>(1, N, incx, hy_gold, hx_2);
+            unit_check_general<U>(1, N, incx, hy_gold, hx_1);
+            unit_check_general<U>(1, N, incx, hy_gold, hx_2);
         }
 
         if(arg.norm_check)
         {
-            rocblas_error_1 = norm_check_general<T>('F', 1, N, incx, hy_gold, hx_1);
-            rocblas_error_2 = norm_check_general<T>('F', 1, N, incx, hy_gold, hx_2);
+            rocblas_error_1 = norm_check_general<U>('F', 1, N, incx, hy_gold, hx_1);
+            rocblas_error_2 = norm_check_general<U>('F', 1, N, incx, hy_gold, hx_2);
         }
 
     } // end of if unit/norm check
@@ -155,19 +155,19 @@ void testing_scal(const Arguments& arg)
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {
-            rocblas_scal<T>(handle, N, &h_alpha, dx_1, incx);
+            rocblas_scal<T, U>(handle, N, &h_alpha, dx_1, incx);
         }
 
         gpu_time_used = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_hot_calls; iter++)
         {
-            rocblas_scal<T>(handle, N, &h_alpha, dx_1, incx);
+            rocblas_scal<T, U>(handle, N, &h_alpha, dx_1, incx);
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
-        rocblas_gflops    = axpy_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
-        rocblas_bandwidth = (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
+        rocblas_gflops    = axpy_gflop_count<U>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_bandwidth = (2.0 * N) * sizeof(U) / gpu_time_used / 1e3;
 
         std::cout << "N,alpha,incx,rocblas-Gflops,rocblas-GB/s,rocblas-us";
 

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -17,13 +17,9 @@
 template <typename T, typename U = T>
 void testing_scal_bad_arg(const Arguments& arg)
 {
-    rocblas_int N    = 100;
-    rocblas_int incx = 1;
-    U           alpha;
-    if constexpr(is_complex<U>)
-        alpha = T(0.5, 1.0);
-    else
-        alpha = 0.6;
+    rocblas_int N     = 100;
+    rocblas_int incx  = 1;
+    U           alpha = (U)0.6;
 
     rocblas_local_handle handle;
 
@@ -48,13 +44,9 @@ void testing_scal_bad_arg(const Arguments& arg)
 template <typename T, typename U = T>
 void testing_scal(const Arguments& arg)
 {
-    rocblas_int N    = arg.N;
-    rocblas_int incx = arg.incx;
-    T           h_alpha;
-    if constexpr(is_complex<T>)
-        h_alpha = T(arg.alpha, arg.alphai);
-    else
-        h_alpha = arg.alpha;
+    rocblas_int N       = arg.N;
+    rocblas_int incx    = arg.incx;
+    T           h_alpha = arg.getAlphaBeta<T>();
 
     rocblas_local_handle handle;
 

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -14,12 +14,12 @@
 #include "unit.hpp"
 #include "utility.hpp"
 
-template <typename T, typename U=T>
+template <typename T, typename U = T>
 void testing_scal_bad_arg(const Arguments& arg)
 {
-    rocblas_int N     = 100;
-    rocblas_int incx  = 1;
-    U alpha;
+    rocblas_int N    = 100;
+    rocblas_int incx = 1;
+    U           alpha;
     if constexpr(is_complex<U>)
         alpha = T(0.5, 1.0);
     else
@@ -45,12 +45,12 @@ void testing_scal_bad_arg(const Arguments& arg)
                           rocblas_status_invalid_handle);
 }
 
-template <typename T, typename U=T>
+template <typename T, typename U = T>
 void testing_scal(const Arguments& arg)
 {
-    rocblas_int N       = arg.N;
-    rocblas_int incx    = arg.incx;
-    T h_alpha;
+    rocblas_int N    = arg.N;
+    rocblas_int incx = arg.incx;
+    T           h_alpha;
     if constexpr(is_complex<T>)
         h_alpha = T(arg.alpha, arg.alphai);
     else

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -19,7 +19,7 @@ void testing_scal_bad_arg(const Arguments& arg)
 {
     rocblas_int N     = 100;
     rocblas_int incx  = 1;
-    U           alpha = (U)0.6;
+    T           alpha = (T)0.6;
 
     rocblas_local_handle handle;
 

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -19,7 +19,11 @@ void testing_scal_bad_arg(const Arguments& arg)
 {
     rocblas_int N     = 100;
     rocblas_int incx  = 1;
-    T           alpha = 0.6;
+    T alpha;
+    if constexpr(is_complex<T>)
+        alpha = T(0.5, 1.0);
+    else
+        alpha = 0.6;
 
     rocblas_local_handle handle;
 
@@ -46,7 +50,11 @@ void testing_scal(const Arguments& arg)
 {
     rocblas_int N       = arg.N;
     rocblas_int incx    = arg.incx;
-    T           h_alpha = arg.alpha;
+    T h_alpha;
+    if constexpr(is_complex<T>)
+        h_alpha = T(arg.alpha, arg.alphai);
+    else
+        h_alpha = arg.alpha;
 
     rocblas_local_handle handle;
 

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -23,7 +23,7 @@ void testing_scal_bad_arg(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    size_t size_x = N * static_cast<size_t>(incx);
+    size_t size_x = N * size_t(incx);
 
     // allocate memory on device
     device_vector<U> dx(size_x);
@@ -46,7 +46,7 @@ void testing_scal(const Arguments& arg)
 {
     rocblas_int N       = arg.N;
     rocblas_int incx    = arg.incx;
-    T           h_alpha = arg.getAlphaBeta<T>();
+    T           h_alpha = arg.get_alpha<T>();
 
     rocblas_local_handle handle;
 
@@ -66,7 +66,7 @@ void testing_scal(const Arguments& arg)
         return;
     }
 
-    size_t size_x = N * static_cast<size_t>(incx);
+    size_t size_x = N * size_t(incx);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<U> hx_1(size_x);

--- a/clients/include/testing_set_get_matrix.hpp
+++ b/clients/include/testing_set_get_matrix.hpp
@@ -49,17 +49,17 @@ void testing_set_get_matrix(const Arguments& arg)
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> ha(cols * static_cast<size_t>(lda));
-    host_vector<T> hb(cols * static_cast<size_t>(ldb));
-    host_vector<T> hc(cols * static_cast<size_t>(ldc));
-    host_vector<T> hb_gold(cols * static_cast<size_t>(ldb));
+    host_vector<T> ha(cols * size_t(lda));
+    host_vector<T> hb(cols * size_t(ldb));
+    host_vector<T> hc(cols * size_t(ldc));
+    host_vector<T> hb_gold(cols * size_t(ldb));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_bandwidth, cpu_bandwidth;
     double rocblas_error = 0.0;
 
     // allocate memory on device
-    device_vector<T> dc(cols * static_cast<size_t>(ldc));
+    device_vector<T> dc(cols * size_t(ldc));
     if(!dc)
     {
         CHECK_HIP_ERROR(hipErrorOutOfMemory);

--- a/clients/include/testing_set_get_vector.hpp
+++ b/clients/include/testing_set_get_vector.hpp
@@ -45,17 +45,17 @@ void testing_set_get_vector(const Arguments& arg)
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hx(M * static_cast<size_t>(incx));
-    host_vector<T> hy(M * static_cast<size_t>(incy));
-    host_vector<T> hb(M * static_cast<size_t>(incb));
-    host_vector<T> hy_gold(M * static_cast<size_t>(incy));
+    host_vector<T> hx(M * size_t(incx));
+    host_vector<T> hy(M * size_t(incy));
+    host_vector<T> hb(M * size_t(incb));
+    host_vector<T> hy_gold(M * size_t(incy));
 
     double gpu_time_used, cpu_time_used;
     double rocblas_bandwidth, cpu_bandwidth;
     double rocblas_error = 0.0;
 
     // allocate memory on device
-    device_vector<T> db(M * static_cast<size_t>(incb));
+    device_vector<T> db(M * size_t(incb));
     if(!db)
     {
         CHECK_HIP_ERROR(hipErrorOutOfMemory);

--- a/clients/include/testing_symv.hpp
+++ b/clients/include/testing_symv.hpp
@@ -22,8 +22,8 @@ void testing_symv(const Arguments& arg)
     rocblas_int incx = arg.incx;
     rocblas_int incy = arg.incy;
 
-    T alpha = static_cast<T>(arg.alpha);
-    T beta  = static_cast<T>(arg.beta);
+    T alpha(arg.alpha);
+    T beta(arg.beta);
 
     rocblas_fill uplo = char2rocblas_fill(arg.uplo);
 

--- a/clients/include/testing_trmm.hpp
+++ b/clients/include/testing_trmm.hpp
@@ -35,8 +35,8 @@ void testing_trmm(const Arguments& arg)
     rocblas_diagonal  diag   = char2rocblas_diagonal(char_diag);
 
     rocblas_int K      = (side == rocblas_side_left ? M : N);
-    size_t      size_A = lda * static_cast<size_t>(K);
-    size_t      size_B = ldb * static_cast<size_t>(N);
+    size_t      size_A = lda * size_t(K);
+    size_t      size_B = ldb * size_t(N);
 
     // check here to prevent undefined memory allocation error
     if(M < 0 || N < 0 || lda < 0 || ldb < 0)

--- a/clients/include/testing_trsm_ex.hpp
+++ b/clients/include/testing_trsm_ex.hpp
@@ -54,8 +54,8 @@ void testing_trsm_ex(const Arguments& arg)
     rocblas_diagonal  diag   = char2rocblas_diagonal(char_diag);
 
     rocblas_int K      = side == rocblas_side_left ? M : N;
-    size_t      size_A = lda * static_cast<size_t>(K);
-    size_t      size_B = ldb * static_cast<size_t>(N);
+    size_t      size_A = lda * size_t(K);
+    size_t      size_B = ldb * size_t(N);
 
     rocblas_local_handle handle;
 

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -22,7 +22,7 @@ void testing_trtri(const Arguments& arg)
     rocblas_int ldinvA;
     ldinvA = lda = arg.lda;
 
-    size_t size_A = static_cast<size_t>(lda) * N;
+    size_t size_A = size_t(lda) * N;
 
     char char_uplo = arg.uplo;
     char char_diag = arg.diag;

--- a/clients/include/testing_trtri_batched.hpp
+++ b/clients/include/testing_trtri_batched.hpp
@@ -23,7 +23,7 @@ void testing_trtri_batched(const Arguments& arg)
     rocblas_int batch_count = arg.batch_count;
 
     rocblas_int bsa    = lda * N;
-    size_t      size_A = static_cast<size_t>(bsa) * batch_count;
+    size_t      size_A = size_t(bsa) * batch_count;
 
     char char_uplo = arg.uplo;
     char char_diag = arg.diag;

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -41,10 +41,19 @@ auto rocblas_simple_dispatch(const Arguments& arg)
 template <template <typename...> class TEST>
 auto rocblas_blas1_dispatch(const Arguments& arg)
 {
-    const auto Ti = arg.a_type, To = arg.d_type;
-
+    const auto Ti = arg.a_type, Tb = arg.b_type, To = arg.d_type;
     if(Ti == To)
-        return rocblas_simple_dispatch<TEST>(arg);
+    {
+        if(Tb == Ti)
+            return rocblas_simple_dispatch<TEST>(arg);
+        else
+        { // for csscal and zdscal only
+            if(Ti == rocblas_datatype_f32_c && Tb == rocblas_datatype_f32_r)
+                return TEST<rocblas_float_complex, float>{}(arg);
+            else if(Ti == rocblas_datatype_f64_c && Tb == rocblas_datatype_f64_r)
+                return TEST<rocblas_double_complex, double>{}(arg);
+        }
+    }
     //  else if(Ti == rocblas_datatype_f16_c && To == rocblas_datatype_f16_r)
     //      return TEST<rocblas_half_complex, rocblas_half>{}(arg);
     else if(Ti == rocblas_datatype_f32_c && To == rocblas_datatype_f32_r)

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -48,18 +48,18 @@ auto rocblas_blas1_dispatch(const Arguments& arg)
             return rocblas_simple_dispatch<TEST>(arg);
         else
         { // for csscal and zdscal only
-            if(Ti == rocblas_datatype_f32_c && Tb == rocblas_datatype_f32_r)
-                return TEST<rocblas_float_complex, float>{}(arg);
-            else if(Ti == rocblas_datatype_f64_c && Tb == rocblas_datatype_f64_r)
-                return TEST<rocblas_double_complex, double>{}(arg);
+            if(Ti == rocblas_datatype_f32_r && Tb == rocblas_datatype_f32_c)
+                return TEST<float, rocblas_float_complex>{}(arg);
+            else if(Ti == rocblas_datatype_f64_r && Tb == rocblas_datatype_f64_c)
+                return TEST<double, rocblas_double_complex>{}(arg);
         }
     }
     //  else if(Ti == rocblas_datatype_f16_c && To == rocblas_datatype_f16_r)
     //      return TEST<rocblas_half_complex, rocblas_half>{}(arg);
-    else if(Ti == rocblas_datatype_f32_c && To == rocblas_datatype_f32_r)
-        return TEST<rocblas_float_complex, float>{}(arg);
-    else if(Ti == rocblas_datatype_f64_c && To == rocblas_datatype_f64_r)
-        return TEST<rocblas_double_complex, double>{}(arg);
+    else if(Ti == rocblas_datatype_f32_r && To == rocblas_datatype_f32_c)
+        return TEST<float, rocblas_float_complex>{}(arg);
+    else if(Ti == rocblas_datatype_f64_r && To == rocblas_datatype_f64_c)
+        return TEST<double, rocblas_double_complex>{}(arg);
 
     return TEST<void>{}(arg);
 }

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -54,12 +54,12 @@ auto rocblas_blas1_dispatch(const Arguments& arg)
                 return TEST<double, rocblas_double_complex>{}(arg);
         }
     }
+    else if(Ti == rocblas_datatype_f32_r && Tb == rocblas_datatype_f32_c)
+        return TEST<float, rocblas_float_complex>{}(arg);
+    else if(Ti == rocblas_datatype_f64_r && Tb == rocblas_datatype_f64_c)
+        return TEST<double, rocblas_double_complex>{}(arg);
     //  else if(Ti == rocblas_datatype_f16_c && To == rocblas_datatype_f16_r)
     //      return TEST<rocblas_half_complex, rocblas_half>{}(arg);
-    else if(Ti == rocblas_datatype_f32_r && To == rocblas_datatype_f32_c)
-        return TEST<float, rocblas_float_complex>{}(arg);
-    else if(Ti == rocblas_datatype_f64_r && To == rocblas_datatype_f64_c)
-        return TEST<double, rocblas_double_complex>{}(arg);
 
     return TEST<void>{}(arg);
 }

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -48,16 +48,16 @@ auto rocblas_blas1_dispatch(const Arguments& arg)
             return rocblas_simple_dispatch<TEST>(arg);
         else
         { // for csscal and zdscal only
-            if(Ti == rocblas_datatype_f32_r && Tb == rocblas_datatype_f32_c)
-                return TEST<float, rocblas_float_complex>{}(arg);
-            else if(Ti == rocblas_datatype_f64_r && Tb == rocblas_datatype_f64_c)
-                return TEST<double, rocblas_double_complex>{}(arg);
+            if(Ti == rocblas_datatype_f32_c && Tb == rocblas_datatype_f32_r)
+                return TEST<rocblas_float_complex, float>{}(arg);
+            else if(Ti == rocblas_datatype_f64_c && Tb == rocblas_datatype_f64_r)
+                return TEST<rocblas_double_complex, double>{}(arg);
         }
     }
-    else if(Ti == rocblas_datatype_f32_r && Tb == rocblas_datatype_f32_c)
-        return TEST<float, rocblas_float_complex>{}(arg);
-    else if(Ti == rocblas_datatype_f64_r && Tb == rocblas_datatype_f64_c)
-        return TEST<double, rocblas_double_complex>{}(arg);
+    else if(Ti == rocblas_datatype_f32_c && Tb == rocblas_datatype_f32_r)
+        return TEST<rocblas_float_complex, float>{}(arg);
+    else if(Ti == rocblas_datatype_f64_c && Tb == rocblas_datatype_f64_r)
+        return TEST<rocblas_double_complex, double>{}(arg);
     //  else if(Ti == rocblas_datatype_f16_c && To == rocblas_datatype_f16_r)
     //      return TEST<rocblas_half_complex, rocblas_half>{}(arg);
 

--- a/clients/include/unit.hpp
+++ b/clients/include/unit.hpp
@@ -37,22 +37,22 @@
 
 #define ASSERT_HALF_EQ(a, b) ASSERT_FLOAT_EQ(half_to_float(a), half_to_float(b))
 
-#define ASSERT_BFLOAT16_EQ(a, b) ASSERT_FLOAT_EQ(static_cast<float>(a), static_cast<float>(b))
+#define ASSERT_BFLOAT16_EQ(a, b) ASSERT_FLOAT_EQ(float(a), float(b))
 
-#define ASSERT_FLOAT_COMPLEX_EQ(a, b) \
-    do                                \
-    {                                 \
-        auto ta = (a), tb = (b);      \
-        ASSERT_FLOAT_EQ(ta.x, tb.x);  \
-        ASSERT_FLOAT_EQ(ta.y, tb.y);  \
+#define ASSERT_FLOAT_COMPLEX_EQ(a, b)                  \
+    do                                                 \
+    {                                                  \
+        auto ta = (a), tb = (b);                       \
+        ASSERT_FLOAT_EQ(std::real(ta), std::real(tb)); \
+        ASSERT_FLOAT_EQ(std::imag(ta), std::imag(tb)); \
     } while(0)
 
-#define ASSERT_DOUBLE_COMPLEX_EQ(a, b) \
-    do                                 \
-    {                                  \
-        auto ta = (a), tb = (b);       \
-        ASSERT_DOUBLE_EQ(ta.x, tb.x);  \
-        ASSERT_DOUBLE_EQ(ta.y, tb.y);  \
+#define ASSERT_DOUBLE_COMPLEX_EQ(a, b)                  \
+    do                                                  \
+    {                                                   \
+        auto ta = (a), tb = (b);                        \
+        ASSERT_DOUBLE_EQ(std::real(ta), std::real(tb)); \
+        ASSERT_DOUBLE_EQ(std::imag(ta), std::imag(tb)); \
     } while(0)
 
 template <typename T>

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -87,6 +87,26 @@ inline void rocblas_print_vector(std::vector<T>& A, size_t M, size_t N, size_t l
 }
 
 /* ============================================================================================ */
+/*! \brief  Common infrastructure for unit/near testing for real and complex values */
+template <typename T>
+inline double getAbsError(T val)
+{
+    return std::abs(val);
+}
+
+template <>
+inline double getAbsError<rocblas_float_complex>(rocblas_float_complex val)
+{
+    return (double)val.magnitude();
+}
+
+template <>
+inline double getAbsError<rocblas_double_complex>(rocblas_double_complex val)
+{
+    return val.magnitude();
+}
+
+/* ============================================================================================ */
 /*! \brief  Debugging purpose, print out CPU and GPU result matrix, not valid in complex number  */
 template <typename T>
 inline void rocblas_print_matrix(

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -87,26 +87,6 @@ inline void rocblas_print_vector(std::vector<T>& A, size_t M, size_t N, size_t l
 }
 
 /* ============================================================================================ */
-/*! \brief  Common infrastructure for unit/near testing for real and complex values */
-template <typename T>
-inline double getMagnitude(T val)
-{
-    return std::abs(val);
-}
-
-template <>
-inline double getMagnitude<rocblas_float_complex>(rocblas_float_complex val)
-{
-    return (double)val.magnitude();
-}
-
-template <>
-inline double getMagnitude<rocblas_double_complex>(rocblas_double_complex val)
-{
-    return val.magnitude();
-}
-
-/* ============================================================================================ */
 /*! \brief  Debugging purpose, print out CPU and GPU result matrix, not valid in complex number  */
 template <typename T>
 inline void rocblas_print_matrix(

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -89,19 +89,19 @@ inline void rocblas_print_vector(std::vector<T>& A, size_t M, size_t N, size_t l
 /* ============================================================================================ */
 /*! \brief  Common infrastructure for unit/near testing for real and complex values */
 template <typename T>
-inline double getAbsError(T val)
+inline double getMagnitude(T val)
 {
     return std::abs(val);
 }
 
 template <>
-inline double getAbsError<rocblas_float_complex>(rocblas_float_complex val)
+inline double getMagnitude<rocblas_float_complex>(rocblas_float_complex val)
 {
     return (double)val.magnitude();
 }
 
 template <>
-inline double getAbsError<rocblas_double_complex>(rocblas_double_complex val)
+inline double getMagnitude<rocblas_double_complex>(rocblas_double_complex val)
 {
     return val.magnitude();
 }

--- a/clients/samples/example_bf16_r_gemm_ex.cpp
+++ b/clients/samples/example_bf16_r_gemm_ex.cpp
@@ -86,7 +86,7 @@ void print_matrix(
     {
         for(int j = 0; j < n && j < max_size; j++)
         {
-            std::cout << std::setw(4) << static_cast<float>(A[i + j * lda]) << " ";
+            std::cout << std::setw(4) << float(A[i + j * lda]) << " ";
         }
         std::cout << "\n";
     }
@@ -117,11 +117,10 @@ void mat_mat_mult(float                          alpha,
             float t = 0.0;
             for(int i3 = 0; i3 < K; i3++)
             {
-                t += static_cast<float>(A[i1 * As1 + i3 * As2])
-                     * static_cast<float>(B[i3 * Bs1 + i2 * Bs2]);
+                t += float(A[i1 * As1 + i3 * As2]) * float(B[i3 * Bs1 + i2 * Bs2]);
             }
-            D[i1 * Ds1 + i2 * Ds2] = static_cast<rocblas_bfloat16>(
-                beta * static_cast<float>(C[i1 * Cs1 + i2 * Cs2]) + alpha * t);
+            D[i1 * Ds1 + i2 * Ds2]
+                = rocblas_bfloat16(beta * float(C[i1 * Cs1 + i2 * Cs2]) + alpha * t);
         }
     }
 }
@@ -325,18 +324,15 @@ void initialize_a_b_c(std::vector<rocblas_bfloat16>& ha,
 {
     for(int i = 0; i < size_a; ++i)
     {
-        ha[i]
-            = static_cast<rocblas_bfloat16>(std::uniform_int_distribution<int>(-3, 3)(rocblas_rng));
+        ha[i] = rocblas_bfloat16(std::uniform_int_distribution<int>(-3, 3)(rocblas_rng));
     }
     for(int i = 0; i < size_b; ++i)
     {
-        hb[i]
-            = static_cast<rocblas_bfloat16>(std::uniform_int_distribution<int>(-3, 3)(rocblas_rng));
+        hb[i] = rocblas_bfloat16(std::uniform_int_distribution<int>(-3, 3)(rocblas_rng));
     }
     for(int i = 0; i < size_c; ++i)
     {
-        hc[i]
-            = static_cast<rocblas_bfloat16>(std::uniform_int_distribution<int>(-3, 3)(rocblas_rng));
+        hc[i] = rocblas_bfloat16(std::uniform_int_distribution<int>(-3, 3)(rocblas_rng));
     }
 }
 
@@ -535,8 +531,7 @@ int main(int argc, char* argv[])
     {
         for(int i_n = 0; i_n < n; i_n++)
         {
-            float error = static_cast<float>(hd_gold[i_m + i_n * ldd])
-                          - static_cast<float>(hd[i_m + i_n * ldd]);
+            float error = float(hd_gold[i_m + i_n * ldd]) - float(hd[i_m + i_n * ldd]);
 
             error = error >= 0 ? error : -error;
 

--- a/clients/samples/example_i8_r_gemm_ex.cpp
+++ b/clients/samples/example_i8_r_gemm_ex.cpp
@@ -65,7 +65,7 @@ void print_matrix(
     {
         for(int j = 0; j < n && j < max_size; j++)
         {
-            std::cout << std::setw(4) << static_cast<int>(A[i + j * lda]) << " ";
+            std::cout << std::setw(4) << int(A[i + j * lda]) << " ";
         }
         std::cout << "\n";
     }
@@ -96,8 +96,7 @@ void mat_mat_mult(int32_t               alpha,
             int32_t t = 0.0;
             for(int i3 = 0; i3 < K; i3++)
             {
-                t += static_cast<int32_t>(A[i1 * As1 + i3 * As2])
-                     * static_cast<int32_t>(B[i3 * Bs1 + i2 * Bs2]);
+                t += int32_t(A[i1 * As1 + i3 * As2]) * int32_t(B[i3 * Bs1 + i2 * Bs2]);
             }
             D[i1 * Ds1 + i2 * Ds2] = beta * C[i1 * Cs1 + i2 * Cs2] + alpha * t;
         }

--- a/library/include/rocblas-complex-types.h
+++ b/library/include/rocblas-complex-types.h
@@ -1,0 +1,366 @@
+/* ************************************************************************
+ * Copyright 2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+/*! \file
+ * \brief rocblas-complex-types.h defines complex data types used by rocblas
+ */
+
+#pragma once
+#ifndef _ROCBLAS_COMPLEX_TYPES_H_
+#define _ROCBLAS_COMPLEX_TYPES_H_
+
+#if __cplusplus < 201402L || !defined(__HCC__)
+
+// If this is a C compiler, C++ compiler below C++14, or a host-only compiler, we only
+// include minimal definitions of rocblas_float_complex and rocblas_double_complex
+
+typedef struct
+{
+    float x, y;
+} rocblas_float_complex;
+typedef struct
+{
+    double x, y;
+} rocblas_double_complex;
+
+#else // __cplusplus < 201402L || !defined(__HCC__)
+
+// If this a full internal build, we need full support of complex arithmetic
+// and classes. We need __host__ and __device__ so we use <hip/hip_runtime.h>.
+
+#include <complex>
+#include <hip/hip_runtime.h>
+#include <math.h>
+#include <ostream>
+#include <type_traits>
+
+/*! \brief rocblas_complex_num is a structure which represents a complex number
+ *         with precision T.
+ */
+template <typename T>
+class rocblas_complex_num
+{
+    T x; // The real part of the number.
+    T y; // The imaginary part of the number.
+
+    // Internal real absolute function, to be sure we're on both device and host
+    static __forceinline__ __device__ __host__ T abs(T r)
+    {
+        return r < 0 ? -r : r;
+    }
+
+public:
+    // We do not initialize the members x or y by default, to ensure that it can
+    // be used in __shared__ and that it is a trivial class compatible with C.
+    __device__ __host__ rocblas_complex_num()                           = default;
+    __device__ __host__ rocblas_complex_num(const rocblas_complex_num&) = default;
+    __device__ __host__ rocblas_complex_num(rocblas_complex_num&&)      = default;
+    __device__ __host__ rocblas_complex_num& operator=(const rocblas_complex_num& rhs) = default;
+    __device__ __host__ rocblas_complex_num& operator=(rocblas_complex_num&& rhs) = default;
+    __device__                               __host__ ~rocblas_complex_num()      = default;
+
+    // Constructor
+    __device__ __host__ rocblas_complex_num(T r, T i)
+        : x(r)
+        , y(i)
+    {
+    }
+
+    // Conversion from real
+    __device__ __host__ rocblas_complex_num(T r)
+        : x(r)
+        , y(0)
+    {
+    }
+
+    // Conversion from different complex (explicit)
+    template <typename U, typename std::enable_if<std::is_constructible<T, U>{}, int>::type = 0>
+    __device__ __host__ explicit rocblas_complex_num(const rocblas_complex_num<U>& z)
+        : x(z.x)
+        , y(z.y)
+    {
+    }
+
+    // Conversion to bool
+    __device__ __host__ explicit operator bool() const
+    {
+        return x || y;
+    }
+
+    // Accessors
+    friend __device__ __host__ T std::real(const rocblas_complex_num& z);
+    friend __device__ __host__ T std::imag(const rocblas_complex_num& z);
+
+    // stream output
+    friend auto& operator<<(std::ostream& out, const rocblas_complex_num& z)
+    {
+        return out << '(' << z.x << ',' << z.y << ')';
+    }
+
+    // complex-real operations
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    __device__ __host__ auto& operator+=(const U& rhs)
+    {
+        return (x += T(rhs)), *this;
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}>::type* = 0>
+    __device__ __host__ auto& operator-=(const U& rhs)
+    {
+        return (x -= T(rhs)), *this;
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    __device__ __host__ auto& operator*=(const U& rhs)
+    {
+        return (x *= rhs), (y *= T(rhs)), *this;
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    __device__ __host__ auto& operator/=(const U& rhs)
+    {
+        return (x /= T(rhs)), (y /= T(rhs)), *this;
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    __device__ __host__ bool operator==(const U& rhs) const
+    {
+        return x == T(rhs) && y == 0;
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    __device__ __host__ bool operator!=(const U& rhs) const
+    {
+        return !(*this == rhs);
+    }
+
+    // Increment and decrement
+    __device__ __host__ auto& operator++()
+    {
+        return ++x, *this;
+    }
+
+    __device__ __host__ rocblas_complex_num operator++(int)
+    {
+        return {x++, y};
+    }
+
+    __device__ __host__ auto& operator--()
+    {
+        return --x, *this;
+    }
+
+    __device__ __host__ rocblas_complex_num operator--(int)
+    {
+        return {x--, y};
+    }
+
+    // Unary operations
+    __device__ __host__ rocblas_complex_num operator-() const
+    {
+        return {-x, -y};
+    }
+
+    __device__ __host__ rocblas_complex_num operator+() const
+    {
+        return *this;
+    }
+
+    friend __device__ __host__ T asum(const rocblas_complex_num& z)
+    {
+        return abs(z.x) + abs(z.y);
+    }
+
+    friend __device__ __host__ rocblas_complex_num std::conj(const rocblas_complex_num& z);
+    friend __device__ __host__ T                   std::norm(const rocblas_complex_num& z);
+    friend __device__ T                            std::abs(const rocblas_complex_num& z);
+    friend __host__ T                              std::abs(const rocblas_complex_num& z);
+
+    // in-place complex-complex operations
+    __device__ __host__ auto& operator*=(const rocblas_complex_num& rhs)
+    {
+        return *this = {x * rhs.x - y * rhs.y, y * rhs.x + x * rhs.y};
+    }
+
+    __device__ __host__ auto& operator+=(const rocblas_complex_num& rhs)
+    {
+        return *this = {x + rhs.x, y + rhs.y};
+    }
+
+    __device__ __host__ auto& operator-=(const rocblas_complex_num& rhs)
+    {
+        return *this = {x - rhs.x, y - rhs.y};
+    }
+
+    __device__ __host__ auto& operator/=(const rocblas_complex_num& rhs)
+    {
+        if(abs(rhs.x) > abs(rhs.y))
+        {
+            T ratio = rhs.y / rhs.x;
+            T scale = 1 / (rhs.x + rhs.y * ratio);
+            *this   = {(x + y * ratio) * scale, (y - x * ratio) * scale};
+        }
+        else
+        {
+            T ratio = rhs.x / rhs.y;
+            T scale = 1 / (rhs.x * ratio + rhs.y);
+            *this   = {(y + x * ratio) * scale, (y * ratio - x) * scale};
+        }
+        return *this;
+    }
+
+    // out-of-place complex-complex operations
+    __device__ __host__ auto operator+(const rocblas_complex_num& rhs) const
+    {
+        auto lhs = *this;
+        return lhs += rhs;
+    }
+
+    __device__ __host__ auto operator-(const rocblas_complex_num& rhs) const
+    {
+        auto lhs = *this;
+        return lhs -= rhs;
+    }
+
+    __device__ __host__ auto operator*(const rocblas_complex_num& rhs) const
+    {
+        auto lhs = *this;
+        return lhs *= rhs;
+    }
+
+    __device__ __host__ auto operator/(const rocblas_complex_num& rhs) const
+    {
+        auto lhs = *this;
+        return lhs /= rhs;
+    }
+
+    __device__ __host__ bool operator==(const rocblas_complex_num& rhs) const
+    {
+        return x == rhs.x && y == rhs.y;
+    }
+
+    __device__ __host__ bool operator!=(const rocblas_complex_num& rhs) const
+    {
+        return !(*this == rhs);
+    }
+
+    // real-complex operations (complex-real is handled above)
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    friend __device__ __host__ rocblas_complex_num operator+(const U&                   lhs,
+                                                             const rocblas_complex_num& rhs)
+    {
+        return {T(lhs) + rhs.x, rhs.y};
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    friend __device__ __host__ rocblas_complex_num operator-(const U&                   lhs,
+                                                             const rocblas_complex_num& rhs)
+    {
+        return {T(lhs) - rhs.x, -rhs.y};
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    friend __device__ __host__ rocblas_complex_num operator*(const U&                   lhs,
+                                                             const rocblas_complex_num& rhs)
+    {
+        return {T(lhs) * rhs.x, T(lhs) * rhs.y};
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    friend __device__ __host__ rocblas_complex_num operator/(const U&                   lhs,
+                                                             const rocblas_complex_num& rhs)
+    {
+        if(abs(rhs.x) > abs(rhs.y))
+        {
+            T ratio = rhs.y / rhs.x;
+            T scale = T(lhs) / (rhs.x + rhs.y * ratio);
+            return {scale, -scale * ratio};
+        }
+        else
+        {
+            T ratio = rhs.x / rhs.y;
+            T scale = T(lhs) / (rhs.x * ratio + rhs.y);
+            return {ratio * scale, -scale};
+        }
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    friend __device__ __host__ bool operator==(const U& lhs, const rocblas_complex_num& rhs)
+    {
+        return T(lhs) == rhs.x && 00 == rhs.y;
+    }
+
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    friend __device__ __host__ bool operator!=(const U& lhs, const rocblas_complex_num& rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+// Inject standard functions into namespace std
+namespace std
+{
+    template <typename T>
+    __device__ __host__ T real(const rocblas_complex_num<T>& z)
+    {
+        return z.x;
+    }
+
+    template <typename T>
+    __device__ __host__ T imag(const rocblas_complex_num<T>& z)
+    {
+        return z.y;
+    }
+
+    template <typename T>
+    __device__ __host__ rocblas_complex_num<T> conj(const rocblas_complex_num<T>& z)
+    {
+        return {z.x, -z.y};
+    }
+
+    template <typename T>
+    __device__ __host__ T norm(const rocblas_complex_num<T>& z)
+    {
+        return (z.x * z.x) + (z.y * z.y);
+    }
+
+    // We must define abs twice separately in order to resolve sqrt() correctly
+#define ROCBLAS_COMPLEX_ABS(DEVICE_HOST)                                                          \
+    template <typename T>                                                                         \
+    DEVICE_HOST T abs(const rocblas_complex_num<T>& z)                                            \
+    {                                                                                             \
+        T tr = abs(z.x), ti = abs(z.y);                                                           \
+        return tr > ti ? (ti /= tr, tr * sqrt(ti * ti + 1)) : (tr /= ti, ti * sqrt(tr * tr + 1)); \
+    }
+
+    ROCBLAS_COMPLEX_ABS(__device__)
+    ROCBLAS_COMPLEX_ABS(__host__)
+}
+
+// Test for C compatibility
+template <typename T>
+class rocblas_complex_num_check
+{
+    static_assert(
+        std::is_standard_layout<rocblas_complex_num<T>>{},
+        "rocblas_complex_num<T> is not a standard layout type, and thus is incompatible with C.");
+
+    static_assert(std::is_trivial<rocblas_complex_num<T>>{},
+                  "rocblas_complex_num<T> is not a trivial type, and thus is incompatible with C.");
+
+    static_assert(
+        sizeof(rocblas_complex_num<T>) == 2 * sizeof(T),
+        "rocblas_complex_num<T> is not the correct size, and thus is incompatible with C.");
+};
+
+template class rocblas_complex_num_check<float>;
+template class rocblas_complex_num_check<double>;
+
+// rocBLAS complex data types
+using rocblas_float_complex  = rocblas_complex_num<float>;
+using rocblas_double_complex = rocblas_complex_num<double>;
+
+#endif // __cplusplus < 201402L || !defined(__HCC__)
+
+#endif

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -101,15 +101,17 @@ ROCBLAS_EXPORT rocblas_status rocblas_zscal(rocblas_handle                handle
                                             rocblas_double_complex*       x,
                                             rocblas_int                   incx);
 
-ROCBLAS_EXPORT rocblas_status rocblas_csscal(rocblas_handle handle,
-                                             rocblas_int n,
-                                             const float *alpha,
-                                             rocblas_float_complex *x, rocblas_int incx);
+ROCBLAS_EXPORT rocblas_status rocblas_csscal(rocblas_handle         handle,
+                                             rocblas_int            n,
+                                             const float*           alpha,
+                                             rocblas_float_complex* x,
+                                             rocblas_int            incx);
 
-ROCBLAS_EXPORT rocblas_status rocblas_zdscal(rocblas_handle handle,
-                                             rocblas_int n,
-                                             const double *alpha,
-                                             rocblas_double_complex *x, rocblas_int incx);
+ROCBLAS_EXPORT rocblas_status rocblas_zdscal(rocblas_handle          handle,
+                                             rocblas_int             n,
+                                             const double*           alpha,
+                                             rocblas_double_complex* x,
+                                             rocblas_int             incx);
 
 /*! \brief BLAS Level 1 API
 
@@ -149,15 +151,19 @@ ROCBLAS_EXPORT rocblas_status rocblas_dcopy(rocblas_handle handle,
                                             double*        y,
                                             rocblas_int    incy);
 
-ROCBLAS_EXPORT rocblas_status rocblas_ccopy(rocblas_handle handle,
-                                            rocblas_int n,
-                                            const rocblas_float_complex *x, rocblas_int incx,
-                                            rocblas_float_complex* y,       rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_ccopy(rocblas_handle               handle,
+                                            rocblas_int                  n,
+                                            const rocblas_float_complex* x,
+                                            rocblas_int                  incx,
+                                            rocblas_float_complex*       y,
+                                            rocblas_int                  incy);
 
-ROCBLAS_EXPORT rocblas_status rocblas_zcopy(rocblas_handle handle,
-                                            rocblas_int n,
-                                            const rocblas_double_complex *x, rocblas_int incx,
-                                            rocblas_double_complex* y,       rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_zcopy(rocblas_handle                handle,
+                                            rocblas_int                   n,
+                                            const rocblas_double_complex* x,
+                                            rocblas_int                   incx,
+                                            rocblas_double_complex*       y,
+                                            rocblas_int                   incy);
 
 /*! \brief BLAS Level 1 API
 
@@ -265,16 +271,19 @@ ROCBLAS_EXPORT rocblas_status rocblas_sswap(
 ROCBLAS_EXPORT rocblas_status rocblas_dswap(
     rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status rocblas_cswap(rocblas_handle handle,
-                                            rocblas_int n,
-                                            rocblas_float_complex *x, rocblas_int incx,
-                                            rocblas_float_complex* y, rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_cswap(rocblas_handle         handle,
+                                            rocblas_int            n,
+                                            rocblas_float_complex* x,
+                                            rocblas_int            incx,
+                                            rocblas_float_complex* y,
+                                            rocblas_int            incy);
 
-ROCBLAS_EXPORT rocblas_status rocblas_zswap(rocblas_handle handle,
-                                            rocblas_int n,
-                                            rocblas_double_complex *x, rocblas_int incx,
-                                            rocblas_double_complex* y, rocblas_int incy);
-
+ROCBLAS_EXPORT rocblas_status rocblas_zswap(rocblas_handle          handle,
+                                            rocblas_int             n,
+                                            rocblas_double_complex* x,
+                                            rocblas_int             incx,
+                                            rocblas_double_complex* y,
+                                            rocblas_int             incy);
 
 /*! \brief BLAS Level 1 API
 
@@ -583,6 +592,32 @@ ROCBLAS_EXPORT rocblas_status rocblas_dgemv(rocblas_handle    handle,
                                             double*           y,
                                             rocblas_int       incy);
 
+ROCBLAS_EXPORT rocblas_status rocblas_cgemv(rocblas_handle               handle,
+                                            rocblas_operation            trans,
+                                            rocblas_int                  m,
+                                            rocblas_int                  n,
+                                            const rocblas_float_complex* alpha,
+                                            const rocblas_float_complex* A,
+                                            rocblas_int                  lda,
+                                            const rocblas_float_complex* x,
+                                            rocblas_int                  incx,
+                                            const rocblas_float_complex* beta,
+                                            rocblas_float_complex*       y,
+                                            rocblas_int                  incy);
+
+// ROCBLAS_EXPORT rocblas_status rocblas_zgemv(rocblas_handle                    handle,
+//                                             rocblas_operation                 trans,
+//                                             rocblas_int                       m,
+//                                             rocblas_int                       n,
+//                                             const rocblas_double_complex*     alpha,
+//                                             const rocblas_double_complex*     A,
+//                                             rocblas_int                       lda,
+//                                             const rocblas_double_complex*     x,
+//                                             rocblas_int                       incx,
+//                                             const rocblas_double_complex*     beta,
+//                                             rocblas_double_complex*           y,
+//                                             rocblas_int                       incy);
+
 /*! \brief BLAS Level 2 API
 
     \details
@@ -659,6 +694,34 @@ ROCBLAS_EXPORT rocblas_status rocblas_dgemv_batched(rocblas_handle      handle,
                                                     double* const       y[],
                                                     rocblas_int         incy,
                                                     rocblas_int         batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_cgemv_batched(rocblas_handle                     handle,
+                                                    rocblas_operation                  trans,
+                                                    rocblas_int                        m,
+                                                    rocblas_int                        n,
+                                                    const rocblas_float_complex*       alpha,
+                                                    const rocblas_float_complex* const A[],
+                                                    rocblas_int                        lda,
+                                                    const rocblas_float_complex* const x[],
+                                                    rocblas_int                        incx,
+                                                    const rocblas_float_complex*       beta,
+                                                    rocblas_float_complex* const       y[],
+                                                    rocblas_int                        incy,
+                                                    rocblas_int                        batch_count);
+
+// ROCBLAS_EXPORT rocblas_status rocblas_zgemv_batched(rocblas_handle                      handle,
+//                                                     rocblas_operation                   trans,
+//                                                     rocblas_int                         m,
+//                                                     rocblas_int                         n,
+//                                                     const rocblas_double_complex*       alpha,
+//                                                     const rocblas_double_complex* const A[],
+//                                                     rocblas_int                         lda,
+//                                                     const rocblas_double_complex* const x[],
+//                                                     rocblas_int                         incx,
+//                                                     const rocblas_double_complex*       beta,
+//                                                     rocblas_double_complex* const       y[],
+//                                                     rocblas_int                         incy,
+//                                                     rocblas_int                         batch_count);
 
 /*! \brief BLAS Level 2 API
 
@@ -752,6 +815,40 @@ ROCBLAS_EXPORT rocblas_status rocblas_dgemv_strided_batched(rocblas_handle    ha
                                                             rocblas_int       stridey,
                                                             rocblas_int       batch_count);
 
+ROCBLAS_EXPORT rocblas_status rocblas_cgemv_strided_batched(rocblas_handle               handle,
+                                                            rocblas_operation            transA,
+                                                            rocblas_int                  m,
+                                                            rocblas_int                  n,
+                                                            const rocblas_float_complex* alpha,
+                                                            const rocblas_float_complex* A,
+                                                            rocblas_int                  lda,
+                                                            rocblas_int                  strideA,
+                                                            const rocblas_float_complex* x,
+                                                            rocblas_int                  incx,
+                                                            rocblas_int                  stridex,
+                                                            const rocblas_float_complex* beta,
+                                                            rocblas_float_complex*       y,
+                                                            rocblas_int                  incy,
+                                                            rocblas_int                  stridey,
+                                                            rocblas_int batch_count);
+
+// ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                    handle,
+//                                                             rocblas_operation                 transA,
+//                                                             rocblas_int                       m,
+//                                                             rocblas_int                       n,
+//                                                             const rocblas_double_complex*     alpha,
+//                                                             const rocblas_double_complex*     A,
+//                                                             rocblas_int                       lda,
+//                                                             rocblas_int                       strideA,
+//                                                             const rocblas_double_complex*     x,
+//                                                             rocblas_int                       incx,
+//                                                             rocblas_int                       stridex,
+//                                                             const rocblas_double_complex*     beta,
+//                                                             rocblas_double_complex*           y,
+//                                                             rocblas_int                       incy,
+//                                                             rocblas_int                       stridey,
+//                                                             rocblas_int                       batch_count);
+
 /*! \brief BLAS Level 2 API
 
     \details
@@ -823,28 +920,6 @@ ROCBLAS_EXPORT rocblas_status rocblas_dtrsv(rocblas_handle    handle,
                                             rocblas_int       lda,
                                             double*           x,
                                             rocblas_int       incx);
-
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_cgemv(rocblas_handle handle,
-                 rocblas_operation trans,
-                 rocblas_int m, rocblas_int n,
-                 const rocblas_float_complex *alpha,
-                 const rocblas_float_complex *A, rocblas_int lda,
-                 const rocblas_float_complex *x, rocblas_int incx,
-                 const rocblas_float_complex *beta,
-                 rocblas_float_complex *y, rocblas_int incy);
-
-ROCBLAS_EXPORT rocblas_status
-rocblas_zgemv(rocblas_handle handle,
-                 rocblas_operation trans,
-                 rocblas_int m, rocblas_int n,
-                 const rocblas_double_complex *alpha,
-                 const rocblas_double_complex *A, rocblas_int lda,
-                 const rocblas_double_complex *x, rocblas_int incx,
-                 const rocblas_double_complex *beta,
-                 rocblas_double_complex *y, rocblas_int incy);
-*/
 
 /*! \brief BLAS Level 2 API
 

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -605,18 +605,18 @@ ROCBLAS_EXPORT rocblas_status rocblas_cgemv(rocblas_handle               handle,
                                             rocblas_float_complex*       y,
                                             rocblas_int                  incy);
 
-// ROCBLAS_EXPORT rocblas_status rocblas_zgemv(rocblas_handle                    handle,
-//                                             rocblas_operation                 trans,
-//                                             rocblas_int                       m,
-//                                             rocblas_int                       n,
-//                                             const rocblas_double_complex*     alpha,
-//                                             const rocblas_double_complex*     A,
-//                                             rocblas_int                       lda,
-//                                             const rocblas_double_complex*     x,
-//                                             rocblas_int                       incx,
-//                                             const rocblas_double_complex*     beta,
-//                                             rocblas_double_complex*           y,
-//                                             rocblas_int                       incy);
+ROCBLAS_EXPORT rocblas_status rocblas_zgemv(rocblas_handle                handle,
+                                            rocblas_operation             trans,
+                                            rocblas_int                   m,
+                                            rocblas_int                   n,
+                                            const rocblas_double_complex* alpha,
+                                            const rocblas_double_complex* A,
+                                            rocblas_int                   lda,
+                                            const rocblas_double_complex* x,
+                                            rocblas_int                   incx,
+                                            const rocblas_double_complex* beta,
+                                            rocblas_double_complex*       y,
+                                            rocblas_int                   incy);
 
 /*! \brief BLAS Level 2 API
 

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -178,19 +178,15 @@ ROCBLAS_EXPORT rocblas_status rocblas_dcopy(rocblas_handle handle,
                                             double*        y,
                                             rocblas_int    incy);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_ccopy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    rocblas_float_complex* y,       rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_ccopy(rocblas_handle handle,
+                                            rocblas_int n,
+                                            const rocblas_float_complex *x, rocblas_int incx,
+                                            rocblas_float_complex* y,       rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_zcopy(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    rocblas_double_complex* y,       rocblas_int incy);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_zcopy(rocblas_handle handle,
+                                            rocblas_int n,
+                                            const rocblas_double_complex *x, rocblas_int incx,
+                                            rocblas_double_complex* y,       rocblas_int incy);
 
 /*! \brief BLAS Level 1 API
 
@@ -298,19 +294,16 @@ ROCBLAS_EXPORT rocblas_status rocblas_sswap(
 ROCBLAS_EXPORT rocblas_status rocblas_dswap(
     rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_cswap(rocblas_handle handle,
-    rocblas_int n,
-    rocblas_float_complex *x, rocblas_int incx,
-    rocblas_float_complex* y, rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_cswap(rocblas_handle handle,
+                                            rocblas_int n,
+                                            rocblas_float_complex *x, rocblas_int incx,
+                                            rocblas_float_complex* y, rocblas_int incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_zswap(rocblas_handle handle,
-    rocblas_int n,
-    rocblas_double_complex *x, rocblas_int incx,
-    rocblas_double_complex* y, rocblas_int incy);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_zswap(rocblas_handle handle,
+                                            rocblas_int n,
+                                            rocblas_double_complex *x, rocblas_int incx,
+                                            rocblas_double_complex* y, rocblas_int incy);
+
 
 /*! \brief BLAS Level 1 API
 

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -709,19 +709,19 @@ ROCBLAS_EXPORT rocblas_status rocblas_cgemv_batched(rocblas_handle              
                                                     rocblas_int                        incy,
                                                     rocblas_int                        batch_count);
 
-// ROCBLAS_EXPORT rocblas_status rocblas_zgemv_batched(rocblas_handle                      handle,
-//                                                     rocblas_operation                   trans,
-//                                                     rocblas_int                         m,
-//                                                     rocblas_int                         n,
-//                                                     const rocblas_double_complex*       alpha,
-//                                                     const rocblas_double_complex* const A[],
-//                                                     rocblas_int                         lda,
-//                                                     const rocblas_double_complex* const x[],
-//                                                     rocblas_int                         incx,
-//                                                     const rocblas_double_complex*       beta,
-//                                                     rocblas_double_complex* const       y[],
-//                                                     rocblas_int                         incy,
-//                                                     rocblas_int                         batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_zgemv_batched(rocblas_handle                      handle,
+                                                    rocblas_operation                   trans,
+                                                    rocblas_int                         m,
+                                                    rocblas_int                         n,
+                                                    const rocblas_double_complex*       alpha,
+                                                    const rocblas_double_complex* const A[],
+                                                    rocblas_int                         lda,
+                                                    const rocblas_double_complex* const x[],
+                                                    rocblas_int                         incx,
+                                                    const rocblas_double_complex*       beta,
+                                                    rocblas_double_complex* const       y[],
+                                                    rocblas_int                         incy,
+                                                    rocblas_int                         batch_count);
 
 /*! \brief BLAS Level 2 API
 
@@ -832,22 +832,22 @@ ROCBLAS_EXPORT rocblas_status rocblas_cgemv_strided_batched(rocblas_handle      
                                                             rocblas_int                  stridey,
                                                             rocblas_int batch_count);
 
-// ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                    handle,
-//                                                             rocblas_operation                 transA,
-//                                                             rocblas_int                       m,
-//                                                             rocblas_int                       n,
-//                                                             const rocblas_double_complex*     alpha,
-//                                                             const rocblas_double_complex*     A,
-//                                                             rocblas_int                       lda,
-//                                                             rocblas_int                       strideA,
-//                                                             const rocblas_double_complex*     x,
-//                                                             rocblas_int                       incx,
-//                                                             rocblas_int                       stridex,
-//                                                             const rocblas_double_complex*     beta,
-//                                                             rocblas_double_complex*           y,
-//                                                             rocblas_int                       incy,
-//                                                             rocblas_int                       stridey,
-//                                                             rocblas_int                       batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                    handle,
+                                                            rocblas_operation                 transA,
+                                                            rocblas_int                       m,
+                                                            rocblas_int                       n,
+                                                            const rocblas_double_complex*     alpha,
+                                                            const rocblas_double_complex*     A,
+                                                            rocblas_int                       lda,
+                                                            rocblas_int                       strideA,
+                                                            const rocblas_double_complex*     x,
+                                                            rocblas_int                       incx,
+                                                            rocblas_int                       stridex,
+                                                            const rocblas_double_complex*     beta,
+                                                            rocblas_double_complex*           y,
+                                                            rocblas_int                       incy,
+                                                            rocblas_int                       stridey,
+                                                            rocblas_int                       batch_count);
 
 /*! \brief BLAS Level 2 API
 

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -721,7 +721,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_zgemv_batched(rocblas_handle              
                                                     const rocblas_double_complex*       beta,
                                                     rocblas_double_complex* const       y[],
                                                     rocblas_int                         incy,
-                                                    rocblas_int                         batch_count);
+                                                    rocblas_int batch_count);
 
 /*! \brief BLAS Level 2 API
 
@@ -832,22 +832,22 @@ ROCBLAS_EXPORT rocblas_status rocblas_cgemv_strided_batched(rocblas_handle      
                                                             rocblas_int                  stridey,
                                                             rocblas_int batch_count);
 
-ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                    handle,
-                                                            rocblas_operation                 transA,
-                                                            rocblas_int                       m,
-                                                            rocblas_int                       n,
-                                                            const rocblas_double_complex*     alpha,
-                                                            const rocblas_double_complex*     A,
-                                                            rocblas_int                       lda,
-                                                            rocblas_int                       strideA,
-                                                            const rocblas_double_complex*     x,
-                                                            rocblas_int                       incx,
-                                                            rocblas_int                       stridex,
-                                                            const rocblas_double_complex*     beta,
-                                                            rocblas_double_complex*           y,
-                                                            rocblas_int                       incy,
-                                                            rocblas_int                       stridey,
-                                                            rocblas_int                       batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                handle,
+                                                            rocblas_operation             transA,
+                                                            rocblas_int                   m,
+                                                            rocblas_int                   n,
+                                                            const rocblas_double_complex* alpha,
+                                                            const rocblas_double_complex* A,
+                                                            rocblas_int                   lda,
+                                                            rocblas_int                   strideA,
+                                                            const rocblas_double_complex* x,
+                                                            rocblas_int                   incx,
+                                                            rocblas_int                   stridex,
+                                                            const rocblas_double_complex* beta,
+                                                            rocblas_double_complex*       y,
+                                                            rocblas_int                   incy,
+                                                            rocblas_int                   stridey,
+                                                            rocblas_int batch_count);
 
 /*! \brief BLAS Level 2 API
 

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -101,44 +101,15 @@ ROCBLAS_EXPORT rocblas_status rocblas_zscal(rocblas_handle                handle
                                             rocblas_double_complex*       x,
                                             rocblas_int                   incx);
 
-/*
- * ===========================================================================
- *    level 1 BLAS
- * ===========================================================================
- */
+ROCBLAS_EXPORT rocblas_status rocblas_csscal(rocblas_handle handle,
+                                             rocblas_int n,
+                                             const float *alpha,
+                                             rocblas_float_complex *x, rocblas_int incx);
 
-/*! \brief BLAS Level 1 API
-
-    \details
-    scalrc  scal the complex vector x[i] with real scalar alpha, for  i = 1 , … , n
-
-        x := alpha * x ,
-
-    @param[in]
-    handle    rocblas_handle.
-              handle to the rocblas library context queue.
-    @param[in]
-    n         rocblas_int.
-    @param[in]
-    alpha     specifies the real scalar alpha.
-    @param[inout]
-    x         pointer storing complex vector x on the GPU.
-    @param[in]
-    incx      specifies the increment for the elements of x.
-
-
-    ********************************************************************/
-ROCBLAS_EXPORT rocblas_status rocblas_csscal(rocblas_handle         handle,
-                                             rocblas_int            n,
-                                             const float*           alpha,
-                                             rocblas_float_complex* x,
-                                             rocblas_int            incx);
-
-ROCBLAS_EXPORT rocblas_status rocblas_zdscal(rocblas_handle          handle,
-                                             rocblas_int             n,
-                                             const double*           alpha,
-                                             rocblas_double_complex* x,
-                                             rocblas_int             incx);
+ROCBLAS_EXPORT rocblas_status rocblas_zdscal(rocblas_handle handle,
+                                             rocblas_int n,
+                                             const double *alpha,
+                                             rocblas_double_complex *x, rocblas_int incx);
 
 /*! \brief BLAS Level 1 API
 
@@ -2418,34 +2389,6 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle    
     compute_type rocblas_datatype
             specifies the datatype of computation
 
-<<<<<<< HEAD
-=======
-    @param[in]
-    option  rocblas_trsm_option
-            enumerant specifying the selected trsm memory option.
-            -   rocblas_trsm_high_performance
-            -   rocblas_trsm_low_memory
-            Trsm can choose algorithms that either use large work memory size in order
-            to get high performance, or small work memory with reduced performance.
-            User can inspect returned work memory size to fit their application needs.
-    @param[in, out]
-    x_temp_size size_t*
-            During setup the suggested size of x_temp is returned with respect
-            to the selected rocblas_trsm_option.
-            During run x_temp_size specifies the size allocated for
-            x_temp_workspace
-            Note: Must use rocblas_trsm_high_performance suggest size
-            If rocblas_side_left and m is not a multiple of 128
-            If rocblas_side_right and n is not a multiple of 128
-    @parm[in]
-    x_temp_workspace void*
-            During setup x_temp_workspace must hold a null pointer to signal
-            the request for x_temp_size
-            During run x_temp_workspace is a pointer to store temporary matrix X
-            on the GPU.
-            x_temp_workspace is of dimension ( m, x_temp_size/m )
-
->>>>>>> develop
     ********************************************************************/
 
 ROCBLAS_EXPORT rocblas_status rocblas_trsm_ex(rocblas_handle    handle,

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -89,19 +89,56 @@ ROCBLAS_EXPORT rocblas_status rocblas_sscal(
 ROCBLAS_EXPORT rocblas_status rocblas_dscal(
     rocblas_handle handle, rocblas_int n, const double* alpha, double* x, rocblas_int incx);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_cscal(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *alpha,
-    rocblas_float_complex *x, rocblas_int incx);
+ROCBLAS_EXPORT rocblas_status rocblas_cscal(rocblas_handle               handle,
+                                            rocblas_int                  n,
+                                            const rocblas_float_complex* alpha,
+                                            rocblas_float_complex*       x,
+                                            rocblas_int                  incx);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_zscal(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *alpha,
-    rocblas_double_complex *x, rocblas_int incx);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_zscal(rocblas_handle                handle,
+                                            rocblas_int                   n,
+                                            const rocblas_double_complex* alpha,
+                                            rocblas_double_complex*       x,
+                                            rocblas_int                   incx);
+
+/*
+ * ===========================================================================
+ *    level 1 BLAS
+ * ===========================================================================
+ */
+
+/*! \brief BLAS Level 1 API
+
+    \details
+    scalrc  scal the complex vector x[i] with real scalar alpha, for  i = 1 , … , n
+
+        x := alpha * x ,
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    n         rocblas_int.
+    @param[in]
+    alpha     specifies the real scalar alpha.
+    @param[inout]
+    x         pointer storing complex vector x on the GPU.
+    @param[in]
+    incx      specifies the increment for the elements of x.
+
+
+    ********************************************************************/
+ROCBLAS_EXPORT rocblas_status rocblas_csscal(rocblas_handle         handle,
+                                             rocblas_int            n,
+                                             const float*           alpha,
+                                             rocblas_float_complex* x,
+                                             rocblas_int            incx);
+
+ROCBLAS_EXPORT rocblas_status rocblas_zdscal(rocblas_handle          handle,
+                                             rocblas_int             n,
+                                             const double*           alpha,
+                                             rocblas_double_complex* x,
+                                             rocblas_int             incx);
 
 /*! \brief BLAS Level 1 API
 
@@ -199,21 +236,37 @@ ROCBLAS_EXPORT rocblas_status rocblas_ddot(rocblas_handle handle,
                                            rocblas_int    incy,
                                            double*        result);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_cdotu(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    const rocblas_float_complex *y, rocblas_int incy,
-    rocblas_float_complex *result);
+ROCBLAS_EXPORT rocblas_status rocblas_cdotu(rocblas_handle               handle,
+                                            rocblas_int                  n,
+                                            const rocblas_float_complex* x,
+                                            rocblas_int                  incx,
+                                            const rocblas_float_complex* y,
+                                            rocblas_int                  incy,
+                                            rocblas_float_complex*       result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_zdotu(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    const rocblas_double_complex *y, rocblas_int incy,
-    rocblas_double_complex *result);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_zdotu(rocblas_handle                handle,
+                                            rocblas_int                   n,
+                                            const rocblas_double_complex* x,
+                                            rocblas_int                   incx,
+                                            const rocblas_double_complex* y,
+                                            rocblas_int                   incy,
+                                            rocblas_double_complex*       result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_cdotc(rocblas_handle               handle,
+                                            rocblas_int                  n,
+                                            const rocblas_float_complex* x,
+                                            rocblas_int                  incx,
+                                            const rocblas_float_complex* y,
+                                            rocblas_int                  incy,
+                                            rocblas_float_complex*       result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_zdotc(rocblas_handle                handle,
+                                            rocblas_int                   n,
+                                            const rocblas_double_complex* x,
+                                            rocblas_int                   incx,
+                                            const rocblas_double_complex* y,
+                                            rocblas_int                   incy,
+                                            rocblas_double_complex*       result);
 
 /*! \brief BLAS Level 1 API
 
@@ -308,21 +361,21 @@ ROCBLAS_EXPORT rocblas_status rocblas_daxpy(rocblas_handle handle,
                                             double*        y,
                                             rocblas_int    incy);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_caxpy(rocblas_handle handle,
-rocblas_int n,
-const rocblas_float_complex *alpha,
-const rocblas_float_complex *x, rocblas_int incx,
-rocblas_float_complex *y,  rocblas_int incy);
+ROCBLAS_EXPORT rocblas_status rocblas_caxpy(rocblas_handle               handle,
+                                            rocblas_int                  n,
+                                            const rocblas_float_complex* alpha,
+                                            const rocblas_float_complex* x,
+                                            rocblas_int                  incx,
+                                            rocblas_float_complex*       y,
+                                            rocblas_int                  incy);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_zaxpy(rocblas_handle handle,
-rocblas_int n,
-const rocblas_double_complex *alpha,
-const rocblas_double_complex *x, rocblas_int incx,
-rocblas_double_complex *y,  rocblas_int incy);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_zaxpy(rocblas_handle                handle,
+                                            rocblas_int                   n,
+                                            const rocblas_double_complex* alpha,
+                                            const rocblas_double_complex* x,
+                                            rocblas_int                   incx,
+                                            rocblas_double_complex*       y,
+                                            rocblas_int                   incy);
 
 /*! \brief BLAS Level 1 API
 
@@ -354,19 +407,17 @@ ROCBLAS_EXPORT rocblas_status rocblas_sasum(
 ROCBLAS_EXPORT rocblas_status rocblas_dasum(
     rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_scasum(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    float *result);
+ROCBLAS_EXPORT rocblas_status rocblas_scasum(rocblas_handle               handle,
+                                             rocblas_int                  n,
+                                             const rocblas_float_complex* x,
+                                             rocblas_int                  incx,
+                                             float*                       result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dzasum(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    double *result);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_dzasum(rocblas_handle                handle,
+                                             rocblas_int                   n,
+                                             const rocblas_double_complex* x,
+                                             rocblas_int                   incx,
+                                             double*                       result);
 
 /*! \brief BLAS Level 1 API
 
@@ -397,19 +448,17 @@ ROCBLAS_EXPORT rocblas_status rocblas_snrm2(
 ROCBLAS_EXPORT rocblas_status rocblas_dnrm2(
     rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_scnrm2(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    float *result);
+ROCBLAS_EXPORT rocblas_status rocblas_scnrm2(rocblas_handle               handle,
+                                             rocblas_int                  n,
+                                             const rocblas_float_complex* x,
+                                             rocblas_int                  incx,
+                                             float*                       result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_dznrm2(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    double *result);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_dznrm2(rocblas_handle                handle,
+                                             rocblas_int                   n,
+                                             const rocblas_double_complex* x,
+                                             rocblas_int                   incx,
+                                             double*                       result);
 
 /*! \brief BLAS Level 1 API
 
@@ -440,19 +489,17 @@ ROCBLAS_EXPORT rocblas_status rocblas_isamax(
 ROCBLAS_EXPORT rocblas_status rocblas_idamax(
     rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_iscamax(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    rocblas_int *result);
+ROCBLAS_EXPORT rocblas_status rocblas_icamax(rocblas_handle               handle,
+                                             rocblas_int                  n,
+                                             const rocblas_float_complex* x,
+                                             rocblas_int                  incx,
+                                             rocblas_int*                 result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_idzamax(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    rocblas_int *result);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_izamax(rocblas_handle                handle,
+                                             rocblas_int                   n,
+                                             const rocblas_double_complex* x,
+                                             rocblas_int                   incx,
+                                             rocblas_int*                  result);
 
 /*! \brief BLAS Level 1 API
 
@@ -483,19 +530,17 @@ ROCBLAS_EXPORT rocblas_status rocblas_isamin(
 ROCBLAS_EXPORT rocblas_status rocblas_idamin(
     rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result);
 
-/* not implemented
-ROCBLAS_EXPORT rocblas_status
-rocblas_iscamin(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_float_complex *x, rocblas_int incx,
-    rocblas_int *result);
+ROCBLAS_EXPORT rocblas_status rocblas_icamin(rocblas_handle               handle,
+                                             rocblas_int                  n,
+                                             const rocblas_float_complex* x,
+                                             rocblas_int                  incx,
+                                             rocblas_int*                 result);
 
-ROCBLAS_EXPORT rocblas_status
-rocblas_idzamin(rocblas_handle handle,
-    rocblas_int n,
-    const rocblas_double_complex *x, rocblas_int incx,
-    rocblas_int *result);
-*/
+ROCBLAS_EXPORT rocblas_status rocblas_izamin(rocblas_handle                handle,
+                                             rocblas_int                   n,
+                                             const rocblas_double_complex* x,
+                                             rocblas_int                   incx,
+                                             rocblas_int*                  result);
 
 /*
  * ===========================================================================

--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -42,14 +42,16 @@ typedef int64_t rocblas_long;
 typedef uint16_t rocblas_half;
 
 // complex types
-typedef struct
-{
-    float x, y;
-} rocblas_float_complex;
-typedef struct
-{
-    double x, y;
-} rocblas_double_complex;
+// C++11 std::complex is guaranted to be layout-compatible with C99 _Complex
+#ifdef __cplusplus
+#include <complex>
+typedef std::complex<float> rocblas_float_complex;
+typedef std::complex<double> rocblas_double_complex;
+#else
+#include <complex.h>
+typedef float complex rocblas_float_complex;
+typedef double complex rocblas_double_complex;
+#endif
 
 /* ============================================================================================ */
 

--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -37,21 +37,13 @@ typedef int32_t rocblas_int;
 typedef int64_t rocblas_long;
 #endif
 
-// half types
-// TODO: should be replaced with a struct, to become a unique type
-typedef uint16_t rocblas_half;
+// floating point types
+typedef float    rocblas_float;
+typedef double   rocblas_double;
+typedef uint16_t rocblas_half; // TODO: should be replaced with a struct, to become a unique type
 
 // complex types
-// C++11 std::complex is guaranted to be layout-compatible with C99 _Complex
-#ifdef __cplusplus
-#include <complex>
-typedef std::complex<float> rocblas_float_complex;
-typedef std::complex<double> rocblas_double_complex;
-#else
-#include <complex.h>
-typedef float complex rocblas_float_complex;
-typedef double complex rocblas_double_complex;
-#endif
+#include "rocblas-complex-types.h"
 
 /* ============================================================================================ */
 

--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -30,21 +30,24 @@
 #ifndef _ROCBLAS_BFLOAT16_H_
 #define _ROCBLAS_BFLOAT16_H_
 
-#ifndef _ROCBLAS_INTERNAL_BFLOAT16_
+#if __cplusplus < 201402L || !defined(__HCC__)
+
+// If this is a C compiler, C++ compiler below C++14, or a host-only compiler, we only
+// include a minimal definition of rocblas_bfloat16
 
 #include <stdint.h>
 typedef struct
 {
     uint16_t data;
-} rocblas_bloat16;
+} rocblas_bfloat16;
 
-#else
+#else // __cplusplus < 201402L || !defined(__HCC__)
 
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <hip/hip_runtime.h>
-#include <iostream>
+#include <ostream>
 #include <type_traits>
 
 struct rocblas_bfloat16
@@ -246,5 +249,6 @@ inline rocblas_bfloat16 cos(rocblas_bfloat16 a)
     return rocblas_bfloat16(cosf(float(a)));
 }
 
-#endif // _ROCBLAS_INTERNAL_BFLOAT16_
+#endif // __cplusplus < 201402L || !defined(__HCC__)
+
 #endif // _ROCBLAS_BFLOAT16_H_

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -23,8 +23,6 @@ endfunction( )
 # package_targets is used as a list of install target
 set( package_targets rocblas )
 
-add_definitions(-D_ROCBLAS_INTERNAL_BFLOAT16_)
-
 # Set up Tensile  Dependency
 if( BUILD_WITH_TENSILE )
   # If we want to build a shared rocblas lib, force Tensile to build as a static lib to absorb into rocblas

--- a/library/src/blas1/fetch_template.h
+++ b/library/src/blas1/fetch_template.h
@@ -8,38 +8,27 @@
 #define _FETCH_TEMPLATE_
 
 #include "rocblas.h"
-#include <cmath>
 
 template <typename T>
-__device__ __host__ inline T fetch_asum(T A)
+__device__ __host__ inline auto fetch_asum(T A)
 {
-    return std::abs(A);
+    return A < 0 ? -A : A;
 }
 
-__device__ __host__ inline float fetch_asum(rocblas_float_complex A)
+__device__ __host__ inline auto fetch_asum(rocblas_float_complex A)
 {
-    return std::abs(A.x) + std::abs(A.y);
+    return asum(A);
 }
 
-__device__ __host__ inline double fetch_asum(rocblas_double_complex A)
+__device__ __host__ inline auto fetch_asum(rocblas_double_complex A)
 {
-    return std::abs(A.x) + std::abs(A.y);
+    return asum(A);
 }
 
 template <typename T>
-__device__ __host__ inline T fetch_abs2(T A)
+__device__ __host__ inline auto fetch_abs2(T A)
 {
-    return A * A;
-}
-
-__device__ __host__ inline float fetch_abs2(rocblas_float_complex A)
-{
-    return A.x * A.x + A.y * A.y;
-}
-
-__device__ __host__ inline double fetch_abs2(rocblas_double_complex A)
-{
-    return A.x * A.x + A.y * A.y;
+    return std::norm(A);
 }
 
 #endif

--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -188,26 +188,22 @@ rocblas_status JOIN(rocblas_ida, MAX_MIN)(
     return rocblas_iamaxmin<double>(handle, n, x, incx, result);
 }
 
-#if 0 // complex not supported
-
-rocblas_status JOIN(rocblas_isca, MAX_MIN)(rocblas_handle handle,
-                                           rocblas_int n,
-                                           const rocblas_float_complex* x,
-                                           rocblas_int incx,
-                                           rocblas_int* result)
+rocblas_status JOIN(rocblas_ica, MAX_MIN)(rocblas_handle               handle,
+                                          rocblas_int                  n,
+                                          const rocblas_float_complex* x,
+                                          rocblas_int                  incx,
+                                          rocblas_int*                 result)
 {
-    return rocblas_iamaxmin<float>(handle, n, x, incx, result);
+    return rocblas_iamaxmin<rocblas_float_complex>(handle, n, x, incx, result);
 }
 
-rocblas_status JOIN(rocblas_idza, MAX_MIN)(rocblas_handle handle,
-                                           rocblas_int n,
-                                           const rocblas_double_complex* x,
-                                           rocblas_int incx,
-                                           rocblas_int* result)
+rocblas_status JOIN(rocblas_iza, MAX_MIN)(rocblas_handle                handle,
+                                          rocblas_int                   n,
+                                          const rocblas_double_complex* x,
+                                          rocblas_int                   incx,
+                                          rocblas_int*                  result)
 {
-    return rocblas_iamaxmin<double>(handle, n, x, incx, result);
+    return rocblas_iamaxmin<rocblas_double_complex>(handle, n, x, incx, result);
 }
-
-#endif
 
 } // extern "C"

--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -194,7 +194,7 @@ rocblas_status JOIN(rocblas_ica, MAX_MIN)(rocblas_handle               handle,
                                           rocblas_int                  incx,
                                           rocblas_int*                 result)
 {
-    return rocblas_iamaxmin<rocblas_float_complex>(handle, n, x, incx, result);
+    return rocblas_iamaxmin<float, rocblas_float_complex>(handle, n, x, incx, result);
 }
 
 rocblas_status JOIN(rocblas_iza, MAX_MIN)(rocblas_handle                handle,
@@ -203,7 +203,7 @@ rocblas_status JOIN(rocblas_iza, MAX_MIN)(rocblas_handle                handle,
                                           rocblas_int                   incx,
                                           rocblas_int*                  result)
 {
-    return rocblas_iamaxmin<rocblas_double_complex>(handle, n, x, incx, result);
+    return rocblas_iamaxmin<double, rocblas_double_complex>(handle, n, x, incx, result);
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -107,20 +107,20 @@ rocblas_status rocblas_dasum(
     return rocblas_asum(handle, n, x, incx, result);
 }
 
-rocblas_status rocblas_scasum(rocblas_handle handle,
-                              rocblas_int n,
+rocblas_status rocblas_scasum(rocblas_handle               handle,
+                              rocblas_int                  n,
                               const rocblas_float_complex* x,
-                              rocblas_int incx,
-                              float* result)
+                              rocblas_int                  incx,
+                              float*                       result)
 {
     return rocblas_asum(handle, n, x, incx, result);
 }
 
-rocblas_status rocblas_dzasum(rocblas_handle handle,
-                              rocblas_int n,
+rocblas_status rocblas_dzasum(rocblas_handle                handle,
+                              rocblas_int                   n,
                               const rocblas_double_complex* x,
-                              rocblas_int incx,
-                              double* result)
+                              rocblas_int                   incx,
+                              double*                       result)
 {
     return rocblas_asum(handle, n, x, incx, result);
 }

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -107,8 +107,6 @@ rocblas_status rocblas_dasum(
     return rocblas_asum(handle, n, x, incx, result);
 }
 
-#if 0 // complex not supported
-
 rocblas_status rocblas_scasum(rocblas_handle handle,
                               rocblas_int n,
                               const rocblas_float_complex* x,
@@ -126,7 +124,5 @@ rocblas_status rocblas_dzasum(rocblas_handle handle,
 {
     return rocblas_asum(handle, n, x, incx, result);
 }
-
-#endif
 
 } // extern "C"

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -24,7 +24,7 @@ namespace
     constexpr char rocblas_axpy_name<rocblas_double_complex>[] = "rocblas_zaxpy";
 
     template <typename T>
-    void axpy_log_bench(
+    typename std::enable_if<!is_complex<T>>::type axpy_log_bench(
         rocblas_handle handle, rocblas_int n, const T* alpha, rocblas_int incx, rocblas_int incy)
     {
         log_bench(handle,
@@ -40,44 +40,19 @@ namespace
                   incy);
     }
 
-    template <>
-    void axpy_log_bench<rocblas_float_complex>(rocblas_handle               handle,
-                                               rocblas_int                  n,
-                                               const rocblas_float_complex* alpha,
-                                               rocblas_int                  incx,
-                                               rocblas_int                  incy)
+    template <typename T>
+    typename std::enable_if<is_complex<T>>::type axpy_log_bench(
+        rocblas_handle handle, rocblas_int n, const T* alpha, rocblas_int incx, rocblas_int incy)
     {
         log_bench(handle,
                   "./rocblas-bench -f axpy -r",
-                  rocblas_precision_string<rocblas_float_complex>,
+                  rocblas_precision_string<T>,
                   "-n",
                   n,
                   "--alpha",
-                  real(*alpha),
+                  std::real(*alpha),
                   "--alphai",
-                  imag(*alpha),
-                  "--incx",
-                  incx,
-                  "--incy",
-                  incy);
-    }
-
-    template <>
-    void axpy_log_bench<rocblas_double_complex>(rocblas_handle                handle,
-                                                rocblas_int                   n,
-                                                const rocblas_double_complex* alpha,
-                                                rocblas_int                   incx,
-                                                rocblas_int                   incy)
-    {
-        log_bench(handle,
-                  "./rocblas-bench -f axpy -r",
-                  rocblas_precision_string<rocblas_double_complex>,
-                  "-n",
-                  n,
-                  "--alpha",
-                  real(*alpha),
-                  "--alphai",
-                  imag(*alpha),
+                  std::imag(*alpha),
                   "--incx",
                   incx,
                   "--incy",
@@ -100,9 +75,7 @@ namespace
             if(layer_mode & rocblas_layer_mode_log_trace)
                 log_trace(handle, rocblas_axpy_name<T>, n, *alpha, x, incx, y, incy);
             if(layer_mode & rocblas_layer_mode_log_bench)
-            {
                 axpy_log_bench(handle, n, alpha, incx, incy);
-            }
         }
         else if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_axpy_name<T>, n, alpha, x, incx, y, incy);

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -111,33 +111,7 @@ namespace
         if(!alpha)
             return rocblas_status_invalid_pointer;
 
-        auto layer_mode = handle->layer_mode;
-        if(handle->pointer_mode == rocblas_pointer_mode_host)
-        {
-            if(layer_mode & rocblas_layer_mode_log_trace)
-                log_trace(handle, rocblas_axpy_name<T>, n, *alpha, x, incx, y, incy);
-            if(layer_mode & rocblas_layer_mode_log_bench)
-                log_bench(handle,
-                          "./rocblas-bench -f axpy -r",
-                          rocblas_precision_string<T>,
-                          "-n",
-                          n,
-                          "--alpha",
-                          *alpha,
-                          "--incx",
-                          incx,
-                          "--incy",
-                          incy);
-        }
-        else
-        {
-            if(layer_mode & rocblas_layer_mode_log_trace)
-                log_trace(handle, rocblas_axpy_name<T>, n, alpha, x, incx, y, incy);
-        }
-
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(handle, rocblas_axpy_name<T>, "N", n, "incx", incx, "incy", incy);
-
+        rocblas_axpy_log(handle, n, alpha, x, incx, y, incy);
         if(!x || !y)
             return rocblas_status_invalid_pointer;
         if(n <= 0) // Quick return if possible. Not Argument error

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -23,6 +23,95 @@ namespace
     template <>
     constexpr char rocblas_axpy_name<rocblas_double_complex>[] = "rocblas_zaxpy";
 
+    template <typename T>
+    void axpy_log_bench(
+        rocblas_handle handle, rocblas_int n, const T* alpha, rocblas_int incx, rocblas_int incy)
+    {
+        log_bench(handle,
+                  "./rocblas-bench -f axpy -r",
+                  rocblas_precision_string<T>,
+                  "-n",
+                  n,
+                  "--alpha",
+                  *alpha,
+                  "--incx",
+                  incx,
+                  "--incy",
+                  incy);
+    }
+
+    template <>
+    void axpy_log_bench<rocblas_float_complex>(rocblas_handle               handle,
+                                               rocblas_int                  n,
+                                               const rocblas_float_complex* alpha,
+                                               rocblas_int                  incx,
+                                               rocblas_int                  incy)
+    {
+        log_bench(handle,
+                  "./rocblas-bench -f axpy -r",
+                  rocblas_precision_string<rocblas_float_complex>,
+                  "-n",
+                  n,
+                  "--alpha",
+                  alpha->x,
+                  "--alphai",
+                  alpha->y,
+                  "--incx",
+                  incx,
+                  "--incy",
+                  incy);
+    }
+
+    template <>
+    void axpy_log_bench<rocblas_double_complex>(rocblas_handle                handle,
+                                                rocblas_int                   n,
+                                                const rocblas_double_complex* alpha,
+                                                rocblas_int                   incx,
+                                                rocblas_int                   incy)
+    {
+        log_bench(handle,
+                  "./rocblas-bench -f axpy -r",
+                  rocblas_precision_string<rocblas_double_complex>,
+                  "-n",
+                  n,
+                  "--alpha",
+                  alpha->x,
+                  "--alphai",
+                  alpha->y,
+                  "--incx",
+                  incx,
+                  "--incy",
+                  incy);
+    }
+
+    template <typename T>
+    void rocblas_axpy_log(rocblas_handle handle,
+                          rocblas_int    n,
+                          const T*       alpha,
+                          const T*       x,
+                          rocblas_int    incx,
+                          T*             y,
+                          rocblas_int    incy)
+    {
+        auto layer_mode = handle->layer_mode;
+
+        if(handle->pointer_mode == rocblas_pointer_mode_host)
+        {
+            if(layer_mode & rocblas_layer_mode_log_trace)
+                log_trace(handle, rocblas_axpy_name<T>, n, *alpha, x, incx, y, incy);
+            if(layer_mode & rocblas_layer_mode_log_bench)
+            {
+                axpy_log_bench(handle, n, alpha, incx, incy);
+            }
+        }
+        else if(layer_mode & rocblas_layer_mode_log_trace)
+            log_trace(handle, rocblas_axpy_name<T>, n, alpha, x, incx, y, incy);
+
+        if(layer_mode & rocblas_layer_mode_log_profile)
+            log_profile(handle, rocblas_axpy_name<T>, "N", n, "incx", incx, "incy", incy);
+    }
+>>>>>>> Removed c++17 references to if constexpr, other cleanup.
+
     template <typename T, typename U>
     __global__ void axpy_kernel(
         rocblas_int n, U alpha_device_host, const T* x, rocblas_int incx, T* y, rocblas_int incy)

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -53,9 +53,9 @@ namespace
                   "-n",
                   n,
                   "--alpha",
-                  alpha->x,
+                  real(*alpha),
                   "--alphai",
-                  alpha->y,
+                  imag(*alpha),
                   "--incx",
                   incx,
                   "--incy",
@@ -75,9 +75,9 @@ namespace
                   "-n",
                   n,
                   "--alpha",
-                  alpha->x,
+                  real(*alpha),
                   "--alphai",
-                  alpha->y,
+                  imag(*alpha),
                   "--incx",
                   incx,
                   "--incy",
@@ -110,7 +110,6 @@ namespace
         if(layer_mode & rocblas_layer_mode_log_profile)
             log_profile(handle, rocblas_axpy_name<T>, "N", n, "incx", incx, "incy", incy);
     }
->>>>>>> Removed c++17 references to if constexpr, other cleanup.
 
     template <typename T, typename U>
     __global__ void axpy_kernel(

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -57,19 +57,23 @@ namespace
             if(layer_mode & rocblas_layer_mode_log_trace)
                 log_trace(handle, rocblas_axpy_name<T>, n, *alpha, x, incx, y, incy);
             if(layer_mode & rocblas_layer_mode_log_bench)
+            {
+                std::stringstream alphass;
+                alphass << "--alpha " << std::real(*alpha)
+                        << (std::imag(*alpha) != 0
+                                ? (" --alphai " + std::to_string(std::imag(*alpha)))
+                                : "");
                 log_bench(handle,
                           "./rocblas-bench -f axpy -r",
                           rocblas_precision_string<T>,
                           "-n",
                           n,
-                          "--alpha",
-                          std::real(*alpha),
-                          std::imag(*alpha) != 0 ? "--alphai " + std::to_string(std::imag(*alpha))
-                                                 : "",
+                          alphass.str(),
                           "--incx",
                           incx,
                           "--incy",
                           incy);
+            }
         }
         else if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_axpy_name<T>, n, alpha, x, incx, y, incy);
@@ -175,19 +179,23 @@ namespace
             if(layer_mode & rocblas_layer_mode_log_trace)
                 log_trace(handle, rocblas_axpy_name<rocblas_half>, n, *alpha, x, incx, y, incy);
             if(layer_mode & rocblas_layer_mode_log_bench)
+            {
+                std::stringstream alphass;
+                alphass << "--alpha " << std::real(*alpha)
+                        << (std::imag(*alpha) != 0
+                                ? (" --alphai " + std::to_string(std::imag(*alpha)))
+                                : "");
                 log_bench(handle,
                           "./rocblas-bench -f axpy -r",
                           rocblas_precision_string<rocblas_half>,
                           "-n",
                           n,
-                          "--alpha",
-                          std::real(*alpha),
-                          std::imag(*alpha) != 0 ? "--alphai " + std::to_string(std::imag(*alpha))
-                                                 : "",
+                          alphass.str(),
                           "--incx",
                           incx,
                           "--incy",
                           incy);
+            }
         }
         else if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_axpy_name<rocblas_half>, n, alpha, x, incx, y, incy);

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -24,9 +24,9 @@ namespace
 
         // bound
         if(tid < n)
-            tmp[tx] = y[tid * incy] * (CONJ ? conjugate(x[tid * incx]) : x[tid * incx]);
+            tmp[tx] = y[tid * incy] * (CONJ ? conj(x[tid * incx]) : x[tid * incx]);
         else
-            tmp[tx] = (T)0; // pad with zero
+            tmp[tx] = T(0); // pad with zero
 
         rocblas_sum_reduce<NB>(tx, tmp);
 
@@ -95,12 +95,14 @@ namespace
     constexpr char rocblas_dot_name<CONJ, float>[] = "rocblas_sdot";
     template <bool CONJ>
     constexpr char rocblas_dot_name<CONJ, double>[] = "rocblas_ddot";
-    template <bool CONJ>
-    constexpr char rocblas_dot_name<CONJ, rocblas_float_complex>[]
-        = CONJ ? "rocblas_cdotc" : "rocblas_cdotu";
-    template <bool CONJ>
-    constexpr char rocblas_dot_name<CONJ, rocblas_double_complex>[]
-        = CONJ ? "rocblas_zdotc" : "rocblas_zdotu";
+    template <>
+    constexpr char rocblas_dot_name<true, rocblas_float_complex>[] = "rocblas_cdotc";
+    template <>
+    constexpr char rocblas_dot_name<false, rocblas_float_complex>[] = "rocblas_cdotu";
+    template <>
+    constexpr char rocblas_dot_name<true, rocblas_double_complex>[] = "rocblas_zdotc";
+    template <>
+    constexpr char rocblas_dot_name<false, rocblas_double_complex>[] = "rocblas_zdotu";
 
     // allocate workspace inside this API
     template <bool CONJ, typename T>
@@ -127,7 +129,6 @@ namespace
                       n,
                       "--incx",
                       incx,
-
                       "--incy",
                       incy);
 
@@ -145,7 +146,7 @@ namespace
             else if(rocblas_pointer_mode_device == handle->pointer_mode)
                 RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(*result)));
             else
-                *result = (T)0;
+                *result = T(0);
             return rocblas_status_success;
         }
 

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -24,7 +24,7 @@ namespace
 
         // bound
         if(tid < n)
-            tmp[tx] = y[tid * incy] * (CONJ ? conj(x[tid * incx]) : x[tid * incx]);
+            tmp[tx] = y[tid * incy] * (CONJ ? std::conj(x[tid * incx]) : x[tid * incx]);
         else
             tmp[tx] = T(0); // pad with zero
 

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -13,7 +13,7 @@ namespace
     // setting to 512 for gfx803.
     constexpr int NB = 512;
 
-    template <typename T>
+    template <bool CONJ, typename T>
     __global__ void dot_kernel_part1(
         rocblas_int n, const T* x, rocblas_int incx, const T* y, rocblas_int incy, T* workspace)
     {
@@ -24,7 +24,7 @@ namespace
 
         // bound
         if(tid < n)
-            tmp[tx] = y[tid * incy] * x[tid * incx];
+            tmp[tx] = y[tid * incy] * (CONJ ? conjugate(x[tid * incx]) : x[tid * incx]);
         else
             tmp[tx] = 0; // pad with zero
 
@@ -36,7 +36,7 @@ namespace
 
     // assume workspace has already been allocated, recommened for repeated calling of dot product
     // routine
-    template <typename T>
+    template <bool CONJ, typename T>
     rocblas_status rocblas_dot_workspace(rocblas_handle __restrict__ handle,
                                          rocblas_int n,
                                          const T*    x,
@@ -61,7 +61,7 @@ namespace
         if(incy < 0)
             y -= ptrdiff_t(incy) * (n - 1);
 
-        hipLaunchKernelGGL(dot_kernel_part1,
+        hipLaunchKernelGGL(dot_kernel_part1<CONJ>,
                            grid,
                            threads,
                            0,
@@ -73,7 +73,7 @@ namespace
                            incy,
                            workspace);
 
-        hipLaunchKernelGGL((rocblas_reduction_kernel_part2<NB>),
+        hipLaunchKernelGGL(rocblas_reduction_kernel_part2<NB>,
                            1,
                            threads,
                            0,
@@ -89,19 +89,21 @@ namespace
         return rocblas_status_success;
     }
 
-    template <typename>
+    template <bool, typename>
     constexpr char rocblas_dot_name[] = "unknown";
-    template <>
-    constexpr char rocblas_dot_name<float>[] = "rocblas_sdot";
-    template <>
-    constexpr char rocblas_dot_name<double>[] = "rocblas_ddot";
-    template <>
-    constexpr char rocblas_dot_name<rocblas_float_complex>[] = "rocblas_cdot";
-    template <>
-    constexpr char rocblas_dot_name<rocblas_double_complex>[] = "rocblas_zdot";
+    template <bool CONJ>
+    constexpr char rocblas_dot_name<CONJ, float>[] = "rocblas_sdot";
+    template <bool CONJ>
+    constexpr char rocblas_dot_name<CONJ, double>[] = "rocblas_ddot";
+    template <bool CONJ>
+    constexpr char rocblas_dot_name<CONJ, rocblas_float_complex>[]
+        = CONJ ? "rocblas_cdotc" : "rocblas_cdotu";
+    template <bool CONJ>
+    constexpr char rocblas_dot_name<CONJ, rocblas_double_complex>[]
+        = CONJ ? "rocblas_zdotc" : "rocblas_zdotu";
 
     // allocate workspace inside this API
-    template <typename T>
+    template <bool CONJ, typename T>
     rocblas_status rocblas_dot(rocblas_handle handle,
                                rocblas_int    n,
                                const T*       x,
@@ -115,7 +117,7 @@ namespace
 
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(handle, rocblas_dot_name<T>, n, x, incx, y, incy);
+            log_trace(handle, rocblas_dot_name<CONJ, T>, n, x, incx, y, incy);
 
         if(layer_mode & rocblas_layer_mode_log_bench)
             log_bench(handle,
@@ -125,11 +127,12 @@ namespace
                       n,
                       "--incx",
                       incx,
+
                       "--incy",
                       incy);
 
         if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(handle, rocblas_dot_name<T>, "N", n, "incx", incx, "incy", incy);
+            log_profile(handle, rocblas_dot_name<CONJ, T>, "N", n, "incx", incx, "incy", incy);
 
         if(!x || !y || !result)
             return rocblas_status_invalid_pointer;
@@ -154,7 +157,7 @@ namespace
         if(!mem)
             return rocblas_status_memory_error;
 
-        return rocblas_dot_workspace<T>(handle, n, x, incx, y, incy, result, (T*)mem, blocks);
+        return rocblas_dot_workspace<CONJ>(handle, n, x, incx, y, incy, result, (T*)mem, blocks);
     }
 
 } // namespace
@@ -175,7 +178,7 @@ rocblas_status rocblas_sdot(rocblas_handle handle,
                             rocblas_int    incy,
                             float*         result)
 {
-    return rocblas_dot(handle, n, x, incx, y, incy, result);
+    return rocblas_dot<false>(handle, n, x, incx, y, incy, result);
 }
 
 rocblas_status rocblas_ddot(rocblas_handle handle,
@@ -186,33 +189,51 @@ rocblas_status rocblas_ddot(rocblas_handle handle,
                             rocblas_int    incy,
                             double*        result)
 {
-    return rocblas_dot(handle, n, x, incx, y, incy, result);
+    return rocblas_dot<false>(handle, n, x, incx, y, incy, result);
 }
 
-#if 0 //  complex not supported
-
-rocblas_status rocblas_cdotu(rocblas_handle handle,
-                             rocblas_int n,
+rocblas_status rocblas_cdotu(rocblas_handle               handle,
+                             rocblas_int                  n,
                              const rocblas_float_complex* x,
-                             rocblas_int incx,
+                             rocblas_int                  incx,
                              const rocblas_float_complex* y,
-                             rocblas_int incy,
-                             rocblas_float_complex* result)
+                             rocblas_int                  incy,
+                             rocblas_float_complex*       result)
 {
-    return rocblas_dot(handle, n, x, incx, y, incy, result);
+    return rocblas_dot<false>(handle, n, x, incx, y, incy, result);
 }
 
-rocblas_status rocblas_zdotu(rocblas_handle handle,
-                             rocblas_int n,
+rocblas_status rocblas_zdotu(rocblas_handle                handle,
+                             rocblas_int                   n,
                              const rocblas_double_complex* x,
-                             rocblas_int incx,
+                             rocblas_int                   incx,
                              const rocblas_double_complex* y,
-                             rocblas_int incy,
-                             rocblas_double_complex* result)
+                             rocblas_int                   incy,
+                             rocblas_double_complex*       result)
 {
-    return rocblas_dot(handle, n, x, incx, y, incy, result);
+    return rocblas_dot<false>(handle, n, x, incx, y, incy, result);
 }
 
-#endif
+rocblas_status rocblas_cdotc(rocblas_handle               handle,
+                             rocblas_int                  n,
+                             const rocblas_float_complex* x,
+                             rocblas_int                  incx,
+                             const rocblas_float_complex* y,
+                             rocblas_int                  incy,
+                             rocblas_float_complex*       result)
+{
+    return rocblas_dot<true>(handle, n, x, incx, y, incy, result);
+}
+
+rocblas_status rocblas_zdotc(rocblas_handle                handle,
+                             rocblas_int                   n,
+                             const rocblas_double_complex* x,
+                             rocblas_int                   incx,
+                             const rocblas_double_complex* y,
+                             rocblas_int                   incy,
+                             rocblas_double_complex*       result)
+{
+    return rocblas_dot<true>(handle, n, x, incx, y, incy, result);
+}
 
 } // extern "C"

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -24,7 +24,7 @@ namespace
 
         // bound
         if(tid < n)
-            tmp[tx] = y[tid * incy] * (CONJ ? std::conj(x[tid * incx]) : x[tid * incx]);
+            tmp[tx] = y[tid * incy] * (CONJ ? conj(x[tid * incx]) : x[tid * incx]);
         else
             tmp[tx] = T(0); // pad with zero
 

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -26,7 +26,7 @@ namespace
         if(tid < n)
             tmp[tx] = y[tid * incy] * (CONJ ? conjugate(x[tid * incx]) : x[tid * incx]);
         else
-            tmp[tx] = 0; // pad with zero
+            tmp[tx] = (T)0; // pad with zero
 
         rocblas_sum_reduce<NB>(tx, tmp);
 
@@ -145,7 +145,7 @@ namespace
             else if(rocblas_pointer_mode_device == handle->pointer_mode)
                 RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(*result)));
             else
-                *result = 0;
+                *result = (T)0;
             return rocblas_status_success;
         }
 

--- a/library/src/blas1/rocblas_nrm2.cpp
+++ b/library/src/blas1/rocblas_nrm2.cpp
@@ -123,26 +123,22 @@ rocblas_status rocblas_dnrm2(
     return rocblas_nrm2(handle, n, x, incx, result);
 }
 
-#if 0 // complex not supported
-
-rocblas_status rocblas_scnrm2(rocblas_handle handle,
-                              rocblas_int n,
+rocblas_status rocblas_scnrm2(rocblas_handle               handle,
+                              rocblas_int                  n,
                               const rocblas_float_complex* x,
-                              rocblas_int incx,
-                              float* result)
+                              rocblas_int                  incx,
+                              float*                       result)
 {
     return rocblas_nrm2(handle, n, x, incx, result);
 }
 
-rocblas_status rocblas_dznrm2(rocblas_handle handle,
-                              rocblas_int n,
+rocblas_status rocblas_dznrm2(rocblas_handle                handle,
+                              rocblas_int                   n,
                               const rocblas_double_complex* x,
-                              rocblas_int incx,
-                              double* result)
+                              rocblas_int                   incx,
+                              double*                       result)
 {
     return rocblas_nrm2(handle, n, x, incx, result);
 }
-
-#endif
 
 } // extern "C"

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -56,6 +56,12 @@ namespace
             // with --a_type and --b_type (?)
             // ANSWER: -r is syntatic sugar; the types can be specified separately
             if(layer_mode & rocblas_layer_mode_log_bench)
+            {
+                std::stringstream alphass;
+                alphass << "--alpha " << std::real(*alpha)
+                        << (std::imag(*alpha) != 0
+                                ? (" --alphai " + std::to_string(std::imag(*alpha)))
+                                : "");
                 log_bench(handle,
                           "./rocblas-bench -f scal --a_type",
                           rocblas_precision_string<T>,
@@ -65,10 +71,8 @@ namespace
                           n,
                           "--incx",
                           incx,
-                          "--alpha",
-                          *alpha,
-                          std::imag(*alpha) != 0 ? "--alphai " + std::to_string(std::imag(*alpha))
-                                                 : "");
+                          alphass.str());
+            }
         }
         else
         {

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -70,7 +70,7 @@ namespace
                           incx,
                           "--alpha",
                           real(*alpha),
-                          "--alpha_imag",
+                          "--alphai",
                           imag(*alpha));
         }
         else

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -110,26 +110,22 @@ rocblas_status rocblas_dscal(
     return rocblas_scal(handle, n, alpha, x, incx);
 }
 
-#if 0 // complex not supported
-
-rocblas_status rocblas_cscal(rocblas_handle handle,
-                             rocblas_int n,
+rocblas_status rocblas_cscal(rocblas_handle               handle,
+                             rocblas_int                  n,
                              const rocblas_float_complex* alpha,
-                             rocblas_float_complex* x,
-                             rocblas_int incx)
+                             rocblas_float_complex*       x,
+                             rocblas_int                  incx)
 {
     return rocblas_scal(handle, n, alpha, x, incx);
 }
 
-rocblas_status rocblas_zscal(rocblas_handle handle,
-                             rocblas_int n,
+rocblas_status rocblas_zscal(rocblas_handle                handle,
+                             rocblas_int                   n,
                              const rocblas_double_complex* alpha,
-                             rocblas_double_complex* x,
-                             rocblas_int incx)
+                             rocblas_double_complex*       x,
+                             rocblas_int                   incx)
 {
     return rocblas_scal(handle, n, alpha, x, incx);
 }
-
-#endif
 
 } // extern "C"

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -48,6 +48,14 @@ namespace
             if(layer_mode & rocblas_layer_mode_log_trace)
                 log_trace(handle, rocblas_scal_name<T>, n, *alpha, x, incx);
 
+            double ar = 0, ai = 0;
+            if constexpr(std::is_same<T, rocblas_float_complex>{} || std::is_same<T, rocblas_double_complex>{})
+            {
+                ar = alpha->x;
+                ai = alpha->y;
+            }
+            else
+                ar = *alpha;
             if(layer_mode & rocblas_layer_mode_log_bench)
                 log_bench(handle,
                           "./rocblas-bench -f scal -r",
@@ -57,7 +65,9 @@ namespace
                           "--incx",
                           incx,
                           "--alpha",
-                          *alpha);
+                          ar,
+                          "--alphai",
+                          ai);
         }
         else
         {

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -22,22 +22,22 @@ namespace
             x[tid * incx] *= alpha;
     }
 
-    template <typename, typename>
+    template <typename T, typename = T>
     constexpr char rocblas_scal_name[] = "unknown";
     template <>
-    constexpr char rocblas_scal_name<float, float>[] = "rocblas_sscal";
+    constexpr char rocblas_scal_name<float>[] = "rocblas_sscal";
     template <>
-    constexpr char rocblas_scal_name<double, double>[] = "rocblas_dscal";
+    constexpr char rocblas_scal_name<double>[] = "rocblas_dscal";
     template <>
-    constexpr char rocblas_scal_name<rocblas_float_complex, rocblas_float_complex>[] = "rocblas_cscal";
+    constexpr char rocblas_scal_name<rocblas_float_complex>[] = "rocblas_cscal";
     template <>
-    constexpr char rocblas_scal_name<rocblas_double_complex, rocblas_double_complex>[] = "rocblas_zscal";
+    constexpr char rocblas_scal_name<rocblas_double_complex>[] = "rocblas_zscal";
     template<>
-    constexpr char rocblas_scal_name<float, rocblas_float_complex>[] = "rocblas_csscal";
+    constexpr char rocblas_scal_name<rocblas_float_complex, float>[] = "rocblas_csscal";
     template<>
-    constexpr char rocblas_scal_name<double, rocblas_double_complex>[] = "rocblas_zdscal";
+    constexpr char rocblas_scal_name<rocblas_double_complex, double>[] = "rocblas_zdscal";
 
-    template <class T, class U = T>
+    template <class T, class U>
     rocblas_status
         rocblas_scal(rocblas_handle handle, rocblas_int n, const U* alpha, T* x, rocblas_int incx)
     {
@@ -143,20 +143,20 @@ rocblas_status rocblas_zscal(rocblas_handle                handle,
 }
 
 // Scal with a real alpha & complex vector
-rocblas_status rocblas_csscal(rocblas_handle handle,
-                              rocblas_int n,
-                              const float* alpha,
+rocblas_status rocblas_csscal(rocblas_handle         handle,
+                              rocblas_int            n,
+                              const float*           alpha,
                               rocblas_float_complex* x,
-                              rocblas_int incx)
+                              rocblas_int            incx)
 {
     return rocblas_scal(handle, n, alpha, x, incx);
 }
 
-rocblas_status rocblas_zdscal(rocblas_handle handle,
-                              rocblas_int n,
-                              const double* alpha,
+rocblas_status rocblas_zdscal(rocblas_handle          handle,
+                              rocblas_int             n,
+                              const double*           alpha,
                               rocblas_double_complex* x,
-                              rocblas_int incx)
+                              rocblas_int             incx)
 {
     return rocblas_scal(handle, n, alpha, x, incx);
 }

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -11,7 +11,7 @@ namespace
     constexpr int NB = 256;
 
     template <typename T, typename U>
-    __global__ void scal_kernel(rocblas_int n, T alpha_device_host, U* x, rocblas_int incx)
+    __global__ void scal_kernel(rocblas_int n, U alpha_device_host, T* x, rocblas_int incx)
     {
         auto      alpha = load_scalar(alpha_device_host);
         ptrdiff_t tid   = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -38,7 +38,7 @@ namespace
 
     template <typename T, typename U>
     rocblas_status
-        rocblas_scal(rocblas_handle handle, rocblas_int n, const T* alpha, U* x, rocblas_int incx)
+        rocblas_scal(rocblas_handle handle, rocblas_int n, const U* alpha, T* x, rocblas_int incx)
     {
         if(!handle)
             return rocblas_status_invalid_handle;

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -5,7 +5,6 @@
 #include "logging.h"
 #include "rocblas.h"
 #include "utility.h"
-#include <complex.h>
 
 namespace
 {
@@ -32,9 +31,9 @@ namespace
     constexpr char rocblas_scal_name<rocblas_float_complex>[] = "rocblas_cscal";
     template <>
     constexpr char rocblas_scal_name<rocblas_double_complex>[] = "rocblas_zscal";
-    template<>
+    template <>
     constexpr char rocblas_scal_name<rocblas_float_complex, float>[] = "rocblas_csscal";
-    template<>
+    template <>
     constexpr char rocblas_scal_name<rocblas_double_complex, double>[] = "rocblas_zdscal";
 
     template <class T, class U>

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -21,40 +21,6 @@ namespace
             x[tid * incx] *= alpha;
     }
 
-    template <typename T, typename U, typename std::enable_if<!is_complex<T>, int>::type = 0>
-    void scal_log_bench(rocblas_handle handle, rocblas_int n, const T* alpha, rocblas_int incx)
-    {
-        log_bench(handle,
-                  "./rocblas-bench -f scal --a_type",
-                  rocblas_precision_string<T>,
-                  "--b_type",
-                  rocblas_precision_string<U>,
-                  "-n",
-                  n,
-                  "--incx",
-                  incx,
-                  "--alpha",
-                  *alpha);
-    }
-
-    template <typename T, typename U, typename std::enable_if<is_complex<T>, int>::type = 0>
-    void scal_log_bench(rocblas_handle handle, rocblas_int n, const T* alpha, rocblas_int incx)
-    {
-        log_bench(handle,
-                  "./rocblas-bench -f scal --a_type",
-                  rocblas_precision_string<T>,
-                  "--b_type",
-                  rocblas_precision_string<U>,
-                  "-n",
-                  n,
-                  "--incx",
-                  incx,
-                  "--alpha",
-                  std::real(*alpha),
-                  "--alphai",
-                  std::imag(*alpha));
-    }
-
     template <typename T, typename = T>
     constexpr char rocblas_scal_name[] = "unknown";
     template <>
@@ -90,7 +56,19 @@ namespace
             // with --a_type and --b_type (?)
             // ANSWER: -r is syntatic sugar; the types can be specified separately
             if(layer_mode & rocblas_layer_mode_log_bench)
-                scal_log_bench<T, U>(handle, n, alpha, incx);
+                log_bench(handle,
+                          "./rocblas-bench -f scal --a_type",
+                          rocblas_precision_string<T>,
+                          "--b_type",
+                          rocblas_precision_string<U>,
+                          "-n",
+                          n,
+                          "--incx",
+                          incx,
+                          "--alpha",
+                          *alpha,
+                          std::imag(*alpha) != 0 ? "--alphai " + std::to_string(std::imag(*alpha))
+                                                 : "");
         }
         else
         {

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -106,8 +106,6 @@ rocblas_status rocblas_dswap(
     return rocblas_swap(handle, n, x, incx, y, incy);
 }
 
-#if 0 // complex not supported
-
 rocblas_status rocblas_cswap(rocblas_handle handle,
                              rocblas_int n,
                              rocblas_float_complex* x,
@@ -127,7 +125,5 @@ rocblas_status rocblas_zswap(rocblas_handle handle,
 {
     return rocblas_swap(handle, n, x, incx, y, incy);
 }
-
-#endif
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -106,22 +106,22 @@ rocblas_status rocblas_dswap(
     return rocblas_swap(handle, n, x, incx, y, incy);
 }
 
-rocblas_status rocblas_cswap(rocblas_handle handle,
-                             rocblas_int n,
+rocblas_status rocblas_cswap(rocblas_handle         handle,
+                             rocblas_int            n,
                              rocblas_float_complex* x,
-                             rocblas_int incx,
+                             rocblas_int            incx,
                              rocblas_float_complex* y,
-                             rocblas_int incy)
+                             rocblas_int            incy)
 {
     return rocblas_swap(handle, n, x, incx, y, incy);
 }
 
-rocblas_status rocblas_zswap(rocblas_handle handle,
-                             rocblas_int n,
+rocblas_status rocblas_zswap(rocblas_handle          handle,
+                             rocblas_int             n,
                              rocblas_double_complex* x,
-                             rocblas_int incx,
+                             rocblas_int             incx,
                              rocblas_double_complex* y,
-                             rocblas_int incy)
+                             rocblas_int             incy)
 {
     return rocblas_swap(handle, n, x, incx, y, incy);
 }

--- a/library/src/blas2/gemv_device.hpp
+++ b/library/src/blas2/gemv_device.hpp
@@ -279,10 +279,10 @@ __device__ void gemvc_kernel(rocblas_int m,
     rocblas_int m_full = (m / NB_X) * NB_X;
 
     for(rocblas_int i = 0; i < m_full; i += NB_X)
-        res += conj(A[i]) * x[(tx + i) * incx];
+        res += std::conj(A[i]) * x[(tx + i) * incx];
 
     if(tx + m_full < m)
-        res += conj(A[m_full]) * x[(tx + m_full) * incx];
+        res += std::conj(A[m_full]) * x[(tx + m_full) * incx];
 
     sdata[tx] = res;
 

--- a/library/src/blas2/gemv_device.hpp
+++ b/library/src/blas2/gemv_device.hpp
@@ -85,10 +85,25 @@ __device__ void gemvn_kernel(rocblas_int m,
     // if n  is not multiple of (DIM_Y * 4)
     if(n_tail > 0)
     {
-        res_x[0] = (col + 0 < n) ? x[(col + 0) * incx] : 0;
-        res_x[1] = (col + 1 < n) ? x[(col + 1) * incx] : 0;
-        res_x[2] = (col + 2 < n) ? x[(col + 2) * incx] : 0;
-        res_x[3] = (col + 3 < n) ? x[(col + 3) * incx] : 0;
+        if(col + 0 < n)
+            res_x[0] = x[(col + 0) * incx];
+        else
+            res_x[0] = 0.0;
+
+        if(col + 1 < n)
+            res_x[1] = x[(col + 1) * incx];
+        else
+            res_x[1] = 0.0;
+
+        if(col + 2 < n)
+            res_x[2] = x[(col + 2) * incx];
+        else
+            res_x[2] = 0.0;
+
+        if(col + 3 < n)
+            res_x[3] = x[(col + 3) * incx];
+        else
+            res_x[3] = 0.0;
 
         if(ind < m)
         {
@@ -140,7 +155,7 @@ __device__ void gemvn_kernel(rocblas_int m,
         {
             if(beta != 0)
             {
-                y[ind * incy] = alpha * sdata[thread_id] + beta * y[ind * incy];
+                y[ind * incy] = (alpha * sdata[thread_id]) + (beta * y[ind * incy]);
             }
             else
             {
@@ -152,6 +167,73 @@ __device__ void gemvn_kernel(rocblas_int m,
 
 template <rocblas_int NB_X, typename T, typename U>
 __device__ void gemvc_kernel(rocblas_int m,
+                             rocblas_int n,
+                             U           alpha,
+                             const T*    A,
+                             rocblas_int lda,
+                             const T*    x,
+                             rocblas_int incx,
+                             U           beta,
+                             T*          y,
+                             rocblas_int incy)
+{
+    rocblas_int tx = hipThreadIdx_x;
+
+    if(tx < m)
+        A += tx;
+
+    rocblas_int col = hipBlockIdx_x;
+    A += col * lda;
+
+    T res;
+    res = 0.0;
+
+    __shared__ T sdata[NB_X];
+
+    // partial sums
+    rocblas_int m_full = (m / NB_X) * NB_X;
+
+    for(rocblas_int i = 0; i < m_full; i += NB_X)
+        res += conjugateVal(A[i]) * x[(tx + i) * incx];
+
+    if(tx + m_full < m)
+        res += conjugateVal(A[m_full]) * x[(tx + m_full) * incx];
+
+    sdata[tx] = res;
+
+    // tree reduction of partial sums,
+    if(NB_X > 16)
+    {
+        rocblas_sum_reduce<NB_X>(tx, sdata);
+    }
+    else
+    {
+        __syncthreads();
+
+        if(tx == 0)
+        {
+            for(rocblas_int i = 1; i < m && i < NB_X; i++)
+                sdata[0] += sdata[i];
+        }
+
+        __syncthreads();
+    }
+
+    if(tx == 0)
+    {
+        if(beta != 0)
+        {
+            y[col * incy] = alpha * sdata[0] + beta * y[col * incy];
+        }
+        else
+        {
+            y[col * incy] = alpha * sdata[0];
+        }
+    }
+}
+
+template <rocblas_int NB_X, typename T, typename U>
+__device__ void gemvt_kernel(rocblas_int m,
                              rocblas_int n,
                              U           alpha,
                              const T*    A,
@@ -287,6 +369,39 @@ __global__ void gemvc_kernel_strided(rocblas_int m,
     gemvc_kernel<NB_X>(m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
+template <rocblas_int NB_X, typename T, typename U>
+__global__ void gemvt_kernel_strided(rocblas_int m,
+                                     rocblas_int n,
+                                     U           alpha_device_host,
+                                     const T*    Aa,
+                                     rocblas_int lda,
+                                     rocblas_int strideA,
+                                     const T*    xa,
+                                     rocblas_int incx,
+                                     rocblas_int stridex,
+                                     U           beta_device_host,
+                                     T*          ya,
+                                     rocblas_int incy,
+                                     rocblas_int stridey)
+{
+    const T* A;
+    const T* x;
+    T*       y;
+    A = Aa + hipBlockIdx_y * strideA;
+    x = xa + hipBlockIdx_y * stridex;
+    y = ya + hipBlockIdx_y * stridey;
+
+    if(incx < 0)
+        x -= ssize_t(incx) * (m - 1);
+    if(incy < 0)
+        y -= ssize_t(incy) * (n - 1);
+
+    auto alpha = load_scalar(alpha_device_host);
+    auto beta  = load_scalar(beta_device_host);
+
+    gemvt_kernel<NB_X>(m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
 template <rocblas_int DIM_X, rocblas_int DIM_Y, typename T, typename U>
 __global__ void gemvn_kernel_batched(rocblas_int    m,
                                      rocblas_int    n,
@@ -349,6 +464,36 @@ __global__ void gemvc_kernel_batched(rocblas_int    m,
     auto beta  = load_scalar(beta_device_host);
 
     gemvc_kernel<NB_X>(m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+template <rocblas_int NB_X, typename T, typename U>
+__global__ void gemvt_kernel_batched(rocblas_int    m,
+                                     rocblas_int    n,
+                                     U              alpha_device_host,
+                                     const T* const Aa[],
+                                     rocblas_int    lda,
+                                     const T* const xa[],
+                                     rocblas_int    incx,
+                                     U              beta_device_host,
+                                     T* const       ya[],
+                                     rocblas_int    incy)
+{
+    const T* A;
+    const T* x;
+    T*       y;
+    A = Aa[hipBlockIdx_y];
+    x = xa[hipBlockIdx_y];
+    y = ya[hipBlockIdx_y];
+
+    if(incx < 0)
+        x -= ssize_t(incx) * (m - 1);
+    if(incy < 0)
+        y -= ssize_t(incy) * (n - 1);
+
+    auto alpha = load_scalar(alpha_device_host);
+    auto beta  = load_scalar(beta_device_host);
+
+    gemvt_kernel<NB_X>(m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 #endif

--- a/library/src/blas2/gemv_device.hpp
+++ b/library/src/blas2/gemv_device.hpp
@@ -251,6 +251,24 @@ __device__ void gemvn_kernel(rocblas_int                   m,
     }
 }
 
+template <typename T>
+__device__ T conjugateVal(const T& val)
+{
+    return val;
+}
+
+template <>
+__device__ rocblas_float_complex conjugateVal(const rocblas_float_complex& val)
+{
+    return val.getConjugate();
+}
+
+template <>
+__device__ rocblas_double_complex conjugateVal(const rocblas_double_complex& val)
+{
+    return val.getConjugate();
+}
+
 template <rocblas_int NB_X, typename T, typename U>
 __device__ void gemvc_kernel(rocblas_int m,
                              rocblas_int n,

--- a/library/src/blas2/gemv_device.hpp
+++ b/library/src/blas2/gemv_device.hpp
@@ -279,10 +279,10 @@ __device__ void gemvc_kernel(rocblas_int m,
     rocblas_int m_full = (m / NB_X) * NB_X;
 
     for(rocblas_int i = 0; i < m_full; i += NB_X)
-        res += std::conj(A[i]) * x[(tx + i) * incx];
+        res += conj(A[i]) * x[(tx + i) * incx];
 
     if(tx + m_full < m)
-        res += std::conj(A[m_full]) * x[(tx + m_full) * incx];
+        res += conj(A[m_full]) * x[(tx + m_full) * incx];
 
     sdata[tx] = res;
 

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -67,6 +67,12 @@ namespace
                               incy);
 
                 if(layer_mode & rocblas_layer_mode_log_bench)
+                {
+                    std::stringstream alphass;
+                    alphass << "--alpha " << std::real(*alpha)
+                            << (std::imag(*alpha) != 0
+                                    ? (" --alphai " + std::to_string(std::imag(*alpha)))
+                                    : "");
                     log_bench(handle,
                               "./rocblas-bench -f gemv -r",
                               rocblas_precision_string<T>,
@@ -76,11 +82,7 @@ namespace
                               m,
                               "-n",
                               n,
-                              "--alpha",
-                              *alpha,
-                              std::imag(*alpha) != 0
-                                  ? "--alphai " + std::to_string(std::imag(*alpha))
-                                  : "",
+                              alphass.str(),
                               "--lda",
                               lda,
                               "--incx",
@@ -89,6 +91,7 @@ namespace
                               *beta,
                               "--incy",
                               incy);
+                }
             }
             else
             {

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -16,6 +16,10 @@ namespace
     constexpr char rocblas_gemv_name<float>[] = "rocblas_sgemv";
     template <>
     constexpr char rocblas_gemv_name<double>[] = "rocblas_dgemv";
+    template <>
+    constexpr char rocblas_gemv_name<rocblas_float_complex>[] = "rocblas_cgemv";
+    template <>
+    constexpr char rocblas_gemv_name<rocblas_double_complex>[] = "rocblas_zgemv";
 
     template <typename T>
     rocblas_status rocblas_gemv_impl(rocblas_handle    handle,
@@ -167,5 +171,37 @@ rocblas_status rocblas_dgemv(rocblas_handle    handle,
 {
     return rocblas_gemv_impl(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
+
+rocblas_status rocblas_cgemv(rocblas_handle               handle,
+                             rocblas_operation            transA,
+                             rocblas_int                  m,
+                             rocblas_int                  n,
+                             const rocblas_float_complex* alpha,
+                             const rocblas_float_complex* A,
+                             rocblas_int                  lda,
+                             const rocblas_float_complex* x,
+                             rocblas_int                  incx,
+                             const rocblas_float_complex* beta,
+                             rocblas_float_complex*       y,
+                             rocblas_int                  incy)
+{
+    return rocblas_gemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+
+// rocblas_status rocblas_zgemv(rocblas_handle               handle,
+//                             rocblas_operation             transA,
+//                             rocblas_int                   m,
+//                             rocblas_int                   n,
+//                             const rocblas_double_complex* alpha,
+//                             const rocblas_double_complex* A,
+//                             rocblas_int                   lda,
+//                             const rocblas_double_complex* x,
+//                             rocblas_int                   incx,
+//                             const rocblas_double_complex* beta,
+//                             rocblas_double_complex*       y,
+//                             rocblas_int                   incy)
+// {
+//     return rocblas_gemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+// }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -185,7 +185,7 @@ rocblas_status rocblas_cgemv(rocblas_handle               handle,
                              rocblas_float_complex*       y,
                              rocblas_int                  incy)
 {
-    return rocblas_gemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+    return rocblas_gemv_impl(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 rocblas_status rocblas_zgemv(rocblas_handle                handle,
@@ -201,7 +201,7 @@ rocblas_status rocblas_zgemv(rocblas_handle                handle,
                              rocblas_double_complex*       y,
                              rocblas_int                   incy)
 {
-    return rocblas_gemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+    return rocblas_gemv_impl(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -188,20 +188,20 @@ rocblas_status rocblas_cgemv(rocblas_handle               handle,
     return rocblas_gemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
-// rocblas_status rocblas_zgemv(rocblas_handle               handle,
-//                             rocblas_operation             transA,
-//                             rocblas_int                   m,
-//                             rocblas_int                   n,
-//                             const rocblas_double_complex* alpha,
-//                             const rocblas_double_complex* A,
-//                             rocblas_int                   lda,
-//                             const rocblas_double_complex* x,
-//                             rocblas_int                   incx,
-//                             const rocblas_double_complex* beta,
-//                             rocblas_double_complex*       y,
-//                             rocblas_int                   incy)
-// {
-//     return rocblas_gemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
-// }
+rocblas_status rocblas_zgemv(rocblas_handle                handle,
+                             rocblas_operation             transA,
+                             rocblas_int                   m,
+                             rocblas_int                   n,
+                             const rocblas_double_complex* alpha,
+                             const rocblas_double_complex* A,
+                             rocblas_int                   lda,
+                             const rocblas_double_complex* x,
+                             rocblas_int                   incx,
+                             const rocblas_double_complex* beta,
+                             rocblas_double_complex*       y,
+                             rocblas_int                   incy)
+{
+    return rocblas_gemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -78,6 +78,9 @@ namespace
                               n,
                               "--alpha",
                               *alpha,
+                              std::imag(*alpha) != 0
+                                  ? "--alphai " + std::to_string(std::imag(*alpha))
+                                  : "",
                               "--lda",
                               lda,
                               "--incx",

--- a/library/src/blas2/rocblas_gemv.hpp
+++ b/library/src/blas2/rocblas_gemv.hpp
@@ -21,6 +21,9 @@ rocblas_status rocblas_gemv_template(rocblas_handle    handle,
                                      T*                y,
                                      rocblas_int       incy)
 {
+    if(!m || !n)
+        return rocblas_status_success;
+
     hipStream_t rocblas_stream = handle->rocblas_stream;
 
     if(transA == rocblas_operation_none)

--- a/library/src/blas2/rocblas_gemv.hpp
+++ b/library/src/blas2/rocblas_gemv.hpp
@@ -21,10 +21,6 @@ rocblas_status rocblas_gemv_template(rocblas_handle    handle,
                                      T*                y,
                                      rocblas_int       incy)
 {
-    // Quick return
-    if(!m || !n)
-        return rocblas_status_success;
-
     hipStream_t rocblas_stream = handle->rocblas_stream;
 
     if(transA == rocblas_operation_none)
@@ -33,7 +29,8 @@ rocblas_status rocblas_gemv_template(rocblas_handle    handle,
         static constexpr int GEMVN_DIM_X = 64;
         static constexpr int GEMVN_DIM_Y = 16;
         rocblas_int          blocks      = (m - 1) / (GEMVN_DIM_X * 4) + 1;
-
+        if(std::is_same<T, rocblas_double_complex>{})
+            blocks = (m - 1) / (GEMVN_DIM_X) + 1;
         dim3 gemvn_grid(blocks, 1);
         dim3 gemvn_threads(GEMVN_DIM_X, GEMVN_DIM_Y);
 
@@ -83,11 +80,64 @@ rocblas_status rocblas_gemv_template(rocblas_handle    handle,
                                0); // stridey = 0
         }
     }
-    else
+    else if(transA == rocblas_operation_transpose)
     {
         // transpose
-        // number of columns on the y-dim of the grid, using gemvc because gemvt(transpose) is a
-        // instance of gemvc (conjugate)
+        // number of columns on the y-dim of the grid
+        static constexpr int NB = 256;
+        dim3                 gemvt_grid(n, 1);
+        dim3                 gemvt_threads(NB);
+
+        if(handle->pointer_mode == rocblas_pointer_mode_device)
+        {
+            hipLaunchKernelGGL(gemvt_kernel_strided<NB>,
+                               gemvt_grid,
+                               gemvt_threads,
+                               0,
+                               rocblas_stream,
+                               m,
+                               n,
+                               alpha,
+                               A,
+                               lda,
+                               0, // strideA = 0
+                               x,
+                               incx,
+                               0, // stridex = 0
+                               beta,
+                               y,
+                               incy,
+                               0); // stridey = 0
+        }
+        else
+        {
+            if(!*alpha && *beta == 1)
+                return rocblas_status_success;
+
+            hipLaunchKernelGGL(gemvt_kernel_strided<NB>,
+                               gemvt_grid,
+                               gemvt_threads,
+                               0,
+                               rocblas_stream,
+                               m,
+                               n,
+                               *alpha,
+                               A,
+                               lda,
+                               0, // strideA = 0
+                               x,
+                               incx,
+                               0, // stridex = 0
+                               *beta,
+                               y,
+                               incy,
+                               0); // stridey = 0
+        }
+    }
+    else // conjugate transpose
+    {
+        // conjugate transpose
+        // number of columns on the y-dim of the grid
         static constexpr int NB = 256;
         dim3                 gemvc_grid(n, 1);
         dim3                 gemvc_threads(NB);

--- a/library/src/blas2/rocblas_gemv_batched.cpp
+++ b/library/src/blas2/rocblas_gemv_batched.cpp
@@ -351,22 +351,22 @@ rocblas_status rocblas_cgemv_batched(rocblas_handle                     handle,
         handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
 }
 
-// rocblas_status rocblas_zgemv_batched(rocblas_handle                      handle,
-//                                      rocblas_operation                   transA,
-//                                      rocblas_int                        m,
-//                                      rocblas_int                         n,
-//                                      const rocblas_double_complex*       alpha,
-//                                      const rocblas_double_complex* const A[],
-//                                      rocblas_int                         lda,
-//                                      const rocblas_double_complex* const x[],
-//                                      rocblas_int                         incx,
-//                                      const rocblas_double_complex*       beta,
-//                                      rocblas_double_complex* const       y[],
-//                                      rocblas_int                         incy,
-//                                      rocblas_int                         batch_count)
-// {
-//     return rocblas_gemv_batched(
-//         handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
-// }
+rocblas_status rocblas_zgemv_batched(rocblas_handle                      handle,
+                                     rocblas_operation                   transA,
+                                     rocblas_int                         m,
+                                     rocblas_int                         n,
+                                     const rocblas_double_complex*       alpha,
+                                     const rocblas_double_complex* const A[],
+                                     rocblas_int                         lda,
+                                     const rocblas_double_complex* const x[],
+                                     rocblas_int                         incx,
+                                     const rocblas_double_complex*       beta,
+                                     rocblas_double_complex* const       y[],
+                                     rocblas_int                         incy,
+                                     rocblas_int                         batch_count)
+{
+    return rocblas_gemv_batched(
+        handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+}
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv_batched.cpp
+++ b/library/src/blas2/rocblas_gemv_batched.cpp
@@ -79,6 +79,9 @@ namespace
                               n,
                               "--alpha",
                               *alpha,
+                              std::imag(*alpha) != 0
+                                  ? "--alphai " + std::to_string(std::imag(*alpha))
+                                  : "",
                               "--lda",
                               lda,
                               "--incx",

--- a/library/src/blas2/rocblas_gemv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_gemv_strided_batched.cpp
@@ -85,6 +85,9 @@ namespace
                               n,
                               "--alpha",
                               *alpha,
+                              std::imag(*alpha) != 0
+                                  ? "--alphai " + std::to_string(std::imag(*alpha))
+                                  : "",
                               "--lda",
                               lda,
                               "--strideA",

--- a/library/src/blas2/rocblas_gemv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_gemv_strided_batched.cpp
@@ -442,39 +442,39 @@ rocblas_status rocblas_cgemv_strided_batched(rocblas_handle               handle
                                         batch_count);
 }
 
-// rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                    handle,
-//                                              rocblas_operation                 transA,
-//                                              rocblas_int                       m,
-//                                              rocblas_int                       n,
-//                                              const rocblas_double_complex*     alpha,
-//                                              const rocblas_double_complex*     A,
-//                                              rocblas_int                       lda,
-//                                              rocblas_int                       strideA,
-//                                              const rocblas_double_complex*     x,
-//                                              rocblas_int                       incx,
-//                                              rocblas_int                       stridex,
-//                                              const rocblas_double_complex*     beta,
-//                                              rocblas_double_complex*           y,
-//                                              rocblas_int                       incy,
-//                                              rocblas_int                       stridey,
-//                                              rocblas_int                       batch_count)
-// {
-//     return rocblas_gemv_strided_batched(handle,
-//                                         transA,
-//                                         m,
-//                                         n,
-//                                         alpha,
-//                                         A,
-//                                         lda,
-//                                         strideA,
-//                                         x,
-//                                         incx,
-//                                         stridex,
-//                                         beta,
-//                                         y,
-//                                         incy,
-//                                         stridey,
-//                                         batch_count);
-// }
+rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                handle,
+                                             rocblas_operation             transA,
+                                             rocblas_int                   m,
+                                             rocblas_int                   n,
+                                             const rocblas_double_complex* alpha,
+                                             const rocblas_double_complex* A,
+                                             rocblas_int                   lda,
+                                             rocblas_int                   strideA,
+                                             const rocblas_double_complex* x,
+                                             rocblas_int                   incx,
+                                             rocblas_int                   stridex,
+                                             const rocblas_double_complex* beta,
+                                             rocblas_double_complex*       y,
+                                             rocblas_int                   incy,
+                                             rocblas_int                   stridey,
+                                             rocblas_int                   batch_count)
+{
+    return rocblas_gemv_strided_batched(handle,
+                                        transA,
+                                        m,
+                                        n,
+                                        alpha,
+                                        A,
+                                        lda,
+                                        strideA,
+                                        x,
+                                        incx,
+                                        stridex,
+                                        beta,
+                                        y,
+                                        incy,
+                                        stridey,
+                                        batch_count);
+}
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_gemv_strided_batched.cpp
@@ -15,6 +15,10 @@ namespace
     constexpr char rocblas_gemv_name<float>[] = "rocblas_sgemv_strided_batched";
     template <>
     constexpr char rocblas_gemv_name<double>[] = "rocblas_dgemv_strided_batched";
+    template <>
+    constexpr char rocblas_gemv_name<rocblas_float_complex>[] = "rocblas_cgemv_strided_batched";
+    template <>
+    constexpr char rocblas_gemv_name<rocblas_double_complex>[] = "rocblas_zgemv_strided_batched";
 
     template <typename T>
     rocblas_status rocblas_gemv_strided_batched(rocblas_handle    handle,
@@ -212,13 +216,66 @@ namespace
                                    stridey);
             }
         }
-        else
+        else if(transA == rocblas_operation_transpose)
         {
             // transpose
-            // number of columns on the y-dim of the grid, using gemvc because gemvt(transpose) is a
-            // instance of gemvc (conjugate)
+            // number of columns on the y-dim of the grid
             static constexpr int NB = 256;
-            dim3                 gemvc_grid(n, batch_count);
+            dim3                 gemvt_grid(n, batch_count);
+            dim3                 gemvt_threads(NB);
+
+            if(handle->pointer_mode == rocblas_pointer_mode_device)
+            {
+                hipLaunchKernelGGL(gemvt_kernel_strided<NB>,
+                                   gemvt_grid,
+                                   gemvt_threads,
+                                   0,
+                                   rocblas_stream,
+                                   m,
+                                   n,
+                                   alpha,
+                                   A,
+                                   lda,
+                                   strideA,
+                                   x,
+                                   incx,
+                                   stridex,
+                                   beta,
+                                   y,
+                                   incy,
+                                   stridey);
+            }
+            else
+            {
+                if(!*alpha && *beta == 1)
+                    return rocblas_status_success;
+
+                hipLaunchKernelGGL(gemvt_kernel_strided<NB>,
+                                   gemvt_grid,
+                                   gemvt_threads,
+                                   0,
+                                   rocblas_stream,
+                                   m,
+                                   n,
+                                   *alpha,
+                                   A,
+                                   lda,
+                                   strideA,
+                                   x,
+                                   incx,
+                                   stridex,
+                                   *beta,
+                                   y,
+                                   incy,
+                                   stridey);
+            }
+        }
+        else // conjugate transpose
+        {
+            // conjugate transpose
+            // number of columns on the y-dim of the grid
+            static constexpr int NB = 256;
+            dim3                 gemvc_grid(n, 1);
             dim3                 gemvc_threads(NB);
 
             if(handle->pointer_mode == rocblas_pointer_mode_device)
@@ -349,5 +406,75 @@ rocblas_status rocblas_dgemv_strided_batched(rocblas_handle    handle,
                                         stridey,
                                         batch_count);
 }
+
+rocblas_status rocblas_cgemv_strided_batched(rocblas_handle               handle,
+                                             rocblas_operation            transA,
+                                             rocblas_int                  m,
+                                             rocblas_int                  n,
+                                             const rocblas_float_complex* alpha,
+                                             const rocblas_float_complex* A,
+                                             rocblas_int                  lda,
+                                             rocblas_int                  strideA,
+                                             const rocblas_float_complex* x,
+                                             rocblas_int                  incx,
+                                             rocblas_int                  stridex,
+                                             const rocblas_float_complex* beta,
+                                             rocblas_float_complex*       y,
+                                             rocblas_int                  incy,
+                                             rocblas_int                  stridey,
+                                             rocblas_int                  batch_count)
+{
+    return rocblas_gemv_strided_batched(handle,
+                                        transA,
+                                        m,
+                                        n,
+                                        alpha,
+                                        A,
+                                        lda,
+                                        strideA,
+                                        x,
+                                        incx,
+                                        stridex,
+                                        beta,
+                                        y,
+                                        incy,
+                                        stridey,
+                                        batch_count);
+}
+
+// rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                    handle,
+//                                              rocblas_operation                 transA,
+//                                              rocblas_int                       m,
+//                                              rocblas_int                       n,
+//                                              const rocblas_double_complex*     alpha,
+//                                              const rocblas_double_complex*     A,
+//                                              rocblas_int                       lda,
+//                                              rocblas_int                       strideA,
+//                                              const rocblas_double_complex*     x,
+//                                              rocblas_int                       incx,
+//                                              rocblas_int                       stridex,
+//                                              const rocblas_double_complex*     beta,
+//                                              rocblas_double_complex*           y,
+//                                              rocblas_int                       incy,
+//                                              rocblas_int                       stridey,
+//                                              rocblas_int                       batch_count)
+// {
+//     return rocblas_gemv_strided_batched(handle,
+//                                         transA,
+//                                         m,
+//                                         n,
+//                                         alpha,
+//                                         A,
+//                                         lda,
+//                                         strideA,
+//                                         x,
+//                                         incx,
+//                                         stridex,
+//                                         beta,
+//                                         y,
+//                                         incy,
+//                                         stridey,
+//                                         batch_count);
+// }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trmm.cpp
+++ b/library/src/blas3/rocblas_trmm.cpp
@@ -78,7 +78,7 @@ namespace
                                                               T*                C,
                                                               rocblas_int       ldc)
     {
-        T rC[6][6] = {{(T)0}};
+        T rC[6][6] = {{T(0)}};
         T rA[1][6];
         T rB[1][6];
 

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -56,6 +56,17 @@ protected:
         }
     }
 
+    // Complex output
+    template<typename T>
+    static void print_value(std::ostream& os, const rocblas_complex_num<T>& x)
+    {
+        os << "'(";
+        print_value(os, std::real(x));
+        os << ",";
+        print_value(os, std::imag(x));
+        os << ")'";
+    }
+
     // Character output
     static void print_value(std::ostream& os, char c)
     {
@@ -122,15 +133,15 @@ protected:
      * Compute value hashes for (key1, value1, key2, value2, ...) tuples
      ************************************************************************************/
     // Workaround for compilers which don't implement C++14 enum hash (LWG 2148)
-    template <typename T>
-    static typename std::enable_if<std::is_enum<T>{}, size_t>::type hash(const T& x)
+    template <typename T, typename std::enable_if<std::is_enum<T>{}, int>::type = 0>
+    static size_t hash(const T& x)
     {
         return std::hash<typename std::underlying_type<T>::type>{}(x);
     }
 
     // Default hash for non-enum types
-    template <typename T>
-    static typename std::enable_if<!std::is_enum<T>{}, size_t>::type hash(const T& x)
+    template <typename T, typename std::enable_if<!std::is_enum<T>{}, int>::type = 0>
+    static size_t hash(const T& x)
     {
         return std::hash<T>{}(x);
     }

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -57,7 +57,7 @@ protected:
     }
 
     // Complex output
-    template<typename T>
+    template <typename T>
     static void print_value(std::ostream& os, const rocblas_complex_num<T>& x)
     {
         os << "'(";

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -57,27 +57,6 @@ inline bool isAligned(const void* pointer, size_t byte_count)
     return reinterpret_cast<uintptr_t>(pointer) % byte_count == 0;
 }
 
-// conj(x) defaults to x. For complex, there are separate ADL definitions.
-template <typename T>
-__forceinline__ __device__ __host__ T conj(T x)
-{
-    return x;
-}
-
-// real(x) defaults to x. For complex, there are separate ADL definitions.
-template <typename T>
-__forceinline__ __device__ __host__ T real(T x)
-{
-    return x;
-}
-
-// imag(x) defaults to 0. For complex, there are separate ADL definitions.
-template <typename T>
-__forceinline__ __device__ __host__ T imag(T x)
-{
-    return 0;
-}
-
 // clang-format off
 // return letter N,T,C in place of rocblas_operation enum
 constexpr auto rocblas_transpose_letter(rocblas_operation trans)

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -8,6 +8,8 @@
 #include "rocblas.h"
 #include <hip/hip_runtime.h>
 
+#pragma STDC CX_LIMITED_RANGE ON
+
 // half vectors
 typedef _Float16 rocblas_half8 __attribute__((ext_vector_type(8)));
 typedef _Float16 rocblas_half2 __attribute__((ext_vector_type(2)));
@@ -55,22 +57,25 @@ inline bool isAligned(const void* pointer, size_t byte_count)
     return reinterpret_cast<uintptr_t>(pointer) % byte_count == 0;
 }
 
+// conj(x) defaults to x. For complex, there are separate ADL definitions.
 template <typename T>
-__forceinline__ __device__ __host__ T conjugate(T x)
+__forceinline__ __device__ __host__ T conj(T x)
 {
     return x;
 }
 
-template <>
-__forceinline__ __device__ __host__ auto conjugate(rocblas_float_complex x)
+// real(x) defaults to x. For complex, there are separate ADL definitions.
+template <typename T>
+__forceinline__ __device__ __host__ T real(T x)
 {
-    return conj(x);
+    return x;
 }
 
-template <>
-__forceinline__ __device__ __host__ auto conjugate(rocblas_double_complex x)
+// imag(x) defaults to 0. For complex, there are separate ADL definitions.
+template <typename T>
+__forceinline__ __device__ __host__ T imag(T x)
 {
-    return conj(x);
+    return 0;
 }
 
 // clang-format off

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -55,6 +55,24 @@ inline bool isAligned(const void* pointer, size_t byte_count)
     return reinterpret_cast<uintptr_t>(pointer) % byte_count == 0;
 }
 
+template <typename T>
+__forceinline__ __device__ __host__ T conjugate(T x)
+{
+    return x;
+}
+
+template <>
+__forceinline__ __device__ __host__ auto conjugate(rocblas_float_complex x)
+{
+    return conj(x);
+}
+
+template <>
+__forceinline__ __device__ __host__ auto conjugate(rocblas_double_complex x)
+{
+    return conj(x);
+}
+
 // clang-format off
 // return letter N,T,C in place of rocblas_operation enum
 constexpr auto rocblas_transpose_letter(rocblas_operation trans)

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -6,7 +6,9 @@
 #define UTILITY_H
 #include "definitions.h"
 #include "rocblas.h"
+#include <complex>
 #include <hip/hip_runtime.h>
+#include <type_traits>
 
 #pragma STDC CX_LIMITED_RANGE ON
 
@@ -25,24 +27,18 @@ __device__ inline rocblas_half2
     return llvm_fma_v2f16(multiplier, multiplicand, addend);
 }
 
-// Conjugate a value. For most types, simply call std::conj, for floats and doubles
-// do nothing and return themselves
-template <typename T>
-__device__ __host__ inline T conj(const T& z)
+// Conjugate a value. For most types, simply return argument; for
+// rocblas_float_complex and rocblas_double_complex, return std::conj(z)
+template <typename T, typename std::enable_if<!is_complex<T>, int>::type = 0>
+__device__ __host__ inline auto conj(const T& z)
+{
+    return z;
+}
+
+template <typename T, typename std::enable_if<is_complex<T>, int>::type = 0>
+__device__ __host__ inline auto conj(const T& z)
 {
     return std::conj(z);
-}
-
-template <>
-__device__ __host__ inline float conj(const float& z)
-{
-    return z;
-}
-
-template <>
-__device__ __host__ inline double conj(const double& z)
-{
-    return z;
 }
 
 // Load a scalar. If the argument is a pointer, dereference it; otherwise copy

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -25,6 +25,26 @@ __device__ inline rocblas_half2
     return llvm_fma_v2f16(multiplier, multiplicand, addend);
 }
 
+// Conjugate a value. For most types, simply call std::conj, for floats and doubles
+// do nothing and return themselves
+template <typename T>
+__device__ __host__ inline T conj(const T& z)
+{
+    return std::conj(z);
+}
+
+template <>
+__device__ __host__ inline float conj(const float& z)
+{
+    return z;
+}
+
+template <>
+__device__ __host__ inline double conj(const double& z)
+{
+    return z;
+}
+
 // Load a scalar. If the argument is a pointer, dereference it; otherwise copy
 // it. Allows the same kernels to be used for host and device scalars.
 


### PR DESCRIPTION
Adding following complex BLAS functions:
- rocblas_caxpy / rocblas_zaxpy
- rocblas_cdotu / rocblas_zdotu
- rocblas_cdotc / rocblas_zdotc
- rocblas_scnrm2 / rocblas_dznrm2
- rocblas_cscal / rocblas_zscal
- rocblas_csscal / rocblas_zdscal
- rocblas_icamax / rocblas_izamax
- rocblas_icamin / rocblas_izamin
- rocblas_scasum / rocblas_dzasum
- rocblas_cswap / rocblas_zswap
- rocblas_ccopy / rocblas_zcopy
- rocblas_cgemv / rocblas_zgemv

Added types:
- rocblas_float_complex
- rocblas_double_complex
