### PR TITLE
Add support for Vega 64

### DIFF
--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_DB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_HB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_HBH.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_DB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_HB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_HBH.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_DB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_HB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_HBH.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bjlk_SB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_DB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_DB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_HB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_HB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_HBH.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_HBH.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/library/src/blas3/Tensile/Logic/asm_full/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -2,7 +2,7 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]','Vega 10 XT [Radeon RX Vega 64]']
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false


### PR DESCRIPTION
Resolves #653 

In the long run, a more reliable way of identifying the hardware is needed (why not just go by gfx***?)