### PR TITLE
Reduction template slight modification

### DIFF
--- a/library/src/blas1/reduction_strided_batched.h
+++ b/library/src/blas1/reduction_strided_batched.h
@@ -178,7 +178,6 @@ size_t
 // kernel 1 writes partial results per thread block in workspace; number of partial results is
 // blocks
 template <rocblas_int NB,
-          typename Ti,
           typename FETCH,
           typename REDUCE = rocblas_reduce_sum,
           typename TPtrX,
@@ -197,7 +196,7 @@ __global__ void
     ptrdiff_t     tid = hipBlockIdx_x * hipBlockDim_x + tx;
     __shared__ To tmp[NB];
 
-    const Ti* x = load_ptr_batch(xvec, hipBlockIdx_y, shiftx, stridex);
+    const auto* x = load_ptr_batch(xvec, hipBlockIdx_y, shiftx, stridex);
 
     // bound
     if(tid < n)
@@ -299,7 +298,6 @@ __global__ void
               return is 0.0 if n, incx<=0.
     ********************************************************************/
 template <rocblas_int NB,
-          typename Ti,
           typename FETCH,
           typename REDUCE   = rocblas_reduce_sum,
           typename FINALIZE = rocblas_finalize_identity,
@@ -318,7 +316,7 @@ rocblas_status rocblas_reduction_strided_batched_kernel(rocblas_handle __restric
 {
     rocblas_int blocks = rocblas_reduction_kernel_block_count(n, NB);
 
-    hipLaunchKernelGGL((rocblas_reduction_strided_batched_kernel_part1<NB, Ti, FETCH, REDUCE>),
+    hipLaunchKernelGGL((rocblas_reduction_strided_batched_kernel_part1<NB, FETCH, REDUCE>),
                        dim3(blocks, batch_count),
                        NB,
                        0,

--- a/library/src/blas1/rocblas_asum.hpp
+++ b/library/src/blas1/rocblas_asum.hpp
@@ -40,6 +40,6 @@ rocblas_status rocblas_asum_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    return rocblas_reduction_strided_batched_kernel<NB, Ti, rocblas_fetch_asum<To>>(
+    return rocblas_reduction_strided_batched_kernel<NB, rocblas_fetch_asum<To>>(
         handle, n, x, shiftx, incx, 0, 1, workspace, result);
 }

--- a/library/src/blas1/rocblas_asum_batched.hpp
+++ b/library/src/blas1/rocblas_asum_batched.hpp
@@ -9,15 +9,15 @@
 #include "rocblas.h"
 #include "rocblas_asum.hpp"
 
-template <rocblas_int NB, typename Ti, typename To>
-rocblas_status rocblas_asum_batched_template(rocblas_handle  handle,
-                                             rocblas_int     n,
-                                             const Ti* const x[],
-                                             rocblas_int     shiftx,
-                                             rocblas_int     incx,
-                                             rocblas_int     batch_count,
-                                             To*             workspace,
-                                             To*             results)
+template <rocblas_int NB, typename U, typename To>
+rocblas_status rocblas_asum_batched_template(rocblas_handle handle,
+                                             rocblas_int    n,
+                                             U              x,
+                                             rocblas_int    shiftx,
+                                             rocblas_int    incx,
+                                             rocblas_int    batch_count,
+                                             To*            workspace,
+                                             To*            results)
 {
     // Quick return if possible.
     if(n <= 0 || incx <= 0 || batch_count == 0)
@@ -36,6 +36,6 @@ rocblas_status rocblas_asum_batched_template(rocblas_handle  handle,
         return rocblas_status_success;
     }
 
-    return rocblas_reduction_strided_batched_kernel<NB, Ti, rocblas_fetch_asum<To>>(
+    return rocblas_reduction_strided_batched_kernel<NB, rocblas_fetch_asum<To>>(
         handle, n, x, shiftx, incx, 0, batch_count, workspace, results);
 }

--- a/library/src/blas1/rocblas_asum_strided_batched.hpp
+++ b/library/src/blas1/rocblas_asum_strided_batched.hpp
@@ -9,10 +9,10 @@
 #include "rocblas.h"
 #include "rocblas_asum.hpp"
 
-template <rocblas_int NB, typename Ti, typename To>
+template <rocblas_int NB, typename U, typename To>
 rocblas_status rocblas_asum_strided_batched_template(rocblas_handle handle,
                                                      rocblas_int    n,
-                                                     const Ti*      x,
+                                                     U              x,
                                                      rocblas_int    shiftx,
                                                      rocblas_int    incx,
                                                      rocblas_stride stridex,
@@ -38,6 +38,6 @@ rocblas_status rocblas_asum_strided_batched_template(rocblas_handle handle,
         return rocblas_status_success;
     }
 
-    return rocblas_reduction_strided_batched_kernel<NB, Ti, rocblas_fetch_asum<To>>(
+    return rocblas_reduction_strided_batched_kernel<NB, rocblas_fetch_asum<To>>(
         handle, n, x, shiftx, incx, stridex, batch_count, workspace, results);
 }

--- a/library/src/blas1/rocblas_nrm2.hpp
+++ b/library/src/blas1/rocblas_nrm2.hpp
@@ -50,7 +50,6 @@ rocblas_status rocblas_nrm2_template(rocblas_handle handle,
     }
 
     return rocblas_reduction_strided_batched_kernel<NB,
-                                                    Ti,
                                                     rocblas_fetch_nrm2<To>,
                                                     rocblas_reduce_sum,
                                                     rocblas_finalize_nrm2>(

--- a/library/src/blas1/rocblas_nrm2_batched.hpp
+++ b/library/src/blas1/rocblas_nrm2_batched.hpp
@@ -9,15 +9,15 @@
 #include "rocblas.h"
 #include "rocblas_nrm2.hpp"
 
-template <rocblas_int NB, typename Ti, typename To>
-rocblas_status rocblas_nrm2_batched_template(rocblas_handle  handle,
-                                             rocblas_int     n,
-                                             const Ti* const x[],
-                                             rocblas_int     shiftx,
-                                             rocblas_int     incx,
-                                             rocblas_int     batch_count,
-                                             To*             workspace,
-                                             To*             results)
+template <rocblas_int NB, typename U, typename To>
+rocblas_status rocblas_nrm2_batched_template(rocblas_handle handle,
+                                             rocblas_int    n,
+                                             U              x,
+                                             rocblas_int    shiftx,
+                                             rocblas_int    incx,
+                                             rocblas_int    batch_count,
+                                             To*            workspace,
+                                             To*            results)
 {
     // Quick return if possible.
     if(n <= 0 || incx <= 0 || batch_count == 0)
@@ -38,7 +38,6 @@ rocblas_status rocblas_nrm2_batched_template(rocblas_handle  handle,
     }
 
     return rocblas_reduction_strided_batched_kernel<NB,
-                                                    Ti,
                                                     rocblas_fetch_nrm2<To>,
                                                     rocblas_reduce_sum,
                                                     rocblas_finalize_nrm2>(

--- a/library/src/blas1/rocblas_nrm2_strided_batched.hpp
+++ b/library/src/blas1/rocblas_nrm2_strided_batched.hpp
@@ -9,10 +9,10 @@
 #include "rocblas.h"
 #include "rocblas_nrm2.hpp"
 
-template <rocblas_int NB, typename Ti, typename To>
+template <rocblas_int NB, typename U, typename To>
 rocblas_status rocblas_nrm2_strided_batched_template(rocblas_handle handle,
                                                      rocblas_int    n,
-                                                     const Ti*      x,
+                                                     U              x,
                                                      rocblas_int    shiftx,
                                                      rocblas_int    incx,
                                                      rocblas_stride stridex,
@@ -38,7 +38,6 @@ rocblas_status rocblas_nrm2_strided_batched_template(rocblas_handle handle,
     }
 
     return rocblas_reduction_strided_batched_kernel<NB,
-                                                    Ti,
                                                     rocblas_fetch_nrm2<To>,
                                                     rocblas_reduce_sum,
                                                     rocblas_finalize_nrm2>(


### PR DESCRIPTION
Remove an unnecessary template parameter in the reduction_strided_batched template.
This is a small PR, prior needed changes for merging asum/nrm2/iamax/iamin.

Other simplifications will follow in other PR (to keep PRs small).

Summary of proposed changes:

-1  library/src/blas1/reduction_strided_batched.h
      
     Remove the Ti parameter.

File where the use of the template is fixed:

-2  library/src/blas1/rocblas_asum.hpp
-3  library/src/blas1/rocblas_asum_batched.hpp
-4  library/src/blas1/rocblas_asum_strided_batched.hpp
-5  library/src/blas1/rocblas_nrm2.hpp
-6  library/src/blas1/rocblas_nrm2_batched.hpp
-7  library/src/blas1/rocblas_nrm2_strided_batched.hpp
