### PR TITLE
Removed centos jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ rocBLASCI:
     rocblas.paths.build_command = './install.sh -lasm_ci -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['ubuntu && gfx900', 'gfx900 && centos7', 'gfx906 && centos7', 'sles && gfx906'], rocblas)
+    def nodes = new dockerNodes(['ubuntu && gfx900', 'ubuntu && gfx906', 'sles && gfx906'], rocblas)
 
     boolean formatCheck = true
 


### PR DESCRIPTION
- CentOS jobs are currently failing due to a mismatch in intrinsic sse headers (i.e. xmmintrin.h), so this PR disables them from CI
- Added Vega 20 Ubuntu job as well