### PR TITLE
Enable if

### DIFF
--- a/clients/include/rocblas_random.hpp
+++ b/clients/include/rocblas_random.hpp
@@ -46,7 +46,7 @@ class rocblas_nan_rng
 
 public:
     // Random integer
-    template <typename T, typename = typename std::enable_if<std::is_integral<T>{}>::type>
+    template <typename T, typename std::enable_if<std::is_integral<T>{}, int>::type = 0>
     explicit operator T()
     {
         return std::uniform_int_distribution<T>{}(rocblas_rng);

--- a/library/include/rocblas-complex-types.h
+++ b/library/include/rocblas-complex-types.h
@@ -115,7 +115,7 @@ public:
         return (x += T(rhs)), *this;
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}>::type* = 0>
+    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
     __device__ __host__ auto& operator-=(const U& rhs)
     {
         return (x -= T(rhs)), *this;

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -130,8 +130,10 @@ public:
 
     // Allocate one or more sizes
     template <typename... Ss,
-              typename = typename std::enable_if<
-                  sizeof...(Ss) && conjunction<std::is_constructible<size_t, Ss>...>{}>::type>
+              typename std::enable_if<sizeof...(Ss)
+                                          && conjunction<std::is_constructible<size_t, Ss>...>{},
+                                      int>::type
+              = 0>
     auto device_malloc(Ss... sizes)
     {
         return _device_malloc<sizeof...(Ss)>(this, size_t(sizes)...);


### PR DESCRIPTION
Use integer template parameters instead of types for functional `enable_if`. Avoids ambiguity.
