### PR TITLE
Add zlib package to install script and dockerfiles

### DIFF
--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -34,7 +34,8 @@ RUN yum install -y \
     libcxx-devel \
     boost-devel \
     numactl-libs \
-    rpm-build \ 
+    rpm-build \
+    zlib-devel \ 
     deltarpm
 
 RUN echo '#!/bin/bash' | tee /etc/profile.d/devtoolset7.sh && echo \

--- a/docker/dockerfile-build-fedora
+++ b/docker/dockerfile-build-fedora
@@ -28,6 +28,7 @@ RUN dnf -y update && dnf install -y \
     libcxx-devel \
     rpm-build \
     boost-devel \
+    zlib-devel \
     && \
     dnf -y clean all
 

--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -30,6 +30,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     gfortran \
     libboost-program-options-dev \
     libnuma1 \
+    zlib1g-dev \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/install.sh
+++ b/install.sh
@@ -122,16 +122,16 @@ install_packages( )
   local library_dependencies_ubuntu=( "make" "cmake-curses-gui" "pkg-config"
                                       "python2.7" "python3" "python-yaml" "python3-yaml"
                                       "llvm-6.0-dev"
-                                      "hip_hcc" "rocm_smi64" )
+                                      "hip_hcc" "rocm_smi64" "zlib1g-dev")
   local library_dependencies_centos=( "epel-release"
                                       "make" "cmake3" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "llvm7.0-devel" "llvm7.0-static"
-                                      "hip_hcc" "rocm_smi64" )
+                                      "hip_hcc" "rocm_smi64" "zlib-devel" )
   local library_dependencies_fedora=( "make" "cmake" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "libcxx-devel"
-                                      "hip_hcc" "rocm_smi64" )
+                                      "hip_hcc" "rocm_smi64" "zlib-devel" )
 
   if [[ "${build_cuda}" == true ]]; then
     # Ideally, this could be cuda-cublas-dev, but the package name has a version number in it


### PR DESCRIPTION
rocBLAS currently fails to compile if the user does not have the zlib package installed on their machine. This may cause problems with CI as the CentOS image does not have zlib-devel installed by default