### PR TITLE
fix centos/redhat include order

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ rocBLASCI:
     rocblas.paths.build_command = './install.sh -lasm_ci -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['ubuntu && gfx900', 'ubuntu && gfx906', 'sles && gfx906'], rocblas)
+    def nodes = new dockerNodes(['ubuntu && gfx900', 'centos7 && gfx900', 'centos7 && gfx906', 'sles && gfx906'], rocblas)
 
     boolean formatCheck = true
 

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -150,7 +150,6 @@ endif( )
 if( OS_ID_rhel OR OS_ID_centos)
     # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
     set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
-else()
 endif()
 
 set_target_properties( rocblas-bench PROPERTIES CXX_EXTENSIONS NO )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -68,7 +68,8 @@ set( BLIS_LIBRARY ${CMAKE_SOURCE_DIR}/build/deps/blis/lib/libblis.so )
 
 if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
     if( OS_ID_rhel OR OS_ID_centos)
-        set( OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
+        # defer OpenMP include as search order must come after clang
+        set( XXX_OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
         set( OPENMP_LIBRARY /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/libgomp.so )
     else()
     #SLES
@@ -145,6 +146,12 @@ elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
   # GCC or hip-clang needs specific flags to turn on f16c intrinsics
   target_compile_options( rocblas-bench PRIVATE -mf16c )
 endif( )
+
+if( OS_ID_rhel OR OS_ID_centos)
+    # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
+    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
+else()
+endif()
 
 set_target_properties( rocblas-bench PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocblas-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -200,7 +200,6 @@ endif( )
 if( OS_ID_rhel OR OS_ID_centos)
     # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
     set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
-else()
 endif()
 
 if( CXX_VERSION_STRING MATCHES "clang" )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -107,7 +107,8 @@ set( BLIS_LIBRARY ${CMAKE_SOURCE_DIR}/build/deps/blis/lib/libblis.so )
 
 if( OS_ID_rhel OR OS_ID_centos OR OS_ID_sles)
     if( OS_ID_rhel OR OS_ID_centos)
-        set( OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
+        # defer OpenMP include as search order must come after clang
+        set( XXX_OPENMP_INCLUDE_DIR /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include )
         set( OPENMP_LIBRARY /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/libgomp.so )
     else()
     #SLES
@@ -195,6 +196,12 @@ elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
   # GCC or hip-clang needs specific flag to turn on f16c intrinsics
   target_compile_options( rocblas-test PRIVATE -mf16c )
 endif( )
+
+if( OS_ID_rhel OR OS_ID_centos)
+    # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
+    set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
+else()
+endif()
 
 if( CXX_VERSION_STRING MATCHES "clang" )
   target_link_libraries( rocblas-test PRIVATE -lpthread -lm )


### PR DESCRIPTION
resolves centos and redhat build failures in gtest and benchmarks

Summary of proposed changes:

Forces clang include to come before the conflicting system ones.
We need the OpenMP currently found in:
 /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include
but other includes conflict as too old.  Longer term solution still recommended.

E.g. include searching:
ignoring nonexistent directory "/opt/rocm/hcc/bin/../hcc/include"
ignoring nonexistent directory "/include"
ignoring duplicate directory "/opt/rocm/hcc/bin/../include"
  as it is a non-system directory that duplicates a system directory
ignoring duplicate directory "/opt/rocm/hcc/lib/clang/10.0.0/include"
ignoring duplicate directory "/usr/local/include"
ignoring duplicate directory "/opt/rocm/hcc/lib/clang/10.0.0/include"
ignoring duplicate directory "/usr/include"
#include "..." search starts here:
#include <...> search starts here:
 /home/rocBLAS/clients/benchmarks/../include
 /opt/rocm/hsa/include
 /home/rocBLAS/library/include
 /home/rocBLAS/library/src/include
 /home/rocBLAS/build/release/include
 /home/rocBLAS/build/deps/blis/include/blis
 /opt/rocm/hip/include
 /opt/rocm/hcc/bin/../include
 /opt/rocm/hcc/lib/clang/10.0.0/include
 /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include
 /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/../../../../include/c++/7
 /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/../../../../include/c++/7/x86_64-redhat-linux
 /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/../../../../include/c++/7/backward
 /usr/local/include
 /usr/include
End of search list.
