### PR TITLE
Revert "Updating to new Tensile cmake (#660)" 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,18 +176,21 @@ if( BUILD_WITH_TENSILE )
   set_property( CACHE Tensile_COMPILER PROPERTY STRINGS hcc hipcc)
 
   include(virtualenv)
+
   if (Tensile_TEST_LOCAL_PATH)
     virtualenv_install(${Tensile_TEST_LOCAL_PATH})
     message (STATUS "using local Tensile from ${Tensile_TEST_LOCAL_PATH}, copied to ${Tensile_ROOT}")
   else()
     # Use the virtual-env setup and download package from specified repot:
     set( tensile_fork "ROCmSoftwarePlatform" CACHE STRING "Tensile fork to use" )
-    set( tensile_tag 8d594c27375a36d2f6eb4db39086ba6248440bf5 CACHE STRING "Tensile tag to download" )
+    set( tensile_tag a472399c5e97ac13b171092c2eb61d87d3a08d53 CACHE STRING "Tensile tag to download" )
     virtualenv_install("git+https://github.com/${tensile_fork}/Tensile.git@${tensile_tag}")
     message (STATUS "using GIT Tensile fork=${tensile_fork} from branch=${tensile_tag}")
   endif()
   list(APPEND CMAKE_PREFIX_PATH ${VIRTUALENV_HOME_DIR})
-  find_package(Tensile REQUIRED)
+  set( Tensile_ROOT "${VIRTUALENV_HOME_DIR}/bin" CACHE STRING "Local path of Tensile" )
+  set( Tensile_TensileConfig ${VIRTUALENV_HOME_DIR}/cmake/TensileConfig.cmake)
+
 endif()
 
 # Find HCC/HIP dependencies

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -36,6 +36,12 @@ if( BUILD_WITH_TENSILE )
     list( APPEND package_targets Tensile )
   endif( )
 
+  # HACK: We include the config file directly because find_package(Tensile) is broken
+  #include( ${Tensile_TensileConfig} )
+  execute_process(COMMAND "${VIRTUALENV_HOME_DIR}/bin/TensileGetPath" OUTPUT_VARIABLE INSTALLED_TENSILE_PATH)
+  message(STATUS "TENSILE_PATH: ${INSTALLED_TENSILE_PATH}")
+  find_package(Tensile 4.11.0 EXACT REQUIRED HIP LLVM OpenMP PATHS "${INSTALLED_TENSILE_PATH}")
+
   set( Tensile_RUNTIME_LANGUAGE "HIP" )
   message( STATUS "AMDGPU_TARGETS=${AMDGPU_TARGETS}" )
   TensileCreateLibraryCmake(
@@ -46,7 +52,8 @@ if( BUILD_WITH_TENSILE )
       ${Tensile_MERGE_FILES}
       ${Tensile_SHORT_FILENAMES}
       ${Tensile_PRINT_DEBUG}
-   )
+      Tensile_ROOT ${Tensile_ROOT}
+  )
 
   # Create a unique name for Tensile compiled for rocBLAS
   set_target_properties( Tensile PROPERTIES OUTPUT_NAME tensile-rocblas CXX_EXTENSIONS NO )


### PR DESCRIPTION
This commit does not pass CI. Cmake system is broken with Paul's changes. Tensile include headers are changed with this new system.

This reverts commit bae39ccb155f009660f9d9047d917449cee55157.
