### PR TITLE
Check hip-clang as well.

### DIFF
--- a/library/include/rocblas-complex-types.h
+++ b/library/include/rocblas-complex-types.h
@@ -10,7 +10,7 @@
 #ifndef _ROCBLAS_COMPLEX_TYPES_H_
 #define _ROCBLAS_COMPLEX_TYPES_H_
 
-#if __cplusplus < 201402L || !defined(__HCC__)
+#if __cplusplus < 201402L || (!defined(__HCC__) && !defined(__HIPCC__))
 
 // If this is a C compiler, C++ compiler below C++14, or a host-only compiler, we only
 // include minimal definitions of rocblas_float_complex and rocblas_double_complex
@@ -24,7 +24,7 @@ typedef struct
     double x, y;
 } rocblas_double_complex;
 
-#else // __cplusplus < 201402L || !defined(__HCC__)
+#else // __cplusplus < 201402L || (!defined(__HCC__) && !defined(__HIPCC__))
 
 // If this a full internal build, we need full support of complex arithmetic
 // and classes. We need __host__ and __device__ so we use <hip/hip_runtime.h>.
@@ -376,6 +376,6 @@ static constexpr bool is_complex<rocblas_float_complex> = true;
 template <>
 static constexpr bool is_complex<rocblas_double_complex> = true;
 
-#endif // __cplusplus < 201402L || !defined(__HCC__)
+#endif // __cplusplus < 201402L || (!defined(__HCC__) && !defined(__HIPCC__))
 
 #endif

--- a/library/include/rocblas_bfloat16.h
+++ b/library/include/rocblas_bfloat16.h
@@ -30,7 +30,7 @@
 #ifndef _ROCBLAS_BFLOAT16_H_
 #define _ROCBLAS_BFLOAT16_H_
 
-#if __cplusplus < 201402L || !defined(__HCC__)
+#if __cplusplus < 201402L || (!defined(__HCC__) && !defined(__HIPCC__))
 
 // If this is a C compiler, C++ compiler below C++14, or a host-only compiler, we only
 // include a minimal definition of rocblas_bfloat16
@@ -41,7 +41,7 @@ typedef struct
     uint16_t data;
 } rocblas_bfloat16;
 
-#else // __cplusplus < 201402L || !defined(__HCC__)
+#else // __cplusplus < 201402L || (!defined(__HCC__) && !defined(__HIPCC__))
 
 #include <cmath>
 #include <cstddef>
@@ -249,6 +249,6 @@ inline rocblas_bfloat16 cos(rocblas_bfloat16 a)
     return rocblas_bfloat16(cosf(float(a)));
 }
 
-#endif // __cplusplus < 201402L || !defined(__HCC__)
+#endif // __cplusplus < 201402L || (!defined(__HCC__) && !defined(__HIPCC__))
 
 #endif // _ROCBLAS_BFLOAT16_H_


### PR DESCRIPTION
resolves SWDEV-198354

- Need to check hip-clang as well to include the full definition of bfloat16 & complex