### PR TITLE
drops float precision for large N asum,nrm2

### DIFF
--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -109,8 +109,8 @@ Tests:
     function:
       - scal_batched: *single_double_precisions_complex_real
       - scal_batched: *single_double_complex_real_in_complex_out
-      - asum_batched: *single_double_precisions_complex_real
-      - nrm2_batched: *single_double_precisions_complex_real
+      - asum_batched: *double_precision_complex_real
+      - nrm2_batched: *double_precision_complex_real
 
   - name: blas1_strided_batched
     category: pre_checkin
@@ -123,8 +123,8 @@ Tests:
     function:
       - scal_strided_batched: *single_double_precisions_complex_real
       - scal_strided_batched: *single_double_complex_real_in_complex_out
-      - asum_strided_batched: *single_double_precisions_complex_real
-      - nrm2_strided_batched: *single_double_precisions_complex_real
+      - asum_strided_batched: *double_precision_complex_real
+      - nrm2_strided_batched: *double_precision_complex_real
 
   - name: blas1
     category: nightly


### PR DESCRIPTION
Summary of proposed changes for pre-checkin test failure:
Tests with large N for single precision accumulation functions got accidentally put in with a merge
Removes large N single precision pre-checkin tests on asum, nrm2 rather than increase tolerance, keeps all other data types with large N and still checks single precision in other tests

