### PR TITLE
HIP Clang defaults to CO V3 & Tensile_COMPILER=hipcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
 # Versioning via rocm-cmake
-set ( VERSION_STRING "2.6.4" )
+set ( VERSION_STRING "2.6.5" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
@@ -178,7 +178,7 @@ if( BUILD_WITH_TENSILE )
   else()
     # Use the virtual-env setup and download package from specified repot:
     set( tensile_fork "ROCmSoftwarePlatform" CACHE STRING "Tensile fork to use" )
-    set( tensile_tag 1c58828cafd5f1285bf17b75ad5c04ca6c8fa88c CACHE STRING "Tensile tag to download" )
+    set( tensile_tag 61a5741c591322762f64e7bd3e6a898eb2715093 CACHE STRING "Tensile tag to download" )
     virtualenv_install("git+https://github.com/${tensile_fork}/Tensile.git@${tensile_tag}")
     message (STATUS "using GIT Tensile fork=${tensile_fork} from branch=${tensile_tag}")
   endif()

--- a/install.sh
+++ b/install.sh
@@ -269,6 +269,7 @@ while true; do
         shift ;;
     --hip-clang)
         build_hip_clang=true
+        tensile_cov=V3
         shift ;;
     --prefix)
         install_prefix=${2}
@@ -360,6 +361,7 @@ pushd .
   compiler="hcc"
   if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"
+    cmake_common_options="${cmake_common_options} -DTensile_COMPILER=hipcc"
   fi
 
   # Uncomment for cmake debugging


### PR DESCRIPTION
When building rocBLAS with `install.sh --hip-clang`, it needs to default to code object V3 and set cmake variable Tensile_COMPILER to hipcc.
