### PR TITLE
removed space in empty block

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -103,6 +103,7 @@ PointerAlignment: Left
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Never
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false


### PR DESCRIPTION
Rocm2.8 has a new version of clang format that adds a space between the brackets of constructors that do not have a body

ex. class A(int a, double b) {} -> class A(int a, double b) { }

I've added a one-line change to clang-format that ignores this regression, and allows our CI to pass the format check. I'll add this to all projects