### PR TITLE
Adding flag to install script to choose cpu lib

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -36,10 +36,14 @@ if( NOT cblas_FOUND )
   message( FATAL_ERROR "cblas is a required dependency and is not found;  try adding cblas path to CMAKE_PREFIX_PATH" )
 endif( )
 
+if(LINK_BLIS)
+  set( BLIS_CPP ../common/blis_interface.cpp )
+endif()
+
 set( rocblas_benchmark_common
       ../common/utility.cpp
       ../common/cblas_interface.cpp
-      ../common/blis_interface.cpp
+      ${BLIS_CPP}
       ../common/rocblas_parse_data.cpp
     )
 
@@ -77,8 +81,12 @@ if( EXISTS /etc/redhat-release)
         $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
         $<BUILD_INTERFACE:${OPENMP_INCLUDE_DIR}> 
 	)
+    if(LINK_BLIS)
+      target_link_libraries( rocblas-bench PRIVATE ${Boost_LIBRARIES} ${BLIS_LIBRARY} ${OPENMP_LIBRARY} cblas lapack roc::rocblas )
+    else()
+      target_link_libraries( rocblas-bench PRIVATE ${Boost_LIBRARIES} ${OPENMP_LIBRARY} cblas lapack roc::rocblas )
+    endif()
 
-    target_link_libraries( rocblas-bench PRIVATE ${Boost_LIBRARIES} ${BLIS_LIBRARY} ${OPENMP_LIBRARY} cblas lapack roc::rocblas )
 else()
     # External header includes included as system files
     target_include_directories( rocblas-bench
@@ -90,7 +98,12 @@ else()
         $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
     )
     
-    target_link_libraries( rocblas-bench PRIVATE ${Boost_LIBRARIES} ${BLIS_LIBRARY} cblas lapack roc::rocblas )
+    if(LINK_BLIS)
+      target_link_libraries( rocblas-bench PRIVATE ${Boost_LIBRARIES} ${BLIS_LIBRARY} cblas lapack roc::rocblas )
+    else()
+      target_link_libraries( rocblas-bench PRIVATE ${Boost_LIBRARIES} cblas lapack roc::rocblas )
+    endif()
+
 endif()
 
 get_target_property( HIPHCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -62,11 +62,14 @@ set(rocblas_test_source
     trtri_gtest.cpp
     )
 
+if(LINK_BLIS)
+  set( BLIS_CPP ../common/blis_interface.cpp )
+endif()
 
 set( rocblas_benchmark_common
       ../common/utility.cpp
       ../common/cblas_interface.cpp
-      ../common/blis_interface.cpp
+      ${BLIS_CPP}
       ../common/rocblas_parse_data.cpp
     )
 
@@ -116,7 +119,11 @@ if( EXISTS /etc/redhat-release)
         $<BUILD_INTERFACE:${OPENMP_INCLUDE_DIR}> 
         )
 
-    target_link_libraries( rocblas-test PRIVATE ${GTEST_LIBRARIES} ${Boost_LIBRARIES} ${BLIS_LIBRARY} ${OPENMP_LIBRARY} cblas lapack roc::rocblas )
+    if(LINK_BLIS)
+      target_link_libraries( rocblas-test PRIVATE ${GTEST_LIBRARIES} ${Boost_LIBRARIES} ${BLIS_LIBRARY} ${OPENMP_LIBRARY} cblas lapack roc::rocblas )
+    else()
+      target_link_libraries( rocblas-test PRIVATE ${GTEST_LIBRARIES} ${Boost_LIBRARIES} ${OPENMP_LIBRARY} cblas lapack roc::rocblas )
+    endif()
 else()
     # External header includes included as system files
     target_include_directories( rocblas-test
@@ -129,7 +136,11 @@ else()
         $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
     )
     
-    target_link_libraries( rocblas-test PRIVATE ${GTEST_LIBRARIES} ${Boost_LIBRARIES} ${BLIS_LIBRARY} cblas lapack roc::rocblas )
+    if(LINK_BLIS)
+      target_link_libraries( rocblas-test PRIVATE ${GTEST_LIBRARIES} ${Boost_LIBRARIES} ${BLIS_LIBRARY} cblas lapack roc::rocblas )
+    else()
+      target_link_libraries( rocblas-test PRIVATE ${GTEST_LIBRARIES} ${Boost_LIBRARIES} cblas lapack roc::rocblas )
+    endif()
 endif()
 
 get_target_property( HIPHCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ function display_help()
   echo "    [-o|--cov] Set tensile code_object_version (V2 or V3)"
   echo "    [-t|--test_local_path] Use a local path for tensile instead of remote GIT repot"
 #  echo "    [--cuda] build library for cuda backend"
-  echo "    [--cpu_lib] specify libary to use for cpu reference code in testing (blis or lapack)"
+  echo "    [--cpu_ref_lib] specify libary to use for cpu reference code in testing (blis or lapack)"
   echo "    [--hip-clang] build library for amdgpu backend using hip-clang"
 }
 
@@ -219,7 +219,7 @@ tensile_tag=
 tensile_test_local_path=
 build_clients=false
 build_cuda=false
-cpu_lib=blis
+cpu_ref_lib=blis
 build_release=true
 build_hip_clang=false
 
@@ -230,7 +230,7 @@ build_hip_clang=false
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,logic:,cov:,fork:,branch:test_local_path:,cpu_lib: --options hicdgl:o:f:b:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,logic:,cov:,fork:,branch:test_local_path:,cpu_ref_lib: --options hicdgl:o:f:b:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -279,8 +279,8 @@ while true; do
     --cuda)
         build_cuda=true
         shift ;;
-    --cpu_lib)
-        cpu_lib=${2}
+    --cpu_ref_lib)
+        cpu_ref_lib=${2}
         shift 2 ;;
     --hip-clang)
         build_hip_clang=true
@@ -295,9 +295,9 @@ while true; do
   esac
 done
 
-if [[ "${cpu_lib}" == blis ]]; then
+if [[ "${cpu_ref_lib}" == blis ]]; then
   LINK_BLIS=true
-elif [[ "${cpu_lib}" == lapack ]]; then
+elif [[ "${cpu_ref_lib}" == lapack ]]; then
   LINK_BLIS=false
 else
   echo "Currently the only CPU library options are blis and lapack"
@@ -344,7 +344,7 @@ if [[ "${install_dependencies}" == true ]]; then
 
 fi
 
-if [[ "${cpu_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]]; then
+if [[ "${cpu_ref_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]]; then
   git submodule update --init
   cd extern/blis
   if [[ -e "/etc/redhat-release" ]]; then  

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,7 @@ function display_help()
   echo "    [-o|--cov] Set tensile code_object_version (V2 or V3)"
   echo "    [-t|--test_local_path] Use a local path for tensile instead of remote GIT repot"
 #  echo "    [--cuda] build library for cuda backend"
+  echo "    [--cpu_lib] specify libary to use for cpu reference code in testing (blis or lapack)"
   echo "    [--hip-clang] build library for amdgpu backend using hip-clang"
 }
 
@@ -218,6 +219,7 @@ tensile_tag=
 tensile_test_local_path=
 build_clients=false
 build_cuda=false
+cpu_lib=blis
 build_release=true
 build_hip_clang=false
 
@@ -228,7 +230,7 @@ build_hip_clang=false
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,logic:,cov:,fork:,branch:test_local_path: --options hicdgl:o:f:b:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,logic:,cov:,fork:,branch:test_local_path:,cpu_lib: --options hicdgl:o:f:b:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -277,6 +279,9 @@ while true; do
     --cuda)
         build_cuda=true
         shift ;;
+    --cpu_lib)
+        cpu_lib=${2}
+        shift 2 ;;
     --hip-clang)
         build_hip_clang=true
         shift ;;
@@ -289,6 +294,15 @@ while true; do
         ;;
   esac
 done
+
+if [[ "${cpu_lib}" == blis ]]; then
+  LINK_BLIS=true
+elif [[ "${cpu_lib}" == lapack ]]; then
+  LINK_BLIS=false
+else
+  echo "Currently the only CPU library options are blis and lapack"
+      exit 2
+fi
 
 build_dir=./build
 printf "\033[32mCreating project build directory in: \033[33m${build_dir}\033[0m\n"
@@ -330,7 +344,7 @@ if [[ "${install_dependencies}" == true ]]; then
 
 fi
 
-if [[ ! -f "${build_dir}/deps/blis/lib/libblis.a" ]]; then
+if [[ "${cpu_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]]; then
   git submodule update --init
   cd extern/blis
   if [[ -e "/etc/redhat-release" ]]; then  
@@ -356,6 +370,7 @@ pushd .
   cmake_client_options=""
 
   cmake_common_options="${cmake_common_options} -lpthread -DTensile_LOGIC=${tensile_logic} -DTensile_CODE_OBJECT_VERSION=${tensile_cov}"
+  cmake_client_options="-DLINK_BLIS=${LINK_BLIS}"
 
   # build type
   if [[ "${build_release}" == true ]]; then


### PR DESCRIPTION
I have added a flag to the install script to be able to choose between the blis and lapack cpu libraries.
- cpu_lib flag is set to blis by default. 

I believe I should update the wiki page to include information on this flag when building the client.