### PR TITLE
Fix header file checks to not depend on hardcoded paths

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -214,5 +214,5 @@ add_custom_command(
   TARGET rocblas
   POST_BUILD
   COMMAND ${CMAKE_HOME_DIRECTORY}/header_compilation_tests.sh
-  WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
- )
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)


### PR DESCRIPTION
resolves #664

Change `header_compilation_tests.sh` to use CMake variables and data extracted from files, instead of hard-coded paths.

I have verified that it works in a `/tmp` build directory instead of the standard rocBLAS build tree. Running `install.sh` and running `make` from `build/release` still run the header checks.

We are nearing code-complete and this will be merged into `master` (or the `staging` branch) shortly, which will add parallelism to the existing script on `master`, making it less annoying during builds.
