### PR TITLE
Adding complex flops calcs. and updating other flop calcs.

### DIFF
--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -10,7 +10,8 @@
 
 /*!\file
  * \brief provides Floating point counts of Basic Linear Algebra Subprograms (BLAS) of Level 1, 2,
- * 3.
+ * 3. Where possible we are using the values of NOP from the legacy BLAS files [sdcz]blas[23]time.f
+ * for flop count.
  */
 
 /*
@@ -96,46 +97,47 @@ constexpr double scal_gflop_count<rocblas_double_complex, double>(rocblas_int n)
 template <typename T>
 constexpr double gemv_gflop_count(rocblas_int m, rocblas_int n)
 {
-    return (2.0 * m * n) / 1e9;
+    return (2.0 * m * n + 2.0 * m * n) / 1e9;
 }
 template <>
 constexpr double gemv_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n)
 {
-    return (8.0 * m * n) / 1e9;
+    return (8.0 * m * n + 6.0 * m * n) / 1e9;
 }
 
 template <>
 constexpr double gemv_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n)
 {
-    return (8.0 * m * n) / 1e9;
+    return (8.0 * m * n + 6.0 * m * n) / 1e9;
 }
 
 /* \brief floating point counts of TRSV */
 template <typename T>
 constexpr double trsv_gflop_count(rocblas_int m)
 {
-    return (m * (m + 1.0)) / 1e9;
+    return (m * m) / 1e9;
 }
 
 /* \brief floating point counts of SY(HE)MV */
 template <typename T>
 constexpr double symv_gflop_count(rocblas_int n)
 {
-    return (2.0 * n * n) / 1e9;
+    return (2.0 * n * n + 2.0 * n) / 1e9;
 }
 
 /* \brief floating point counts of GER */
 template <typename T>
 constexpr double ger_gflop_count(rocblas_int m, rocblas_int n)
 {
-    return (2.0 * m * n) / 1e9;
+    rocblas_int min = (m < n) ? m : n;
+    return (2.0 * m * n + min) / 1e9;
 }
 
 /* \brief floating point counts of SYR */
 template <typename T>
 constexpr double syr_gflop_count(rocblas_int n)
 {
-    return ((2.0 * n * (n + 1)) / 2) / 1e9;
+    return (n * (n + 1) + n) / 1e9;
 }
 
 /*
@@ -176,21 +178,21 @@ constexpr double geam_gflop_count(rocblas_int m, rocblas_int n)
 template <typename T>
 constexpr double trsm_gflop_count(rocblas_int m, rocblas_int n, rocblas_int k)
 {
-    return (1.0 * m * n * (k + 1)) / 1e9;
+    return (m * n * k) / 1e9;
 }
 
 template <>
 constexpr double
     trsm_gflop_count<rocblas_float_complex>(rocblas_int m, rocblas_int n, rocblas_int k)
 {
-    return (4.0 * m * n * (k + 1)) / 1e9;
+    return (4.0 * m * n * k) / 1e9;
 }
 
 template <>
 constexpr double
     trsm_gflop_count<rocblas_double_complex>(rocblas_int m, rocblas_int n, rocblas_int k)
 {
-    return (4.0 * m * n * (k + 1)) / 1e9;
+    return (4.0 * m * n * k) / 1e9;
 }
 
 /* \brief floating point counts of TRTRI */

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -23,15 +23,67 @@ constexpr double axpy_gflop_count(rocblas_int n)
 {
     return (2.0 * n) / 1e9;
 }
-template <typename T>
+template <>
+constexpr double axpy_gflop_count<rocblas_float_complex>(rocblas_int n)
+{
+    return (8.0 * n) / 1e9; // 6 for complex-complex multiply, 2 for c-c add
+}
+template <>
+constexpr double axpy_gflop_count<rocblas_double_complex>(rocblas_int n)
+{
+    return (8.0 * n) / 1e9;
+}
+
+template <bool CONJ, typename T>
 constexpr double dot_gflop_count(rocblas_int n)
 {
     return (2.0 * n) / 1e9;
 }
-template <typename T>
+template <>
+constexpr double dot_gflop_count<false, rocblas_float_complex>(rocblas_int n)
+{
+    return (8.0 * n) / 1e9; // 6 for each c-c multiply, 2 for each c-c add
+}
+template <>
+constexpr double dot_gflop_count<false, rocblas_double_complex>(rocblas_int n)
+{
+    return (8.0 * n) / 1e9;
+}
+template <>
+constexpr double dot_gflop_count<true, rocblas_float_complex>(rocblas_int n)
+{
+    return (9.0 * n) / 1e9; // regular dot (8n) + 1n for complex conjugate
+}
+template <>
+constexpr double dot_gflop_count<true, rocblas_double_complex>(rocblas_int n)
+{
+    return (9.0 * n) / 1e9;
+}
+
+template <typename T, typename U>
 constexpr double scal_gflop_count(rocblas_int n)
 {
     return (1.0 * n) / 1e9;
+}
+template <>
+constexpr double scal_gflop_count<rocblas_float_complex, rocblas_float_complex>(rocblas_int n)
+{
+    return (6.0 * n) / 1e9; // 6 for c-c multiply
+}
+template <>
+constexpr double scal_gflop_count<rocblas_double_complex, rocblas_double_complex>(rocblas_int n)
+{
+    return (6.0 * n) / 1e9;
+}
+template <>
+constexpr double scal_gflop_count<rocblas_float_complex, float>(rocblas_int n)
+{
+    return (2.0 * n) / 1e9; // 2 for real-complex multiply
+}
+template <>
+constexpr double scal_gflop_count<rocblas_double_complex, double>(rocblas_int n)
+{
+    return (2.0 * n) / 1e9;
 }
 
 /*

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -143,7 +143,7 @@ void testing_dot(const Arguments& arg)
         cpu_time_used = get_time_us();
         (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx, incx, hy, incy, &cpu_result);
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops  = dot_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = dot_gflop_count<CONJ, T>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
@@ -182,7 +182,7 @@ void testing_dot(const Arguments& arg)
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
-        rocblas_gflops    = dot_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_gflops    = dot_gflop_count<CONJ, T>(N) / gpu_time_used * 1e6 * 1;
         rocblas_bandwidth = (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         std::cout << "N,incx,incy,rocblas-Gflops,rocblas-GB/s,rocblas-us";

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -233,7 +233,7 @@ void testing_dot_batched(const Arguments& arg)
             (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx[b], incx, hy[b], incy, &cpu_result[b]);
         }
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops  = batch_count * dot_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = batch_count * dot_gflop_count<CONJ, T>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
@@ -287,7 +287,7 @@ void testing_dot_batched(const Arguments& arg)
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
-        rocblas_gflops    = batch_count * dot_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_gflops    = batch_count * dot_gflop_count<CONJ, T>(N) / gpu_time_used * 1e6 * 1;
         rocblas_bandwidth = batch_count * (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         std::cout << "N,incx,incy,batch_count,rocblas-Gflops,rocblas-GB/s,rocblas-us";

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -231,7 +231,7 @@ void testing_dot_strided_batched(const Arguments& arg)
                                                   &cpu_result[b]);
         }
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops  = batch_count * dot_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = batch_count * dot_gflop_count<CONJ, T>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
@@ -290,7 +290,7 @@ void testing_dot_strided_batched(const Arguments& arg)
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
-        rocblas_gflops    = batch_count * dot_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_gflops    = batch_count * dot_gflop_count<CONJ, T>(N) / gpu_time_used * 1e6 * 1;
         rocblas_bandwidth = batch_count * (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         std::cout

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -123,7 +123,7 @@ void testing_scal(const Arguments& arg)
         cpu_time_used = get_time_us();
         cblas_scal<T, U>(N, h_alpha, hy_gold, incx);
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops  = scal_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = scal_gflop_count<T, U>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
@@ -158,7 +158,7 @@ void testing_scal(const Arguments& arg)
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
-        rocblas_gflops    = scal_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_gflops    = scal_gflop_count<T, U>(N) / gpu_time_used * 1e6 * 1;
         rocblas_bandwidth = (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         std::cout << "N,alpha,incx,rocblas-Gflops,rocblas-GB/s,rocblas-us";

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -140,7 +140,7 @@ void testing_scal_batched(const Arguments& arg)
             cblas_scal<T, U>(N, h_alpha, hx_gold[i], incx);
         }
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops  = batch_count * scal_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = batch_count * scal_gflop_count<T, U>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
@@ -175,7 +175,7 @@ void testing_scal_batched(const Arguments& arg)
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
-        rocblas_gflops    = batch_count * scal_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_gflops    = batch_count * scal_gflop_count<T, U>(N) / gpu_time_used * 1e6 * 1;
         rocblas_bandwidth = batch_count * (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         std::cout << "N,alpha,incx,rocblas-Gflops,rocblas-GB/s,rocblas-us";

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -122,7 +122,7 @@ void testing_scal_strided_batched(const Arguments& arg)
         }
 
         cpu_time_used = get_time_us() - cpu_time_used;
-        cblas_gflops  = batch_count * scal_gflop_count<T>(N) / cpu_time_used * 1e6 * 1;
+        cblas_gflops  = batch_count * scal_gflop_count<T, U>(N) / cpu_time_used * 1e6 * 1;
 
         if(arg.unit_check)
         {
@@ -161,7 +161,7 @@ void testing_scal_strided_batched(const Arguments& arg)
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;
-        rocblas_gflops    = batch_count * scal_gflop_count<T>(N) / gpu_time_used * 1e6 * 1;
+        rocblas_gflops    = batch_count * scal_gflop_count<T, U>(N) / gpu_time_used * 1e6 * 1;
         rocblas_bandwidth = batch_count * (2.0 * N) * sizeof(T) / gpu_time_used / 1e3;
 
         std::cout << "N,alpha,incx,rocblas-Gflops,rocblas-GB/s,rocblas-us";


### PR DESCRIPTION
Correcting complex flops calculations for L1 functions that do flops calculations:
- caxpy/zaxpy
- cdotu/zdotu & cdotc/zdotc
- scscal/dzscal & cscal/zscal

We should probably add flops calculations to all of the other functions some time in the future, and add them to logging.