### PR TITLE
Mintests

### DIFF
--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -31,7 +31,7 @@ Tests:
     - nrm2:  *single_double_precisions_complex_real
     - asum:  *single_double_precisions_complex_real
     - iamax: *single_double_precisions_complex_real
-#   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
+    - iamin: *single_double_precisions_complex_real
     - axpy:  *half_single_precisions_complex_real
     - copy:  *single_double_precisions_complex_real
     - dot:   *half_bfloat_single_double_complex_real_precisions
@@ -52,7 +52,7 @@ Tests:
     - nrm2:  *double_precision_complex_real
     - asum:  *double_precision_complex_real
     - iamax: *single_double_precisions_complex_real
-#   - iamin: *single_double_precisions_complex_real # broken for now -- cause unknown
+    - iamin: *single_double_precisions_complex_real
     - axpy:  *half_single_precisions_complex_real
     - copy:  *single_double_precisions_complex_real
     - dot:   *double_precision_complex_real

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -162,86 +162,52 @@ static constexpr auto rocblas_nrm2<rocblas_float_complex, float> = rocblas_scnrm
 template <>
 static constexpr auto rocblas_nrm2<rocblas_double_complex, double> = rocblas_dznrm2;
 
-// iamax and iamin need to be full functions rather than references, in order
-// to allow them to be passed as template arguments
+//
+// iamax and iamin.
+//
+
+//
+// Define the signature type.
+//
+template <typename T>
+using rocblas_iamax_iamin_t = rocblas_status (*)(
+    rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result);
+
 //
 // iamax
+//
 template <typename T>
-rocblas_status rocblas_iamax(
-    rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result);
+rocblas_iamax_iamin_t<T> rocblas_iamax;
 
 template <>
-inline rocblas_status rocblas_iamax(
-    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
-{
-    return rocblas_isamax(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamax<float> = rocblas_isamax;
 
 template <>
-inline rocblas_status rocblas_iamax(
-    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
-{
-    return rocblas_idamax(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamax<double> = rocblas_idamax;
 
 template <>
-inline rocblas_status rocblas_iamax(rocblas_handle               handle,
-                                    rocblas_int                  n,
-                                    const rocblas_float_complex* x,
-                                    rocblas_int                  incx,
-                                    rocblas_int*                 result)
-{
-    return rocblas_icamax(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamax<rocblas_float_complex> = rocblas_icamax;
 
 template <>
-inline rocblas_status rocblas_iamax(rocblas_handle                handle,
-                                    rocblas_int                   n,
-                                    const rocblas_double_complex* x,
-                                    rocblas_int                   incx,
-                                    rocblas_int*                  result)
-{
-    return rocblas_izamax(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamax<rocblas_double_complex> = rocblas_izamax;
 
+//
 // iamin
+//
 template <typename T>
-rocblas_status rocblas_iamin(
-    rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result);
+rocblas_iamax_iamin_t<T> rocblas_iamin;
 
 template <>
-inline rocblas_status rocblas_iamin(
-    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
-{
-    return rocblas_isamin(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamin<float> = rocblas_isamin;
 
 template <>
-inline rocblas_status rocblas_iamin(
-    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
-{
-    return rocblas_idamin(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamin<double> = rocblas_idamin;
 
 template <>
-inline rocblas_status rocblas_iamin(rocblas_handle               handle,
-                                    rocblas_int                  n,
-                                    const rocblas_float_complex* x,
-                                    rocblas_int                  incx,
-                                    rocblas_int*                 result)
-{
-    return rocblas_icamin(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamin<rocblas_float_complex> = rocblas_icamin;
 
 template <>
-inline rocblas_status rocblas_iamin(rocblas_handle                handle,
-                                    rocblas_int                   n,
-                                    const rocblas_double_complex* x,
-                                    rocblas_int                   incx,
-                                    rocblas_int*                  result)
-{
-    return rocblas_izamin(handle, n, x, incx, result);
-}
+static constexpr auto rocblas_iamin<rocblas_double_complex> = rocblas_izamin;
 
 // axpy
 template <typename T>

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -40,17 +40,16 @@ void testing_iamax_iamin_bad_arg(const Arguments& arg, rocblas_iamax_iamin_t<T> 
 template <typename T>
 void testing_iamax_bad_arg(const Arguments& arg)
 {
-  testing_iamax_iamin_bad_arg<T>(arg, rocblas_iamax<T>);
+    testing_iamax_iamin_bad_arg<T>(arg, rocblas_iamax<T>);
 }
 
 template <typename T>
 void testing_iamin_bad_arg(const Arguments& arg)
 {
-  testing_iamax_iamin_bad_arg<T>(arg, rocblas_iamin<T>);
+    testing_iamax_iamin_bad_arg<T>(arg, rocblas_iamin<T>);
 }
 
-template <typename T,
-          void CBLAS_FUNC(rocblas_int, const T*, rocblas_int, rocblas_int*)>
+template <typename T, void CBLAS_FUNC(rocblas_int, const T*, rocblas_int, rocblas_int*)>
 void testing_iamax_iamin(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
 {
     rocblas_int N    = arg.N;
@@ -257,11 +256,11 @@ namespace rocblas_cblas
 template <typename T>
 void testing_iamax(const Arguments& arg)
 {
-  testing_iamax_iamin<T, rocblas_cblas::cblas_iamax<T>>(arg, rocblas_iamax<T>);
+    testing_iamax_iamin<T, rocblas_cblas::cblas_iamax<T>>(arg, rocblas_iamax<T>);
 }
 
 template <typename T>
 void testing_iamin(const Arguments& arg)
 {
-  testing_iamax_iamin<T, rocblas_cblas::cblas_iamin<T>>(arg, rocblas_iamin<T>);
+    testing_iamax_iamin<T, rocblas_cblas::cblas_iamin<T>>(arg, rocblas_iamin<T>);
 }

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -13,9 +13,8 @@
 #include "unit.hpp"
 #include "utility.hpp"
 
-template <typename T,
-          rocblas_status (&FUNC)(rocblas_handle, rocblas_int, const T*, rocblas_int, rocblas_int*)>
-void testing_iamax_iamin_bad_arg(const Arguments& arg)
+template <typename T>
+void testing_iamax_iamin_bad_arg(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
 {
     rocblas_int         N         = 100;
     rocblas_int         incx      = 1;
@@ -31,29 +30,28 @@ void testing_iamax_iamin_bad_arg(const Arguments& arg)
 
     rocblas_int h_rocblas_result;
 
-    EXPECT_ROCBLAS_STATUS(FUNC(handle, N, nullptr, incx, &h_rocblas_result),
+    EXPECT_ROCBLAS_STATUS(func(handle, N, nullptr, incx, &h_rocblas_result),
                           rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(FUNC(handle, N, dx, incx, nullptr), rocblas_status_invalid_pointer);
-    EXPECT_ROCBLAS_STATUS(FUNC(nullptr, N, dx, incx, &h_rocblas_result),
+    EXPECT_ROCBLAS_STATUS(func(handle, N, dx, incx, nullptr), rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(func(nullptr, N, dx, incx, &h_rocblas_result),
                           rocblas_status_invalid_handle);
 }
 
 template <typename T>
 void testing_iamax_bad_arg(const Arguments& arg)
 {
-    testing_iamax_iamin_bad_arg<T, rocblas_iamax<T>>(arg);
+  testing_iamax_iamin_bad_arg<T>(arg, rocblas_iamax<T>);
 }
 
 template <typename T>
 void testing_iamin_bad_arg(const Arguments& arg)
 {
-    testing_iamax_iamin_bad_arg<T, rocblas_iamin<T>>(arg);
+  testing_iamax_iamin_bad_arg<T>(arg, rocblas_iamin<T>);
 }
 
 template <typename T,
-          rocblas_status (&FUNC)(rocblas_handle, rocblas_int, const T*, rocblas_int, rocblas_int*),
           void CBLAS_FUNC(rocblas_int, const T*, rocblas_int, rocblas_int*)>
-void testing_iamax_iamin(const Arguments& arg)
+void testing_iamax_iamin(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
 {
     rocblas_int N    = arg.N;
     rocblas_int incx = arg.incx;
@@ -76,7 +74,7 @@ void testing_iamax_iamin(const Arguments& arg)
             CHECK_HIP_ERROR(hipErrorOutOfMemory);
             return;
         }
-        CHECK_ROCBLAS_ERROR(FUNC(handle, N, dx, incx, &h_rocblas_result_1));
+        CHECK_ROCBLAS_ERROR(func(handle, N, dx, incx, &h_rocblas_result_1));
 
 #ifdef GOOGLE_TEST
         EXPECT_EQ(h_rocblas_result_1, 0);
@@ -112,11 +110,11 @@ void testing_iamax_iamin(const Arguments& arg)
     {
         // GPU BLAS rocblas_pointer_mode_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(FUNC(handle, N, dx, incx, &h_rocblas_result_1));
+        CHECK_ROCBLAS_ERROR(func(handle, N, dx, incx, &h_rocblas_result_1));
 
         // GPU BLAS, rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(FUNC(handle, N, dx, incx, d_rocblas_result));
+        CHECK_ROCBLAS_ERROR(func(handle, N, dx, incx, d_rocblas_result));
         CHECK_HIP_ERROR(hipMemcpy(
             &h_rocblas_result_2, d_rocblas_result, sizeof(rocblas_int), hipMemcpyDeviceToHost));
 
@@ -148,14 +146,14 @@ void testing_iamax_iamin(const Arguments& arg)
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {
-            FUNC(handle, N, dx, incx, d_rocblas_result);
+            func(handle, N, dx, incx, d_rocblas_result);
         }
 
         gpu_time_used = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_hot_calls; iter++)
         {
-            FUNC(handle, N, dx, incx, d_rocblas_result);
+            func(handle, N, dx, incx, d_rocblas_result);
         }
 
         gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
@@ -259,11 +257,11 @@ namespace rocblas_cblas
 template <typename T>
 void testing_iamax(const Arguments& arg)
 {
-    testing_iamax_iamin<T, rocblas_iamax<T>, rocblas_cblas::cblas_iamax<T>>(arg);
+  testing_iamax_iamin<T, rocblas_cblas::cblas_iamax<T>>(arg, rocblas_iamax<T>);
 }
 
 template <typename T>
 void testing_iamin(const Arguments& arg)
 {
-    testing_iamax_iamin<T, rocblas_iamin<T>, rocblas_cblas::cblas_iamin<T>>(arg);
+  testing_iamax_iamin<T, rocblas_cblas::cblas_iamin<T>>(arg, rocblas_iamin<T>);
 }

--- a/library/src/blas1/reduction.h
+++ b/library/src/blas1/reduction.h
@@ -154,6 +154,7 @@ template <rocblas_int NB,
           typename REDUCE = rocblas_reduce_sum,
           typename Ti,
           typename To>
+__attribute__((amdgpu_flat_work_group_size((NB < 128) ? NB : 128, (NB > 256) ? NB : 256)))
 __global__ void
     rocblas_reduction_kernel_part1(rocblas_int n, const Ti* x, rocblas_int incx, To* workspace)
 {
@@ -180,7 +181,9 @@ template <rocblas_int NB,
           typename FINALIZE = rocblas_finalize_identity,
           typename To,
           typename Tr>
-__global__ void rocblas_reduction_kernel_part2(rocblas_int nblocks, To* workspace, Tr* result)
+__attribute__((amdgpu_flat_work_group_size((NB < 128) ? NB : 128, (NB > 256) ? NB : 256)))
+__global__ void
+    rocblas_reduction_kernel_part2(rocblas_int nblocks, To* workspace, Tr* result)
 {
     rocblas_int   tx = hipThreadIdx_x;
     __shared__ To tmp[NB];


### PR DESCRIPTION
Put back the ignored test on iamin (see the JIRA ticket SWDEV-201525) 
and clean clients/include/rocblas.hpp.

Summary of proposed changes:
- 1/ clients/gtest/blas1_gtest.yaml: uncomment ignored tests

- 2/ clients/include/rocblas.hpp: 
    - a/ remove unnecessary full functions iamax/iamin (see modifications on testing_iamax_iamin.hpp)
    - b/ instead, define the references like ALL the other functions. 

- 3/ clients/include/testing_iamax_iamin.hpp
    - a/ no need for the function to be a template parameter, causing the issue of having to define full functions in rocblas.hpp. Instead, pass the function pointer as a function parameter.

- 4/ library/src/blas1/reduction.h
   - a/ Specify the work group size attribute to remove the non-deterministic behavior causing the iamin test failure. (see the JIRA ticket SWDEV-201525). The min is 128 by default and the max is 256 by default, only changing these values if NB is out of bounds.


