### PR TITLE
Add known bugs for BF16 cases

### DIFF
--- a/clients/gtest/known_bugs.yaml
+++ b/clients/gtest/known_bugs.yaml
@@ -3,3 +3,7 @@
 # Wildcards can be used for the function
 
 Known bugs:
+- { function: "gemm_ex", a_type: "bf16_r", b_type: "bf16_r", c_type: "bf16_r", d_type: "bf16_r", compute_type: "f32_r", transA: 'C', transB: 'N', M: 1024, N: 1024, K: 1024, lda: 1024, ldb: 1024, ldc: 1024, ldd: 1024, alpha: 5.0, alphai: 0.0, beta: 0.0, betai: 0.0 }
+- { function: "gemm_ex", a_type: "bf16_r", b_type: "bf16_r", c_type: "bf16_r", d_type: "bf16_r", compute_type: "f32_r", transA: 'C', transB: 'N', M: 1024, N: 1024, K: 1024, lda: 1024, ldb: 1024, ldc: 1024, ldd: 1024, alpha: 0.0, alphai: 0.0, beta: 3.0, betai: 0.0 }
+- { function: "gemm_ex", a_type: "bf16_r", b_type: "bf16_r", c_type: "bf16_r", d_type: "bf16_r", compute_type: "f32_r", transA: 'C', transB: 'N', M: 1024, N: 1024, K: 1024, lda: 1024, ldb: 1024, ldc: 1024, ldd: 1024, alpha: 1.0, alphai: 0.0, beta: 3.0, betai: 0.0 }
+- { function: "gemm_ex", a_type: "bf16_r", b_type: "bf16_r", c_type: "bf16_r", d_type: "bf16_r", compute_type: "f32_r", transA: 'C', transB: 'N', M: 1024, N: 1024, K: 1024, lda: 1024, ldb: 1024, ldc: 1024, ldd: 1024, alpha: 1.0, alphai: 0.0, beta: 1.0, betai: 0.0 }


### PR DESCRIPTION
```
rocBLAS version: 2.9.0.1588-c909d79

Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : Vega 20
with 34.3 GB memory, clock rate 1701MHz @ computing capability 3.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Note: Google Test filter = *known_bug*
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from known_bug/gemm_ex
[ RUN      ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_5_1024_1024_0_1024_1024
[       OK ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_5_1024_1024_0_1024_1024 (6021 ms)
[ RUN      ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_0_1024_1024_3_1024_1024
[       OK ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_0_1024_1024_3_1024_1024 (289 ms)
[ RUN      ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_1_1024_1024_3_1024_1024
[       OK ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_1_1024_1024_3_1024_1024 (322 ms)
[ RUN      ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_1_1024_1024_1_1024_1024
[       OK ] known_bug/gemm_ex.blas3/bf16_rbf16_rbf16_rbf16_rf32_r_CN_1024_1024_1024_1_1024_1024_1_1024_1024 (323 ms)
[----------] 4 tests from known_bug/gemm_ex (6957 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (7010 ms total)
[  PASSED  ] 4 tests.

```
