### PR TITLE
Changed packages that are installed with running with the -d flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ install_packages( )
   local library_dependencies_ubuntu=( "make" "cmake-curses-gui" "pkg-config"
                                       "python2.7" "python3" "python-yaml" "python3-yaml"
                                       "llvm-6.0-dev" "hip_hcc" "rocm_smi64" "zlib1g-dev"
-				      "libboost-program-options-dev" )
+				                      "libboost-program-options-dev" )
   local library_dependencies_centos=( "epel-release" "boost-devel"
                                       "make" "cmake3" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
@@ -157,10 +157,10 @@ install_packages( )
   fi
 
   # dependencies to build the client
-  local client_dependencies_ubuntu=( "gfortran" "libomp-dev")
-  local client_dependencies_centos=( "gcc-gfortran" "libgomp")
-  local client_dependencies_fedora=( "gcc-gfortran" "libgomp")
-  local client_dependencies_sles=( "gcc-fortran" "libgomp1")
+  local client_dependencies_ubuntu=( "gfortran" "libomp-dev" "libboost-program-options-dev")
+  local client_dependencies_centos=( "gcc-gfortran" "libgomp" "boost-devel")
+  local client_dependencies_fedora=( "gcc-gfortran" "libgomp" "boost-devel")
+  local client_dependencies_sles=( "gcc-fortran" "libgomp1" "libboost_program_options1_66_0-devel" "boost-devel")
 
   case "${ID}" in
     ubuntu)

--- a/install.sh
+++ b/install.sh
@@ -132,19 +132,20 @@ install_packages( )
     exit 2
   fi
 
-  # dependencies needed for rocblas and clients to build
+  # dependencies needed to build the rocblas library
   local library_dependencies_ubuntu=( "make" "cmake-curses-gui" "pkg-config"
                                       "python2.7" "python3" "python-yaml" "python3-yaml"
-                                      "llvm-6.0-dev" "hip_hcc" "rocm_smi64" "zlib1g-dev")
-  local library_dependencies_centos=( "epel-release"
+                                      "llvm-6.0-dev" "hip_hcc" "rocm_smi64" "zlib1g-dev"
+				      "libboost-program-options-dev" )
+  local library_dependencies_centos=( "epel-release" "boost-devel"
                                       "make" "cmake3" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "llvm7.0-devel" "llvm7.0-static"
                                       "hip_hcc" "rocm_smi64" "zlib-devel" )
-  local library_dependencies_fedora=( "make" "cmake" "rpm-build"
+  local library_dependencies_fedora=( "make" "cmake" "rpm-build" "boost-devel"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "libcxx-devel" "hip_hcc" "rocm_smi64" "zlib-devel" )
-  local library_dependencies_sles=(   "make" "cmake" "python3-PyYAM"
+  local library_dependencies_sles=(   "make" "cmake" "python3-PyYAM" "libboost_program_options1_66_0-devel"
                                       "hip_hcc" "gcc-c++" "libcxxtools9" "rpm-build" )
 
   if [[ "${build_cuda}" == true ]]; then
@@ -155,10 +156,11 @@ install_packages( )
     library_dependencies_sles+=( "" )
   fi
 
-  local client_dependencies_ubuntu=( "gfortran" "libboost-program-options-dev" "libomp-dev")
-  local client_dependencies_centos=( "gcc-gfortran" "boost-devel" "libgomp")
-  local client_dependencies_fedora=( "gcc-gfortran" "boost-devel" "libgomp")
-  local client_dependencies_sles=( "gcc-fortran" "boost-devel" "libboost_program_options1_66_0-devel" "libgomp1")
+  # dependencies to build the client
+  local client_dependencies_ubuntu=( "gfortran" "libomp-dev")
+  local client_dependencies_centos=( "gcc-gfortran" "libgomp")
+  local client_dependencies_fedora=( "gcc-gfortran" "libgomp")
+  local client_dependencies_sles=( "gcc-fortran" "libgomp1")
 
   case "${ID}" in
     ubuntu)
@@ -363,37 +365,56 @@ esac
 # #################################################
 if [[ "${install_dependencies}" == true ]]; then
   install_packages
-fi
 
-if [[ "${build_clients}" == true ]]; then
+  if [[ "${build_clients}" == true ]]; then
 
-  # The following builds googletest & lapack from source, installs into cmake default /usr/local
-  pushd .
+    # The following builds googletest & lapack from source, installs into cmake default /usr/local
+    pushd .
     printf "\033[32mBuilding \033[33mgoogletest & lapack\033[32m from source; installing into \033[33m/usr/local\033[0m\n"
     mkdir -p ${build_dir}/deps && cd ${build_dir}/deps
     ${cmake_executable} -lpthread -DBUILD_BOOST=OFF ../../deps
     make -j$(nproc)
     elevate_if_not_root make install
-  popd
+    popd
 
-  if [[ "${cpu_ref_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]]; then
-    git submodule update --init
-    cd extern/blis
-    case "${ID}" in
-        centos|rhel|sles)
-            ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
-            ;;
-        ubuntu)
-            ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang auto
-            ;;
-        *)
-            echo "Unsupported OS for this script"
-            ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
-            ;;
-    esac
-    make install
-    cd ../..
+    if [[ "${cpu_ref_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]]; then
+      git submodule update --init
+      cd extern/blis
+      case "${ID}" in
+          centos|rhel|sles)
+              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+              ;;
+          ubuntu)
+              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang auto
+              ;;
+          *)
+              echo "Unsupported OS for this script"
+              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+              ;;
+      esac
+      make install
+      cd ../..
+    fi
   fi
+fi
+
+if [[ "${cpu_ref_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]] && [[ "${build_clients}" == true ]]; then
+  git submodule update --init
+  cd extern/blis
+  case "${ID}" in
+    centos|rhel|sles)
+      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+      ;;
+    ubuntu)
+      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang auto
+      ;;
+    *)
+      echo "Unsupported OS for this script"
+      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+      ;;
+  esac
+  make install
+  cd ../..
 fi
 
 # We append customary rocm path; if user provides custom rocm path in ${path}, our
@@ -408,7 +429,6 @@ pushd .
   cmake_client_options=""
 
   cmake_common_options="${cmake_common_options} -lpthread -DTensile_LOGIC=${tensile_logic} -DTensile_CODE_OBJECT_VERSION=${tensile_cov}"
-  cmake_client_options="-DLINK_BLIS=${LINK_BLIS}"
 
   # build type
   if [[ "${build_release}" == true ]]; then
@@ -450,7 +470,7 @@ esac
   fi
 
   if [[ "${build_clients}" == true ]]; then
-    cmake_client_options="${cmake_client_options} ${tensile_opt} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON"
+    cmake_client_options="${cmake_client_options} ${tensile_opt} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON -DLINK_BLIS=${LINK_BLIS}"
   fi
 
   compiler="hcc"

--- a/install.sh
+++ b/install.sh
@@ -135,17 +135,16 @@ install_packages( )
   # dependencies needed to build the rocblas library
   local library_dependencies_ubuntu=( "make" "cmake-curses-gui" "pkg-config"
                                       "python2.7" "python3" "python-yaml" "python3-yaml"
-                                      "llvm-6.0-dev" "hip_hcc" "rocm_smi64" "zlib1g-dev"
-				                      "libboost-program-options-dev" )
-  local library_dependencies_centos=( "epel-release" "boost-devel"
+                                      "llvm-6.0-dev" "hip_hcc" "rocm_smi64" "zlib1g-dev")
+  local library_dependencies_centos=( "epel-release"
                                       "make" "cmake3" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "llvm7.0-devel" "llvm7.0-static"
                                       "hip_hcc" "rocm_smi64" "zlib-devel" )
-  local library_dependencies_fedora=( "make" "cmake" "rpm-build" "boost-devel"
+  local library_dependencies_fedora=( "make" "cmake" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "libcxx-devel" "hip_hcc" "rocm_smi64" "zlib-devel" )
-  local library_dependencies_sles=(   "make" "cmake" "python3-PyYAM" "libboost_program_options1_66_0-devel"
+  local library_dependencies_sles=(   "make" "cmake" "python3-PyYAM"
                                       "hip_hcc" "gcc-c++" "libcxxtools9" "rpm-build" )
 
   if [[ "${build_cuda}" == true ]]; then

--- a/install.sh
+++ b/install.sh
@@ -135,17 +135,15 @@ install_packages( )
   # dependencies needed for rocblas and clients to build
   local library_dependencies_ubuntu=( "make" "cmake-curses-gui" "pkg-config"
                                       "python2.7" "python3" "python-yaml" "python3-yaml"
-                                      "llvm-6.0-dev" "libomp-dev"
-                                      "hip_hcc" "rocm_smi64" "zlib1g-dev")
+                                      "llvm-6.0-dev" "hip_hcc" "rocm_smi64" "zlib1g-dev")
   local library_dependencies_centos=( "epel-release"
                                       "make" "cmake3" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "llvm7.0-devel" "llvm7.0-static"
-                                      "hip_hcc" "rocm_smi64" "libgomp" "zlib-devel" )
+                                      "hip_hcc" "rocm_smi64" "zlib-devel" )
   local library_dependencies_fedora=( "make" "cmake" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
-                                      "gcc-c++" "libcxx-devel" "libgomp"
-                                      "hip_hcc" "rocm_smi64" "zlib-devel" )
+                                      "gcc-c++" "libcxx-devel" "hip_hcc" "rocm_smi64" "zlib-devel" )
   local library_dependencies_sles=(   "make" "cmake" "python3-PyYAM"
                                       "hip_hcc" "gcc-c++" "libcxxtools9" "rpm-build" )
 
@@ -364,8 +362,10 @@ esac
 # dependencies
 # #################################################
 if [[ "${install_dependencies}" == true ]]; then
-
   install_packages
+fi
+
+if [[ "${build_clients}" == true ]]; then
 
   # The following builds googletest & lapack from source, installs into cmake default /usr/local
   pushd .
@@ -376,25 +376,24 @@ if [[ "${install_dependencies}" == true ]]; then
     elevate_if_not_root make install
   popd
 
-fi
-
-if [[ "${cpu_ref_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]]; then
-  git submodule update --init
-  cd extern/blis
-  case "${ID}" in
-      centos|rhel|sles)
-          ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
-          ;;
-      ubuntu)
-          ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang auto
-          ;;
-      *)
-          echo "Unsupported OS for this script"
-          ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
-          ;;
-  esac
-  make install
-  cd ../..
+  if [[ "${cpu_ref_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis.so" ]]; then
+    git submodule update --init
+    cd extern/blis
+    case "${ID}" in
+        centos|rhel|sles)
+            ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+            ;;
+        ubuntu)
+            ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang auto
+            ;;
+        *)
+            echo "Unsupported OS for this script"
+            ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+            ;;
+    esac
+    make install
+    cd ../..
+  fi
 fi
 
 # We append customary rocm path; if user provides custom rocm path in ${path}, our


### PR DESCRIPTION
- Removes gtest and lapack as library dependency
- Removes libgomp as a library dependency
- Removes blis as a library dependency 

All are now client dependencies
