### PR TITLE
SWDEV-205829-ignore-installed-rocblas

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -57,9 +57,10 @@ else()
 endif()
 
 # Internal header includes
-target_include_directories( rocblas-bench
+target_include_directories( rocblas-bench 
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
 )
 
 set( BLIS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/build/deps/blis/include/blis )
@@ -151,6 +152,9 @@ if( OS_ID_rhel OR OS_ID_centos)
     # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
     set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
 endif()
+
+# include order workaround to force /opt/rocm/include later in order to ignore installed rocblas 
+set(CMAKE_CXX_FLAGS "-isystem /opt/rocm/include ${CMAKE_CXX_FLAGS}")
 
 set_target_properties( rocblas-bench PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocblas-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 target_include_directories( rocblas-test
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
 )
 
 # External header includes included as system files
@@ -201,6 +202,9 @@ if( OS_ID_rhel OR OS_ID_centos)
     # force clang includes to take precedence over devtoolset-7 which we only want for OpenMP
     set(CMAKE_CXX_FLAGS "-isystem ${CLANG_INCLUDE_DIR} -isystem ${XXX_OPENMP_INCLUDE_DIR} ${CMAKE_CXX_FLAGS}")
 endif()
+
+# include order workaround to force /opt/rocm/include later in order to ignore installed rocblas 
+set(CMAKE_CXX_FLAGS "-isystem /opt/rocm/include ${CMAKE_CXX_FLAGS}")
 
 if( CXX_VERSION_STRING MATCHES "clang" )
   target_link_libraries( rocblas-test PRIVATE -lpthread -lm )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -30,9 +30,11 @@ foreach( exe ${sample_list} )
 
   set_target_properties( ${exe} PROPERTIES CXX_EXTENSIONS NO )
   set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
-  target_include_directories( ${exe}
+
+  target_include_directories( ${exe} 
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
       )
 
   target_include_directories( ${exe}
@@ -65,4 +67,7 @@ foreach( exe ${sample_list} )
     target_compile_options( ${exe} PRIVATE -mf16c )
   endif( )
 endforeach( )
+
+# include order workaround to force /opt/rocm/include later in order to ignore installed rocblas 
+set(CMAKE_CXX_FLAGS "-isystem /opt/rocm/include ${CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
Summary of proposed changes:
-  local includes forced before /opt/rocm/include by explicitly adding /opt/rocm/include as system include

