### PR TITLE
Batched swap

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -26,6 +26,8 @@
 #include "testing_set_get_matrix.hpp"
 #include "testing_set_get_vector.hpp"
 #include "testing_swap.hpp"
+#include "testing_swap_batched.hpp"
+#include "testing_swap_strided_batched.hpp"
 #include "testing_syr.hpp"
 #include "testing_trtri.hpp"
 #include "testing_trtri_batched.hpp"
@@ -143,6 +145,10 @@ struct perf_blas<
             testing_dot<T>(arg);
         else if(!strcmp(arg.function, "swap"))
             testing_swap<T>(arg);
+        else if(!strcmp(arg.function, "swap_batched"))
+            testing_swap_batched<T>(arg);
+        else if(!strcmp(arg.function, "swap_strided_batched"))
+            testing_swap_strided_batched<T>(arg);
         else if(!strcmp(arg.function, "iamax"))
             testing_iamax<T>(arg);
         else if(!strcmp(arg.function, "iamin"))
@@ -253,6 +259,10 @@ struct perf_blas<T,
             testing_nrm2<T>(arg);
         else if(!strcmp(arg.function, "swap"))
             testing_swap<T>(arg);
+        else if(!strcmp(arg.function, "swap_batched"))
+            testing_swap_batched<T>(arg);
+        else if(!strcmp(arg.function, "swap_strided_batched"))
+            testing_swap_strided_batched<T>(arg);
         else if(!strcmp(arg.function, "iamax"))
             testing_iamax<T>(arg);
         else if(!strcmp(arg.function, "iamin"))

--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -196,17 +196,26 @@ def setdefaults(test):
     # These are only for dynamic defaults
     # TODO: This should be ideally moved to YAML file, with eval'd expressions.
 
-    if all([x in test for x in ('M', 'incx', 'strideScale')]) and test['function']=='ger_strided_batched':
-        test.setdefault('stride_x', int(test['M'] * abs(test['incx']) *
-                                    test['strideScale']))
+    if test['function']=='swap_strided_batched':    
+        if all([x in test for x in ('N', 'incx', 'stride_scale')]):
+            test.setdefault('stride_x', int(test['N'] * abs(test['incx']) *
+                                            test['stride_scale']))
+        if all([x in test for x in ('N', 'incy', 'stride_scale')]):
+            test.setdefault('stride_y', int(test['N'] * abs(test['incy']) *
+                                            test['stride_scale']))
     else:
-       test.setdefault('stride_x', 0)
-
-    if all([x in test for x in ('N', 'incy', 'strideScale')]) and test['function']=='ger_strided_batched':
-        test.setdefault('stride_y', int(test['N'] * abs(test['incy']) *
+        if all([x in test for x in ('M', 'incx', 'strideScale')]) and test['function']=='ger_strided_batched':
+            test.setdefault('stride_x', int(test['M'] * abs(test['incx']) *
                                         test['strideScale']))
-    else:
-        test.setdefault('stride_y', 0)
+        else:
+            test.setdefault('stride_x', 0)
+
+        if all([x in test for x in ('N', 'incy', 'strideScale')]) and test['function']=='ger_strided_batched':
+            test.setdefault('stride_y', int(test['N'] * abs(test['incy']) *
+                                            test['strideScale']))
+        else:
+            test.setdefault('stride_y', 0)
+
 
     if test['transA'] == '*' or test['transB'] == '*':
         test.setdefault('lda', 0)

--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -196,7 +196,7 @@ def setdefaults(test):
     # These are only for dynamic defaults
     # TODO: This should be ideally moved to YAML file, with eval'd expressions.
 
-    if test['function']=='swap_strided_batched':    
+    if test['function'] in ('swap_strided_batched'):    
         if all([x in test for x in ('N', 'incx', 'stride_scale')]):
             test.setdefault('stride_x', int(test['N'] * abs(test['incx']) *
                                             test['stride_scale']))

--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -200,9 +200,13 @@ def setdefaults(test):
         if all([x in test for x in ('N', 'incx', 'stride_scale')]):
             test.setdefault('stride_x', int(test['N'] * abs(test['incx']) *
                                             test['stride_scale']))
+        else:
+            test.setdefault('stride_x', 0)
         if all([x in test for x in ('N', 'incy', 'stride_scale')]):
             test.setdefault('stride_y', int(test['N'] * abs(test['incy']) *
                                             test['stride_scale']))
+        else:
+            test.setdefault('stride_y', 0)
     else:
         if all([x in test for x in ('M', 'incx', 'strideScale')]) and test['function']=='ger_strided_batched':
             test.setdefault('stride_x', int(test['M'] * abs(test['incx']) *

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -15,6 +15,8 @@
 #include "testing_rotmg.hpp"
 #include "testing_scal.hpp"
 #include "testing_swap.hpp"
+#include "testing_swap_batched.hpp"
+#include "testing_swap_strided_batched.hpp"
 #include "type_dispatch.hpp"
 #include "utility.hpp"
 
@@ -32,6 +34,8 @@ namespace
         dotc,
         scal,
         swap,
+        swap_batched,
+        swap_strided_batched,
         rot,
         rotg,
         rotm,
@@ -79,8 +83,19 @@ namespace
                 name << '_' << arg.incx;
 
                 if(BLAS1 == blas1::axpy || BLAS1 == blas1::copy || BLAS1 == blas1::dot
-                   || BLAS1 == blas1::swap || BLAS1 == blas1::rot || BLAS1 == blas1::rotm)
+                   || BLAS1 == blas1::swap || BLAS1 == blas1::swap_batched || BLAS1 == blas1::swap_strided_batched
+                   || BLAS1 == blas1::rot || BLAS1 == blas1::rotm)
                     name << '_' << arg.incy;
+            
+                if(BLAS1 == blas1::swap_strided_batched)
+                {
+                    name << '_' << arg.stride_x << "_" << arg.stride_y;
+                }
+
+                if(BLAS1 == blas1::swap_batched || BLAS1 == blas1::swap_strided_batched)
+                {
+                    name << "_" << arg.batch_count;
+                }
             }
 
             return std::move(name);
@@ -138,7 +153,8 @@ namespace
                     || std::is_same<Ti, rocblas_float_complex>{}
                     || std::is_same<Ti, rocblas_double_complex>{}))
 
-            || (BLAS1 == blas1::swap && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+            || ((BLAS1 == blas1::swap || BLAS1 == blas1::swap_batched || BLAS1 == blas1::swap_strided_batched) 
+                && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
                 && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}
                     || std::is_same<Ti, rocblas_float_complex>{}
                     || std::is_same<Ti, rocblas_double_complex>{}))
@@ -228,10 +244,13 @@ BLAS1_TESTING(dot,   ARG1)
 BLAS1_TESTING(dotc,  ARG1)
 BLAS1_TESTING(scal,  ARG2)
 BLAS1_TESTING(swap,  ARG1)
+BLAS1_TESTING(swap_batched, ARG1)
+BLAS1_TESTING(swap_strided_batched, ARG1)
 BLAS1_TESTING(rot,   ARG3)
 BLAS1_TESTING(rotg,  ARG2)
 BLAS1_TESTING(rotm,  ARG1)
 BLAS1_TESTING(rotmg, ARG1)
+
 
     // clang-format on
 

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -90,6 +90,7 @@ namespace
                 if(BLAS1 == blas1::swap_strided_batched)
                 {
                     name << '_' << arg.stride_x << "_" << arg.stride_y;
+                    name << '_' << arg.stride_scale;
                 }
 
                 if(BLAS1 == blas1::swap_batched || BLAS1 == blas1::swap_strided_batched)

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -91,7 +91,6 @@ namespace
                 if(BLAS1 == blas1::swap_strided_batched)
                 {
                     name << '_' << arg.stride_x << "_" << arg.stride_y;
-                    name << '_' << arg.stride_scale;
                 }
 
                 if(BLAS1 == blas1::swap_batched || BLAS1 == blas1::swap_strided_batched)

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -83,10 +83,11 @@ namespace
                 name << '_' << arg.incx;
 
                 if(BLAS1 == blas1::axpy || BLAS1 == blas1::copy || BLAS1 == blas1::dot
-                   || BLAS1 == blas1::swap || BLAS1 == blas1::swap_batched || BLAS1 == blas1::swap_strided_batched
-                   || BLAS1 == blas1::rot || BLAS1 == blas1::rotm)
+                   || BLAS1 == blas1::swap || BLAS1 == blas1::swap_batched
+                   || BLAS1 == blas1::swap_strided_batched || BLAS1 == blas1::rot
+                   || BLAS1 == blas1::rotm)
                     name << '_' << arg.incy;
-            
+
                 if(BLAS1 == blas1::swap_strided_batched)
                 {
                     name << '_' << arg.stride_x << "_" << arg.stride_y;
@@ -154,7 +155,8 @@ namespace
                     || std::is_same<Ti, rocblas_float_complex>{}
                     || std::is_same<Ti, rocblas_double_complex>{}))
 
-            || ((BLAS1 == blas1::swap || BLAS1 == blas1::swap_batched || BLAS1 == blas1::swap_strided_batched) 
+            || ((BLAS1 == blas1::swap || BLAS1 == blas1::swap_batched
+                 || BLAS1 == blas1::swap_strided_batched)
                 && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
                 && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{}
                     || std::is_same<Ti, rocblas_float_complex>{}
@@ -251,7 +253,6 @@ BLAS1_TESTING(rot,   ARG3)
 BLAS1_TESTING(rotg,  ARG2)
 BLAS1_TESTING(rotm,  ARG1)
 BLAS1_TESTING(rotmg, ARG1)
-
 
     // clang-format on
 

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -38,11 +38,8 @@ Tests:
     - dotc:  *single_double_precisions_complex
     - scal:  *single_double_precisions_complex_real
     - scal:  *single_double_complex_real_in_complex_out
-    - swap:  *single_double_precisions_complex_real
     - rot:   *rot_precisions
     - rotm:   *single_double_precisions_complex_real
-#    - swap_batched:  *single_double_precisions
-#    - swap_strided_batched:  *single_double_precisions
 
 - name: blas1
   category: pre_checkin
@@ -61,61 +58,8 @@ Tests:
     - dotc:  *double_precision_complex_real
     - scal:  *single_double_precisions_complex_real
     - scal:  *single_double_complex_real_in_complex_out
-    - swap:  *single_double_precisions_complex_real
     - rot:   *rot_precisions
     - rotm:   *single_double_precisions_complex_real
-#    - swap_batched:  *single_double_precisions
-#    - swap_strided_batched:  *single_double_precisions
-
-- name: blas1_swap_batched
-  category: pre_checkin
-  N: [ 1048576, 1049600, 4000000, 8000000 ]
-  incx_incy: *incx_incy_range
-  batch_count: [1, 10]
-  function: 
-    - swap_batched: *single_double_precisions_complex_real
-
-
-
-- name: blas1_swap_batched
-  category: quick
-  N: [ -1, 0, 5, 10, 1025, 7111, 10000, 33792 ]
-  incx_incy: *incx_incy_range
-  batch_count: [-1, 0, 1, 10]
-  function: 
-    - swap_batched: *single_double_precisions_complex_real
-
-- name: blas1_swap_strided_batched
-  category: quick
-  N: [ 7111, 10000, 33792 ] 
-  incx_incy: *incx_incy_range 
-  batch_count: [-1, 0, 10]
-  stride_scale: [ 0, 1 ]
-  #stride_x: [1, 68000]
-  #stride_y: [1, 68000]
-  function:
-    - swap_strided_batched: *single_double_precisions_complex_real
-
-- name: blas1_swap_strided_batched
-  category: quick
-  N: [ -1, 0, 1025] 
-  incx: [ 1 ]
-  incy: [ 1 ]
-  batch_count: [-1, 0, 1]
-  stride_scale: [ 0, 1 ]
-  #stride_x: [1, 68000]
-  #stride_y: [1, 68000]
-  function:
-    - swap_strided_batched: *single_double_precisions_complex_real
-
-- name: blas1_swap_strided_batched
-  category: pre_checkin
-  N: [ 1025, 800000 ]
-  incx_incy: *incx_incy_range
-  batch_count: [1, 10]
-  stride_scale: [ 0, 1 ]
-  function:
-    - swap_strided_batched: *single_double_precisions_complex_real
 
 - name: blas1_bad_arg
   category: pre_checkin
@@ -131,8 +75,8 @@ Tests:
     - scal_bad_arg:  *single_double_precisions_complex_real
     - scal_bad_arg:  *single_double_complex_real_in_complex_out
     - swap_bad_arg:  *single_double_precisions_complex_real
-    - swap_batched_bad_arg:  *single_double_precisions
-    - swap_strided_batched_bad_arg:  *single_double_precisions
+    - swap_batched_bad_arg:  *single_double_precisions_complex_real
+    - swap_strided_batched_bad_arg:  *single_double_precisions_complex_real
     - rot_bad_arg:   *rot_precisions
     - rotg_bad_arg:  *rotg_precisions
     - rotm_bad_arg:  *single_double_precisions_complex_real
@@ -143,3 +87,56 @@ Tests:
   function:
     - rotg:  *rotg_precisions
     - rotmg: *single_double_precisions_complex_real
+
+# blas1 swap variants
+
+- name: blas1_swap
+  category: quick
+  N: [ -1, 0, 1025] 
+  incx: [ 1 ]
+  incy: [ 1 ]
+  function: 
+    - swap: *single_double_precisions_complex_real
+
+- name: blas1_swap
+  category: pre_checkin
+  N: [ 5000, 800000 ]
+  incx_incy: *incx_incy_range
+  function: 
+    - swap: *single_double_precisions_complex_real
+
+- name: blas1_swap_batched
+  category: quick
+  N: [ -1, 0, 1025] 
+  incx: [ 1 ]
+  incy: [ 1 ]
+  batch_count: [-1, 0, 1]
+  function: 
+    - swap_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_batched
+  category: pre_checkin
+  N: [ 5000, 800000 ]
+  incx_incy: *incx_incy_range
+  batch_count: [1, 7]
+  function: 
+    - swap_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_strided_batched
+  category: quick
+  N: [ -1, 0, 1025] 
+  incx: [ 1 ]
+  incy: [ 1 ]
+  batch_count: [-1, 0, 1]
+  stride_scale: [ 0, 1 ]
+  function:
+    - swap_strided_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_strided_batched
+  category: pre_checkin
+  N: [ 5000, 800000 ]
+  incx_incy: *incx_incy_range
+  batch_count: [1, 7] 
+  stride_scale: [ 1 ]
+  function:
+    - swap_strided_batched: *single_double_precisions_complex_real

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -41,6 +41,8 @@ Tests:
     - swap:  *single_double_precisions_complex_real
     - rot:   *rot_precisions
     - rotm:   *single_double_precisions_complex_real
+#    - swap_batched:  *single_double_precisions
+#    - swap_strided_batched:  *single_double_precisions
 
 - name: blas1
   category: pre_checkin
@@ -62,6 +64,44 @@ Tests:
     - swap:  *single_double_precisions_complex_real
     - rot:   *rot_precisions
     - rotm:   *single_double_precisions_complex_real
+#    - swap_batched:  *single_double_precisions
+#    - swap_strided_batched:  *single_double_precisions
+
+- name: blas1_swap_batched
+  category: pre_checkin
+  N: [ 1048576, 1049600, 4000000, 8000000 ]
+  incx_incy: *incx_incy_range
+  batch_count: [1, 10]
+  function: 
+    - swap_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_strided_batched
+  category: pre_checkin
+  N: [ 1048576, 1049600, 4000000, 8000000 ]
+  incx_incy: *incx_incy_range
+  batch_count: [1, 10]
+  stride_x: [1, 16000000]
+  stride_y: [1, 16000000]
+  function:
+    - swap_strided_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_batched
+  category: quick
+  N: [ -1, 0, 5, 10, 1025, 7111, 10000, 33792 ]
+  incx_incy: *incx_incy_range
+  batch_count: [-1, 0, 1, 10]
+  function: 
+    - swap_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_strided_batched
+  category: quick
+  N: [ -1, 0, 5, 10, 1025, 7111, 10000, 33792 ] 
+  incx_incy: *incx_incy_range 
+  batch_count: [-1, 0, 1, 10]
+  stride_x: [1, 68000]
+  stride_y: [1, 68000]
+  function:
+    - swap_strided_batched: *single_double_precisions_complex_real
 
 - name: blas1_bad_arg
   category: pre_checkin
@@ -77,6 +117,8 @@ Tests:
     - scal_bad_arg:  *single_double_precisions_complex_real
     - scal_bad_arg:  *single_double_complex_real_in_complex_out
     - swap_bad_arg:  *single_double_precisions_complex_real
+    - swap_batched_bad_arg:  *single_double_precisions
+    - swap_strided_batched_bad_arg:  *single_double_precisions
     - rot_bad_arg:   *rot_precisions
     - rotg_bad_arg:  *rotg_precisions
     - rotm_bad_arg:  *single_double_precisions_complex_real
@@ -87,4 +129,3 @@ Tests:
   function:
     - rotg:  *rotg_precisions
     - rotmg: *single_double_precisions_complex_real
-...

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -75,15 +75,7 @@ Tests:
   function: 
     - swap_batched: *single_double_precisions_complex_real
 
-- name: blas1_swap_strided_batched
-  category: pre_checkin
-  N: [ 1048576, 1049600, 4000000, 8000000 ]
-  incx_incy: *incx_incy_range
-  batch_count: [1, 10]
-  stride_x: [1, 16000000]
-  stride_y: [1, 16000000]
-  function:
-    - swap_strided_batched: *single_double_precisions_complex_real
+
 
 - name: blas1_swap_batched
   category: quick
@@ -95,11 +87,33 @@ Tests:
 
 - name: blas1_swap_strided_batched
   category: quick
-  N: [ -1, 0, 5, 10, 1025, 7111, 10000, 33792 ] 
+  N: [ 7111, 10000, 33792 ] 
   incx_incy: *incx_incy_range 
-  batch_count: [-1, 0, 1, 10]
-  stride_x: [1, 68000]
-  stride_y: [1, 68000]
+  batch_count: [-1, 0, 10]
+  stride_scale: [ 0, 1 ]
+  #stride_x: [1, 68000]
+  #stride_y: [1, 68000]
+  function:
+    - swap_strided_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_strided_batched
+  category: quick
+  N: [ -1, 0, 1025] 
+  incx: [ 1 ]
+  incy: [ 1 ]
+  batch_count: [-1, 0, 1]
+  stride_scale: [ 0, 1 ]
+  #stride_x: [1, 68000]
+  #stride_y: [1, 68000]
+  function:
+    - swap_strided_batched: *single_double_precisions_complex_real
+
+- name: blas1_swap_strided_batched
+  category: pre_checkin
+  N: [ 1025, 800000 ]
+  incx_incy: *incx_incy_range
+  batch_count: [1, 10]
+  stride_scale: [ 0, 1 ]
   function:
     - swap_strided_batched: *single_double_precisions_complex_real
 

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -112,10 +112,10 @@ rocblas_status (*rocblas_swap_strided_batched)(rocblas_handle handle,
                                                rocblas_int    n,
                                                T*             x,
                                                rocblas_int    incx,
-                                               rocblas_int    stridex,
+                                               rocblas_stride stridex,
                                                T*             y,
                                                rocblas_int    incy,
-                                               rocblas_int    stridey,
+                                               rocblas_stride stridey,
                                                rocblas_int    batch_count);
 
 template <>

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -84,6 +84,40 @@ static constexpr auto rocblas_swap<rocblas_float_complex> = rocblas_cswap;
 template <>
 static constexpr auto rocblas_swap<rocblas_double_complex> = rocblas_zswap;
 
+// swap_batched
+template <typename T>
+rocblas_status (*rocblas_swap_batched)(
+    rocblas_handle handle, rocblas_int n, T* x[], rocblas_int incx, T* y[], rocblas_int incy, rocblas_int batch_count);
+
+template <>
+static constexpr auto rocblas_swap_batched<float> = rocblas_sswap_batched;
+
+template <>
+static constexpr auto rocblas_swap_batched<double> = rocblas_dswap_batched;
+
+template <>
+static constexpr auto rocblas_swap_batched<rocblas_float_complex> = rocblas_cswap_batched;
+
+template <>
+static constexpr auto rocblas_swap_batched<rocblas_double_complex> = rocblas_zswap_batched;
+
+// swap_strided_batched
+template <typename T>
+rocblas_status (*rocblas_swap_strided_batched)(
+    rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, rocblas_int stridex, T* y, rocblas_int incy, rocblas_int stridey, rocblas_int batch_count);
+
+template <>
+static constexpr auto rocblas_swap_strided_batched<float> = rocblas_sswap_strided_batched;
+
+template <>
+static constexpr auto rocblas_swap_strided_batched<double> = rocblas_dswap_strided_batched;
+
+template <>
+static constexpr auto rocblas_swap_strided_batched<rocblas_float_complex> = rocblas_cswap_strided_batched;
+
+template <>
+static constexpr auto rocblas_swap_strided_batched<rocblas_double_complex> = rocblas_zswap_strided_batched;
+
 // dot
 template <typename T>
 rocblas_status (*rocblas_dot)(rocblas_handle handle,

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -86,8 +86,13 @@ static constexpr auto rocblas_swap<rocblas_double_complex> = rocblas_zswap;
 
 // swap_batched
 template <typename T>
-rocblas_status (*rocblas_swap_batched)(
-    rocblas_handle handle, rocblas_int n, T* x[], rocblas_int incx, T* y[], rocblas_int incy, rocblas_int batch_count);
+rocblas_status (*rocblas_swap_batched)(rocblas_handle handle,
+                                       rocblas_int    n,
+                                       T*             x[],
+                                       rocblas_int    incx,
+                                       T*             y[],
+                                       rocblas_int    incy,
+                                       rocblas_int    batch_count);
 
 template <>
 static constexpr auto rocblas_swap_batched<float> = rocblas_sswap_batched;
@@ -103,8 +108,15 @@ static constexpr auto rocblas_swap_batched<rocblas_double_complex> = rocblas_zsw
 
 // swap_strided_batched
 template <typename T>
-rocblas_status (*rocblas_swap_strided_batched)(
-    rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, rocblas_int stridex, T* y, rocblas_int incy, rocblas_int stridey, rocblas_int batch_count);
+rocblas_status (*rocblas_swap_strided_batched)(rocblas_handle handle,
+                                               rocblas_int    n,
+                                               T*             x,
+                                               rocblas_int    incx,
+                                               rocblas_int    stridex,
+                                               T*             y,
+                                               rocblas_int    incy,
+                                               rocblas_int    stridey,
+                                               rocblas_int    batch_count);
 
 template <>
 static constexpr auto rocblas_swap_strided_batched<float> = rocblas_sswap_strided_batched;
@@ -113,10 +125,12 @@ template <>
 static constexpr auto rocblas_swap_strided_batched<double> = rocblas_dswap_strided_batched;
 
 template <>
-static constexpr auto rocblas_swap_strided_batched<rocblas_float_complex> = rocblas_cswap_strided_batched;
+static constexpr auto
+    rocblas_swap_strided_batched<rocblas_float_complex> = rocblas_cswap_strided_batched;
 
 template <>
-static constexpr auto rocblas_swap_strided_batched<rocblas_double_complex> = rocblas_zswap_strided_batched;
+static constexpr auto
+    rocblas_swap_strided_batched<rocblas_double_complex> = rocblas_zswap_strided_batched;
 
 // dot
 template <typename T>

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -62,8 +62,7 @@ struct Arguments
     rocblas_int stride_b; //  stride_b > transB == 'N' ? ldb * N : ldb * K
     rocblas_int stride_c; //  stride_c > ldc * N
     rocblas_int stride_d; //  stride_d > ldd * N
-
-    rocblas_int stride_x;
+    rocblas_int stride_x; 
     rocblas_int stride_y;
 
     rocblas_int norm_check;

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -62,7 +62,7 @@ struct Arguments
     rocblas_int stride_b; //  stride_b > transB == 'N' ? ldb * N : ldb * K
     rocblas_int stride_c; //  stride_c > ldc * N
     rocblas_int stride_d; //  stride_d > ldd * N
-    rocblas_int stride_x; 
+    rocblas_int stride_x;
     rocblas_int stride_y;
     rocblas_int stride_scale;
 

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -64,6 +64,7 @@ struct Arguments
     rocblas_int stride_d; //  stride_d > ldd * N
     rocblas_int stride_x; 
     rocblas_int stride_y;
+    rocblas_int stride_scale;
 
     rocblas_int norm_check;
     rocblas_int unit_check;
@@ -149,6 +150,7 @@ struct Arguments
         ROCBLAS_FORMAT_CHECK(stride_d);
         ROCBLAS_FORMAT_CHECK(stride_x);
         ROCBLAS_FORMAT_CHECK(stride_y);
+        ROCBLAS_FORMAT_CHECK(stride_scale);
         ROCBLAS_FORMAT_CHECK(norm_check);
         ROCBLAS_FORMAT_CHECK(unit_check);
         ROCBLAS_FORMAT_CHECK(timing);
@@ -300,6 +302,7 @@ private:
         print("stride_d", arg.stride_d);
         print("stride_x", arg.stride_x);
         print("stride_y", arg.stride_y);
+        print("stride_scale", arg.stride_scale);
         print("algo", arg.algo);
         print("solution_index", arg.solution_index);
         print("flags", arg.flags);

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -64,7 +64,6 @@ struct Arguments
     rocblas_int stride_d; //  stride_d > ldd * N
     rocblas_int stride_x;
     rocblas_int stride_y;
-    rocblas_int stride_scale;
 
     rocblas_int norm_check;
     rocblas_int unit_check;
@@ -150,7 +149,6 @@ struct Arguments
         ROCBLAS_FORMAT_CHECK(stride_d);
         ROCBLAS_FORMAT_CHECK(stride_x);
         ROCBLAS_FORMAT_CHECK(stride_y);
-        ROCBLAS_FORMAT_CHECK(stride_scale);
         ROCBLAS_FORMAT_CHECK(norm_check);
         ROCBLAS_FORMAT_CHECK(unit_check);
         ROCBLAS_FORMAT_CHECK(timing);
@@ -302,7 +300,6 @@ private:
         print("stride_d", arg.stride_d);
         print("stride_x", arg.stride_x);
         print("stride_y", arg.stride_y);
-        print("stride_scale", arg.stride_scale);
         print("algo", arg.algo);
         print("solution_index", arg.solution_index);
         print("flags", arg.flags);

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -252,6 +252,7 @@ Arguments:
   - stride_d: rocblas_int
   - stride_x: rocblas_int
   - stride_y: rocblas_int
+  - stride_scale: rocblas_int
   - norm_check: rocblas_int
   - unit_check: rocblas_int
   - timing: rocblas_int
@@ -321,6 +322,7 @@ Defaults:
   stride_b: 0
   stride_c: 0
   stride_d: 0
+  stride_scale: 1
   norm_check: 0
   unit_check: 1
   timing: 0

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -252,7 +252,6 @@ Arguments:
   - stride_d: rocblas_int
   - stride_x: rocblas_int
   - stride_y: rocblas_int
-  - stride_scale: rocblas_int
   - norm_check: rocblas_int
   - unit_check: rocblas_int
   - timing: rocblas_int

--- a/clients/include/rocblas_template.yaml
+++ b/clients/include/rocblas_template.yaml
@@ -9,6 +9,10 @@ Functions:
   rocblas_dcopy: { function: copy, <<: *double_precision }
   rocblas_sswap: { function: swap, <<: *single_precision }
   rocblas_dswap: { function: swap, <<: *double_precision }
+  rocblas_sswap_batched: { function: swap_batched, <<: *single_precision }
+  rocblas_dswap_batched: { function: swap_batched, <<: *double_precision }
+  rocblas_sswap_strided_batched: { function: swap_strided_batched, <<: *single_precision }
+  rocblas_dswap_strided_batched: { function: swap_strided_batched, <<: *double_precision }
   rocblas_sdot:  { function: dot, <<: *single_precision  }
   rocblas_ddot:  { function: dot, <<: *double_precision  }
   rocblas_sasum: { function: asum, <<: *single_precision }

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -1,0 +1,233 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "cblas_interface.hpp"
+#include "norm.hpp"
+#include "rocblas.hpp"
+#include "rocblas_init.hpp"
+#include "rocblas_math.hpp"
+#include "rocblas_random.hpp"
+#include "rocblas_test.hpp"
+#include "rocblas_vector.hpp"
+#include "unit.hpp"
+#include "utility.hpp"
+
+template <typename T>
+void testing_swap_batched_bad_arg(const Arguments& arg)
+{
+    rocblas_int N           = 100;
+    rocblas_int incx        = 1;
+    rocblas_int incy        = 1;
+    rocblas_int batch_count = 1;
+
+    rocblas_local_handle handle;
+
+    T** dxt;
+    hipMalloc(&dxt, sizeof(T*));
+    T** dyt;
+    hipMalloc(&dyt, sizeof(T*));
+    if(!dxt || !dyt)
+    {
+        CHECK_HIP_ERROR(hipErrorOutOfMemory);
+        return;
+    }
+
+    EXPECT_ROCBLAS_STATUS(rocblas_swap_batched<T>(handle, N, nullptr, incx, dyt, incy, batch_count),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocblas_swap_batched<T>(handle, N, dxt, incx, nullptr, incy, batch_count),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocblas_swap_batched<T>(nullptr, N, dxt, incx, dyt, incy, batch_count),
+                          rocblas_status_invalid_handle);
+
+    hipFree(dxt);
+    hipFree(dyt);
+}
+
+template <typename T>
+void testing_swap_batched(const Arguments& arg)
+{
+    rocblas_int N           = arg.N;
+    rocblas_int incx        = arg.incx;
+    rocblas_int incy        = arg.incy;
+    rocblas_int batch_count = arg.batch_count;
+
+    rocblas_local_handle handle;
+
+    // argument sanity check before allocating invalid memory
+    if(batch_count < 0)
+    {
+        static const size_t safe_size = 100; //  arbitrarily set to 100
+
+        T** dxt;
+        hipMalloc(&dxt, sizeof(T*));
+        T** dyt;
+        hipMalloc(&dyt, sizeof(T*));
+        if(!dxt || !dyt)
+        {
+            CHECK_HIP_ERROR(hipErrorOutOfMemory);
+            return;
+        }
+
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+        EXPECT_ROCBLAS_STATUS(rocblas_swap_batched<T>(handle, N, dxt, incx, dyt, incy, batch_count),
+                              rocblas_status_invalid_size);
+        CHECK_HIP_ERROR(hipFree(dxt));
+        CHECK_HIP_ERROR(hipFree(dyt));
+        return;
+    }
+
+    if(N <= 0 || batch_count == 0)
+    {
+        static const size_t safe_size = 100; //  arbitrarily set to 100
+
+        T** dxt;
+        hipMalloc(&dxt, sizeof(T*));
+        T** dyt;
+        hipMalloc(&dyt, sizeof(T*));
+        if(!dxt || !dyt)
+        {
+            CHECK_HIP_ERROR(hipErrorOutOfMemory);
+            return;
+        }
+
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+        CHECK_ROCBLAS_ERROR(rocblas_swap_batched<T>(handle, N, dxt, incx, dyt, incy, batch_count));
+        CHECK_HIP_ERROR(hipFree(dxt));
+        CHECK_HIP_ERROR(hipFree(dyt));
+        return;
+    }
+
+    ssize_t abs_incx = (incx >= 0) ? incx : -incx;
+    ssize_t abs_incy = (incy >= 0) ? incy : -incy;
+
+    size_t size_x = N * abs_incx;
+    size_t size_y = N * abs_incy;
+
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx[batch_count]; 
+    host_vector<T> hy[batch_count]; 
+    host_vector<T> hx_gold[batch_count]; 
+    host_vector<T> hy_gold[batch_count]; 
+
+    for(int i = 0; i < batch_count; i++)
+    {
+        hx[i]      = host_vector<T>(size_x);
+        hy[i]      = host_vector<T>(size_y);
+        hx_gold[i] = host_vector<T>(size_x);
+        hy_gold[i] = host_vector<T>(size_y); 
+    }
+
+    // Initial Data on CPU
+    rocblas_seedrand();
+    for(int i = 0; i < batch_count; i++)
+    {
+        rocblas_init<T>(hx[i], 1, N, abs_incx);
+        // make hy different to hx
+        for(size_t j = 0; j < N; j++)
+        {
+            hy[i][j * abs_incy] = hx[i][j * abs_incx] + 1.0;
+        }
+        hx_gold[i] = hx[i]; // swapped later by cblas_swap
+        hy_gold[i] = hy[i];   
+    }
+
+
+    device_batch_vector<T> dxvec(batch_count, size_x);
+    device_batch_vector<T> dyvec(batch_count, size_y);
+
+    // copy data from host to device
+    for(int i = 0; i < batch_count; i++)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dxvec[i], hx[i], sizeof(T) * size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dyvec[i], hy[i], sizeof(T) * size_y, hipMemcpyHostToDevice));
+    }
+
+    // vector pointers on gpu
+    
+    T** dx_pvec;
+    T** dy_pvec;
+    CHECK_HIP_ERROR(hipMalloc(&dx_pvec, batch_count * sizeof(T*)));
+    CHECK_HIP_ERROR(hipMalloc(&dy_pvec, batch_count * sizeof(T*)));
+    if(!dx_pvec || !dy_pvec)
+    {
+        CHECK_HIP_ERROR(hipErrorOutOfMemory);
+        return;
+    }
+
+    // copy gpu vector pointers from host to device pointer array
+    CHECK_HIP_ERROR(hipMemcpy(dx_pvec, dxvec, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy_pvec, dyvec, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error = 0.0;
+
+    if(arg.unit_check || arg.norm_check)
+    {
+        // GPU BLAS
+        CHECK_ROCBLAS_ERROR(
+            rocblas_swap_batched<T>(handle, N, dx_pvec, incx, dy_pvec, incy, batch_count));
+
+        // copy data from device to CPU
+        for(int i = 0; i < batch_count; i++)
+        {
+            CHECK_HIP_ERROR(hipMemcpy(hx[i], dxvec[i], sizeof(T) * size_x, hipMemcpyDeviceToHost));
+            CHECK_HIP_ERROR(hipMemcpy(hy[i], dyvec[i], sizeof(T) * size_y, hipMemcpyDeviceToHost));
+        }
+
+        // CPU BLAS
+        cpu_time_used = get_time_us();
+        for(int i = 0; i < batch_count; i++)
+        {
+            cblas_swap<T>(N, hx_gold[i], incx, hy_gold[i], incy);
+        }
+        cpu_time_used = get_time_us() - cpu_time_used;
+
+        if(arg.unit_check)
+        {
+            for(int i = 0; i < batch_count; i++)
+            {
+                unit_check_general<T>(1, N, abs_incx, hx_gold[i], hx[i]);
+                unit_check_general<T>(1, N, abs_incy, hy_gold[i], hy[i]);
+            }
+        }
+
+        if(arg.norm_check)
+        {
+            for(int i = 0; i < batch_count; i++)
+            {
+                rocblas_error = norm_check_general<T>('F', 1, N, abs_incx, hx_gold[i], hx[i]);
+                rocblas_error = norm_check_general<T>('F', 1, N, abs_incy, hy_gold[i], hy[i]);
+            }
+        }
+    }
+
+    if(arg.timing)
+    {
+        int number_cold_calls = 2;
+        int number_hot_calls  = 100;
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        for(int iter = 0; iter < number_cold_calls; iter++)
+        {
+            rocblas_swap_batched<T>(handle, N, dx_pvec, incx, dy_pvec, incy, batch_count);
+        }
+
+        gpu_time_used = get_time_us(); // in microseconds
+
+        for(int iter = 0; iter < number_hot_calls; iter++)
+        {
+            rocblas_swap_batched<T>(handle, N, dx_pvec, incx, dy_pvec, incy, batch_count);
+        }
+
+        gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
+
+        std::cout << "N,incx,incy,batch_count,rocblas-us" << std::endl;
+        std::cout << N << "," << incx << "," << incy << "," << batch_count << "," << gpu_time_used
+                  << std::endl;
+    }
+
+    CHECK_HIP_ERROR(hipFree(dx_pvec));
+    CHECK_HIP_ERROR(hipFree(dy_pvec));
+}

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -24,10 +24,8 @@ void testing_swap_batched_bad_arg(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    T** dxt;
-    hipMalloc(&dxt, sizeof(T*));
-    T** dyt;
-    hipMalloc(&dyt, sizeof(T*));
+    device_vector<T*, 0, T> dxt(1);
+    device_vector<T*, 0, T> dyt(1);
     if(!dxt || !dyt)
     {
         CHECK_HIP_ERROR(hipErrorOutOfMemory);
@@ -40,9 +38,6 @@ void testing_swap_batched_bad_arg(const Arguments& arg)
                           rocblas_status_invalid_pointer);
     EXPECT_ROCBLAS_STATUS(rocblas_swap_batched<T>(nullptr, N, dxt, incx, dyt, incy, batch_count),
                           rocblas_status_invalid_handle);
-
-    hipFree(dxt);
-    hipFree(dyt);
 }
 
 template <typename T>

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -108,20 +108,12 @@ void testing_swap_strided_batched(const Arguments& arg)
 
     // Initial Data on CPU
     rocblas_seedrand();
-    // make all batches hx
-    rocblas_init<T>(hx, 1, size_x * batch_count, 1);
-    // make hy different to hx
-    for(int i = 0; i < batch_count; i++)
-    {
-        for(size_t j = 0; j < N; j++)
-        {
-            hy[i * stridex + j * abs_incy] = hx[i * stridex + j * abs_incx] + 1.0;
-        }
-    }
+    rocblas_init<T>(hx, 1, N, abs_incx, size_x, batch_count);
+    rocblas_init<T>(hy, 1, N, abs_incy, size_y, batch_count);
 
     hx_gold = hx;
     hy_gold = hy;
-    // use cpu BLAS to swap gold
+    // using cpu BLAS to compute swap gold later on
 
     // allocate memory on device
     device_vector<T> dx(size_x * batch_count);

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -59,12 +59,8 @@ void testing_swap_strided_batched(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    size_t abs_incx = incx >= 0 ? incx : -incx;
-    size_t abs_incy = incy >= 0 ? incy : -incy;
-
     // argument sanity check before allocating invalid memory
-    if(stridex < N * abs_incx || stridey < N * abs_incy || stridex < 0 || stridey < 0
-       || batch_count < 0)
+    if(batch_count < 0)
     {
         static const size_t safe_size = 100; //  arbitrarily set to 100
         device_vector<T>    dx(safe_size);
@@ -97,8 +93,15 @@ void testing_swap_strided_batched(const Arguments& arg)
         return;
     }
 
-    size_t size_x = (size_t)stridex;
-    size_t size_y = (size_t)stridey;
+
+    size_t abs_incx = incx >= 0 ? incx : -incx;
+    size_t abs_incy = incy >= 0 ? incy : -incy;
+
+    size_t size_x = (size_t) (stridex >= 0 ? stridex : -stridex);
+    size_t size_y = (size_t) (stridey >= 0 ? stridey : -stridey);
+    // not testing non-standard strides
+    size_x = std::max(size_x, N*abs_incx);
+    size_y = std::max(size_y, N*abs_incy);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(size_x * batch_count);

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -16,12 +16,12 @@
 template <typename T>
 void testing_swap_strided_batched_bad_arg(const Arguments& arg)
 {
-    rocblas_int N           = 100;
-    rocblas_int incx        = 1;
-    rocblas_int incy        = 1;
-    rocblas_int stridex     = 1;
-    rocblas_int stridey     = 1;
-    rocblas_int batch_count = 5;
+    rocblas_int    N           = 100;
+    rocblas_int    incx        = 1;
+    rocblas_int    incy        = 1;
+    rocblas_stride stridex     = 1;
+    rocblas_stride stridey     = 1;
+    rocblas_int    batch_count = 5;
 
     static const size_t safe_size = 100; //  arbitrarily set to 100
 
@@ -50,12 +50,12 @@ void testing_swap_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_swap_strided_batched(const Arguments& arg)
 {
-    rocblas_int N           = arg.N;
-    rocblas_int incx        = arg.incx;
-    rocblas_int incy        = arg.incy;
-    rocblas_int stridex     = arg.stride_x;
-    rocblas_int stridey     = arg.stride_y;
-    rocblas_int batch_count = arg.batch_count;
+    rocblas_int    N           = arg.N;
+    rocblas_int    incx        = arg.incx;
+    rocblas_int    incy        = arg.incy;
+    rocblas_stride stridex     = arg.stride_x;
+    rocblas_stride stridey     = arg.stride_y;
+    rocblas_int    batch_count = arg.batch_count;
 
     rocblas_local_handle handle;
 
@@ -93,15 +93,14 @@ void testing_swap_strided_batched(const Arguments& arg)
         return;
     }
 
-
     size_t abs_incx = incx >= 0 ? incx : -incx;
     size_t abs_incy = incy >= 0 ? incy : -incy;
 
-    size_t size_x = (size_t) (stridex >= 0 ? stridex : -stridex);
-    size_t size_y = (size_t) (stridey >= 0 ? stridey : -stridey);
+    size_t size_x = (size_t)(stridex >= 0 ? stridex : -stridex);
+    size_t size_y = (size_t)(stridey >= 0 ? stridey : -stridey);
     // not testing non-standard strides
-    size_x = std::max(size_x, N*abs_incx);
-    size_y = std::max(size_y, N*abs_incy);
+    size_x = std::max(size_x, N * abs_incx);
+    size_y = std::max(size_y, N * abs_incy);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(size_x * batch_count);
@@ -149,7 +148,7 @@ void testing_swap_strided_batched(const Arguments& arg)
         cpu_time_used = get_time_us();
         for(int i = 0; i < batch_count; i++)
         {
-            cblas_swap<T>(N, &hx_gold[i * stridex], incx, &hy_gold[i * stridey], incy);
+            cblas_swap<T>(N, hx_gold + i * stridex, incx, hy_gold + i * stridey, incy);
         }
         cpu_time_used = get_time_us() - cpu_time_used;
 

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -1,0 +1,208 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "cblas_interface.hpp"
+#include "norm.hpp"
+#include "rocblas.hpp"
+#include "rocblas_init.hpp"
+#include "rocblas_math.hpp"
+#include "rocblas_random.hpp"
+#include "rocblas_test.hpp"
+#include "rocblas_vector.hpp"
+#include "unit.hpp"
+#include "utility.hpp"
+
+template <typename T>
+void testing_swap_strided_batched_bad_arg(const Arguments& arg)
+{
+    rocblas_int N           = 100;
+    rocblas_int incx        = 1;
+    rocblas_int incy        = 1;
+    rocblas_int stridex     = 1;
+    rocblas_int stridey     = 1;
+    rocblas_int batch_count = 5;
+
+    static const size_t safe_size = 100; //  arbitrarily set to 100
+
+    rocblas_local_handle handle;
+
+    // allocate memory on device
+    device_vector<T> dx(safe_size);
+    device_vector<T> dy(safe_size);
+    if(!dx || !dy)
+    {
+        CHECK_HIP_ERROR(hipErrorOutOfMemory);
+        return;
+    }
+
+    EXPECT_ROCBLAS_STATUS(rocblas_swap_strided_batched<T>(
+                              handle, N, nullptr, incx, stridex, dy, incy, stridey, batch_count),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocblas_swap_strided_batched<T>(
+                              handle, N, dx, incx, stridex, nullptr, incy, stridey, batch_count),
+                          rocblas_status_invalid_pointer);
+    EXPECT_ROCBLAS_STATUS(rocblas_swap_strided_batched<T>(
+                              nullptr, N, dx, incx, stridex, dy, incy, stridey, batch_count),
+                          rocblas_status_invalid_handle);
+}
+
+template <typename T>
+void testing_swap_strided_batched(const Arguments& arg)
+{
+    rocblas_int N           = arg.N;
+    rocblas_int incx        = arg.incx;
+    rocblas_int incy        = arg.incy;
+    rocblas_int stridex     = arg.stride_x;
+    rocblas_int stridey     = arg.stride_y;
+    rocblas_int batch_count = arg.batch_count;
+
+    rocblas_local_handle handle;
+
+    size_t abs_incx = incx >= 0 ? incx : -incx;
+    size_t abs_incy = incy >= 0 ? incy : -incy;
+
+    // argument sanity check before allocating invalid memory
+    if(stridex < N * abs_incx || stridey < N * abs_incy ||
+       stridex < 0 || stridey < 0 || batch_count < 0)
+    {
+        static const size_t safe_size = 100; //  arbitrarily set to 100
+        device_vector<T>    dx(safe_size);
+        device_vector<T>    dy(safe_size);
+        if(!dx || !dy)
+        {
+            CHECK_HIP_ERROR(hipErrorOutOfMemory);
+            return;
+        }
+
+        EXPECT_ROCBLAS_STATUS(rocblas_swap_strided_batched<T>(
+                                  handle, N, dx, incx, stridex, dy, incy, stridey, batch_count),
+                              rocblas_status_invalid_size);
+        return;
+    }
+
+    if(N <= 0 || batch_count == 0)
+    {
+        static const size_t safe_size = 100; //  arbitrarily set to 100
+        device_vector<T>    dx(safe_size);
+        device_vector<T>    dy(safe_size);
+        if(!dx || !dy)
+        {
+            CHECK_HIP_ERROR(hipErrorOutOfMemory);
+            return;
+        }
+
+        CHECK_ROCBLAS_ERROR(rocblas_swap_strided_batched<T>(
+            handle, N, dx, incx, stridex, dy, incy, stridey, batch_count));
+        return;
+    }
+
+    size_t size_x = (size_t)stridex;
+    size_t size_y = (size_t)stridey;
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx(size_x * batch_count);
+    host_vector<T> hy(size_y * batch_count);
+    host_vector<T> hx_gold(size_x * batch_count);
+    host_vector<T> hy_gold(size_y * batch_count); 
+
+    // Initial Data on CPU
+    rocblas_seedrand();
+    // make all batches hx
+    rocblas_init<T>(hx, 1, size_x * batch_count, 1);
+    // make hy different to hx
+    for(int i = 0; i < batch_count; i++)
+    {
+        for(size_t j = 0; j < N; j++)
+        {
+            hy[i * stridex + j * abs_incy] = hx[i * stridex + j * abs_incx] + 1.0;
+        }
+    }
+
+    hx_gold = hx;
+    hy_gold = hy;
+    // use cpu BLAS to swap gold
+
+    // allocate memory on device
+    device_vector<T> dx(size_x * batch_count);
+    device_vector<T> dy(size_y * batch_count);
+    if(!dx || !dy)
+    {
+        CHECK_HIP_ERROR(hipErrorOutOfMemory);
+        return;
+    }
+
+    size_t dataSizeX = sizeof(T) * size_x * batch_count;
+    size_t dataSizeY = sizeof(T) * size_y * batch_count;
+
+    // copy vector data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx, dataSizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy, dataSizeY, hipMemcpyHostToDevice));
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error = 0.0;
+
+    if(arg.unit_check || arg.norm_check)
+    {
+        // GPU BLAS
+        CHECK_ROCBLAS_ERROR(rocblas_swap_strided_batched<T>(
+            handle, N, dx, incx, stridex, dy, incy, stridey, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(hx, dx, dataSizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy, dy, dataSizeY, hipMemcpyDeviceToHost));
+
+        // CPU BLAS
+        cpu_time_used = get_time_us();
+        for(int i = 0; i < batch_count; i++)
+        {
+            cblas_swap<T>(N, &hx_gold[i * stridex], incx, &hy_gold[i * stridey], incy);
+        }
+        cpu_time_used = get_time_us() - cpu_time_used;
+
+        if(arg.unit_check)
+        {
+            for(int i = 0; i < batch_count; i++)
+            {
+                unit_check_general<T>(1, N, abs_incx, hx_gold + i * stridex, hx + i * stridex);
+                unit_check_general<T>(1, N, abs_incy, hy_gold + i * stridey, hy + i * stridey);
+            }
+        }
+
+        if(arg.norm_check)
+        {
+            for(int i = 0; i < batch_count; i++)
+            {
+                rocblas_error = norm_check_general<T>(
+                    'F', 1, N, abs_incx, hx_gold + i * stridex, hx + i * stridex);
+                rocblas_error = norm_check_general<T>(
+                    'F', 1, N, abs_incy, hy_gold + i * stridey, hy + i * stridey);
+            }
+        }
+    }
+
+    if(arg.timing)
+    {
+        int number_cold_calls = 2;
+        int number_hot_calls  = 100;
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        for(int iter = 0; iter < number_cold_calls; iter++)
+        {
+            rocblas_swap_strided_batched<T>(
+                handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
+        }
+
+        gpu_time_used = get_time_us(); // in microseconds
+
+        for(int iter = 0; iter < number_hot_calls; iter++)
+        {
+            rocblas_swap_strided_batched<T>(
+                handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
+        }
+
+        gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
+
+        std::cout << "N,incx,incy,stride_x,stride_y,batch_count,rocblas-us" << std::endl;
+        std::cout << N << "," << incx << "," << incy << "," << stridex << "," << stridey << ","
+                  << batch_count << "," << gpu_time_used << std::endl;
+    }
+}

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -63,8 +63,8 @@ void testing_swap_strided_batched(const Arguments& arg)
     size_t abs_incy = incy >= 0 ? incy : -incy;
 
     // argument sanity check before allocating invalid memory
-    if(stridex < N * abs_incx || stridey < N * abs_incy ||
-       stridex < 0 || stridey < 0 || batch_count < 0)
+    if(stridex < N * abs_incx || stridey < N * abs_incy || stridex < 0 || stridey < 0
+       || batch_count < 0)
     {
         static const size_t safe_size = 100; //  arbitrarily set to 100
         device_vector<T>    dx(safe_size);
@@ -104,7 +104,7 @@ void testing_swap_strided_batched(const Arguments& arg)
     host_vector<T> hx(size_x * batch_count);
     host_vector<T> hy(size_y * batch_count);
     host_vector<T> hx_gold(size_x * batch_count);
-    host_vector<T> hy_gold(size_y * batch_count); 
+    host_vector<T> hy_gold(size_y * batch_count);
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -304,6 +304,100 @@ ROCBLAS_EXPORT rocblas_status rocblas_zswap(rocblas_handle          handle,
 /*! \brief BLAS Level 1 API
 
     \details
+    swap_batched performs a batch of interchange vector x_i[j] and y_i[j], for  j = 1 , … , n
+
+        y_i[j] := x_i[j]; x_i[j] := y_i[j]
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    n         rocblas_int.
+    @param[inout]
+    x         array of pointers storing the different vector x_i on the GPU.
+    @param[in]
+    incx      specifies the increment for the elements of x.
+    @param[inout]
+    y         array of pointers storing the different vector y_i on the GPU.
+    @param[in]
+    incy      rocblas_int
+              specifies the increment for the elements of y.
+    @param[in]
+    batch_count rocblas_int
+                number of instances in the batch
+
+    ********************************************************************/
+
+ROCBLAS_EXPORT rocblas_status rocblas_sswap_batched(
+    rocblas_handle handle, rocblas_int n, float* x[], rocblas_int incx, float* y[], rocblas_int incy, rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_dswap_batched(
+    rocblas_handle handle, rocblas_int n, double* x[], rocblas_int incx, double* y[], rocblas_int incy, rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_cswap_batched(
+    rocblas_handle handle, rocblas_int n, rocblas_float_complex* x[], rocblas_int incx, rocblas_float_complex* y[], rocblas_int incy, rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_zswap_batched(
+    rocblas_handle handle, rocblas_int n, rocblas_double_complex* x[], rocblas_int incx, rocblas_double_complex* y[], rocblas_int incy, rocblas_int batch_count);
+
+/*! \brief BLAS Level 1 API
+
+    \details
+    swap_strided_batched performs a batch of interchange vector x_i[j] and y_i[j], for  j = 1 , … , n
+
+        y_i[j] := x_i[j]; x_i[j] := y_i[j]
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    n         rocblas_int.
+    @param[inout]
+    x         a pointer to the first vector x_i on the GPU.
+    @param[in]
+    incx      specifies the increment for the elements of x.
+    @param[in]
+    stridex      specifies the pointer increment between batches for x.
+    @param[inout]
+    y         a pointer to the first vector y_i on the GPU.
+    @param[in]
+    incy      rocblas_int
+              specifies the increment for the elements of y.
+    @param[in]
+    stridey      specifies the pointer increment between batches for y.
+    @param[in]
+    batch_count rocblas_int
+                number of instances in the batch
+
+    ********************************************************************/
+
+ROCBLAS_EXPORT rocblas_status rocblas_sswap_strided_batched(
+    rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, rocblas_int stridex, 
+    float* y, rocblas_int incy, rocblas_int stridey, rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_dswap_strided_batched(
+    rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, rocblas_int stridex,
+    double* y, rocblas_int incy, rocblas_int stridey, rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
+                                            rocblas_int            n,
+                                            rocblas_float_complex* x,
+                                            rocblas_int            incx, rocblas_int stridex,
+                                            rocblas_float_complex* y,
+                                            rocblas_int            incy, rocblas_int stridey, 
+                                            rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
+                                            rocblas_int             n,
+                                            rocblas_double_complex* x,
+                                            rocblas_int             incx, rocblas_int stridex,
+                                            rocblas_double_complex* y,
+                                            rocblas_int             incy, rocblas_int stridey, 
+                                            rocblas_int batch_count);
+
+/*! \brief BLAS Level 1 API
+
+    \details
     axpy   compute y := alpha * x + y
 
     @param[in]

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -328,17 +328,37 @@ ROCBLAS_EXPORT rocblas_status rocblas_zswap(rocblas_handle          handle,
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status rocblas_sswap_batched(
-    rocblas_handle handle, rocblas_int n, float* x[], rocblas_int incx, float* y[], rocblas_int incy, rocblas_int batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_sswap_batched(rocblas_handle handle,
+                                                    rocblas_int    n,
+                                                    float*         x[],
+                                                    rocblas_int    incx,
+                                                    float*         y[],
+                                                    rocblas_int    incy,
+                                                    rocblas_int    batch_count);
 
-ROCBLAS_EXPORT rocblas_status rocblas_dswap_batched(
-    rocblas_handle handle, rocblas_int n, double* x[], rocblas_int incx, double* y[], rocblas_int incy, rocblas_int batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_dswap_batched(rocblas_handle handle,
+                                                    rocblas_int    n,
+                                                    double*        x[],
+                                                    rocblas_int    incx,
+                                                    double*        y[],
+                                                    rocblas_int    incy,
+                                                    rocblas_int    batch_count);
 
-ROCBLAS_EXPORT rocblas_status rocblas_cswap_batched(
-    rocblas_handle handle, rocblas_int n, rocblas_float_complex* x[], rocblas_int incx, rocblas_float_complex* y[], rocblas_int incy, rocblas_int batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_cswap_batched(rocblas_handle         handle,
+                                                    rocblas_int            n,
+                                                    rocblas_float_complex* x[],
+                                                    rocblas_int            incx,
+                                                    rocblas_float_complex* y[],
+                                                    rocblas_int            incy,
+                                                    rocblas_int            batch_count);
 
-ROCBLAS_EXPORT rocblas_status rocblas_zswap_batched(
-    rocblas_handle handle, rocblas_int n, rocblas_double_complex* x[], rocblas_int incx, rocblas_double_complex* y[], rocblas_int incy, rocblas_int batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_zswap_batched(rocblas_handle          handle,
+                                                    rocblas_int             n,
+                                                    rocblas_double_complex* x[],
+                                                    rocblas_int             incx,
+                                                    rocblas_double_complex* y[],
+                                                    rocblas_int             incy,
+                                                    rocblas_int             batch_count);
 
 /*! \brief BLAS Level 1 API
 
@@ -371,29 +391,45 @@ ROCBLAS_EXPORT rocblas_status rocblas_zswap_batched(
 
     ********************************************************************/
 
-ROCBLAS_EXPORT rocblas_status rocblas_sswap_strided_batched(
-    rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, rocblas_int stridex, 
-    float* y, rocblas_int incy, rocblas_int stridey, rocblas_int batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_sswap_strided_batched(rocblas_handle handle,
+                                                            rocblas_int    n,
+                                                            float*         x,
+                                                            rocblas_int    incx,
+                                                            rocblas_int    stridex,
+                                                            float*         y,
+                                                            rocblas_int    incy,
+                                                            rocblas_int    stridey,
+                                                            rocblas_int    batch_count);
 
-ROCBLAS_EXPORT rocblas_status rocblas_dswap_strided_batched(
-    rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, rocblas_int stridex,
-    double* y, rocblas_int incy, rocblas_int stridey, rocblas_int batch_count);
+ROCBLAS_EXPORT rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
+                                                            rocblas_int    n,
+                                                            double*        x,
+                                                            rocblas_int    incx,
+                                                            rocblas_int    stridex,
+                                                            double*        y,
+                                                            rocblas_int    incy,
+                                                            rocblas_int    stridey,
+                                                            rocblas_int    batch_count);
 
 ROCBLAS_EXPORT rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
-                                            rocblas_int            n,
-                                            rocblas_float_complex* x,
-                                            rocblas_int            incx, rocblas_int stridex,
-                                            rocblas_float_complex* y,
-                                            rocblas_int            incy, rocblas_int stridey, 
-                                            rocblas_int batch_count);
+                                                            rocblas_int            n,
+                                                            rocblas_float_complex* x,
+                                                            rocblas_int            incx,
+                                                            rocblas_int            stridex,
+                                                            rocblas_float_complex* y,
+                                                            rocblas_int            incy,
+                                                            rocblas_int            stridey,
+                                                            rocblas_int            batch_count);
 
 ROCBLAS_EXPORT rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
-                                            rocblas_int             n,
-                                            rocblas_double_complex* x,
-                                            rocblas_int             incx, rocblas_int stridex,
-                                            rocblas_double_complex* y,
-                                            rocblas_int             incy, rocblas_int stridey, 
-                                            rocblas_int batch_count);
+                                                            rocblas_int             n,
+                                                            rocblas_double_complex* x,
+                                                            rocblas_int             incx,
+                                                            rocblas_int             stridex,
+                                                            rocblas_double_complex* y,
+                                                            rocblas_int             incy,
+                                                            rocblas_int             stridey,
+                                                            rocblas_int             batch_count);
 
 /*! \brief BLAS Level 1 API
 

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -395,40 +395,40 @@ ROCBLAS_EXPORT rocblas_status rocblas_sswap_strided_batched(rocblas_handle handl
                                                             rocblas_int    n,
                                                             float*         x,
                                                             rocblas_int    incx,
-                                                            rocblas_int    stridex,
+                                                            rocblas_stride stridex,
                                                             float*         y,
                                                             rocblas_int    incy,
-                                                            rocblas_int    stridey,
+                                                            rocblas_stride stridey,
                                                             rocblas_int    batch_count);
 
 ROCBLAS_EXPORT rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
                                                             rocblas_int    n,
                                                             double*        x,
                                                             rocblas_int    incx,
-                                                            rocblas_int    stridex,
+                                                            rocblas_stride stridex,
                                                             double*        y,
                                                             rocblas_int    incy,
-                                                            rocblas_int    stridey,
+                                                            rocblas_stride stridey,
                                                             rocblas_int    batch_count);
 
 ROCBLAS_EXPORT rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
                                                             rocblas_int            n,
                                                             rocblas_float_complex* x,
                                                             rocblas_int            incx,
-                                                            rocblas_int            stridex,
+                                                            rocblas_stride         stridex,
                                                             rocblas_float_complex* y,
                                                             rocblas_int            incy,
-                                                            rocblas_int            stridey,
+                                                            rocblas_stride         stridey,
                                                             rocblas_int            batch_count);
 
 ROCBLAS_EXPORT rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
                                                             rocblas_int             n,
                                                             rocblas_double_complex* x,
                                                             rocblas_int             incx,
-                                                            rocblas_int             stridex,
+                                                            rocblas_stride          stridex,
                                                             rocblas_double_complex* y,
                                                             rocblas_int             incy,
-                                                            rocblas_int             stridey,
+                                                            rocblas_stride          stridey,
                                                             rocblas_int             batch_count);
 
 /*! \brief BLAS Level 1 API

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -125,6 +125,8 @@ set( rocblas_blas1_source
   blas1/rocblas_rotg.cpp
   blas1/rocblas_rotm.cpp
   blas1/rocblas_rotmg.cpp
+  blas1/rocblas_swap_batched.cpp
+  blas1/rocblas_swap_strided_batched.cpp
 )
 
 prepend_path( ".." rocblas_headers_public relative_rocblas_headers_public )

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -49,7 +49,7 @@ namespace
         RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         constexpr rocblas_int NB = 256;
-        return rocblas_swap_template<NB>(n, x, incx, y, incy);
+        return rocblas_swap_template<NB>(handle, n, x, incx, y, incy);
     }
 
 } // namespace

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -1,27 +1,12 @@
 /* ************************************************************************
  * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
-#include "handle.h"
+#include "rocblas_swap.hpp"
 #include "logging.h"
-#include "rocblas.h"
 #include "utility.h"
 
 namespace
 {
-    constexpr int NB = 256;
-
-    template <typename T>
-    __global__ void swap_kernel(rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
-    {
-        ptrdiff_t tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-        if(tid < n)
-        {
-            auto tmp      = y[tid * incy];
-            y[tid * incy] = x[tid * incx];
-            x[tid * incx] = tmp;
-        }
-    }
-
     template <typename>
     constexpr char rocblas_swap_name[] = "unknown";
     template <>
@@ -36,7 +21,7 @@ namespace
     constexpr char rocblas_swap_name<rocblas_double_complex>[] = "rocblas_zswap";
 
     template <class T>
-    rocblas_status rocblas_swap(
+    rocblas_status rocblas_swap_impl(
         rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
     {
         if(!handle)
@@ -63,23 +48,8 @@ namespace
 
         RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
-        // Quick return if possible.
-        if(n <= 0)
-            return rocblas_status_success;
-
-        hipStream_t rocblas_stream = handle->rocblas_stream;
-        int         blocks         = (n - 1) / NB + 1;
-        dim3        grid(blocks);
-        dim3        threads(NB);
-
-        if(incx < 0)
-            x -= ptrdiff_t(incx) * (n - 1);
-        if(incy < 0)
-            y -= ptrdiff_t(incy) * (n - 1);
-
-        hipLaunchKernelGGL(swap_kernel, grid, threads, 0, rocblas_stream, n, x, incx, y, incy);
-
-        return rocblas_status_success;
+        constexpr rocblas_int NB = 256;
+        return rocblas_swap_template<NB>(n, x, incx, y, incy);
     }
 
 } // namespace
@@ -97,13 +67,13 @@ extern "C" {
 rocblas_status rocblas_sswap(
     rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy)
 {
-    return rocblas_swap(handle, n, x, incx, y, incy);
+    return rocblas_swap_impl(handle, n, x, incx, y, incy);
 }
 
 rocblas_status rocblas_dswap(
     rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy)
 {
-    return rocblas_swap(handle, n, x, incx, y, incy);
+    return rocblas_swap_impl(handle, n, x, incx, y, incy);
 }
 
 rocblas_status rocblas_cswap(rocblas_handle         handle,
@@ -113,7 +83,7 @@ rocblas_status rocblas_cswap(rocblas_handle         handle,
                              rocblas_float_complex* y,
                              rocblas_int            incy)
 {
-    return rocblas_swap(handle, n, x, incx, y, incy);
+    return rocblas_swap_impl(handle, n, x, incx, y, incy);
 }
 
 rocblas_status rocblas_zswap(rocblas_handle          handle,
@@ -123,7 +93,7 @@ rocblas_status rocblas_zswap(rocblas_handle          handle,
                              rocblas_double_complex* y,
                              rocblas_int             incy)
 {
-    return rocblas_swap(handle, n, x, incx, y, incy);
+    return rocblas_swap_impl(handle, n, x, incx, y, incy);
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -20,7 +20,7 @@ namespace
     template <>
     constexpr char rocblas_swap_name<rocblas_double_complex>[] = "rocblas_zswap";
 
-    template <class T>
+    template <rocblas_int NB, class T>
     rocblas_status rocblas_swap_impl(
         rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
     {
@@ -48,7 +48,6 @@ namespace
 
         RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
-        constexpr rocblas_int NB = 256;
         return rocblas_swap_template<NB>(handle, n, x, incx, y, incy);
     }
 
@@ -67,13 +66,15 @@ extern "C" {
 rocblas_status rocblas_sswap(
     rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy)
 {
-    return rocblas_swap_impl(handle, n, x, incx, y, incy);
+    constexpr rocblas_int NB = 256;
+    return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
 }
 
 rocblas_status rocblas_dswap(
     rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy)
 {
-    return rocblas_swap_impl(handle, n, x, incx, y, incy);
+    constexpr rocblas_int NB = 256;
+    return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
 }
 
 rocblas_status rocblas_cswap(rocblas_handle         handle,
@@ -83,7 +84,8 @@ rocblas_status rocblas_cswap(rocblas_handle         handle,
                              rocblas_float_complex* y,
                              rocblas_int            incy)
 {
-    return rocblas_swap_impl(handle, n, x, incx, y, incy);
+    constexpr rocblas_int NB = 256;
+    return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
 }
 
 rocblas_status rocblas_zswap(rocblas_handle          handle,
@@ -93,7 +95,8 @@ rocblas_status rocblas_zswap(rocblas_handle          handle,
                              rocblas_double_complex* y,
                              rocblas_int             incy)
 {
-    return rocblas_swap_impl(handle, n, x, incx, y, incy);
+    constexpr rocblas_int NB = 256;
+    return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap.hpp
+++ b/library/src/blas1/rocblas_swap.hpp
@@ -6,12 +6,11 @@
 #include "rocblas.h"
 
 template <typename T>
-__forceinline__ __device__ __host__ void
-    rocblas_swap_vals(T* x, T* y)
+__forceinline__ __device__ __host__ void rocblas_swap_vals(T* x, T* y)
 {
-    T tmp   = *y;
-    *y = *x;
-    *x = tmp;
+    T tmp = *y;
+    *y    = *x;
+    *x    = tmp;
 }
 
 template <typename T>

--- a/library/src/blas1/rocblas_swap.hpp
+++ b/library/src/blas1/rocblas_swap.hpp
@@ -1,0 +1,41 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+#include "handle.h"
+#include "rocblas.h"
+
+template <typename T>
+__global__ void rocblas_swap_kernel(rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
+{
+    ptrdiff_t tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if(tid < n)
+    {
+        auto tmp      = y[tid * incy];
+        y[tid * incy] = x[tid * incx];
+        x[tid * incx] = tmp;
+    }
+}
+
+template <rocblas_int NB, typename T>
+rocblas_status rocblas_swap_template(
+    rocblas_handle handle, rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
+{
+    // Quick return if possible.
+    if(n <= 0)
+        return rocblas_status_success;
+
+    hipStream_t rocblas_stream = handle->rocblas_stream;
+    int         blocks         = (n - 1) / NB + 1;
+    dim3        grid(blocks);
+    dim3        threads(NB);
+
+    if(incx < 0)
+        x -= ptrdiff_t(incx) * (n - 1);
+    if(incy < 0)
+        y -= ptrdiff_t(incy) * (n - 1);
+
+    hipLaunchKernelGGL(rocblas_swap_kernel, grid, threads, 0, rocblas_stream, n, x, incx, y, incy);
+
+    return rocblas_status_success;
+}

--- a/library/src/blas1/rocblas_swap.hpp
+++ b/library/src/blas1/rocblas_swap.hpp
@@ -6,14 +6,21 @@
 #include "rocblas.h"
 
 template <typename T>
+__forceinline__ __device__ __host__ void
+    rocblas_swap_vals(T* x, T* y)
+{
+    T tmp   = *y;
+    *y = *x;
+    *x = tmp;
+}
+
+template <typename T>
 __global__ void rocblas_swap_kernel(rocblas_int n, T* x, rocblas_int incx, T* y, rocblas_int incy)
 {
     ptrdiff_t tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     if(tid < n)
     {
-        auto tmp      = y[tid * incy];
-        y[tid * incy] = x[tid * incx];
-        x[tid * incx] = tmp;
+        rocblas_swap_vals(x + tid * incx, y + tid * incy);
     }
 }
 

--- a/library/src/blas1/rocblas_swap_batched.cpp
+++ b/library/src/blas1/rocblas_swap_batched.cpp
@@ -1,0 +1,162 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#include "handle.h"
+#include "logging.h"
+#include "rocblas.h"
+#include "utility.h"
+
+namespace
+{
+    constexpr int NB = 256;
+
+    template <typename T>
+    __global__ void
+        swap_kernel_batched(rocblas_int n, T* x[], rocblas_int incx, T* y[], rocblas_int incy)
+    {
+        ssize_t tid = blockIdx.x * blockDim.x + threadIdx.x; // only dim1
+
+        if(tid < n)
+        {
+            T* xb = x[blockIdx.y];
+            T* yb = y[blockIdx.y];
+            // in case of negative inc shift pointer to end of data for negative indexing tid*inc
+            xb -= (incx < 0) ? ptrdiff_t(incx) * (n - 1) : 0;
+            yb -= (incy < 0) ? ptrdiff_t(incy) * (n - 1) : 0;
+
+            auto tmp       = yb[tid * incy];
+            yb[tid * incy] = xb[tid * incx];
+            xb[tid * incx] = tmp;
+        }
+    }
+
+    template <typename>
+    constexpr char rocblas_swap_batched_name[] = "unknown";
+    template <>
+    constexpr char rocblas_swap_batched_name<float>[] = "rocblas_sswap_batched";
+    template <>
+    constexpr char rocblas_swap_batched_name<double>[] = "rocblas_dswap_batched";
+    template <>
+    constexpr char rocblas_swap_batched_name<rocblas_float_complex>[] = "rocblas_cswap_batched";
+    template <>
+    constexpr char rocblas_swap_batched_name<rocblas_double_complex>[] = "rocblas_zswap_batched";
+
+    template <class T>
+    rocblas_status rocblas_swap_batched(rocblas_handle handle,
+                                        rocblas_int    n,
+                                        T*             x[],
+                                        rocblas_int    incx,
+                                        T*             y[],
+                                        rocblas_int    incy,
+                                        rocblas_int    batch_count)
+    {
+        if(!handle)
+            return rocblas_status_invalid_handle;
+
+        auto layer_mode = handle->layer_mode;
+        if(layer_mode & rocblas_layer_mode_log_trace)
+            log_trace(handle, rocblas_swap_batched_name<T>, n, x, incx, y, incy, batch_count);
+        if(layer_mode & rocblas_layer_mode_log_bench)
+            log_bench(handle,
+                      "./rocblas-bench -f swap_batched -r",
+                      rocblas_precision_string<T>,
+                      "-n",
+                      n,
+                      "--incx",
+                      incx,
+                      "--incy",
+                      incy,
+                      "--batch",
+                      batch_count);
+        if(layer_mode & rocblas_layer_mode_log_profile)
+            log_profile(handle,
+                        rocblas_swap_batched_name<T>,
+                        "N",
+                        n,
+                        "incx",
+                        incx,
+                        "incy",
+                        incy,
+                        "batch",
+                        batch_count);
+
+        if(!x || !y)
+            return rocblas_status_invalid_pointer;
+
+        if(batch_count < 0)
+            return rocblas_status_invalid_size;
+
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
+        // Quick return if possible.
+        if(n <= 0 || batch_count == 0)
+            return rocblas_status_success;
+
+        hipStream_t rocblas_stream = handle->rocblas_stream;
+        rocblas_int blocks         = (n - 1) / NB + 1;
+        dim3        grid(blocks, batch_count);
+        dim3        threads(NB);
+
+        hipLaunchKernelGGL(
+            swap_kernel_batched, grid, threads, 0, rocblas_stream, n, x, incx, y, incy);
+
+        return rocblas_status_success;
+    }
+
+} // namespace
+
+/* ============================================================================================ */
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+rocblas_status rocblas_sswap_batched(rocblas_handle handle,
+                                     rocblas_int    n,
+                                     float*         x[],
+                                     rocblas_int    incx,
+                                     float*         y[],
+                                     rocblas_int    incy,
+                                     rocblas_int    batch_count)
+{
+    return rocblas_swap_batched(handle, n, x, incx, y, incy, batch_count);
+}
+
+rocblas_status rocblas_dswap_batched(rocblas_handle handle,
+                                     rocblas_int    n,
+                                     double*        x[],
+                                     rocblas_int    incx,
+                                     double*        y[],
+                                     rocblas_int    incy,
+                                     rocblas_int    batch_count)
+{
+    return rocblas_swap_batched(handle, n, x, incx, y, incy, batch_count);
+}
+
+rocblas_status rocblas_cswap_batched(rocblas_handle         handle,
+                                     rocblas_int            n,
+                                     rocblas_float_complex* x[],
+                                     rocblas_int            incx,
+                                     rocblas_float_complex* y[],
+                                     rocblas_int            incy,
+                                     rocblas_int            batch_count)
+{
+    return rocblas_swap_batched(handle, n, x, incx, y, incy, batch_count);
+}
+
+rocblas_status rocblas_zswap_batched(rocblas_handle          handle,
+                                     rocblas_int             n,
+                                     rocblas_double_complex* x[],
+                                     rocblas_int             incx,
+                                     rocblas_double_complex* y[],
+                                     rocblas_int             incy,
+                                     rocblas_int             batch_count)
+{
+    return rocblas_swap_batched(handle, n, x, incx, y, incy, batch_count);
+}
+
+} // extern "C"

--- a/library/src/blas1/rocblas_swap_batched.hpp
+++ b/library/src/blas1/rocblas_swap_batched.hpp
@@ -4,6 +4,7 @@
 #pragma once
 #include "handle.h"
 #include "rocblas.h"
+#include "rocblas_swap.hpp"
 
 template <typename T>
 __global__ void rocblas_swap_kernel_batched(rocblas_int n,
@@ -11,7 +12,7 @@ __global__ void rocblas_swap_kernel_batched(rocblas_int n,
                                             rocblas_int shiftx,
                                             rocblas_int incx,
                                             T*          y[],
-                                            rocblas_int shiftx,
+                                            rocblas_int shifty,
                                             rocblas_int incy)
 {
     ssize_t tid = blockIdx.x * blockDim.x + threadIdx.x; // only dim1
@@ -24,9 +25,7 @@ __global__ void rocblas_swap_kernel_batched(rocblas_int n,
         xb -= (incx < 0) ? ptrdiff_t(incx) * (n - 1) : 0;
         yb -= (incy < 0) ? ptrdiff_t(incy) * (n - 1) : 0;
 
-        auto tmp       = yb[tid * incy];
-        yb[tid * incy] = xb[tid * incx];
-        xb[tid * incx] = tmp;
+        rocblas_swap_vals(xb + tid * incx, yb + tid * incy);
     }
 }
 
@@ -58,7 +57,8 @@ rocblas_status rocblas_swap_batched_template(rocblas_handle handle,
                        rocblas_stream,
                        n,
                        x,
-                       shiftx incx,
+                       shiftx,
+                       incx,
                        y,
                        shifty,
                        incy);

--- a/library/src/blas1/rocblas_swap_strided_batched.cpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.cpp
@@ -1,0 +1,208 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#include "handle.h"
+#include "logging.h"
+#include "rocblas.h"
+#include "utility.h"
+
+namespace
+{
+    constexpr int NB = 256;
+
+    template <typename T>
+    __global__ void swap_kernel_strided_batched(rocblas_int n,
+                                                T*          x,
+                                                rocblas_int incx,
+                                                rocblas_int stridex,
+                                                T*          y,
+                                                rocblas_int incy,
+                                                rocblas_int stridey)
+    {
+        ssize_t tid = blockIdx.x * blockDim.x + threadIdx.x; // only dim1
+
+        if(tid < n)
+        {
+            T* xb = x + blockIdx.y * stridex;
+            T* yb = y + blockIdx.y * stridey;
+            // in case of negative inc shift pointer to end of data for negative indexing tid*inc
+            xb -= (incx < 0) ? ptrdiff_t(incx) * (n - 1) : 0;
+            yb -= (incy < 0) ? ptrdiff_t(incy) * (n - 1) : 0;
+
+            auto tmp       = yb[tid * incy];
+            yb[tid * incy] = xb[tid * incx];
+            xb[tid * incx] = tmp;
+        }
+    }
+
+    template <typename>
+    constexpr char rocblas_swap_strided_batched_name[] = "unknown";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<float>[] = "rocblas_sswap_strided_batched";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<double>[] = "rocblas_dswap_strided_batched";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<rocblas_float_complex>[]
+        = "rocblas_cswap_strided_batched";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<rocblas_double_complex>[]
+        = "rocblas_zswap_strided_batched";
+
+    template <class T>
+    rocblas_status rocblas_swap_strided_batched(rocblas_handle handle,
+                                                rocblas_int    n,
+                                                T*             x,
+                                                rocblas_int    incx,
+                                                rocblas_int    stridex,
+                                                T*             y,
+                                                rocblas_int    incy,
+                                                rocblas_int    stridey,
+                                                rocblas_int    batch_count)
+    {
+        if(!handle)
+            return rocblas_status_invalid_handle;
+
+        auto layer_mode = handle->layer_mode;
+        if(layer_mode & rocblas_layer_mode_log_trace)
+            log_trace(handle,
+                      rocblas_swap_strided_batched_name<T>,
+                      n,
+                      x,
+                      incx,
+                      stridex,
+                      y,
+                      incy,
+                      stridey,
+                      batch_count);
+        if(layer_mode & rocblas_layer_mode_log_bench)
+            log_bench(handle,
+                      "./rocblas-bench -f swap_strided_batched -r",
+                      rocblas_precision_string<T>,
+                      "-n",
+                      n,
+                      "--incx",
+                      incx,
+                      "--incy",
+                      incy,
+                      "--stride_x",
+                      stridex,
+                      "--stride_y",
+                      stridey,
+                      "--batch",
+                      batch_count);
+        if(layer_mode & rocblas_layer_mode_log_profile)
+            log_profile(handle,
+                        rocblas_swap_strided_batched_name<T>,
+                        "N",
+                        n,
+                        "incx",
+                        incx,
+                        "stride_x",
+                        stridex,
+                        "incy",
+                        incy,
+                        "stride_y",
+                        stridey,
+                        "batch",
+                        batch_count);
+
+        if(!x || !y)
+            return rocblas_status_invalid_pointer;
+
+        size_t abs_incx = incx >= 0 ? incx : -incx;
+        size_t abs_incy = incy >= 0 ? incy : -incy;
+        if((stridex < n * abs_incx) || (stridey < n * abs_incy) || (batch_count < 0))
+            return rocblas_status_invalid_size;
+
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
+        // Quick return if possible.
+        if(n <= 0 || batch_count == 0)
+            return rocblas_status_success;
+
+        hipStream_t rocblas_stream = handle->rocblas_stream;
+        rocblas_int blocks         = (n - 1) / NB + 1;
+        dim3        grid(blocks, batch_count);
+        dim3        threads(NB);
+
+        hipLaunchKernelGGL(swap_kernel_strided_batched,
+                           grid,
+                           threads,
+                           0,
+                           rocblas_stream,
+                           n,
+                           x,
+                           incx,
+                           stridex,
+                           y,
+                           incy,
+                           stridey);
+
+        return rocblas_status_success;
+    }
+
+} // namespace
+
+/* ============================================================================================ */
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+rocblas_status rocblas_sswap_strided_batched(rocblas_handle handle,
+                                             rocblas_int    n,
+                                             float*         x,
+                                             rocblas_int    incx,
+                                             rocblas_int    stridex,
+                                             float*         y,
+                                             rocblas_int    incy,
+                                             rocblas_int    stridey,
+                                             rocblas_int    batch_count)
+{
+    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
+                                             rocblas_int    n,
+                                             double*        x,
+                                             rocblas_int    incx,
+                                             rocblas_int    stridex,
+                                             double*        y,
+                                             rocblas_int    incy,
+                                             rocblas_int    stridey,
+                                             rocblas_int    batch_count)
+{
+    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
+                                             rocblas_int            n,
+                                             rocblas_float_complex* x,
+                                             rocblas_int            incx,
+                                             rocblas_int            stridex,
+                                             rocblas_float_complex* y,
+                                             rocblas_int            incy,
+                                             rocblas_int            stridey,
+                                             rocblas_int            batch_count)
+{
+    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
+                                             rocblas_int             n,
+                                             rocblas_double_complex* x,
+                                             rocblas_int             incx,
+                                             rocblas_int             stridex,
+                                             rocblas_double_complex* y,
+                                             rocblas_int             incy,
+                                             rocblas_int             stridey,
+                                             rocblas_int             batch_count)
+{
+    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+} // extern "C"

--- a/library/src/blas1/rocblas_swap_strided_batched.cpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.cpp
@@ -27,10 +27,10 @@ namespace
                                                      rocblas_int    n,
                                                      T*             x,
                                                      rocblas_int    incx,
-                                                     rocblas_int    stridex,
+                                                     rocblas_stride stridex,
                                                      T*             y,
                                                      rocblas_int    incy,
-                                                     rocblas_int    stridey,
+                                                     rocblas_stride stridey,
                                                      rocblas_int    batch_count)
     {
         if(!handle)
@@ -106,10 +106,10 @@ rocblas_status rocblas_sswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    n,
                                              float*         x,
                                              rocblas_int    incx,
-                                             rocblas_int    stridex,
+                                             rocblas_stride stridex,
                                              float*         y,
                                              rocblas_int    incy,
-                                             rocblas_int    stridey,
+                                             rocblas_stride stridey,
                                              rocblas_int    batch_count)
 {
     return rocblas_swap_strided_batched_impl(
@@ -120,10 +120,10 @@ rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    n,
                                              double*        x,
                                              rocblas_int    incx,
-                                             rocblas_int    stridex,
+                                             rocblas_stride stridex,
                                              double*        y,
                                              rocblas_int    incy,
-                                             rocblas_int    stridey,
+                                             rocblas_stride stridey,
                                              rocblas_int    batch_count)
 {
     return rocblas_swap_strided_batched_impl(
@@ -134,10 +134,10 @@ rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
                                              rocblas_int            n,
                                              rocblas_float_complex* x,
                                              rocblas_int            incx,
-                                             rocblas_int            stridex,
+                                             rocblas_stride         stridex,
                                              rocblas_float_complex* y,
                                              rocblas_int            incy,
-                                             rocblas_int            stridey,
+                                             rocblas_stride         stridey,
                                              rocblas_int            batch_count)
 {
     return rocblas_swap_strided_batched_impl(
@@ -148,10 +148,10 @@ rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
                                              rocblas_int             n,
                                              rocblas_double_complex* x,
                                              rocblas_int             incx,
-                                             rocblas_int             stridex,
+                                             rocblas_stride          stridex,
                                              rocblas_double_complex* y,
                                              rocblas_int             incy,
-                                             rocblas_int             stridey,
+                                             rocblas_stride          stridey,
                                              rocblas_int             batch_count)
 {
     return rocblas_swap_strided_batched_impl(

--- a/library/src/blas1/rocblas_swap_strided_batched.cpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.cpp
@@ -3,6 +3,99 @@
  * ************************************************************************ */
 
 #include "rocblas_swap_strided_batched.hpp"
+#include "logging.h"
+#include "utility.h"
+
+namespace
+{
+
+    template <typename>
+    constexpr char rocblas_swap_strided_batched_name[] = "unknown";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<float>[] = "rocblas_sswap_strided_batched";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<double>[] = "rocblas_dswap_strided_batched";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<rocblas_float_complex>[]
+        = "rocblas_cswap_strided_batched";
+    template <>
+    constexpr char rocblas_swap_strided_batched_name<rocblas_double_complex>[]
+        = "rocblas_zswap_strided_batched";
+
+    template <typename T>
+    rocblas_status rocblas_swap_strided_batched_impl(rocblas_handle handle,
+                                                     rocblas_int    n,
+                                                     T*             x,
+                                                     rocblas_int    incx,
+                                                     rocblas_int    stridex,
+                                                     T*             y,
+                                                     rocblas_int    incy,
+                                                     rocblas_int    stridey,
+                                                     rocblas_int    batch_count)
+    {
+        if(!handle)
+            return rocblas_status_invalid_handle;
+
+        auto layer_mode = handle->layer_mode;
+        if(layer_mode & rocblas_layer_mode_log_trace)
+            log_trace(handle,
+                      rocblas_swap_strided_batched_name<T>,
+                      n,
+                      x,
+                      incx,
+                      stridex,
+                      y,
+                      incy,
+                      stridey,
+                      batch_count);
+        if(layer_mode & rocblas_layer_mode_log_bench)
+            log_bench(handle,
+                      "./rocblas-bench -f swap_strided_batched -r",
+                      rocblas_precision_string<T>,
+                      "-n",
+                      n,
+                      "--incx",
+                      incx,
+                      "--incy",
+                      incy,
+                      "--stride_x",
+                      stridex,
+                      "--stride_y",
+                      stridey,
+                      "--batch",
+                      batch_count);
+        if(layer_mode & rocblas_layer_mode_log_profile)
+            log_profile(handle,
+                        rocblas_swap_strided_batched_name<T>,
+                        "N",
+                        n,
+                        "incx",
+                        incx,
+                        "stride_x",
+                        stridex,
+                        "incy",
+                        incy,
+                        "stride_y",
+                        stridey,
+                        "batch",
+                        batch_count);
+
+        if(!x || !y)
+            return rocblas_status_invalid_pointer;
+
+        size_t abs_incx = incx >= 0 ? incx : -incx;
+        size_t abs_incy = incy >= 0 ? incy : -incy;
+        if(!incx || !incy || (stridex < n * abs_incx) || (stridey < n * abs_incy)
+           || (batch_count < 0))
+            return rocblas_status_invalid_size;
+
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
+        constexpr rocblas_int NB = 256;
+        return rocblas_swap_strided_batched_template<NB>(
+            n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
+    }
+}
 
 /*
  * ===========================================================================
@@ -22,7 +115,8 @@ rocblas_status rocblas_sswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    stridey,
                                              rocblas_int    batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched_impl(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
@@ -35,7 +129,8 @@ rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    stridey,
                                              rocblas_int    batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched_impl(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
@@ -48,7 +143,8 @@ rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
                                              rocblas_int            stridey,
                                              rocblas_int            batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched_impl(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
@@ -61,7 +157,8 @@ rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
                                              rocblas_int             stridey,
                                              rocblas_int             batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched_impl(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap_strided_batched.cpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.cpp
@@ -1,149 +1,8 @@
 /* ************************************************************************
  * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
-#include "handle.h"
-#include "logging.h"
-#include "rocblas.h"
-#include "utility.h"
 
-namespace
-{
-    constexpr int NB = 256;
-
-    template <typename T>
-    __global__ void swap_kernel_strided_batched(rocblas_int n,
-                                                T*          x,
-                                                rocblas_int incx,
-                                                rocblas_int stridex,
-                                                T*          y,
-                                                rocblas_int incy,
-                                                rocblas_int stridey)
-    {
-        ssize_t tid = blockIdx.x * blockDim.x + threadIdx.x; // only dim1
-
-        if(tid < n)
-        {
-            T* xb = x + blockIdx.y * stridex;
-            T* yb = y + blockIdx.y * stridey;
-            // in case of negative inc shift pointer to end of data for negative indexing tid*inc
-            xb -= (incx < 0) ? ptrdiff_t(incx) * (n - 1) : 0;
-            yb -= (incy < 0) ? ptrdiff_t(incy) * (n - 1) : 0;
-
-            auto tmp       = yb[tid * incy];
-            yb[tid * incy] = xb[tid * incx];
-            xb[tid * incx] = tmp;
-        }
-    }
-
-    template <typename>
-    constexpr char rocblas_swap_strided_batched_name[] = "unknown";
-    template <>
-    constexpr char rocblas_swap_strided_batched_name<float>[] = "rocblas_sswap_strided_batched";
-    template <>
-    constexpr char rocblas_swap_strided_batched_name<double>[] = "rocblas_dswap_strided_batched";
-    template <>
-    constexpr char rocblas_swap_strided_batched_name<rocblas_float_complex>[]
-        = "rocblas_cswap_strided_batched";
-    template <>
-    constexpr char rocblas_swap_strided_batched_name<rocblas_double_complex>[]
-        = "rocblas_zswap_strided_batched";
-
-    template <class T>
-    rocblas_status rocblas_swap_strided_batched(rocblas_handle handle,
-                                                rocblas_int    n,
-                                                T*             x,
-                                                rocblas_int    incx,
-                                                rocblas_int    stridex,
-                                                T*             y,
-                                                rocblas_int    incy,
-                                                rocblas_int    stridey,
-                                                rocblas_int    batch_count)
-    {
-        if(!handle)
-            return rocblas_status_invalid_handle;
-
-        auto layer_mode = handle->layer_mode;
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(handle,
-                      rocblas_swap_strided_batched_name<T>,
-                      n,
-                      x,
-                      incx,
-                      stridex,
-                      y,
-                      incy,
-                      stridey,
-                      batch_count);
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench(handle,
-                      "./rocblas-bench -f swap_strided_batched -r",
-                      rocblas_precision_string<T>,
-                      "-n",
-                      n,
-                      "--incx",
-                      incx,
-                      "--incy",
-                      incy,
-                      "--stride_x",
-                      stridex,
-                      "--stride_y",
-                      stridey,
-                      "--batch",
-                      batch_count);
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(handle,
-                        rocblas_swap_strided_batched_name<T>,
-                        "N",
-                        n,
-                        "incx",
-                        incx,
-                        "stride_x",
-                        stridex,
-                        "incy",
-                        incy,
-                        "stride_y",
-                        stridey,
-                        "batch",
-                        batch_count);
-
-        if(!x || !y)
-            return rocblas_status_invalid_pointer;
-
-        size_t abs_incx = incx >= 0 ? incx : -incx;
-        size_t abs_incy = incy >= 0 ? incy : -incy;
-        if((stridex < n * abs_incx) || (stridey < n * abs_incy) || (batch_count < 0))
-            return rocblas_status_invalid_size;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
-
-        // Quick return if possible.
-        if(n <= 0 || batch_count == 0)
-            return rocblas_status_success;
-
-        hipStream_t rocblas_stream = handle->rocblas_stream;
-        rocblas_int blocks         = (n - 1) / NB + 1;
-        dim3        grid(blocks, batch_count);
-        dim3        threads(NB);
-
-        hipLaunchKernelGGL(swap_kernel_strided_batched,
-                           grid,
-                           threads,
-                           0,
-                           rocblas_stream,
-                           n,
-                           x,
-                           incx,
-                           stridex,
-                           y,
-                           incy,
-                           stridey);
-
-        return rocblas_status_success;
-    }
-
-} // namespace
-
-/* ============================================================================================ */
+#include "rocblas_swap_strided_batched.hpp"
 
 /*
  * ===========================================================================
@@ -163,7 +22,7 @@ rocblas_status rocblas_sswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    stridey,
                                              rocblas_int    batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
 }
 
 rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
@@ -176,7 +35,7 @@ rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    stridey,
                                              rocblas_int    batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
 }
 
 rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
@@ -189,7 +48,7 @@ rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
                                              rocblas_int            stridey,
                                              rocblas_int            batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
 }
 
 rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
@@ -202,7 +61,7 @@ rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
                                              rocblas_int             stridey,
                                              rocblas_int             batch_count)
 {
-    return rocblas_swap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+    return rocblas_swap_strided_batched(handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap_strided_batched.cpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.cpp
@@ -83,10 +83,7 @@ namespace
         if(!x || !y)
             return rocblas_status_invalid_pointer;
 
-        size_t abs_incx = incx >= 0 ? incx : -incx;
-        size_t abs_incy = incy >= 0 ? incy : -incy;
-        if(!incx || !incy || (stridex < n * abs_incx) || (stridey < n * abs_incy) || stridex < 0
-           || stridey < 0 || batch_count < 0)
+        if(batch_count < 0)
             return rocblas_status_invalid_size;
 
         RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);

--- a/library/src/blas1/rocblas_swap_strided_batched.cpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.cpp
@@ -85,15 +85,15 @@ namespace
 
         size_t abs_incx = incx >= 0 ? incx : -incx;
         size_t abs_incy = incy >= 0 ? incy : -incy;
-        if(!incx || !incy || (stridex < n * abs_incx) || (stridey < n * abs_incy)
-           || (batch_count < 0))
+        if(!incx || !incy || (stridex < n * abs_incx) || (stridey < n * abs_incy) || stridex < 0
+           || stridey < 0 || batch_count < 0)
             return rocblas_status_invalid_size;
 
         RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         constexpr rocblas_int NB = 256;
         return rocblas_swap_strided_batched_template<NB>(
-            n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
+            handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
     }
 }
 

--- a/library/src/blas1/rocblas_swap_strided_batched.hpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.hpp
@@ -33,16 +33,16 @@ __global__ void rocblas_swap_kernel_strided_batched(rocblas_int n,
 
 template <rocblas_int NB, typename T>
 rocblas_status rocblas_swap_strided_batched_template(rocblas_handle handle,
-                                             rocblas_int    n,
-                                             T*             x,
-                                             rocblas_int    shiftx,
-                                             rocblas_int    incx,
-                                             rocblas_int    stridex,
-                                             T*             y,
-                                             rocblas_int    shifty,
-                                             rocblas_int    incy,
-                                             rocblas_int    stridey,
-                                             rocblas_int    batch_count)
+                                                     rocblas_int    n,
+                                                     T*             x,
+                                                     rocblas_int    shiftx,
+                                                     rocblas_int    incx,
+                                                     rocblas_int    stridex,
+                                                     T*             y,
+                                                     rocblas_int    shifty,
+                                                     rocblas_int    incy,
+                                                     rocblas_int    stridey,
+                                                     rocblas_int    batch_count)
 {
     // Quick return if possible.
     if(n <= 0 || batch_count == 0)

--- a/library/src/blas1/rocblas_swap_strided_batched.hpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.hpp
@@ -7,15 +7,15 @@
 #include "rocblas_swap.hpp"
 
 template <typename T>
-__global__ void rocblas_swap_kernel_strided_batched(rocblas_int n,
-                                                    T*          x,
-                                                    rocblas_int shiftx,
-                                                    rocblas_int incx,
-                                                    rocblas_int stridex,
-                                                    T*          y,
-                                                    rocblas_int shifty,
-                                                    rocblas_int incy,
-                                                    rocblas_int stridey)
+__global__ void rocblas_swap_kernel_strided_batched(rocblas_int    n,
+                                                    T*             x,
+                                                    rocblas_int    shiftx,
+                                                    rocblas_int    incx,
+                                                    rocblas_stride stridex,
+                                                    T*             y,
+                                                    rocblas_int    shifty,
+                                                    rocblas_int    incy,
+                                                    rocblas_stride stridey)
 {
     ssize_t tid = blockIdx.x * blockDim.x + threadIdx.x; // only dim1
 
@@ -37,11 +37,11 @@ rocblas_status rocblas_swap_strided_batched_template(rocblas_handle handle,
                                                      T*             x,
                                                      rocblas_int    shiftx,
                                                      rocblas_int    incx,
-                                                     rocblas_int    stridex,
+                                                     rocblas_stride stridex,
                                                      T*             y,
                                                      rocblas_int    shifty,
                                                      rocblas_int    incy,
-                                                     rocblas_int    stridey,
+                                                     rocblas_stride stridey,
                                                      rocblas_int    batch_count)
 {
     // Quick return if possible.

--- a/library/src/blas1/rocblas_swap_strided_batched.hpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.hpp
@@ -4,6 +4,7 @@
 #pragma once
 #include "handle.h"
 #include "rocblas.h"
+#include "rocblas_swap.hpp"
 
 template <typename T>
 __global__ void rocblas_swap_kernel_strided_batched(rocblas_int n,
@@ -26,14 +27,12 @@ __global__ void rocblas_swap_kernel_strided_batched(rocblas_int n,
         xb -= (incx < 0) ? ptrdiff_t(incx) * (n - 1) : 0;
         yb -= (incy < 0) ? ptrdiff_t(incy) * (n - 1) : 0;
 
-        auto tmp       = yb[tid * incy];
-        yb[tid * incy] = xb[tid * incx];
-        xb[tid * incx] = tmp;
+        rocblas_swap_vals(xb + tid * incx, yb + tid * incy);
     }
 }
 
 template <rocblas_int NB, typename T>
-rocblas_status rocblas_swap_strided_template(rocblas_handle handle,
+rocblas_status rocblas_swap_strided_batched_template(rocblas_handle handle,
                                              rocblas_int    n,
                                              T*             x,
                                              rocblas_int    shiftx,

--- a/library/src/blas1/rocblas_swap_strided_batched.hpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.hpp
@@ -1,0 +1,151 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#include "handle.h"
+#include "logging.h"
+#include "rocblas.h"
+#include "utility.h"
+
+
+template <typename T>
+__global__ void rocblas_swap_kernel_strided_batched(rocblas_int n,
+                                            T*          x,
+                                            rocblas_int shiftx,
+                                            rocblas_int incx,
+                                            rocblas_int stridex,
+                                            T*          y,
+                                            rocblas_int shifty,
+                                            rocblas_int incy,
+                                            rocblas_int stridey)
+{
+    ssize_t tid = blockIdx.x * blockDim.x + threadIdx.x; // only dim1
+
+    if(tid < n)
+    {
+        T* xb = x + blockIdx.y * stridex + shiftx;
+        T* yb = y + blockIdx.y * stridey + shifty; 
+        // in case of negative inc shift pointer to end of data for negative indexing tid*inc
+        xb -= (incx < 0) ? ptrdiff_t(incx) * (n - 1) : 0;
+        yb -= (incy < 0) ? ptrdiff_t(incy) * (n - 1) : 0;
+
+        auto tmp       = yb[tid * incy];
+        yb[tid * incy] = xb[tid * incx];
+        xb[tid * incx] = tmp;
+    }
+}
+
+template <typename>
+constexpr char rocblas_swap_strided_batched_name[] = "unknown";
+template <>
+constexpr char rocblas_swap_strided_batched_name<float>[] = "rocblas_sswap_strided_batched";
+template <>
+constexpr char rocblas_swap_strided_batched_name<double>[] = "rocblas_dswap_strided_batched";
+template <>
+constexpr char rocblas_swap_strided_batched_name<rocblas_float_complex>[]
+    = "rocblas_cswap_strided_batched";
+template <>
+constexpr char rocblas_swap_strided_batched_name<rocblas_double_complex>[]
+    = "rocblas_zswap_strided_batched";
+
+template <class T>
+rocblas_status rocblas_swap_strided_batched(rocblas_handle handle,
+                                            rocblas_int    n,
+                                            T*             x,
+                                            rocblas_int    shiftx,
+                                            rocblas_int    incx,
+                                            rocblas_int    stridex,
+                                            T*             y,
+                                            rocblas_int    shifty,
+                                            rocblas_int    incy,
+                                            rocblas_int    stridey,
+                                            rocblas_int    batch_count)
+{
+    if(!handle)
+        return rocblas_status_invalid_handle;
+
+    auto layer_mode = handle->layer_mode;
+    if(layer_mode & rocblas_layer_mode_log_trace)
+        log_trace(handle,
+                    rocblas_swap_strided_batched_name<T>,
+                    n,
+                    x,
+                    incx,
+                    stridex,
+                    y,
+                    incy,
+                    stridey,
+                    batch_count);
+    if(layer_mode & rocblas_layer_mode_log_bench)
+        log_bench(handle,
+                    "./rocblas-bench -f swap_strided_batched -r",
+                    rocblas_precision_string<T>,
+                    "-n",
+                    n,
+                    "--incx",
+                    incx,
+                    "--incy",
+                    incy,
+                    "--stride_x",
+                    stridex,
+                    "--stride_y",
+                    stridey,
+                    "--batch",
+                    batch_count);
+    if(layer_mode & rocblas_layer_mode_log_profile)
+        log_profile(handle,
+                    rocblas_swap_strided_batched_name<T>,
+                    "N",
+                    n,
+                    "incx",
+                    incx,
+                    "stride_x",
+                    stridex,
+                    "incy",
+                    incy,
+                    "stride_y",
+                    stridey,
+                    "batch",
+                    batch_count);
+
+    if(!x || !y)
+        return rocblas_status_invalid_pointer;
+
+    size_t abs_incx = incx >= 0 ? incx : -incx;
+    size_t abs_incy = incy >= 0 ? incy : -incy;
+    if(!incx || !incy || (stridex < n * abs_incx) || (stridey < n * abs_incy) || (batch_count < 0))
+        return rocblas_status_invalid_size;
+
+    RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
+    // Quick return if possible.
+    if(n <= 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    constexpr int NB = 256;
+    hipStream_t rocblas_stream = handle->rocblas_stream;
+    rocblas_int blocks         = (n - 1) / NB + 1;
+    dim3        grid(blocks, batch_count);
+    dim3        threads(NB);
+
+    hipLaunchKernelGGL(rocblas_swap_kernel_strided_batched,
+                        grid,
+                        threads,
+                        0,
+                        rocblas_stream,
+                        n,
+                        x,
+                        shiftx,
+                        incx,
+                        stridex,
+                        y,
+                        shifty,
+                        incy,
+                        stridey);
+
+    return rocblas_status_success;
+}
+
+
+/* ============================================================================================ */
+
+


### PR DESCRIPTION
This adds into blas1 the batched and strided_batched for swap.  Refactors non batched swap to follow new coding pattern (impl and template).   It defers the merging of the batched and strided_batched kernels until final pattern agreed upon but already shares the simple computation kernel code.

Example combined test times for all 3 cases on Vega20:
372 tests from 6 test cases ran. (31937 ms total)
