### PR TITLE
HIP Clang defaults to CO V3 & Tensile_COMPILER=hipcc (develop branch)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -312,6 +312,7 @@ while true; do
         shift 2 ;;
     --hip-clang)
         build_hip_clang=true
+        tensile_cov=V3
         shift ;;
     --prefix)
         install_prefix=${2}
@@ -447,6 +448,7 @@ esac
   compiler="hcc"
   if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"
+    cmake_common_options="${cmake_common_options} -DTensile_COMPILER=hipcc"
   fi
 
   # Uncomment for cmake debugging


### PR DESCRIPTION
When building rocBLAS with `install.sh --hip-clang`, code object version defaults to V3 and cmake variable Tensile_COMPILER sets to hipcc.  To do a full rocBLAS build with HIP Clang this way, Tensile commit 1e108edd2f113027c49e1b446674128569c4d425 is required for gfx908.  Since rocBLAS build still uses HCC by default, testing can be done with install.sh's -bdevelop option.  The changes to install.sh do not impact HCC build.
