### PR TITLE
Swithing to rocm-cmake rocm_set_soversion

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -169,7 +169,8 @@ if( BUILD_WITH_TENSILE )
   target_compile_definitions( rocblas PRIVATE BUILD_WITH_TENSILE=1 )
 endif()
 
-set_target_properties( rocblas PROPERTIES VERSION ${rocblas_VERSION} SOVERSION ${rocblas_SOVERSION} CXX_EXTENSIONS NO )
+rocm_set_soversion( rocblas ${rocblas_SOVERSION} )
+set_target_properties( rocblas PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocblas PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
 
 # Package that helps me set visibility for function names exported from shared library


### PR DESCRIPTION
Fixing the library version to stop using the package version. This is requested by Radha and is blocker for 2.7.

Please take a look at https://github.com/RadeonOpenCompute/rocm-cmake/pull/15/files

This will fix most of the CI problems.