### PR TITLE
Fixing timeout for rocBLAS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,8 +72,6 @@ rocBLASCI:
         platform.runCommand(this, command)
     }
 
-    rocblas.timeout.test = 10
-
     def testCommand =
     {
         platform, project->


### PR DESCRIPTION
* Timeout unit was changed in the rocJenkins to minutes instead of hours. 

* rocBLAS will use default rocJenkins timeout.