### PR TITLE
Pinning Tensile version to allow for stable Jenkins runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if( BUILD_WITH_TENSILE )
   else()
     # Use the virtual-env setup and download package from specified repot:
     set( tensile_fork "ROCmSoftwarePlatform" CACHE STRING "Tensile fork to use" )
-    set( tensile_tag develop CACHE STRING "Tensile tag to download" )
+    set( tensile_tag a472399c5e97ac13b171092c2eb61d87d3a08d53 CACHE STRING "Tensile tag to download" )
     virtualenv_install("git+https://github.com/${tensile_fork}/Tensile.git@${tensile_tag}")
     message (STATUS "using GIT Tensile fork=${tensile_fork} from branch=${tensile_tag}")
   endif()


### PR DESCRIPTION
Pinning to stable version of Tensile to allow Paul Fultz's PR to merge. https://github.com/ROCmSoftwarePlatform/Tensile/pull/621 will break rocBLAS builds. This will allow us to merge the Tensile PR without causing Jenkins failures.