### PR TITLE
add bf16 to rocblas-bench

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -526,27 +526,27 @@ try
 
         ("precision,r",
          value<std::string>(&precision)->default_value("f32_r"), "Precision. "
-         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,f32_c,f64_c,i8_r,i32_r")
+         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,bf16_r,f32_c,f64_c,i8_r,i32_r")
 
         ("a_type",
          value<std::string>(&a_type), "Precision of matrix A. "
-         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,f32_c,f64_c,i8_r,i32_r")
+         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,bf16_r,f32_c,f64_c,i8_r,i32_r")
 
         ("b_type",
          value<std::string>(&b_type), "Precision of matrix B. "
-         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,f32_c,f64_c,i8_r,i32_r")
+         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,bf16_r,f32_c,f64_c,i8_r,i32_r")
 
         ("c_type",
          value<std::string>(&c_type), "Precision of matrix C. "
-         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,f32_c,f64_c,i8_r,i32_r")
+         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,bf16_r,f32_c,f64_c,i8_r,i32_r")
 
         ("d_type",
          value<std::string>(&d_type), "Precision of matrix D. "
-         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,f32_c,f64_c,i8_r,i32_r")
+         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,bf16_r,f32_c,f64_c,i8_r,i32_r")
 
         ("compute_type",
          value<std::string>(&compute_type), "Precision of computation. "
-         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,f32_c,f64_c,i8_r,i32_r")
+         "Options: h,s,d,c,z,f16_r,f32_r,f64_r,bf16_r,f32_c,f64_c,i8_r,i32_r")
 
         ("initialization",
          value<std::string>(&initialization)->default_value("rand_int"),

--- a/clients/gtest/README.md
+++ b/clients/gtest/README.md
@@ -156,6 +156,7 @@ auto rocblas_simple_dispatch(const Arguments& arg)
       case rocblas_datatype_f16_r: return TEST<rocblas_half>{}(arg);
       case rocblas_datatype_f32_r: return TEST<float>{}(arg);
       case rocblas_datatype_f64_r: return TEST<double>{}(arg);
+      case rocblas_datatype_bf16_r: return TEST<rocblas_bfloat16>{}(arg);
       case rocblas_datatype_f16_c: return TEST<rocblas_half_complex>{}(arg);
       case rocblas_datatype_f32_c: return TEST<rocblas_float_complex>{}(arg);
       case rocblas_datatype_f64_c: return TEST<rocblas_double_complex>{}(arg);

--- a/clients/include/rocblas_datatype2string.hpp
+++ b/clients/include/rocblas_datatype2string.hpp
@@ -213,9 +213,11 @@ inline rocblas_datatype string2rocblas_datatype(const std::string& value)
         value == "f16_r" || value == "h" ? rocblas_datatype_f16_r :
         value == "f32_r" || value == "s" ? rocblas_datatype_f32_r :
         value == "f64_r" || value == "d" ? rocblas_datatype_f64_r :
+        value == "bf16_r"                ? rocblas_datatype_bf16_r :
         value == "f16_c"                 ? rocblas_datatype_f16_c :
         value == "f32_c" || value == "c" ? rocblas_datatype_f32_c :
         value == "f64_c" || value == "z" ? rocblas_datatype_f64_c :
+        value == "bf16_c"                ? rocblas_datatype_bf16_c :
         value == "i8_r"                  ? rocblas_datatype_i8_r  :
         value == "i32_r"                 ? rocblas_datatype_i32_r :
         value == "i8_c"                  ? rocblas_datatype_i8_c  :


### PR DESCRIPTION
- bfloat16 tests are already part of rocblas-test
- small changes are needed to add bfloat16 to rocblas-bench