### PR TITLE
Fix build for hipclang

### DIFF
--- a/library/src/blas1/reduction_strided_batched.h
+++ b/library/src/blas1/reduction_strided_batched.h
@@ -148,7 +148,7 @@ struct rocblas_default_value
     }
 };
 
-size_t rocblas_reduction_kernel_block_count(rocblas_int n, rocblas_int NB)
+inline size_t rocblas_reduction_kernel_block_count(rocblas_int n, rocblas_int NB)
 {
     if(n <= 0)
         n = 1; // avoid sign loss issues

--- a/library/src/blas1/rocblas_dot.hpp
+++ b/library/src/blas1/rocblas_dot.hpp
@@ -91,7 +91,7 @@ rocblas_status rocblas_dot_template(rocblas_handle __restrict__ handle,
     dim3        grid(blocks, batch_count);
     dim3        threads(NB);
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(dot_kernel_part1<NB, CONJ, T>),
+    hipLaunchKernelGGL((dot_kernel_part1<NB, CONJ, T>),
                        grid,
                        threads,
                        0,

--- a/library/src/blas1/rocblas_dot.hpp
+++ b/library/src/blas1/rocblas_dot.hpp
@@ -91,7 +91,7 @@ rocblas_status rocblas_dot_template(rocblas_handle __restrict__ handle,
     dim3        grid(blocks, batch_count);
     dim3        threads(NB);
 
-    hipLaunchKernelGGL(dot_kernel_part1<NB, CONJ, T>,
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(dot_kernel_part1<NB, CONJ, T>),
                        grid,
                        threads,
                        0,

--- a/library/src/blas1/rocblas_rotm.hpp
+++ b/library/src/blas1/rocblas_rotm.hpp
@@ -86,7 +86,7 @@ __global__ void rotm_kernel_batched(rocblas_int    n,
                      h22);
 }
 
-template <typename T>
+template <typename T, typename U>
 __global__ void rotm_kernel_regular(rocblas_int    n,
                                     T*             x_in,
                                     rocblas_int    offset_x,
@@ -96,11 +96,11 @@ __global__ void rotm_kernel_regular(rocblas_int    n,
                                     rocblas_int    offset_y,
                                     rocblas_int    incy,
                                     rocblas_stride stride_y,
-                                    T              flag,
-                                    T              h11,
-                                    T              h21,
-                                    T              h12,
-                                    T              h22)
+                                    U              flag,
+                                    U              h11,
+                                    U              h21,
+                                    U              h12,
+                                    U              h22)
 {
     rotm_kernel_calc(n,
                      x_in,
@@ -111,11 +111,11 @@ __global__ void rotm_kernel_regular(rocblas_int    n,
                      offset_y,
                      incy,
                      stride_y,
-                     flag,
-                     h11,
-                     h21,
-                     h12,
-                     h22);
+                     load_scalar(flag),
+                     load_scalar(h11),
+                     load_scalar(h21),
+                     load_scalar(h12),
+                     load_scalar(h22));
 }
 
 // Workaround to avoid constexpr if - Helper function to quick return when param[0] == -2

--- a/library/src/blas3/Tensile/gemm.hpp
+++ b/library/src/blas3/Tensile/gemm.hpp
@@ -86,24 +86,24 @@ hipError_t tensile_helper(T&                alpha_h,
         sizeL, handle->rocblas_stream, 0, nullptr, nullptr
 
 template <>
-hipError_t tensile_helper(rocblas_half&       alpha_h,
-                          rocblas_half&       beta_h,
-                          const rocblas_half* A,
-                          const rocblas_half* B,
-                          rocblas_half*       C,
-                          rocblas_operation   trans_a,
-                          rocblas_operation   trans_b,
-                          rocblas_stride      strideC1,
-                          rocblas_stride      strideC2,
-                          rocblas_stride      strideA1,
-                          rocblas_stride      strideA2,
-                          rocblas_stride      strideB1,
-                          rocblas_stride      strideB2,
-                          rocblas_int         sizeI,
-                          rocblas_int         sizeJ,
-                          rocblas_int         sizeK,
-                          rocblas_int         sizeL,
-                          rocblas_handle      handle)
+inline hipError_t tensile_helper(rocblas_half&       alpha_h,
+                                 rocblas_half&       beta_h,
+                                 const rocblas_half* A,
+                                 const rocblas_half* B,
+                                 rocblas_half*       C,
+                                 rocblas_operation   trans_a,
+                                 rocblas_operation   trans_b,
+                                 rocblas_stride      strideC1,
+                                 rocblas_stride      strideC2,
+                                 rocblas_stride      strideA1,
+                                 rocblas_stride      strideA2,
+                                 rocblas_stride      strideB1,
+                                 rocblas_stride      strideB2,
+                                 rocblas_int         sizeI,
+                                 rocblas_int         sizeJ,
+                                 rocblas_int         sizeK,
+                                 rocblas_int         sizeL,
+                                 rocblas_handle      handle)
 {
     hipError_t status = hipErrorInvalidValue;
 
@@ -132,7 +132,7 @@ hipError_t tensile_helper(rocblas_half&       alpha_h,
 }
 
 template <>
-hipError_t tensile_helper(float&            alpha_h,
+inline hipError_t tensile_helper(float&            alpha_h,
                           float&            beta_h,
                           const float*      A,
                           const float*      B,
@@ -178,7 +178,7 @@ hipError_t tensile_helper(float&            alpha_h,
 }
 
 template <>
-hipError_t tensile_helper(double&           alpha_h,
+inline hipError_t tensile_helper(double&           alpha_h,
                           double&           beta_h,
                           const double*     A,
                           const double*     B,
@@ -224,7 +224,7 @@ hipError_t tensile_helper(double&           alpha_h,
 }
 
 template <>
-hipError_t tensile_helper(rocblas_float_complex&       alpha_h,
+inline hipError_t tensile_helper(rocblas_float_complex&       alpha_h,
                           rocblas_float_complex&       beta_h,
                           const rocblas_float_complex* A,
                           const rocblas_float_complex* B,
@@ -291,7 +291,7 @@ hipError_t tensile_helper(rocblas_float_complex&       alpha_h,
 }
 
 template <>
-hipError_t tensile_helper(rocblas_double_complex&       alpha_h,
+inline hipError_t tensile_helper(rocblas_double_complex&       alpha_h,
                           rocblas_double_complex&       beta_h,
                           const rocblas_double_complex* A,
                           const rocblas_double_complex* B,
@@ -605,7 +605,7 @@ inline rocblas_status validateArgs(rocblas_handle    handle,
  * Tensile Solution Name (debug only)
  ******************************************************************************/
 template <typename T>
-const char* tensileGetSolutionName(rocblas_operation trans_a,
+inline const char* tensileGetSolutionName(rocblas_operation trans_a,
                                    rocblas_operation trans_b,
                                    rocblas_int       strideC1,
                                    rocblas_int       strideC2,
@@ -628,7 +628,7 @@ const char* tensileGetSolutionName(rocblas_operation trans_a,
         sizeK, sizeL
 
 template <>
-const char* tensileGetSolutionName<rocblas_half>(rocblas_operation trans_a,
+inline const char* tensileGetSolutionName<rocblas_half>(rocblas_operation trans_a,
                                                  rocblas_operation trans_b,
                                                  rocblas_int       strideC1,
                                                  rocblas_int       strideC2,
@@ -660,7 +660,7 @@ const char* tensileGetSolutionName<rocblas_half>(rocblas_operation trans_a,
 }
 
 template <>
-const char* tensileGetSolutionName<float>(rocblas_operation trans_a,
+inline const char* tensileGetSolutionName<float>(rocblas_operation trans_a,
                                           rocblas_operation trans_b,
                                           rocblas_int       strideC1,
                                           rocblas_int       strideC2,
@@ -692,7 +692,7 @@ const char* tensileGetSolutionName<float>(rocblas_operation trans_a,
 }
 
 template <>
-const char* tensileGetSolutionName<double>(rocblas_operation trans_a,
+inline const char* tensileGetSolutionName<double>(rocblas_operation trans_a,
                                            rocblas_operation trans_b,
                                            rocblas_int       strideC1,
                                            rocblas_int       strideC2,
@@ -724,7 +724,7 @@ const char* tensileGetSolutionName<double>(rocblas_operation trans_a,
 }
 
 template <>
-const char* tensileGetSolutionName<rocblas_float_complex>(rocblas_operation trans_a,
+inline const char* tensileGetSolutionName<rocblas_float_complex>(rocblas_operation trans_a,
                                                           rocblas_operation trans_b,
                                                           rocblas_int       strideC1,
                                                           rocblas_int       strideC2,
@@ -761,7 +761,7 @@ const char* tensileGetSolutionName<rocblas_float_complex>(rocblas_operation tran
 }
 
 template <>
-const char* tensileGetSolutionName<rocblas_double_complex>(rocblas_operation trans_a,
+inline const char* tensileGetSolutionName<rocblas_double_complex>(rocblas_operation trans_a,
                                                            rocblas_operation trans_b,
                                                            rocblas_int       strideC1,
                                                            rocblas_int       strideC2,

--- a/library/src/blas3/Tensile/gemm.hpp
+++ b/library/src/blas3/Tensile/gemm.hpp
@@ -133,23 +133,23 @@ inline hipError_t tensile_helper(rocblas_half&       alpha_h,
 
 template <>
 inline hipError_t tensile_helper(float&            alpha_h,
-                          float&            beta_h,
-                          const float*      A,
-                          const float*      B,
-                          float*            C,
-                          rocblas_operation trans_a,
-                          rocblas_operation trans_b,
-                          rocblas_stride    strideC1,
-                          rocblas_stride    strideC2,
-                          rocblas_stride    strideA1,
-                          rocblas_stride    strideA2,
-                          rocblas_stride    strideB1,
-                          rocblas_stride    strideB2,
-                          rocblas_int       sizeI,
-                          rocblas_int       sizeJ,
-                          rocblas_int       sizeK,
-                          rocblas_int       sizeL,
-                          rocblas_handle    handle)
+                                 float&            beta_h,
+                                 const float*      A,
+                                 const float*      B,
+                                 float*            C,
+                                 rocblas_operation trans_a,
+                                 rocblas_operation trans_b,
+                                 rocblas_stride    strideC1,
+                                 rocblas_stride    strideC2,
+                                 rocblas_stride    strideA1,
+                                 rocblas_stride    strideA2,
+                                 rocblas_stride    strideB1,
+                                 rocblas_stride    strideB2,
+                                 rocblas_int       sizeI,
+                                 rocblas_int       sizeJ,
+                                 rocblas_int       sizeK,
+                                 rocblas_int       sizeL,
+                                 rocblas_handle    handle)
 {
     hipError_t status = hipErrorInvalidValue;
 
@@ -179,23 +179,23 @@ inline hipError_t tensile_helper(float&            alpha_h,
 
 template <>
 inline hipError_t tensile_helper(double&           alpha_h,
-                          double&           beta_h,
-                          const double*     A,
-                          const double*     B,
-                          double*           C,
-                          rocblas_operation trans_a,
-                          rocblas_operation trans_b,
-                          rocblas_stride    strideC1,
-                          rocblas_stride    strideC2,
-                          rocblas_stride    strideA1,
-                          rocblas_stride    strideA2,
-                          rocblas_stride    strideB1,
-                          rocblas_stride    strideB2,
-                          rocblas_int       sizeI,
-                          rocblas_int       sizeJ,
-                          rocblas_int       sizeK,
-                          rocblas_int       sizeL,
-                          rocblas_handle    handle)
+                                 double&           beta_h,
+                                 const double*     A,
+                                 const double*     B,
+                                 double*           C,
+                                 rocblas_operation trans_a,
+                                 rocblas_operation trans_b,
+                                 rocblas_stride    strideC1,
+                                 rocblas_stride    strideC2,
+                                 rocblas_stride    strideA1,
+                                 rocblas_stride    strideA2,
+                                 rocblas_stride    strideB1,
+                                 rocblas_stride    strideB2,
+                                 rocblas_int       sizeI,
+                                 rocblas_int       sizeJ,
+                                 rocblas_int       sizeK,
+                                 rocblas_int       sizeL,
+                                 rocblas_handle    handle)
 {
     hipError_t status = hipErrorInvalidValue;
 
@@ -225,23 +225,23 @@ inline hipError_t tensile_helper(double&           alpha_h,
 
 template <>
 inline hipError_t tensile_helper(rocblas_float_complex&       alpha_h,
-                          rocblas_float_complex&       beta_h,
-                          const rocblas_float_complex* A,
-                          const rocblas_float_complex* B,
-                          rocblas_float_complex*       C,
-                          rocblas_operation            trans_a,
-                          rocblas_operation            trans_b,
-                          rocblas_stride               strideC1,
-                          rocblas_stride               strideC2,
-                          rocblas_stride               strideA1,
-                          rocblas_stride               strideA2,
-                          rocblas_stride               strideB1,
-                          rocblas_stride               strideB2,
-                          rocblas_int                  sizeI,
-                          rocblas_int                  sizeJ,
-                          rocblas_int                  sizeK,
-                          rocblas_int                  sizeL,
-                          rocblas_handle               handle)
+                                 rocblas_float_complex&       beta_h,
+                                 const rocblas_float_complex* A,
+                                 const rocblas_float_complex* B,
+                                 rocblas_float_complex*       C,
+                                 rocblas_operation            trans_a,
+                                 rocblas_operation            trans_b,
+                                 rocblas_stride               strideC1,
+                                 rocblas_stride               strideC2,
+                                 rocblas_stride               strideA1,
+                                 rocblas_stride               strideA2,
+                                 rocblas_stride               strideB1,
+                                 rocblas_stride               strideB2,
+                                 rocblas_int                  sizeI,
+                                 rocblas_int                  sizeJ,
+                                 rocblas_int                  sizeK,
+                                 rocblas_int                  sizeL,
+                                 rocblas_handle               handle)
 {
     static_assert(std::is_standard_layout<TensileComplexFloat>{},
                   "TensileComplexFloat is not a standard layout type, and thus is "
@@ -292,23 +292,23 @@ inline hipError_t tensile_helper(rocblas_float_complex&       alpha_h,
 
 template <>
 inline hipError_t tensile_helper(rocblas_double_complex&       alpha_h,
-                          rocblas_double_complex&       beta_h,
-                          const rocblas_double_complex* A,
-                          const rocblas_double_complex* B,
-                          rocblas_double_complex*       C,
-                          rocblas_operation             trans_a,
-                          rocblas_operation             trans_b,
-                          rocblas_stride                strideC1,
-                          rocblas_stride                strideC2,
-                          rocblas_stride                strideA1,
-                          rocblas_stride                strideA2,
-                          rocblas_stride                strideB1,
-                          rocblas_stride                strideB2,
-                          rocblas_int                   sizeI,
-                          rocblas_int                   sizeJ,
-                          rocblas_int                   sizeK,
-                          rocblas_int                   sizeL,
-                          rocblas_handle                handle)
+                                 rocblas_double_complex&       beta_h,
+                                 const rocblas_double_complex* A,
+                                 const rocblas_double_complex* B,
+                                 rocblas_double_complex*       C,
+                                 rocblas_operation             trans_a,
+                                 rocblas_operation             trans_b,
+                                 rocblas_stride                strideC1,
+                                 rocblas_stride                strideC2,
+                                 rocblas_stride                strideA1,
+                                 rocblas_stride                strideA2,
+                                 rocblas_stride                strideB1,
+                                 rocblas_stride                strideB2,
+                                 rocblas_int                   sizeI,
+                                 rocblas_int                   sizeJ,
+                                 rocblas_int                   sizeK,
+                                 rocblas_int                   sizeL,
+                                 rocblas_handle                handle)
 {
     static_assert(std::is_standard_layout<TensileComplexDouble>{},
                   "TensileComplexDouble is not a standard layout type, and thus is "
@@ -606,17 +606,17 @@ inline rocblas_status validateArgs(rocblas_handle    handle,
  ******************************************************************************/
 template <typename T>
 inline const char* tensileGetSolutionName(rocblas_operation trans_a,
-                                   rocblas_operation trans_b,
-                                   rocblas_int       strideC1,
-                                   rocblas_int       strideC2,
-                                   rocblas_int       strideA1,
-                                   rocblas_int       strideA2,
-                                   rocblas_int       strideB1,
-                                   rocblas_int       strideB2,
-                                   rocblas_int       sizeI,
-                                   rocblas_int       sizeJ,
-                                   rocblas_int       sizeK,
-                                   rocblas_int       sizeL)
+                                          rocblas_operation trans_b,
+                                          rocblas_int       strideC1,
+                                          rocblas_int       strideC2,
+                                          rocblas_int       strideA1,
+                                          rocblas_int       strideA2,
+                                          rocblas_int       strideB1,
+                                          rocblas_int       strideB2,
+                                          rocblas_int       sizeI,
+                                          rocblas_int       sizeJ,
+                                          rocblas_int       sizeK,
+                                          rocblas_int       sizeL)
 {
     return "";
 };
@@ -629,17 +629,17 @@ inline const char* tensileGetSolutionName(rocblas_operation trans_a,
 
 template <>
 inline const char* tensileGetSolutionName<rocblas_half>(rocblas_operation trans_a,
-                                                 rocblas_operation trans_b,
-                                                 rocblas_int       strideC1,
-                                                 rocblas_int       strideC2,
-                                                 rocblas_int       strideA1,
-                                                 rocblas_int       strideA2,
-                                                 rocblas_int       strideB1,
-                                                 rocblas_int       strideB2,
-                                                 rocblas_int       sizeI,
-                                                 rocblas_int       sizeJ,
-                                                 rocblas_int       sizeK,
-                                                 rocblas_int       sizeL)
+                                                        rocblas_operation trans_b,
+                                                        rocblas_int       strideC1,
+                                                        rocblas_int       strideC2,
+                                                        rocblas_int       strideA1,
+                                                        rocblas_int       strideA2,
+                                                        rocblas_int       strideB1,
+                                                        rocblas_int       strideB2,
+                                                        rocblas_int       sizeI,
+                                                        rocblas_int       sizeJ,
+                                                        rocblas_int       sizeK,
+                                                        rocblas_int       sizeL)
 {
     switch(GetTransposeMode(trans_a, trans_b))
     {
@@ -661,17 +661,17 @@ inline const char* tensileGetSolutionName<rocblas_half>(rocblas_operation trans_
 
 template <>
 inline const char* tensileGetSolutionName<float>(rocblas_operation trans_a,
-                                          rocblas_operation trans_b,
-                                          rocblas_int       strideC1,
-                                          rocblas_int       strideC2,
-                                          rocblas_int       strideA1,
-                                          rocblas_int       strideA2,
-                                          rocblas_int       strideB1,
-                                          rocblas_int       strideB2,
-                                          rocblas_int       sizeI,
-                                          rocblas_int       sizeJ,
-                                          rocblas_int       sizeK,
-                                          rocblas_int       sizeL)
+                                                 rocblas_operation trans_b,
+                                                 rocblas_int       strideC1,
+                                                 rocblas_int       strideC2,
+                                                 rocblas_int       strideA1,
+                                                 rocblas_int       strideA2,
+                                                 rocblas_int       strideB1,
+                                                 rocblas_int       strideB2,
+                                                 rocblas_int       sizeI,
+                                                 rocblas_int       sizeJ,
+                                                 rocblas_int       sizeK,
+                                                 rocblas_int       sizeL)
 {
     switch(GetTransposeMode(trans_a, trans_b))
     {
@@ -693,17 +693,17 @@ inline const char* tensileGetSolutionName<float>(rocblas_operation trans_a,
 
 template <>
 inline const char* tensileGetSolutionName<double>(rocblas_operation trans_a,
-                                           rocblas_operation trans_b,
-                                           rocblas_int       strideC1,
-                                           rocblas_int       strideC2,
-                                           rocblas_int       strideA1,
-                                           rocblas_int       strideA2,
-                                           rocblas_int       strideB1,
-                                           rocblas_int       strideB2,
-                                           rocblas_int       sizeI,
-                                           rocblas_int       sizeJ,
-                                           rocblas_int       sizeK,
-                                           rocblas_int       sizeL)
+                                                  rocblas_operation trans_b,
+                                                  rocblas_int       strideC1,
+                                                  rocblas_int       strideC2,
+                                                  rocblas_int       strideA1,
+                                                  rocblas_int       strideA2,
+                                                  rocblas_int       strideB1,
+                                                  rocblas_int       strideB2,
+                                                  rocblas_int       sizeI,
+                                                  rocblas_int       sizeJ,
+                                                  rocblas_int       sizeK,
+                                                  rocblas_int       sizeL)
 {
     switch(GetTransposeMode(trans_a, trans_b))
     {
@@ -725,17 +725,17 @@ inline const char* tensileGetSolutionName<double>(rocblas_operation trans_a,
 
 template <>
 inline const char* tensileGetSolutionName<rocblas_float_complex>(rocblas_operation trans_a,
-                                                          rocblas_operation trans_b,
-                                                          rocblas_int       strideC1,
-                                                          rocblas_int       strideC2,
-                                                          rocblas_int       strideA1,
-                                                          rocblas_int       strideA2,
-                                                          rocblas_int       strideB1,
-                                                          rocblas_int       strideB2,
-                                                          rocblas_int       sizeI,
-                                                          rocblas_int       sizeJ,
-                                                          rocblas_int       sizeK,
-                                                          rocblas_int       sizeL)
+                                                                 rocblas_operation trans_b,
+                                                                 rocblas_int       strideC1,
+                                                                 rocblas_int       strideC2,
+                                                                 rocblas_int       strideA1,
+                                                                 rocblas_int       strideA2,
+                                                                 rocblas_int       strideB1,
+                                                                 rocblas_int       strideB2,
+                                                                 rocblas_int       sizeI,
+                                                                 rocblas_int       sizeJ,
+                                                                 rocblas_int       sizeK,
+                                                                 rocblas_int       sizeL)
 {
     switch(GetTransposeMode(trans_a, trans_b))
     {
@@ -762,17 +762,17 @@ inline const char* tensileGetSolutionName<rocblas_float_complex>(rocblas_operati
 
 template <>
 inline const char* tensileGetSolutionName<rocblas_double_complex>(rocblas_operation trans_a,
-                                                           rocblas_operation trans_b,
-                                                           rocblas_int       strideC1,
-                                                           rocblas_int       strideC2,
-                                                           rocblas_int       strideA1,
-                                                           rocblas_int       strideA2,
-                                                           rocblas_int       strideB1,
-                                                           rocblas_int       strideB2,
-                                                           rocblas_int       sizeI,
-                                                           rocblas_int       sizeJ,
-                                                           rocblas_int       sizeK,
-                                                           rocblas_int       sizeL)
+                                                                  rocblas_operation trans_b,
+                                                                  rocblas_int       strideC1,
+                                                                  rocblas_int       strideC2,
+                                                                  rocblas_int       strideA1,
+                                                                  rocblas_int       strideA2,
+                                                                  rocblas_int       strideB1,
+                                                                  rocblas_int       strideB2,
+                                                                  rocblas_int       sizeI,
+                                                                  rocblas_int       sizeJ,
+                                                                  rocblas_int       sizeK,
+                                                                  rocblas_int       sizeL)
 {
     switch(GetTransposeMode(trans_a, trans_b))
     {

--- a/library/src/blas3/rocblas_trtri.hpp
+++ b/library/src/blas3/rocblas_trtri.hpp
@@ -689,7 +689,7 @@ rocblas_status rocblas_trtri_large(rocblas_handle   handle,
     // first stage: invert NB * NB diagonal blocks of A and write the result of invA11 and invA22 in
     // invA - Only deals with maximum even and complete NBxNB diagonals
 
-    hipLaunchKernelGGL(trtri_diagonal_kernel<NB, T>,
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(trtri_diagonal_kernel<NB, T>),
                        grid_trtri,
                        threads,
                        0,
@@ -716,7 +716,7 @@ rocblas_status rocblas_trtri_large(rocblas_handle   handle,
 
         rocblas_int offset_A2    = (n - remainder) + (n - remainder) * lda + offset_Ain;
         rocblas_int offset_invA2 = (n - remainder) + (n - remainder) * ldinvA + offset_invAin;
-        hipLaunchKernelGGL(trtri_remainder_kernel<NB, T>,
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(trtri_remainder_kernel<NB, T>),
                            grid_remainder,
                            threads_remainder,
                            0,

--- a/library/src/blas3/rocblas_trtri.hpp
+++ b/library/src/blas3/rocblas_trtri.hpp
@@ -689,7 +689,7 @@ rocblas_status rocblas_trtri_large(rocblas_handle   handle,
     // first stage: invert NB * NB diagonal blocks of A and write the result of invA11 and invA22 in
     // invA - Only deals with maximum even and complete NBxNB diagonals
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(trtri_diagonal_kernel<NB, T>),
+    hipLaunchKernelGGL((trtri_diagonal_kernel<NB, T>),
                        grid_trtri,
                        threads,
                        0,
@@ -716,7 +716,7 @@ rocblas_status rocblas_trtri_large(rocblas_handle   handle,
 
         rocblas_int offset_A2    = (n - remainder) + (n - remainder) * lda + offset_Ain;
         rocblas_int offset_invA2 = (n - remainder) + (n - remainder) * ldinvA + offset_invAin;
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(trtri_remainder_kernel<NB, T>),
+        hipLaunchKernelGGL((trtri_remainder_kernel<NB, T>),
                            grid_remainder,
                            threads_remainder,
                            0,

--- a/library/src/blas_ex/rocblas_gemm_ex.hpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.hpp
@@ -16,13 +16,13 @@
 // Device Side //
 /////////////////
 // clang-format off
-void device_matrix_copy(const void* src,
-                        rocblas_int ld_src,
-                        void* dst,
-                        rocblas_int ld_dst,
-                        rocblas_int n1,
-                        rocblas_int n2,
-                        size_t elem_size)
+inline void device_matrix_copy(const void* src,
+                               rocblas_int ld_src,
+                               void* dst,
+                               rocblas_int ld_dst,
+                               rocblas_int n1,
+                               rocblas_int n2,
+                               size_t elem_size)
 {
     if(src != dst || ld_src != ld_dst) // no copy if src matrix == dst matrix
     {


### PR DESCRIPTION
Function definitions in hpp files need inline.
Templated functions with multiple template params need HIP_KERNEL_NAME.
Fix rotm kernel templating.