### PR TITLE
introduce rocblas_reduction_template and rocblas_reduction_impl

### DIFF
--- a/library/src/blas1/reduction_strided_batched.h
+++ b/library/src/blas1/reduction_strided_batched.h
@@ -166,13 +166,29 @@ inline size_t rocblas_reduction_kernel_block_count(rocblas_int n, rocblas_int NB
         Number of batches
     ********************************************************************/
 template <rocblas_int NB, typename To>
-size_t
-    rocblas_reduction_kernel_workspace_size(rocblas_int n, rocblas_int batch_count, To* output_type)
+size_t rocblas_reduction_kernel_workspace_size(rocblas_int n, rocblas_int batch_count)
 {
     if(n <= 0)
         n = 1; // allow for return value of empty set
     auto blocks = rocblas_reduction_kernel_block_count(n, NB);
     return sizeof(To) * (blocks + 1) * batch_count;
+}
+
+/*! \brief rocblas_reduction_batched_kernel_workspace_size 
+    Work area for reduction must be at lease sizeof(To) * (blocks + 1) * batch_count
+
+    @param[in]
+    outputType To* 
+        Type of output values
+    @param[in]
+    batch_count rocblas_int 
+        Number of batches
+    ********************************************************************/
+template <rocblas_int NB, typename To>
+size_t
+    rocblas_reduction_kernel_workspace_size(rocblas_int n, rocblas_int batch_count, To* output_type)
+{
+    return rocblas_reduction_kernel_workspace_size<NB, To>(n, batch_count);
 }
 
 // kernel 1 writes partial results per thread block in workspace; number of partial results is

--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -1,12 +1,8 @@
 /* ************************************************************************
  * Copyright 2018-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
-#include "fetch_template.h"
-#include "handle.h"
-#include "logging.h"
-#include "reduction.h"
-#include "rocblas.h"
-#include "utility.h"
+
+#include "rocblas_reduction_impl.hpp"
 
 #ifndef MAX_MIN
 #define MAX_MIN max
@@ -33,7 +29,7 @@ struct index_value_t
 
 // Specialization of default_value for index_value_t<T>
 template <typename T>
-struct default_value<index_value_t<T>>
+struct rocblas_default_value<index_value_t<T>>
 {
     __forceinline__ __host__ __device__ constexpr auto operator()() const
     {
@@ -116,56 +112,26 @@ template <typename To, typename Ti>
 static rocblas_status rocblas_iamaxmin(
     rocblas_handle handle, rocblas_int n, const Ti* x, rocblas_int incx, rocblas_int* result)
 {
-    // HIP support up to 1024 threads/work itmes per thread block/work group
-    static constexpr int NB = 1024;
 
-    if(!handle)
-        return rocblas_status_invalid_handle;
+    static constexpr bool           isbatched     = false;
+    static constexpr rocblas_stride stridex_0     = 0;
+    static constexpr rocblas_int    batch_count_1 = 1;
+    static constexpr int            NB            = 1024;
 
-    auto layer_mode = handle->layer_mode;
-    if(layer_mode & rocblas_layer_mode_log_trace)
-        log_trace(handle, rocblas_iamaxmin_name<Ti>, n, x, incx);
-
-    if(layer_mode & rocblas_layer_mode_log_bench)
-        log_bench(handle,
-                  "./rocblas-bench -f ia" QUOTE(MAX_MIN) " -r",
-                  rocblas_precision_string<Ti>,
-                  "-n",
-                  n,
-                  "--incx",
-                  incx);
-
-    if(layer_mode & rocblas_layer_mode_log_profile)
-        log_profile(handle, rocblas_iamaxmin_name<Ti>, "N", n, "incx", incx);
-
-    if(!x || !result)
-        return rocblas_status_invalid_pointer;
-
-    // Quick return if possible.
-    if(n <= 0 || incx <= 0)
-    {
-        if(handle->is_device_memory_size_query())
-            return rocblas_status_size_unchanged;
-        else if(handle->pointer_mode == rocblas_pointer_mode_device)
-            RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(*result)));
-        else
-            *result = 0;
-        return rocblas_status_success;
-    }
-
-    auto blocks = (n - 1) / NB + 1;
-    if(handle->is_device_memory_size_query())
-        return handle->set_optimal_device_memory_size(sizeof(index_value_t<To>) * blocks);
-
-    auto mem = handle->device_malloc(sizeof(index_value_t<To>) * blocks);
-    if(!mem)
-        return rocblas_status_memory_error;
-
-    return rocblas_reduction_kernel<NB,
-                                    rocblas_fetch_amax_amin<To>,
-                                    AMAX_AMIN_REDUCTION,
-                                    rocblas_finalize_amax_amin>(
-        handle, n, x, incx, result, (index_value_t<To>*)mem, blocks);
+    return rocblas_reduction_impl<NB,
+                                  isbatched,
+                                  rocblas_fetch_amax_amin<To>,
+                                  AMAX_AMIN_REDUCTION,
+                                  rocblas_finalize_amax_amin,
+                                  index_value_t<To>>(handle,
+                                                     n,
+                                                     x,
+                                                     incx,
+                                                     stridex_0,
+                                                     batch_count_1,
+                                                     result,
+                                                     rocblas_iamaxmin_name<Ti>,
+                                                     "ia" QUOTE(MAX_MIN));
 }
 
 /*
@@ -176,34 +142,25 @@ static rocblas_status rocblas_iamaxmin(
 
 extern "C" {
 
-rocblas_status JOIN(rocblas_isa, MAX_MIN)(
-    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, rocblas_int* result)
-{
-    return rocblas_iamaxmin<float>(handle, n, x, incx, result);
-}
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
 
-rocblas_status JOIN(rocblas_ida, MAX_MIN)(
-    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, rocblas_int* result)
-{
-    return rocblas_iamaxmin<double>(handle, n, x, incx, result);
-}
+#define IMPL(name_, typei_, typew_)                                   \
+    rocblas_status name_(rocblas_handle handle,                       \
+                         rocblas_int    n,                            \
+                         const typei_*  x,                            \
+                         rocblas_int    incx,                         \
+                         rocblas_int*   results)                      \
+    {                                                                 \
+        return rocblas_iamaxmin<typew_>(handle, n, x, incx, results); \
+    }
 
-rocblas_status JOIN(rocblas_ica, MAX_MIN)(rocblas_handle               handle,
-                                          rocblas_int                  n,
-                                          const rocblas_float_complex* x,
-                                          rocblas_int                  incx,
-                                          rocblas_int*                 result)
-{
-    return rocblas_iamaxmin<float, rocblas_float_complex>(handle, n, x, incx, result);
-}
+IMPL(JOIN(rocblas_isa, MAX_MIN), float, float);
+IMPL(JOIN(rocblas_ida, MAX_MIN), double, double);
+IMPL(JOIN(rocblas_ica, MAX_MIN), rocblas_float_complex, float);
+IMPL(JOIN(rocblas_iza, MAX_MIN), rocblas_double_complex, double);
 
-rocblas_status JOIN(rocblas_iza, MAX_MIN)(rocblas_handle                handle,
-                                          rocblas_int                   n,
-                                          const rocblas_double_complex* x,
-                                          rocblas_int                   incx,
-                                          rocblas_int*                  result)
-{
-    return rocblas_iamaxmin<double, rocblas_double_complex>(handle, n, x, incx, result);
-}
+#undef IMPL
 
 } // extern "C"

--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -3,8 +3,7 @@
  * ************************************************************************ */
 
 #include "rocblas_asum.hpp"
-#include "logging.h"
-#include "utility.h"
+#include "rocblas_reduction_impl.hpp"
 
 namespace
 {
@@ -22,40 +21,19 @@ namespace
     // allocate workspace inside this API
     template <rocblas_int NB, typename Ti, typename To>
     rocblas_status rocblas_asum_impl(
-        rocblas_handle handle, rocblas_int n, const Ti* x, rocblas_int incx, To* result)
+        rocblas_handle handle, rocblas_int n, const Ti* x, rocblas_int incx, To* results)
     {
-        if(!handle)
-            return rocblas_status_invalid_handle;
+        static constexpr bool           isbatched     = false;
+        static constexpr rocblas_stride stridex_0     = 0;
+        static constexpr rocblas_int    batch_count_1 = 1;
 
-        auto layer_mode = handle->layer_mode;
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(handle, rocblas_asum_name<Ti>, n, x, incx);
-
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench(handle,
-                      "./rocblas-bench -f asum -r",
-                      rocblas_precision_string<Ti>,
-                      "-n",
-                      n,
-                      "--incx",
-                      incx);
-
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(handle, rocblas_asum_name<Ti>, "N", n, "incx", incx);
-
-        if(!x || !result)
-            return rocblas_status_invalid_pointer;
-
-        size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB>(n, 1, result);
-
-        if(handle->is_device_memory_size_query())
-            return handle->set_optimal_device_memory_size(dev_bytes);
-
-        auto mem = handle->device_malloc(dev_bytes);
-        if(!mem)
-            return rocblas_status_memory_error;
-
-        return rocblas_asum_template<NB>(handle, n, x, 0, incx, (To*)mem, result);
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_asum<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_identity,
+                                      To>(
+            handle, n, x, incx, stridex_0, batch_count_1, results, rocblas_asum_name<Ti>, "asum");
     }
 
 } // namespace
@@ -68,38 +46,23 @@ namespace
 
 extern "C" {
 
-rocblas_status rocblas_sasum(
-    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_impl<NB>(handle, n, x, incx, result);
-}
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
 
-rocblas_status rocblas_dasum(
-    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_impl<NB>(handle, n, x, incx, result);
-}
+#define IMPL(name_, typei_, typeo_)                                                               \
+    rocblas_status name_(                                                                         \
+        rocblas_handle handle, rocblas_int n, const typei_* x, rocblas_int incx, typeo_* results) \
+    {                                                                                             \
+        constexpr rocblas_int NB = 512;                                                           \
+        return rocblas_asum_impl<NB>(handle, n, x, incx, results);                                \
+    }
 
-rocblas_status rocblas_scasum(rocblas_handle               handle,
-                              rocblas_int                  n,
-                              const rocblas_float_complex* x,
-                              rocblas_int                  incx,
-                              float*                       result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_impl<NB>(handle, n, x, incx, result);
-}
+IMPL(rocblas_sasum, float, float);
+IMPL(rocblas_dasum, double, double);
+IMPL(rocblas_scasum, rocblas_float_complex, float);
+IMPL(rocblas_dzasum, rocblas_double_complex, double);
 
-rocblas_status rocblas_dzasum(rocblas_handle                handle,
-                              rocblas_int                   n,
-                              const rocblas_double_complex* x,
-                              rocblas_int                   incx,
-                              double*                       result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_impl<NB>(handle, n, x, incx, result);
-}
+#undef IMPL
 
 } // extern "C"

--- a/library/src/blas1/rocblas_asum.hpp
+++ b/library/src/blas1/rocblas_asum.hpp
@@ -3,10 +3,7 @@
  * ************************************************************************ */
 #pragma once
 
-#include "fetch_template.h"
-#include "handle.h"
-#include "reduction_strided_batched.h"
-#include "rocblas.h"
+#include "rocblas_reduction_template.hpp"
 
 template <class To>
 struct rocblas_fetch_asum
@@ -28,18 +25,14 @@ rocblas_status rocblas_asum_template(rocblas_handle handle,
                                      To*            workspace,
                                      To*            result)
 {
-    // Quick return if possible.
-    if(n <= 0 || incx <= 0)
-    {
-        if(handle->is_device_memory_size_query())
-            return rocblas_status_size_unchanged;
-        else if(rocblas_pointer_mode_device == handle->pointer_mode)
-            RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(*result)));
-        else
-            *result = 0;
-        return rocblas_status_success;
-    }
+    static constexpr bool           isbatched     = false;
+    static constexpr rocblas_stride stridex_0     = 0;
+    static constexpr rocblas_int    batch_count_1 = 1;
 
-    return rocblas_reduction_strided_batched_kernel<NB, rocblas_fetch_asum<To>>(
-        handle, n, x, shiftx, incx, 0, 1, workspace, result);
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_asum<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_identity>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count_1, result, workspace);
 }

--- a/library/src/blas1/rocblas_asum_batched.cpp
+++ b/library/src/blas1/rocblas_asum_batched.cpp
@@ -2,8 +2,7 @@
  * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 #include "rocblas_asum_batched.hpp"
-#include "logging.h"
-#include "utility.h"
+#include "rocblas_reduction_impl.hpp"
 
 namespace
 {
@@ -27,45 +26,23 @@ namespace
                                              rocblas_int     batch_count,
                                              To*             results)
     {
-        if(!handle)
-            return rocblas_status_invalid_handle;
 
-        auto layer_mode = handle->layer_mode;
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(handle, rocblas_asum_batched_name<Ti>, n, x, incx, batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench(handle,
-                      "./rocblas-bench -f asum_batched -r",
-                      rocblas_precision_string<Ti>,
-                      "-n",
-                      n,
-                      "--incx",
-                      incx,
-                      "--batch",
-                      batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(
-                handle, rocblas_asum_batched_name<Ti>, "N", n, "incx", incx, "batch", batch_count);
-
-        if(!x || !results)
-            return rocblas_status_invalid_pointer;
-
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB>(n, batch_count, results);
-
-        if(handle->is_device_memory_size_query())
-            return handle->set_optimal_device_memory_size(dev_bytes);
-
-        auto mem = handle->device_malloc(dev_bytes);
-        if(!mem)
-            return rocblas_status_memory_error;
-
-        return rocblas_asum_batched_template<NB>(
-            handle, n, x, 0, incx, batch_count, (To*)mem, results);
+        static constexpr bool           isbatched = true;
+        static constexpr rocblas_stride stridex_0 = 0;
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_asum<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_identity,
+                                      To>(handle,
+                                          n,
+                                          x,
+                                          incx,
+                                          stridex_0,
+                                          batch_count,
+                                          results,
+                                          rocblas_asum_batched_name<Ti>,
+                                          "asum_batched");
     }
 }
 
@@ -77,48 +54,27 @@ namespace
 
 extern "C" {
 
-rocblas_status rocblas_sasum_batched(rocblas_handle     handle,
-                                     rocblas_int        n,
-                                     const float* const x[],
-                                     rocblas_int        incx,
-                                     rocblas_int        batch_count,
-                                     float*             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
 
-rocblas_status rocblas_dasum_batched(rocblas_handle      handle,
-                                     rocblas_int         n,
-                                     const double* const x[],
-                                     rocblas_int         incx,
-                                     rocblas_int         batch_count,
-                                     double*             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+#define IMPL(name_, typei_, typeo_)                                                    \
+    rocblas_status name_(rocblas_handle      handle,                                   \
+                         rocblas_int         n,                                        \
+                         const typei_* const x[],                                      \
+                         rocblas_int         incx,                                     \
+                         rocblas_int         batch_count,                              \
+                         typeo_*             result)                                   \
+    {                                                                                  \
+        constexpr rocblas_int NB = 512;                                                \
+        return rocblas_asum_batched_impl<NB>(handle, n, x, incx, batch_count, result); \
+    }
 
-rocblas_status rocblas_scasum_batched(rocblas_handle                     handle,
-                                      rocblas_int                        n,
-                                      const rocblas_float_complex* const x[],
-                                      rocblas_int                        incx,
-                                      rocblas_int                        batch_count,
-                                      float*                             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+IMPL(rocblas_sasum_batched, float, float);
+IMPL(rocblas_dasum_batched, double, double);
+IMPL(rocblas_scasum_batched, rocblas_float_complex, float);
+IMPL(rocblas_dzasum_batched, rocblas_double_complex, double);
 
-rocblas_status rocblas_dzasum_batched(rocblas_handle                      handle,
-                                      rocblas_int                         n,
-                                      const rocblas_double_complex* const x[],
-                                      rocblas_int                         incx,
-                                      rocblas_int                         batch_count,
-                                      double*                             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+#undef IMPL
 
 } // extern "C"

--- a/library/src/blas1/rocblas_asum_batched.hpp
+++ b/library/src/blas1/rocblas_asum_batched.hpp
@@ -3,11 +3,8 @@
  * ************************************************************************ */
 #pragma once
 
-#include "fetch_template.h"
-#include "handle.h"
-#include "reduction_strided_batched.h"
-#include "rocblas.h"
 #include "rocblas_asum.hpp"
+#include "rocblas_reduction_impl.hpp"
 
 template <rocblas_int NB, typename U, typename To>
 rocblas_status rocblas_asum_batched_template(rocblas_handle handle,
@@ -19,23 +16,12 @@ rocblas_status rocblas_asum_batched_template(rocblas_handle handle,
                                              To*            workspace,
                                              To*            results)
 {
-    // Quick return if possible.
-    if(n <= 0 || incx <= 0 || batch_count == 0)
-    {
-        if(handle->is_device_memory_size_query())
-            return rocblas_status_size_unchanged;
-        else if(rocblas_pointer_mode_device == handle->pointer_mode && batch_count > 0)
-            RETURN_IF_HIP_ERROR(hipMemset(results, 0, batch_count * sizeof(To)));
-        else
-        {
-            for(int i = 0; i < batch_count; i++)
-            {
-                results[i] = 0;
-            }
-        }
-        return rocblas_status_success;
-    }
-
-    return rocblas_reduction_strided_batched_kernel<NB, rocblas_fetch_asum<To>>(
-        handle, n, x, shiftx, incx, 0, batch_count, workspace, results);
+    static constexpr bool           isbatched = true;
+    static constexpr rocblas_stride stridex_0 = 0;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_asum<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_identity>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count, results, workspace);
 }

--- a/library/src/blas1/rocblas_asum_strided_batched.cpp
+++ b/library/src/blas1/rocblas_asum_strided_batched.cpp
@@ -1,9 +1,9 @@
 /* ************************************************************************
  * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
+
 #include "rocblas_asum_strided_batched.hpp"
-#include "logging.h"
-#include "utility.h"
+#include "rocblas_reduction_impl.hpp"
 
 namespace
 {
@@ -31,56 +31,22 @@ namespace
                                                      rocblas_int    batch_count,
                                                      To*            results)
     {
-        if(!handle)
-            return rocblas_status_invalid_handle;
 
-        auto layer_mode = handle->layer_mode;
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(
-                handle, rocblas_asum_strided_batched_name<Ti>, n, x, incx, stridex, batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench(handle,
-                      "./rocblas-bench -f asum_strided_batched -r",
-                      rocblas_precision_string<Ti>,
-                      "-n",
-                      n,
-                      "--incx",
-                      incx,
-                      "--stride_x",
-                      stridex,
-                      "--batch",
-                      batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(handle,
-                        rocblas_asum_strided_batched_name<Ti>,
-                        "N",
-                        n,
-                        "incx",
-                        incx,
-                        "stride_x",
-                        stridex,
-                        "batch",
-                        batch_count);
-
-        if(!x || !results)
-            return rocblas_status_invalid_pointer;
-
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB>(n, batch_count, results);
-
-        if(handle->is_device_memory_size_query())
-            return handle->set_optimal_device_memory_size(dev_bytes);
-
-        auto mem = handle->device_malloc(dev_bytes);
-        if(!mem)
-            return rocblas_status_memory_error;
-
-        return rocblas_asum_strided_batched_template<NB>(
-            handle, n, x, 0, incx, stridex, batch_count, (To*)mem, results);
+        static constexpr bool isbatched = true;
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_asum<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_identity,
+                                      To>(handle,
+                                          n,
+                                          x,
+                                          incx,
+                                          stridex,
+                                          batch_count,
+                                          results,
+                                          rocblas_asum_strided_batched_name<Ti>,
+                                          "asum_strided_batched");
     }
 
 }
@@ -93,52 +59,29 @@ namespace
 
 extern "C" {
 
-rocblas_status rocblas_sasum_strided_batched(rocblas_handle handle,
-                                             rocblas_int    n,
-                                             const float*   x,
-                                             rocblas_int    incx,
-                                             rocblas_stride stridex,
-                                             rocblas_int    batch_count,
-                                             float*         results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, results);
-}
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
 
-rocblas_status rocblas_dasum_strided_batched(rocblas_handle handle,
-                                             rocblas_int    n,
-                                             const double*  x,
-                                             rocblas_int    incx,
-                                             rocblas_stride stridex,
-                                             rocblas_int    batch_count,
-                                             double*        results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, results);
-}
+#define IMPL(name_, typei_, typeo_)                             \
+    rocblas_status name_(rocblas_handle handle,                 \
+                         rocblas_int    n,                      \
+                         const typei_*  x,                      \
+                         rocblas_int    incx,                   \
+                         rocblas_stride stridex,                \
+                         rocblas_int    batch_count,            \
+                         typeo_*        results)                \
+    {                                                           \
+        constexpr rocblas_int NB = 512;                         \
+        return rocblas_asum_strided_batched_impl<NB>(           \
+            handle, n, x, incx, stridex, batch_count, results); \
+    }
 
-rocblas_status rocblas_scasum_strided_batched(rocblas_handle               handle,
-                                              rocblas_int                  n,
-                                              const rocblas_float_complex* x,
-                                              rocblas_int                  incx,
-                                              rocblas_stride               stridex,
-                                              rocblas_int                  batch_count,
-                                              float*                       results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, results);
-}
+IMPL(rocblas_sasum_strided_batched, float, float);
+IMPL(rocblas_dasum_strided_batched, double, double);
+IMPL(rocblas_scasum_strided_batched, rocblas_float_complex, float);
+IMPL(rocblas_dzasum_strided_batched, rocblas_double_complex, double);
 
-rocblas_status rocblas_dzasum_strided_batched(rocblas_handle                handle,
-                                              rocblas_int                   n,
-                                              const rocblas_double_complex* x,
-                                              rocblas_int                   incx,
-                                              rocblas_stride                stridex,
-                                              rocblas_int                   batch_count,
-                                              double*                       results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_asum_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, results);
-}
+#undef IMPL
 
 } // extern "C"

--- a/library/src/blas1/rocblas_asum_strided_batched.hpp
+++ b/library/src/blas1/rocblas_asum_strided_batched.hpp
@@ -3,10 +3,6 @@
  * ************************************************************************ */
 #pragma once
 
-#include "fetch_template.h"
-#include "handle.h"
-#include "reduction_strided_batched.h"
-#include "rocblas.h"
 #include "rocblas_asum.hpp"
 
 template <rocblas_int NB, typename U, typename To>
@@ -20,24 +16,11 @@ rocblas_status rocblas_asum_strided_batched_template(rocblas_handle handle,
                                                      To*            workspace,
                                                      To*            results)
 {
-
-    // Quick return if possible.
-    if(n <= 0 || incx <= 0 || batch_count == 0)
-    {
-        if(handle->is_device_memory_size_query())
-            return rocblas_status_size_unchanged;
-        else if(rocblas_pointer_mode_device == handle->pointer_mode && batch_count > 0)
-            RETURN_IF_HIP_ERROR(hipMemset(results, 0, batch_count * sizeof(To)));
-        else
-        {
-            for(int i = 0; i < batch_count; i++)
-            {
-                results[i] = 0;
-            }
-        }
-        return rocblas_status_success;
-    }
-
-    return rocblas_reduction_strided_batched_kernel<NB, rocblas_fetch_asum<To>>(
-        handle, n, x, shiftx, incx, stridex, batch_count, workspace, results);
+    static constexpr bool isbatched = true;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_asum<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_identity>(
+        handle, n, x, shiftx, incx, stridex, batch_count, results, workspace);
 }

--- a/library/src/blas1/rocblas_nrm2.cpp
+++ b/library/src/blas1/rocblas_nrm2.cpp
@@ -3,8 +3,7 @@
  * ************************************************************************ */
 
 #include "rocblas_nrm2.hpp"
-#include "logging.h"
-#include "utility.h"
+#include "rocblas_reduction_impl.hpp"
 
 namespace
 {
@@ -25,40 +24,18 @@ namespace
     // allocate workspace inside this API
     template <rocblas_int NB, typename Ti, typename To>
     rocblas_status rocblas_nrm2_impl(
-        rocblas_handle handle, rocblas_int n, const Ti* x, rocblas_int incx, To* result)
+        rocblas_handle handle, rocblas_int n, const Ti* x, rocblas_int incx, To* results)
     {
-        if(!handle)
-            return rocblas_status_invalid_handle;
-
-        auto layer_mode = handle->layer_mode;
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(handle, rocblas_nrm2_name<Ti>, n, x, incx);
-
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench(handle,
-                      "./rocblas-bench -f nrm2 -r",
-                      rocblas_precision_string<Ti>,
-                      "-n",
-                      n,
-                      "--incx",
-                      incx);
-
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(handle, rocblas_nrm2_name<Ti>, "N", n, "incx", incx);
-
-        if(!x || !result)
-            return rocblas_status_invalid_pointer;
-
-        size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB>(n, 1, result);
-
-        if(handle->is_device_memory_size_query())
-            return handle->set_optimal_device_memory_size(dev_bytes);
-
-        auto mem = handle->device_malloc(dev_bytes);
-        if(!mem)
-            return rocblas_status_memory_error;
-
-        return rocblas_nrm2_template<NB>(handle, n, x, 0, incx, (To*)mem, result);
+        static constexpr bool           isbatched     = false;
+        static constexpr rocblas_stride stridex_0     = 0;
+        static constexpr rocblas_int    batch_count_1 = 1;
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_nrm2<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_nrm2,
+                                      To>(
+            handle, n, x, incx, stridex_0, batch_count_1, results, rocblas_nrm2_name<Ti>, "nrm2");
     }
 
 } // namespace
@@ -73,38 +50,23 @@ namespace
 
 extern "C" {
 
-rocblas_status rocblas_snrm2(
-    rocblas_handle handle, rocblas_int n, const float* x, rocblas_int incx, float* result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_impl<NB>(handle, n, x, incx, result);
-}
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
 
-rocblas_status rocblas_dnrm2(
-    rocblas_handle handle, rocblas_int n, const double* x, rocblas_int incx, double* result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_impl<NB>(handle, n, x, incx, result);
-}
+#define IMPL(name_, typei_, typeo_)                                                               \
+    rocblas_status name_(                                                                         \
+        rocblas_handle handle, rocblas_int n, const typei_* x, rocblas_int incx, typeo_* results) \
+    {                                                                                             \
+        constexpr rocblas_int NB = 512;                                                           \
+        return rocblas_nrm2_impl<NB>(handle, n, x, incx, results);                                \
+    }
 
-rocblas_status rocblas_scnrm2(rocblas_handle               handle,
-                              rocblas_int                  n,
-                              const rocblas_float_complex* x,
-                              rocblas_int                  incx,
-                              float*                       result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_impl<NB>(handle, n, x, incx, result);
-}
+IMPL(rocblas_snrm2, float, float);
+IMPL(rocblas_dnrm2, double, double);
+IMPL(rocblas_scnrm2, rocblas_float_complex, float);
+IMPL(rocblas_dznrm2, rocblas_double_complex, double);
 
-rocblas_status rocblas_dznrm2(rocblas_handle                handle,
-                              rocblas_int                   n,
-                              const rocblas_double_complex* x,
-                              rocblas_int                   incx,
-                              double*                       result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_impl<NB>(handle, n, x, incx, result);
-}
+#undef IMPL
 
 } // extern "C"

--- a/library/src/blas1/rocblas_nrm2.hpp
+++ b/library/src/blas1/rocblas_nrm2.hpp
@@ -3,10 +3,7 @@
  * ************************************************************************ */
 #pragma once
 
-#include "fetch_template.h"
-#include "handle.h"
-#include "reduction_strided_batched.h"
-#include "rocblas.h"
+#include "rocblas_reduction_template.hpp"
 
 template <class To>
 struct rocblas_fetch_nrm2
@@ -35,23 +32,16 @@ rocblas_status rocblas_nrm2_template(rocblas_handle handle,
                                      rocblas_int    shiftx,
                                      rocblas_int    incx,
                                      To*            workspace,
-                                     To*            result)
+                                     To*            results)
 {
-    // Quick return if possible.
-    if(n <= 0 || incx <= 0)
-    {
-        if(handle->is_device_memory_size_query())
-            return rocblas_status_size_unchanged;
-        else if(rocblas_pointer_mode_device == handle->pointer_mode)
-            RETURN_IF_HIP_ERROR(hipMemset(result, 0, sizeof(*result)));
-        else
-            *result = 0;
-        return rocblas_status_success;
-    }
+    static constexpr bool           isbatched     = false;
+    static constexpr rocblas_stride stridex_0     = 0;
+    static constexpr rocblas_int    batch_count_1 = 1;
 
-    return rocblas_reduction_strided_batched_kernel<NB,
-                                                    rocblas_fetch_nrm2<To>,
-                                                    rocblas_reduce_sum,
-                                                    rocblas_finalize_nrm2>(
-        handle, n, x, shiftx, incx, 0, 1, workspace, result);
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_nrm2<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_nrm2>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count_1, results, workspace);
 }

--- a/library/src/blas1/rocblas_nrm2_batched.cpp
+++ b/library/src/blas1/rocblas_nrm2_batched.cpp
@@ -1,9 +1,9 @@
 /* ************************************************************************
  * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
+
 #include "rocblas_nrm2_batched.hpp"
-#include "logging.h"
-#include "utility.h"
+#include "rocblas_reduction_impl.hpp"
 
 namespace
 {
@@ -29,45 +29,22 @@ namespace
                                              rocblas_int     batch_count,
                                              To*             results)
     {
-        if(!handle)
-            return rocblas_status_invalid_handle;
-
-        auto layer_mode = handle->layer_mode;
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(handle, rocblas_nrm2_batched_name<Ti>, n, x, incx, batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench(handle,
-                      "./rocblas-bench -f nrm2_batched -r",
-                      rocblas_precision_string<Ti>,
-                      "-n",
-                      n,
-                      "--incx",
-                      incx,
-                      "--batch",
-                      batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(
-                handle, rocblas_nrm2_batched_name<Ti>, "N", n, "incx", incx, "batch", batch_count);
-
-        if(!x || !results)
-            return rocblas_status_invalid_pointer;
-
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB>(n, batch_count, results);
-
-        if(handle->is_device_memory_size_query())
-            return handle->set_optimal_device_memory_size(dev_bytes);
-
-        auto mem = handle->device_malloc(dev_bytes);
-        if(!mem)
-            return rocblas_status_memory_error;
-
-        return rocblas_nrm2_batched_template<NB>(
-            handle, n, x, 0, incx, batch_count, (To*)mem, results);
+        static constexpr bool           isbatched = true;
+        static constexpr rocblas_stride stridex_0 = 0;
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_nrm2<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_nrm2,
+                                      To>(handle,
+                                          n,
+                                          x,
+                                          incx,
+                                          stridex_0,
+                                          batch_count,
+                                          results,
+                                          rocblas_nrm2_batched_name<Ti>,
+                                          "nrm2_batched");
     }
 }
 /*
@@ -78,48 +55,27 @@ namespace
 
 extern "C" {
 
-rocblas_status rocblas_snrm2_batched(rocblas_handle     handle,
-                                     rocblas_int        n,
-                                     const float* const x[],
-                                     rocblas_int        incx,
-                                     rocblas_int        batch_count,
-                                     float*             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
 
-rocblas_status rocblas_dnrm2_batched(rocblas_handle      handle,
-                                     rocblas_int         n,
-                                     const double* const x[],
-                                     rocblas_int         incx,
-                                     rocblas_int         batch_count,
-                                     double*             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+#define IMPL(name_, typei_, typeo_)                                                    \
+    rocblas_status name_(rocblas_handle      handle,                                   \
+                         rocblas_int         n,                                        \
+                         const typei_* const x[],                                      \
+                         rocblas_int         incx,                                     \
+                         rocblas_int         batch_count,                              \
+                         typeo_*             result)                                   \
+    {                                                                                  \
+        constexpr rocblas_int NB = 512;                                                \
+        return rocblas_nrm2_batched_impl<NB>(handle, n, x, incx, batch_count, result); \
+    }
 
-rocblas_status rocblas_scnrm2_batched(rocblas_handle                     handle,
-                                      rocblas_int                        n,
-                                      const rocblas_float_complex* const x[],
-                                      rocblas_int                        incx,
-                                      rocblas_int                        batch_count,
-                                      float*                             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+IMPL(rocblas_snrm2_batched, float, float);
+IMPL(rocblas_dnrm2_batched, double, double);
+IMPL(rocblas_scnrm2_batched, rocblas_float_complex, float);
+IMPL(rocblas_dznrm2_batched, rocblas_double_complex, double);
 
-rocblas_status rocblas_dznrm2_batched(rocblas_handle                      handle,
-                                      rocblas_int                         n,
-                                      const rocblas_double_complex* const x[],
-                                      rocblas_int                         incx,
-                                      rocblas_int                         batch_count,
-                                      double*                             results)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_batched_impl<NB>(handle, n, x, incx, batch_count, results);
-}
+#undef IMPL
 
 } // extern "C"

--- a/library/src/blas1/rocblas_nrm2_batched.hpp
+++ b/library/src/blas1/rocblas_nrm2_batched.hpp
@@ -3,10 +3,6 @@
  * ************************************************************************ */
 #pragma once
 
-#include "fetch_template.h"
-#include "handle.h"
-#include "reduction_strided_batched.h"
-#include "rocblas.h"
 #include "rocblas_nrm2.hpp"
 
 template <rocblas_int NB, typename U, typename To>
@@ -19,27 +15,12 @@ rocblas_status rocblas_nrm2_batched_template(rocblas_handle handle,
                                              To*            workspace,
                                              To*            results)
 {
-    // Quick return if possible.
-    if(n <= 0 || incx <= 0 || batch_count == 0)
-    {
-        if(handle->is_device_memory_size_query())
-            return rocblas_status_size_unchanged;
-        else if(rocblas_pointer_mode_device == handle->pointer_mode && batch_count > 0)
-            RETURN_IF_HIP_ERROR(hipMemset(results, 0, batch_count * sizeof(To)));
-        else
-        {
-            for(int i = 0; i < batch_count; i++)
-            {
-                results[i] = 0;
-            }
-        }
-
-        return rocblas_status_success;
-    }
-
-    return rocblas_reduction_strided_batched_kernel<NB,
-                                                    rocblas_fetch_nrm2<To>,
-                                                    rocblas_reduce_sum,
-                                                    rocblas_finalize_nrm2>(
-        handle, n, x, shiftx, incx, 0, batch_count, workspace, results);
+    static constexpr bool           isbatched = true;
+    static constexpr rocblas_stride stridex_0 = 0;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_nrm2<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_nrm2>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count, results, workspace);
 }

--- a/library/src/blas1/rocblas_nrm2_strided_batched.cpp
+++ b/library/src/blas1/rocblas_nrm2_strided_batched.cpp
@@ -2,11 +2,11 @@
  * Copyright 2016-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 #include "rocblas_nrm2_strided_batched.hpp"
-#include "logging.h"
-#include "utility.h"
+#include "rocblas_reduction_impl.hpp"
 
 namespace
 {
+
     template <typename>
     constexpr char rocblas_nrm2_strided_batched_name[] = "unknown";
     template <>
@@ -33,56 +33,21 @@ namespace
                                                      rocblas_int    batch_count,
                                                      To*            results)
     {
-        if(!handle)
-            return rocblas_status_invalid_handle;
-
-        auto layer_mode = handle->layer_mode;
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(
-                handle, rocblas_nrm2_strided_batched_name<Ti>, n, x, incx, stridex, batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench(handle,
-                      "./rocblas-bench -f nrm2_strided_batched -r",
-                      rocblas_precision_string<Ti>,
-                      "-n",
-                      n,
-                      "--incx",
-                      incx,
-                      "--stride_x",
-                      stridex,
-                      "--batch",
-                      batch_count);
-
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile(handle,
-                        rocblas_nrm2_strided_batched_name<Ti>,
-                        "N",
-                        n,
-                        "incx",
-                        incx,
-                        "stride_x",
-                        stridex,
-                        "batch",
-                        batch_count);
-
-        if(!x || !results)
-            return rocblas_status_invalid_pointer;
-
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB>(n, batch_count, results);
-
-        if(handle->is_device_memory_size_query())
-            return handle->set_optimal_device_memory_size(dev_bytes);
-
-        auto mem = handle->device_malloc(dev_bytes);
-        if(!mem)
-            return rocblas_status_memory_error;
-
-        return rocblas_nrm2_strided_batched_template<NB>(
-            handle, n, x, 0, incx, stridex, batch_count, (To*)mem, results);
+        static constexpr bool isbatched = true;
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_nrm2<To>,
+                                      rocblas_reduce_sum,
+                                      rocblas_finalize_nrm2,
+                                      To>(handle,
+                                          n,
+                                          x,
+                                          incx,
+                                          stridex,
+                                          batch_count,
+                                          results,
+                                          rocblas_nrm2_strided_batched_name<Ti>,
+                                          "nrm2_strided_batched");
     }
 
 }
@@ -95,52 +60,29 @@ namespace
 
 extern "C" {
 
-rocblas_status rocblas_snrm2_strided_batched(rocblas_handle handle,
-                                             rocblas_int    n,
-                                             const float*   x,
-                                             rocblas_int    incx,
-                                             rocblas_stride stridex,
-                                             rocblas_int    batch_count,
-                                             float*         result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, result);
-}
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
 
-rocblas_status rocblas_dnrm2_strided_batched(rocblas_handle handle,
-                                             rocblas_int    n,
-                                             const double*  x,
-                                             rocblas_int    incx,
-                                             rocblas_stride stridex,
-                                             rocblas_int    batch_count,
-                                             double*        result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, result);
-}
+#define IMPL(name_, typei_, typeo_)                             \
+    rocblas_status name_(rocblas_handle handle,                 \
+                         rocblas_int    n,                      \
+                         const typei_*  x,                      \
+                         rocblas_int    incx,                   \
+                         rocblas_stride stridex,                \
+                         rocblas_int    batch_count,            \
+                         typeo_*        results)                \
+    {                                                           \
+        constexpr rocblas_int NB = 512;                         \
+        return rocblas_nrm2_strided_batched_impl<NB>(           \
+            handle, n, x, incx, stridex, batch_count, results); \
+    }
 
-rocblas_status rocblas_scnrm2_strided_batched(rocblas_handle               handle,
-                                              rocblas_int                  n,
-                                              const rocblas_float_complex* x,
-                                              rocblas_int                  incx,
-                                              rocblas_stride               stridex,
-                                              rocblas_int                  batch_count,
-                                              float*                       result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, result);
-}
+IMPL(rocblas_snrm2_strided_batched, float, float);
+IMPL(rocblas_dnrm2_strided_batched, double, double);
+IMPL(rocblas_scnrm2_strided_batched, rocblas_float_complex, float);
+IMPL(rocblas_dznrm2_strided_batched, rocblas_double_complex, double);
 
-rocblas_status rocblas_dznrm2_strided_batched(rocblas_handle                handle,
-                                              rocblas_int                   n,
-                                              const rocblas_double_complex* x,
-                                              rocblas_int                   incx,
-                                              rocblas_stride                stridex,
-                                              rocblas_int                   batch_count,
-                                              double*                       result)
-{
-    constexpr rocblas_int NB = 512;
-    return rocblas_nrm2_strided_batched_impl<NB>(handle, n, x, incx, stridex, batch_count, result);
-}
+#undef IMPL
 
 } // extern "C"

--- a/library/src/blas1/rocblas_reduction_impl.hpp
+++ b/library/src/blas1/rocblas_reduction_impl.hpp
@@ -1,0 +1,202 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "logging.h"
+#include "rocblas_reduction_template.hpp"
+#include "utility.h"
+
+template <bool ISBATCHED, typename Ti>
+void reduction_log_bench(rocblas_handle handle,
+                         rocblas_int    n,
+                         const Ti*      x,
+                         rocblas_int    incx,
+                         rocblas_stride stridex,
+                         rocblas_int    batch_count,
+                         const char*    name)
+{
+    if(ISBATCHED)
+    {
+        log_bench(handle,
+                  "./rocblas-bench",
+                  "-f",
+                  name,
+                  "-r",
+                  rocblas_precision_string<Ti>,
+                  "-n",
+                  n,
+                  "--incx",
+                  incx,
+                  "--stride_x",
+                  stridex,
+                  "--batch",
+                  batch_count);
+    }
+    else
+    {
+        log_bench(handle,
+                  "./rocblas-bench",
+                  "-f",
+                  name,
+                  "-r",
+                  rocblas_precision_string<Ti>,
+                  "-n",
+                  n,
+                  "--incx",
+                  incx);
+    }
+}
+
+template <bool ISBATCHED, typename Ti>
+void reduction_log_bench(rocblas_handle   handle,
+                         rocblas_int      n,
+                         const Ti* const* x,
+                         rocblas_int      incx,
+                         rocblas_stride   stridex,
+                         rocblas_int      batch_count,
+                         const char*      name)
+{
+    log_bench(handle,
+              "./rocblas-bench",
+              "-f",
+              name,
+              "-r",
+              rocblas_precision_string<Ti>,
+              "-n",
+              n,
+              "--incx",
+              incx,
+              "--batch",
+              batch_count);
+}
+
+template <bool ISBATCHED, typename Ti>
+void reduction_log_profile(rocblas_handle handle,
+                           rocblas_int    n,
+                           const Ti*      x,
+                           rocblas_int    incx,
+                           rocblas_stride stridex,
+                           rocblas_int    batch_count,
+                           const char*    name)
+{
+    if(ISBATCHED)
+    {
+        log_profile(handle, name, "N", n, "incx", incx, "stride_x", stridex, "batch", batch_count);
+    }
+    else
+    {
+        log_profile(handle, name, "N", n, "incx", incx);
+    }
+}
+
+template <bool ISBATCHED, typename Ti>
+void reduction_log_profile(rocblas_handle   handle,
+                           rocblas_int      n,
+                           const Ti* const* x,
+                           rocblas_int      incx,
+                           rocblas_stride   stridex,
+                           rocblas_int      batch_count,
+                           const char*      name)
+{
+    log_profile(handle, name, "N", n, "incx", incx, "batch", batch_count);
+}
+
+template <bool ISBATCHED, typename Ti>
+void reduction_log_trace(rocblas_handle handle,
+                         rocblas_int    n,
+                         const Ti*      x,
+                         rocblas_int    incx,
+                         rocblas_stride stridex,
+                         rocblas_int    batch_count,
+                         const char*    name)
+{
+    if(ISBATCHED)
+    {
+        log_trace(handle, name, n, x, incx, stridex, batch_count);
+    }
+    else
+    {
+        log_trace(handle, name, n, x, incx);
+    }
+}
+
+template <bool ISBATCHED, typename Ti>
+void reduction_log_trace(rocblas_handle   handle,
+                         rocblas_int      n,
+                         const Ti* const* x,
+                         rocblas_int      incx,
+                         rocblas_stride   stridex,
+                         rocblas_int      batch_count,
+                         const char*      name)
+{
+    log_trace(handle, name, n, x, incx, batch_count);
+}
+
+// allocate workspace inside this API
+template <rocblas_int NB,
+          bool        ISBATCHED,
+          typename FETCH,
+          typename REDUCE,
+          typename FINALIZE,
+          typename Tw,
+          typename U,
+          typename Tr>
+rocblas_status rocblas_reduction_impl(rocblas_handle handle,
+                                      rocblas_int    n,
+                                      U              x,
+                                      rocblas_int    incx,
+                                      rocblas_stride stridex,
+                                      rocblas_int    batch_count,
+                                      Tr*            results,
+                                      const char*    name,
+                                      const char*    name_bench)
+{
+    if(!handle)
+    {
+        return rocblas_status_invalid_handle;
+    }
+
+    auto layer_mode = handle->layer_mode;
+    if(layer_mode & rocblas_layer_mode_log_trace)
+    {
+        reduction_log_trace<ISBATCHED>(handle, n, x, incx, stridex, batch_count, name);
+    }
+
+    if(layer_mode & rocblas_layer_mode_log_bench)
+    {
+        reduction_log_bench<ISBATCHED>(handle, n, x, incx, stridex, batch_count, name_bench);
+    }
+
+    if(layer_mode & rocblas_layer_mode_log_profile)
+    {
+        reduction_log_profile<ISBATCHED>(handle, n, x, incx, stridex, batch_count, name);
+    }
+
+    if(!x || !results)
+    {
+        return rocblas_status_invalid_pointer;
+    }
+
+    if(batch_count < 0)
+    {
+        return rocblas_status_invalid_size;
+    }
+
+    size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB, Tw>(n, batch_count);
+
+    if(handle->is_device_memory_size_query())
+    {
+        return handle->set_optimal_device_memory_size(dev_bytes);
+    }
+
+    auto mem = handle->device_malloc(dev_bytes);
+    if(!mem)
+    {
+        return rocblas_status_memory_error;
+    }
+
+    static constexpr rocblas_int shiftx_0 = 0;
+    return rocblas_reduction_template<NB, ISBATCHED, FETCH, REDUCE, FINALIZE>(
+        handle, n, x, shiftx_0, incx, stridex, batch_count, results, (Tw*)mem);
+}

--- a/library/src/blas1/rocblas_reduction_template.hpp
+++ b/library/src/blas1/rocblas_reduction_template.hpp
@@ -1,0 +1,55 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "fetch_template.h"
+#include "handle.h"
+#include "reduction_strided_batched.h"
+#include "rocblas.h"
+
+// allocate workspace inside this API
+template <rocblas_int NB,
+          bool        ISBATCHED,
+          typename FETCH,
+          typename REDUCE,
+          typename FINALIZE,
+          typename U,
+          typename Tr,
+          typename Tw>
+rocblas_status rocblas_reduction_template(rocblas_handle handle,
+                                          rocblas_int    n,
+                                          U              x,
+                                          rocblas_int    shiftx,
+                                          rocblas_int    incx,
+                                          rocblas_stride stridex,
+                                          rocblas_int    batch_count,
+                                          Tr*            results,
+                                          Tw*            workspace)
+{
+
+    // Quick return if possible.
+    if(n <= 0 || incx <= 0 || (ISBATCHED && batch_count == 0))
+    {
+        if(handle->is_device_memory_size_query())
+        {
+            return rocblas_status_size_unchanged;
+        }
+        else if(rocblas_pointer_mode_device == handle->pointer_mode && batch_count > 0)
+        {
+            RETURN_IF_HIP_ERROR(hipMemset(results, 0, batch_count * sizeof(Tr)));
+        }
+        else
+        {
+
+            for(rocblas_int batch_index = 0; batch_index < batch_count; batch_index++)
+            {
+                results[batch_index] = Tr(0);
+            }
+        }
+        return rocblas_status_success;
+    }
+
+    return rocblas_reduction_strided_batched_kernel<NB, FETCH, REDUCE, FINALIZE>(
+        handle, n, x, shiftx, incx, stridex, batch_count, workspace, results);
+}


### PR DESCRIPTION
and generalize its usage.

Summary of proposed changes:

============================================

Generalize the 'template' and the 'impl' to be used by nrm2/asum/amax/amin

- 3/ NEW: library/src/blas1/rocblas_reduction_template.hpp
- 4/ NEW: library/src/blas1/rocblas_reduction_impl.hpp

============================================

- 5/ MODIFIED library/src/blas1/rocblas_asum.cpp
- 6/ MODIFIED library/src/blas1/rocblas_asum.hpp

- 7/ MODIFIED library/src/blas1/rocblas_asum_batched.cpp
- 8/ MODIFIED library/src/blas1/rocblas_asum_batched.hpp

- 9/ MODIFIED library/src/blas1/rocblas_asum_strided_batched.cpp
- 10/ MODIFIED library/src/blas1/rocblas_asum_strided_batched.hpp

============================================

- 11/ MODIFIED library/src/blas1/rocblas_nrm2.cpp
- 12/ MODIFIED library/src/blas1/rocblas_nrm2.hpp

- 13/ MODIFIED library/src/blas1/rocblas_nrm2_batched.cpp
- 14/ MODIFIED library/src/blas1/rocblas_nrm2_batched.hpp

- 15/ MODIFIED library/src/blas1/rocblas_nrm2_strided_batched.cpp
- 16/ MODIFIED library/src/blas1/rocblas_nrm2_strided_batched.hpp

============================================

- 1/ MODIFIED library/src/blas1/reduction_strided_batched.h
- 2/ MODIFIED library/src/blas1/rocblas_amax_amin.h
