### PR TITLE
batched and strided batched version of iamax iamin

### DIFF
--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -200,7 +200,8 @@ def setdefaults(test):
                             'scal_strided_batched', 'swap_strided_batched',
                             'copy_strided_batched', 'dot_strided_batched',
                             'dotc_strided_batched', 'rot_strided_batched',
-                            'rotm_strided_batched'):
+                            'rotm_strided_batched', 'iamax_strided_batched',
+                            'iamin_strided_batched'):
         if all([x in test for x in ('N', 'incx', 'stride_scale')]):
             ldx = int(test['N'] * abs(test['incx']) * test['stride_scale'])
             test.setdefault('stride_x', ldx)

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -14,6 +14,8 @@
 #include "testing_dot_batched.hpp"
 #include "testing_dot_strided_batched.hpp"
 #include "testing_iamax_iamin.hpp"
+#include "testing_iamax_iamin_batched.hpp"
+#include "testing_iamax_iamin_strided_batched.hpp"
 #include "testing_nrm2.hpp"
 #include "testing_nrm2_batched.hpp"
 #include "testing_nrm2_strided_batched.hpp"
@@ -49,7 +51,11 @@ namespace
         asum_batched,
         asum_strided_batched,
         iamax,
+        iamax_batched,
+        iamax_strided_batched,
         iamin,
+        iamin_batched,
+        iamin_strided_batched,
         axpy,
         copy,
         copy_batched,
@@ -120,6 +126,7 @@ namespace
                                    || BLAS1 == blas1::copy_batched || BLAS1 == blas1::dot_batched
                                    || BLAS1 == blas1::dotc_batched || BLAS1 == blas1::rot_batched
                                    || BLAS1 == blas1::rotm_batched || BLAS1 == blas1::rotg_batched
+                                   || BLAS1 == blas1::iamax_batched || BLAS1 == blas1::iamin_batched
                                    || BLAS1 == blas1::rotmg_batched);
                 bool is_strided
                     = (BLAS1 == blas1::nrm2_strided_batched || BLAS1 == blas1::asum_strided_batched
@@ -131,7 +138,9 @@ namespace
                        || BLAS1 == blas1::rot_strided_batched
                        || BLAS1 == blas1::rotm_strided_batched
                        || BLAS1 == blas1::rotg_strided_batched
-                       || BLAS1 == blas1::rotmg_strided_batched);
+                       || BLAS1 == blas1::rotmg_strided_batched
+                       || BLAS1 == blas1::iamax_strided_batched
+                       || BLAS1 == blas1::iamin_strided_batched);
 
                 if((is_scal || is_rotg || is_rot) && arg.a_type != arg.b_type)
                     name << '_' << rocblas_datatype2string(arg.b_type);
@@ -239,12 +248,16 @@ namespace
                     || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{})
                     || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{})))
 
-            || (BLAS1 == blas1::iamax && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+            || ((BLAS1 == blas1::iamax || BLAS1 == blas1::iamax_batched
+                 || BLAS1 == blas1::iamax_strided_batched)
+                && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
                 && (std::is_same<Ti, rocblas_float_complex>{}
                     || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
                     || std::is_same<Ti, double>{}))
 
-            || (BLAS1 == blas1::iamin && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
+            || ((BLAS1 == blas1::iamin || BLAS1 == blas1::iamin_batched
+                 || BLAS1 == blas1::iamin_strided_batched)
+                && std::is_same<To, Ti>{} && std::is_same<To, Tc>{}
                 && (std::is_same<Ti, rocblas_float_complex>{}
                     || std::is_same<Ti, rocblas_double_complex>{} || std::is_same<Ti, float>{}
                     || std::is_same<Ti, double>{}))
@@ -352,7 +365,11 @@ BLAS1_TESTING(nrm2,  ARG1)
 BLAS1_TESTING(nrm2_batched,  ARG1)
 BLAS1_TESTING(nrm2_strided_batched,  ARG1)
 BLAS1_TESTING(iamax, ARG1)
+BLAS1_TESTING(iamax_batched, ARG1)
+BLAS1_TESTING(iamax_strided_batched, ARG1)
 BLAS1_TESTING(iamin, ARG1)
+BLAS1_TESTING(iamin_batched, ARG1)
+BLAS1_TESTING(iamin_strided_batched, ARG1)
 BLAS1_TESTING(axpy,  ARG1)
 BLAS1_TESTING(copy,  ARG1)
 BLAS1_TESTING(copy_batched,  ARG1)

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -233,6 +233,8 @@ Tests:
     function:
       - asum_batched: *single_double_precisions_complex_real
       - nrm2_batched: *single_double_precisions_complex_real
+      - iamax_batched: *single_double_precisions_complex_real
+      - iamin_batched: *single_double_precisions_complex_real
 
   - name: blas1_strided_batched
     category: quick
@@ -243,6 +245,8 @@ Tests:
     function:
       - asum_strided_batched: *single_double_precisions_complex_real
       - nrm2_strided_batched: *single_double_precisions_complex_real
+      - iamax_strided_batched: *single_double_precisions_complex_real
+      - iamin_strided_batched: *single_double_precisions_complex_real
 
 # pre_checkin
   - name: blas1
@@ -264,6 +268,8 @@ Tests:
     function:
       - asum_batched: *double_precision_complex_real
       - nrm2_batched: *double_precision_complex_real
+      - iamax_batched: *double_precision_complex_real
+      - iamin_batched: *double_precision_complex_real
 
   - name: blas1_strided_batched
     category: pre_checkin
@@ -274,6 +280,8 @@ Tests:
     function:
       - asum_strided_batched: *double_precision_complex_real
       - nrm2_strided_batched: *double_precision_complex_real
+      - iamax_strided_batched: *double_precision_complex_real
+      - iamin_strided_batched: *double_precision_complex_real
 
 # nightly
   - name: blas1
@@ -283,6 +291,8 @@ Tests:
     function:
       - nrm2:  *double_precision_complex_real
       - asum:  *double_precision_complex_real
+      - iamax:  *double_precision_complex_real
+      - iamin:  *double_precision_complex_real
 
   - name: blas1_batched
     category: nightly
@@ -292,6 +302,8 @@ Tests:
     function:
       - asum_batched: *double_precision_complex_real
       - nrm2_batched: *double_precision_complex_real
+      - iamax_batched: *double_precision_complex_real
+      - iamin_batched: *double_precision_complex_real
 
   - name: blas1_strided_batched
     category: nightly
@@ -302,6 +314,8 @@ Tests:
     function:
       - asum_strided_batched: *double_precision_complex_real
       - nrm2_strided_batched: *double_precision_complex_real
+      - iamax_strided_batched: *double_precision_complex_real
+      - iamin_strided_batched: *double_precision_complex_real
 
 # All functions with incx, incy, no alpha
 
@@ -428,7 +442,11 @@ Tests:
       - asum_batched_bad_arg:  *single_double_precisions_complex_real
       - asum_strided_batched_bad_arg:  *single_double_precisions_complex_real
       - iamax_bad_arg: *single_double_precisions_complex_real
+      - iamax_batched_bad_arg: *single_double_precisions_complex_real
+      - iamax_strided_batched_bad_arg: *single_double_precisions_complex_real
       - iamin_bad_arg: *single_double_precisions_complex_real
+      - iamin_batched_bad_arg: *single_double_precisions_complex_real
+      - iamin_strided_batched_bad_arg: *single_double_precisions_complex_real
       - axpy_bad_arg:  *half_single_precisions_complex_real
       - copy_bad_arg:  *single_double_precisions_complex_real
       - copy_batched_bad_arg:  *single_double_precisions_complex_real

--- a/clients/include/device_strided_batch_vector.hpp
+++ b/clients/include/device_strided_batch_vector.hpp
@@ -201,7 +201,7 @@ public:
     hipError_t transfer_from(const host_strided_batch_vector<T>& that)
     {
         return hipMemcpy(
-            this->m_data, that.data(), sizeof(T) * this->nmemb(), hipMemcpyHostToDevice);
+            this->data(), that.data(), sizeof(T) * this->nmemb(), hipMemcpyHostToDevice);
     }
 
     //!

--- a/clients/include/device_strided_batch_vector.hpp
+++ b/clients/include/device_strided_batch_vector.hpp
@@ -96,6 +96,22 @@ public:
     }
 
     //!
+    //! @brief Returns the data pointer.
+    //!
+    T* data()
+    {
+        return this->m_data;
+    }
+
+    //!
+    //! @brief Returns the data pointer.
+    //!
+    const T* data() const
+    {
+        return this->m_data;
+    }
+
+    //!
     //! @brief Returns the length.
     //!
     rocblas_int n() const
@@ -184,7 +200,8 @@ public:
     //!
     hipError_t transfer_from(const host_strided_batch_vector<T>& that)
     {
-        return hipMemcpy((*this)[0], that[0], sizeof(T) * this->nmemb(), hipMemcpyHostToDevice);
+        return hipMemcpy(
+            this->m_data, that.data(), sizeof(T) * this->nmemb(), hipMemcpyHostToDevice);
     }
 
     //!

--- a/clients/include/host_strided_batch_vector.hpp
+++ b/clients/include/host_strided_batch_vector.hpp
@@ -208,7 +208,7 @@ public:
         if(that.n() == this->m_n && that.inc() == this->m_inc && that.stride() == this->m_stride
            && that.batch_count() == this->m_batch_count)
         {
-            memcpy(this->m_data, that.data(), sizeof(T) * this->m_nmemb);
+            memcpy(this->data(), that.data(), sizeof(T) * this->m_nmemb);
             return true;
         }
         else

--- a/clients/include/host_strided_batch_vector.hpp
+++ b/clients/include/host_strided_batch_vector.hpp
@@ -99,6 +99,22 @@ public:
     }
 
     //!
+    //! @brief Returns the data pointer.
+    //!
+    T* data()
+    {
+        return this->m_data;
+    }
+
+    //!
+    //! @brief Returns the data pointer.
+    //!
+    const T* data() const
+    {
+        return this->m_data;
+    }
+
+    //!
     //! @brief Returns the length.
     //!
     rocblas_int n() const
@@ -192,7 +208,7 @@ public:
         if(that.n() == this->m_n && that.inc() == this->m_inc && that.stride() == this->m_stride
            && that.batch_count() == this->m_batch_count)
         {
-            memcpy((*this)[0], that[0], sizeof(T) * this->m_nmemb);
+            memcpy(this->m_data, that.data(), sizeof(T) * this->m_nmemb);
             return true;
         }
         else
@@ -209,13 +225,8 @@ public:
     template <size_t PAD, typename U>
     hipError_t transfer_from(const device_strided_batch_vector<T, PAD, U>& that)
     {
-        auto hip_err
-            = hipMemcpy((*this)[0], that[0], sizeof(T) * this->m_nmemb, hipMemcpyDeviceToHost);
-        if(hipSuccess != hip_err)
-        {
-            return hip_err;
-        }
-        return hipSuccess;
+        return hipMemcpy(
+            this->m_data, that.data(), sizeof(T) * this->m_nmemb, hipMemcpyDeviceToHost);
     }
 
     //!

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -554,6 +554,105 @@ static constexpr auto rocblas_iamin<rocblas_float_complex> = rocblas_icamin;
 template <>
 static constexpr auto rocblas_iamin<rocblas_double_complex> = rocblas_izamin;
 
+//
+// Define the signature type for the iamax_iamin batched.
+//
+template <typename T>
+using rocblas_iamax_iamin_batched_t = rocblas_status (*)(rocblas_handle  handle,
+                                                         rocblas_int     n,
+                                                         const T* const* x,
+                                                         rocblas_int     incx,
+                                                         rocblas_int     batch_count,
+                                                         rocblas_int*    result);
+
+//
+// iamax
+//
+template <typename T>
+rocblas_iamax_iamin_batched_t<T> rocblas_iamax_batched;
+
+template <>
+static constexpr auto rocblas_iamax_batched<float> = rocblas_isamax_batched;
+
+template <>
+static constexpr auto rocblas_iamax_batched<double> = rocblas_idamax_batched;
+
+template <>
+static constexpr auto rocblas_iamax_batched<rocblas_float_complex> = rocblas_icamax_batched;
+
+template <>
+static constexpr auto rocblas_iamax_batched<rocblas_double_complex> = rocblas_izamax_batched;
+
+//
+// iamin
+//
+template <typename T>
+rocblas_iamax_iamin_batched_t<T> rocblas_iamin_batched;
+
+template <>
+static constexpr auto rocblas_iamin_batched<float> = rocblas_isamin_batched;
+
+template <>
+static constexpr auto rocblas_iamin_batched<double> = rocblas_idamin_batched;
+
+template <>
+static constexpr auto rocblas_iamin_batched<rocblas_float_complex> = rocblas_icamin_batched;
+
+template <>
+static constexpr auto rocblas_iamin_batched<rocblas_double_complex> = rocblas_izamin_batched;
+
+//
+// Define the signature type for the iamax_iamin strided batched.
+//
+template <typename T>
+using rocblas_iamax_iamin_strided_batched_t = rocblas_status (*)(rocblas_handle handle,
+                                                                 rocblas_int    n,
+                                                                 const T*       x,
+                                                                 rocblas_int    incx,
+                                                                 rocblas_stride stridex,
+                                                                 rocblas_int    batch_count,
+                                                                 rocblas_int*   result);
+
+//
+// iamax
+//
+template <typename T>
+rocblas_iamax_iamin_strided_batched_t<T> rocblas_iamax_strided_batched;
+
+template <>
+static constexpr auto rocblas_iamax_strided_batched<float> = rocblas_isamax_strided_batched;
+
+template <>
+static constexpr auto rocblas_iamax_strided_batched<double> = rocblas_idamax_strided_batched;
+
+template <>
+static constexpr auto
+    rocblas_iamax_strided_batched<rocblas_float_complex> = rocblas_icamax_strided_batched;
+
+template <>
+static constexpr auto
+    rocblas_iamax_strided_batched<rocblas_double_complex> = rocblas_izamax_strided_batched;
+
+//
+// iamin
+//
+template <typename T>
+rocblas_iamax_iamin_strided_batched_t<T> rocblas_iamin_strided_batched;
+
+template <>
+static constexpr auto rocblas_iamin_strided_batched<float> = rocblas_isamin_strided_batched;
+
+template <>
+static constexpr auto rocblas_iamin_strided_batched<double> = rocblas_idamin_strided_batched;
+
+template <>
+static constexpr auto
+    rocblas_iamin_strided_batched<rocblas_float_complex> = rocblas_icamin_strided_batched;
+
+template <>
+static constexpr auto
+    rocblas_iamin_strided_batched<rocblas_double_complex> = rocblas_izamin_strided_batched;
+
 // axpy
 template <typename T>
 rocblas_status (*rocblas_axpy)(rocblas_handle handle,

--- a/clients/include/rocblas_cblas.hpp
+++ b/clients/include/rocblas_cblas.hpp
@@ -1,0 +1,88 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+//
+//  CBLAS does not have an  function iamin
+//  neither a rocblas_half based function iamax,
+//  so we write our own version of it
+//
+namespace rocblas_cblas
+{
+    template <typename T>
+    T asum(T x)
+    {
+        return x < 0 ? -x : x;
+    }
+
+    rocblas_half asum(rocblas_half x)
+    {
+        return x & 0x7fff;
+    }
+
+    template <typename T>
+    bool lessthan(T x, T y)
+    {
+        return x < y;
+    }
+
+    bool lessthan(rocblas_half x, rocblas_half y)
+    {
+        return half_to_float(x) < half_to_float(y);
+    }
+
+    template <typename T>
+    bool greatherthan(T x, T y)
+    {
+        return x > y;
+    }
+
+    bool greatherthan(rocblas_half x, rocblas_half y)
+    {
+        return half_to_float(x) > half_to_float(y);
+    }
+
+    template <typename T>
+    void iamin(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
+    {
+        rocblas_int minpos = -1;
+        if(N > 0 && incx > 0)
+        {
+            auto min = asum(X[0]);
+            minpos   = 0;
+            for(size_t i = 1; i < N; ++i)
+            {
+                auto a = asum(X[i * incx]);
+                if(lessthan(a, min))
+                {
+                    min    = a;
+                    minpos = i;
+                }
+            }
+        }
+        *result = minpos;
+    }
+
+    template <typename T>
+    void iamax(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
+    {
+        rocblas_int maxpos = -1;
+        if(N > 0 && incx > 0)
+        {
+            auto max = asum(X[0]);
+            maxpos   = 0;
+            for(size_t i = 1; i < N; ++i)
+            {
+                auto a = asum(X[i * incx]);
+                if(greatherthan(a, max))
+                {
+                    max    = a;
+                    maxpos = i;
+                }
+            }
+        }
+        *result = maxpos;
+    }
+
+} // namespace rocblas_cblas

--- a/clients/include/rocblas_iamax_iamin_ref.hpp
+++ b/clients/include/rocblas_iamax_iamin_ref.hpp
@@ -3,12 +3,7 @@
  * ************************************************************************ */
 #pragma once
 
-//
-//  CBLAS does not have an  function iamin
-//  neither a rocblas_half based function iamax,
-//  so we write our own version of it
-//
-namespace rocblas_cblas
+namespace rocblas_iamax_iamin_ref
 {
     template <typename T>
     T asum(T x)
@@ -44,7 +39,7 @@ namespace rocblas_cblas
     }
 
     template <typename T>
-    void iamin(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
+    void cblas_iamin(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
     {
         rocblas_int minpos = -1;
         if(N > 0 && incx > 0)
@@ -65,7 +60,10 @@ namespace rocblas_cblas
     }
 
     template <typename T>
-    void iamax(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
+    void cblas_iamax_ensure_minimum_index(rocblas_int  N,
+                                          const T*     X,
+                                          rocblas_int  incx,
+                                          rocblas_int* result)
     {
         rocblas_int maxpos = -1;
         if(N > 0 && incx > 0)
@@ -85,4 +83,18 @@ namespace rocblas_cblas
         *result = maxpos;
     }
 
-} // namespace rocblas_cblas
+    template <typename T>
+    void iamin(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
+    {
+        cblas_iamin(N, X, incx, result);
+        *result += 1;
+    }
+
+    template <typename T>
+    void iamax(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
+    {
+        cblas_iamax_ensure_minimum_index(N, X, incx, result);
+        *result += 1;
+    }
+
+}

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -61,9 +61,11 @@ void testing_asum_batched_template(const Arguments& arg)
         device_vector<T2> dr(std::max(2, std::abs(batch_count)));
         CHECK_HIP_ERROR(dr.memcheck());
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS((rocblas_asum_batched<T1, T2>(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
-			      (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size : rocblas_status_success);
-	
+        EXPECT_ROCBLAS_STATUS(
+            (rocblas_asum_batched<T1, T2>(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
+            (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
+                                                   : rocblas_status_success);
+
         return;
     }
 

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -53,33 +53,17 @@ void testing_asum_batched_template(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    if(batch_count < 0)
-    {
-        device_batch_vector<T1> dx(100, 1, std::abs(batch_count));
-        CHECK_HIP_ERROR(dx.memcheck());
-
-        device_vector<T2> dr(std::abs(batch_count));
-        CHECK_HIP_ERROR(dr.memcheck());
-
-        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS((rocblas_asum_batched<T1, T2>(handle, N, dx, incx, batch_count, dr)),
-                              rocblas_status_invalid_size);
-        return;
-    }
-
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || batch_count == 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-
-        device_batch_vector<T1> dx(safe_size, 1, std::max(batch_count, 1));
+        device_batch_vector<T1> dx(3, 1, 2);
         CHECK_HIP_ERROR(dx.memcheck());
-
-        device_vector<T2> dr(std::max(batch_count, 1));
+        device_vector<T2> dr(std::max(2, std::abs(batch_count)));
         CHECK_HIP_ERROR(dr.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR((rocblas_asum_batched<T1, T2>(handle, N, dx, incx, batch_count, dr)));
+        EXPECT_ROCBLAS_STATUS((rocblas_asum_batched<T1, T2>(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
+			      (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size : rocblas_status_success);
+	
         return;
     }
 

--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -62,10 +62,11 @@ void testing_asum_strided_batched_template(const Arguments& arg)
         CHECK_HIP_ERROR(dr.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS((rocblas_asum_strided_batched<T1, T2>(handle, N, dx, incx, stridex, batch_count, dr)),
-                              (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
-			      : rocblas_status_success);
-	
+        EXPECT_ROCBLAS_STATUS(
+            (rocblas_asum_strided_batched<T1, T2>(handle, N, dx, incx, stridex, batch_count, dr)),
+            (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
+                                                   : rocblas_status_success);
+
         return;
     }
 

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -5,6 +5,7 @@
 #include "cblas_interface.hpp"
 #include "norm.hpp"
 #include "rocblas.hpp"
+#include "rocblas_cblas.hpp"
 #include "rocblas_init.hpp"
 #include "rocblas_math.hpp"
 #include "rocblas_random.hpp"
@@ -173,94 +174,14 @@ void testing_iamax_iamin(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
     }
 }
 
-// CBLAS does not have a cblas_iamin function, so we write our own version of it
-namespace rocblas_cblas
-{
-    template <typename T>
-    T asum(T x)
-    {
-        return x < 0 ? -x : x;
-    }
-
-    rocblas_half asum(rocblas_half x)
-    {
-        return x & 0x7fff;
-    }
-
-    template <typename T>
-    bool lessthan(T x, T y)
-    {
-        return x < y;
-    }
-
-    bool lessthan(rocblas_half x, rocblas_half y)
-    {
-        return half_to_float(x) < half_to_float(y);
-    }
-
-    template <typename T>
-    bool greatherthan(T x, T y)
-    {
-        return x > y;
-    }
-
-    bool greatherthan(rocblas_half x, rocblas_half y)
-    {
-        return half_to_float(x) > half_to_float(y);
-    }
-
-    template <typename T>
-    void cblas_iamin(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
-    {
-        rocblas_int minpos = -1;
-        if(N > 0 && incx > 0)
-        {
-            auto min = asum(X[0]);
-            minpos   = 0;
-            for(size_t i = 1; i < N; ++i)
-            {
-                auto a = asum(X[i * incx]);
-                if(lessthan(a, min))
-                {
-                    min    = a;
-                    minpos = i;
-                }
-            }
-        }
-        *result = minpos;
-    }
-
-    template <typename T>
-    void cblas_iamax(rocblas_int N, const T* X, rocblas_int incx, rocblas_int* result)
-    {
-        rocblas_int maxpos = -1;
-        if(N > 0 && incx > 0)
-        {
-            auto max = asum(X[0]);
-            maxpos   = 0;
-            for(size_t i = 1; i < N; ++i)
-            {
-                auto a = asum(X[i * incx]);
-                if(greatherthan(a, max))
-                {
-                    max    = a;
-                    maxpos = i;
-                }
-            }
-        }
-        *result = maxpos;
-    }
-
-} // namespace rocblas_cblas
-
 template <typename T>
 void testing_iamax(const Arguments& arg)
 {
-    testing_iamax_iamin<T, rocblas_cblas::cblas_iamax<T>>(arg, rocblas_iamax<T>);
+    testing_iamax_iamin<T, rocblas_cblas::iamax<T>>(arg, rocblas_iamax<T>);
 }
 
 template <typename T>
 void testing_iamin(const Arguments& arg)
 {
-    testing_iamax_iamin<T, rocblas_cblas::cblas_iamin<T>>(arg, rocblas_iamin<T>);
+    testing_iamax_iamin<T, rocblas_cblas::iamin<T>>(arg, rocblas_iamin<T>);
 }

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -5,7 +5,7 @@
 #include "cblas_interface.hpp"
 #include "norm.hpp"
 #include "rocblas.hpp"
-#include "rocblas_cblas.hpp"
+#include "rocblas_iamax_iamin_ref.hpp"
 #include "rocblas_init.hpp"
 #include "rocblas_math.hpp"
 #include "rocblas_random.hpp"
@@ -50,7 +50,7 @@ void testing_iamin_bad_arg(const Arguments& arg)
     testing_iamax_iamin_bad_arg<T>(arg, rocblas_iamin<T>);
 }
 
-template <typename T, void CBLAS_FUNC(rocblas_int, const T*, rocblas_int, rocblas_int*)>
+template <typename T, void REFBLAS_FUNC(rocblas_int, const T*, rocblas_int, rocblas_int*)>
 void testing_iamax_iamin(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
 {
     rocblas_int N    = arg.N;
@@ -121,9 +121,8 @@ void testing_iamax_iamin(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
         // CPU BLAS
         cpu_time_used = get_time_us();
         rocblas_int cpu_result;
-        CBLAS_FUNC(N, hx, incx, &cpu_result);
+        REFBLAS_FUNC(N, hx, incx, &cpu_result);
         cpu_time_used = get_time_us() - cpu_time_used;
-        cpu_result += 1; // make index 1 based as in Fortran BLAS, not 0 based as in CBLAS
 
         if(arg.unit_check)
         {
@@ -177,11 +176,11 @@ void testing_iamax_iamin(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
 template <typename T>
 void testing_iamax(const Arguments& arg)
 {
-    testing_iamax_iamin<T, rocblas_cblas::iamax<T>>(arg, rocblas_iamax<T>);
+    testing_iamax_iamin<T, rocblas_iamax_iamin_ref::iamax<T>>(arg, rocblas_iamax<T>);
 }
 
 template <typename T>
 void testing_iamin(const Arguments& arg)
 {
-    testing_iamax_iamin<T, rocblas_cblas::iamin<T>>(arg, rocblas_iamin<T>);
+    testing_iamax_iamin<T, rocblas_iamax_iamin_ref::iamin<T>>(arg, rocblas_iamin<T>);
 }

--- a/clients/include/testing_iamax_iamin_batched.hpp
+++ b/clients/include/testing_iamax_iamin_batched.hpp
@@ -2,6 +2,7 @@
  * Copyright 2018-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
+#include "rocblas_iamax_iamin_ref.hpp"
 #include "testing_reduction_batched.hpp"
 
 template <typename T>
@@ -13,7 +14,8 @@ void testing_iamax_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_iamax_batched(const Arguments& arg)
 {
-    template_testing_reduction_batched(arg, rocblas_iamax_batched<T>, rocblas_cblas::iamax<T>);
+    template_testing_reduction_batched(
+        arg, rocblas_iamax_batched<T>, rocblas_iamax_iamin_ref::iamax<T>);
 }
 
 template <typename T>
@@ -25,5 +27,6 @@ void testing_iamin_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_iamin_batched(const Arguments& arg)
 {
-    template_testing_reduction_batched(arg, rocblas_iamin_batched<T>, rocblas_cblas::iamin<T>);
+    template_testing_reduction_batched(
+        arg, rocblas_iamin_batched<T>, rocblas_iamax_iamin_ref::iamin<T>);
 }

--- a/clients/include/testing_iamax_iamin_batched.hpp
+++ b/clients/include/testing_iamax_iamin_batched.hpp
@@ -1,0 +1,29 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "testing_reduction_batched.hpp"
+
+template <typename T>
+void testing_iamax_batched_bad_arg(const Arguments& arg)
+{
+    template_testing_reduction_batched_bad_arg(arg, rocblas_iamax_batched<T>);
+}
+
+template <typename T>
+void testing_iamax_batched(const Arguments& arg)
+{
+    template_testing_reduction_batched(arg, rocblas_iamax_batched<T>, rocblas_cblas::iamax<T>);
+}
+
+template <typename T>
+void testing_iamin_batched_bad_arg(const Arguments& arg)
+{
+    template_testing_reduction_batched_bad_arg(arg, rocblas_iamin_batched<T>);
+}
+
+template <typename T>
+void testing_iamin_batched(const Arguments& arg)
+{
+    template_testing_reduction_batched(arg, rocblas_iamin_batched<T>, rocblas_cblas::iamin<T>);
+}

--- a/clients/include/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/testing_iamax_iamin_strided_batched.hpp
@@ -2,6 +2,7 @@
  * Copyright 2018-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
+#include "rocblas_iamax_iamin_ref.hpp"
 #include "testing_reduction_strided_batched.hpp"
 
 template <typename T>
@@ -14,7 +15,7 @@ template <typename T>
 void testing_iamax_strided_batched(const Arguments& arg)
 {
     template_testing_reduction_strided_batched(
-        arg, rocblas_iamax_strided_batched<T>, rocblas_cblas::iamax<T>);
+        arg, rocblas_iamax_strided_batched<T>, rocblas_iamax_iamin_ref::iamax<T>);
 }
 
 template <typename T>
@@ -27,5 +28,5 @@ template <typename T>
 void testing_iamin_strided_batched(const Arguments& arg)
 {
     template_testing_reduction_strided_batched(
-        arg, rocblas_iamin_strided_batched<T>, rocblas_cblas::iamin<T>);
+        arg, rocblas_iamin_strided_batched<T>, rocblas_iamax_iamin_ref::iamin<T>);
 }

--- a/clients/include/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/testing_iamax_iamin_strided_batched.hpp
@@ -1,0 +1,31 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "testing_reduction_strided_batched.hpp"
+
+template <typename T>
+void testing_iamax_strided_batched_bad_arg(const Arguments& arg)
+{
+    template_testing_reduction_strided_batched_bad_arg(arg, rocblas_iamax_strided_batched<T>);
+}
+
+template <typename T>
+void testing_iamax_strided_batched(const Arguments& arg)
+{
+    template_testing_reduction_strided_batched(
+        arg, rocblas_iamax_strided_batched<T>, rocblas_cblas::iamax<T>);
+}
+
+template <typename T>
+void testing_iamin_strided_batched_bad_arg(const Arguments& arg)
+{
+    template_testing_reduction_strided_batched_bad_arg(arg, rocblas_iamin_strided_batched<T>);
+}
+
+template <typename T>
+void testing_iamin_strided_batched(const Arguments& arg)
+{
+    template_testing_reduction_strided_batched(
+        arg, rocblas_iamin_strided_batched<T>, rocblas_cblas::iamin<T>);
+}

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -56,40 +56,18 @@ void testing_nrm2_batched_template(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    if(batch_count < 0)
-    {
-        static const size_t safe_size = 100; //  arbitrarily set to zero
-
-        device_vector<T1*, 0, T1> dx(safe_size);
-        device_vector<T2>         d_rocblas_result(std::max(batch_count, 1));
-        if(!dx || !d_rocblas_result)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
-        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        EXPECT_ROCBLAS_STATUS(
-            (rocblas_nrm2_batched<T1, T2>(handle, N, dx, incx, batch_count, d_rocblas_result)),
-            rocblas_status_invalid_size);
-        return;
-    }
 
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || batch_count == 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
-        static const size_t       safe_size = 100; //  arbitrarily set to zero
-        device_vector<T1*, 0, T1> dx(safe_size);
-        device_vector<T2>         d_rocblas_result(std::max(batch_count, 1));
-        if(!dx || !d_rocblas_result)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
+        device_batch_vector<T1> dx(3, 1, 2);
+        CHECK_HIP_ERROR(dx.memcheck());
+        device_vector<T2> dr(std::max(2, std::abs(batch_count)));
+        CHECK_HIP_ERROR(dr.memcheck());
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(
-            (rocblas_nrm2_batched<T1, T2>(handle, N, dx, incx, batch_count, d_rocblas_result)));
+        EXPECT_ROCBLAS_STATUS((rocblas_nrm2_batched<T1, T2>(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
+                              (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
+                                                                     : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -56,7 +56,6 @@ void testing_nrm2_batched_template(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
@@ -65,9 +64,10 @@ void testing_nrm2_batched_template(const Arguments& arg)
         device_vector<T2> dr(std::max(2, std::abs(batch_count)));
         CHECK_HIP_ERROR(dr.memcheck());
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS((rocblas_nrm2_batched<T1, T2>(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
-                              (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
-                                                                     : rocblas_status_success);
+        EXPECT_ROCBLAS_STATUS(
+            (rocblas_nrm2_batched<T1, T2>(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
+            (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
+                                                   : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -68,9 +68,10 @@ void testing_nrm2_strided_batched_template(const Arguments& arg)
         CHECK_HIP_ERROR(dr.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS((rocblas_nrm2_strided_batched<T1, T2>(handle, N, dx, incx, stridex, batch_count, dr)),
-                              (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
-                                                                     : rocblas_status_success);
+        EXPECT_ROCBLAS_STATUS(
+            (rocblas_nrm2_strided_batched<T1, T2>(handle, N, dx, incx, stridex, batch_count, dr)),
+            (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
+                                                   : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -59,39 +59,18 @@ void testing_nrm2_strided_batched_template(const Arguments& arg)
 
     rocblas_local_handle handle;
 
-    if(batch_count < 0)
-    {
-        static const size_t safe_size = 100; //  arbitrarily set to zero
-        device_vector<T1>   dx(safe_size);
-        device_vector<T2>   d_rocblas_result(std::max(batch_count, 1));
-        if(!dx || !d_rocblas_result)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
-        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS((rocblas_nrm2_strided_batched<T1, T2>(
-                                  handle, N, dx, incx, stridex, batch_count, d_rocblas_result)),
-                              rocblas_status_invalid_size);
-        return;
-    }
-
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || batch_count == 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
-        static const size_t safe_size = 100; //  arbitrarily set to zero
-        device_vector<T1>   dx(safe_size);
-        device_vector<T2>   d_rocblas_result(std::max(batch_count, 1));
-        if(!dx || !d_rocblas_result)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        device_strided_batch_vector<T1> dx(3, 1, 3, 3);
+        CHECK_HIP_ERROR(dx.memcheck());
+        device_vector<T2> dr(std::max(3, std::abs(batch_count)));
+        CHECK_HIP_ERROR(dr.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR((rocblas_nrm2_strided_batched<T1, T2>(
-            handle, N, dx, incx, stridex, batch_count, d_rocblas_result)));
+        EXPECT_ROCBLAS_STATUS((rocblas_nrm2_strided_batched<T1, T2>(handle, N, dx, incx, stridex, batch_count, dr)),
+                              (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
+                                                                     : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_reduction_batched.hpp
+++ b/clients/include/testing_reduction_batched.hpp
@@ -66,7 +66,7 @@ void template_testing_reduction_batched(const Arguments&                  arg,
         CHECK_HIP_ERROR(dr.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        EXPECT_ROCBLAS_STATUS((func(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
+        EXPECT_ROCBLAS_STATUS(func(handle, N, dx.ptr_on_device(), incx, batch_count, dr),
                               rocblas_status_invalid_size);
         return;
     }
@@ -80,7 +80,7 @@ void template_testing_reduction_batched(const Arguments&                  arg,
         device_vector<R> dr(std::max(10, batch_count));
         CHECK_HIP_ERROR(dr.memcheck());
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR((func(handle, N, dx.ptr_on_device(), incx, batch_count, dr)));
+        CHECK_ROCBLAS_ERROR(func(handle, N, dx.ptr_on_device(), incx, batch_count, dr));
         return;
     }
 
@@ -116,7 +116,7 @@ void template_testing_reduction_batched(const Arguments&                  arg,
         //
         {
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-            CHECK_ROCBLAS_ERROR((func(handle, N, dx.ptr_on_device(), incx, batch_count, hr1)));
+            CHECK_ROCBLAS_ERROR(func(handle, N, dx.ptr_on_device(), incx, batch_count, hr1));
         }
 
         //
@@ -124,7 +124,7 @@ void template_testing_reduction_batched(const Arguments&                  arg,
         //
         {
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-            CHECK_ROCBLAS_ERROR((func(handle, N, dx.ptr_on_device(), incx, batch_count, dr)));
+            CHECK_ROCBLAS_ERROR(func(handle, N, dx.ptr_on_device(), incx, batch_count, dr));
             CHECK_HIP_ERROR(hr2.transfer_from(dr));
         }
 

--- a/clients/include/testing_reduction_batched.hpp
+++ b/clients/include/testing_reduction_batched.hpp
@@ -1,0 +1,201 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "cblas_interface.hpp"
+#include "norm.hpp"
+#include "rocblas.hpp"
+#include "rocblas_cblas.hpp"
+#include "rocblas_init.hpp"
+#include "rocblas_math.hpp"
+#include "rocblas_random.hpp"
+#include "rocblas_test.hpp"
+#include "rocblas_vector.hpp"
+#include "unit.hpp"
+#include "utility.hpp"
+
+template <typename T, typename R>
+using rocblas_reduction_batched_t = rocblas_status (*)(rocblas_handle  handle,
+                                                       rocblas_int     n,
+                                                       const T* const* x,
+                                                       rocblas_int     incx,
+                                                       rocblas_int     batch_count,
+                                                       R*              result);
+
+template <typename T, typename R>
+void template_testing_reduction_batched_bad_arg(const Arguments&                  arg,
+                                                rocblas_reduction_batched_t<T, R> func)
+{
+    rocblas_int N = 100, incx = 1, batch_count = 5;
+
+    rocblas_local_handle handle;
+
+    //
+    // allocate memory on device
+    //
+    device_batch_vector<T> dx(N, incx, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    R h_rocblas_result;
+
+    EXPECT_ROCBLAS_STATUS(func(handle, N, nullptr, incx, batch_count, &h_rocblas_result),
+                          rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(func(handle, N, dx, incx, batch_count, nullptr),
+                          rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(func(nullptr, N, dx, incx, batch_count, &h_rocblas_result),
+                          rocblas_status_invalid_handle);
+}
+
+template <typename T, typename R>
+void template_testing_reduction_batched(const Arguments&                  arg,
+                                        rocblas_reduction_batched_t<T, R> func,
+                                        void (*CBLAS_FUNC)(rocblas_int, const T*, rocblas_int, R*))
+{
+    rocblas_int          N = arg.N, incx = arg.incx, batch_count = arg.batch_count;
+    rocblas_stride       stride_x = arg.stride_x;
+    double               rocblas_error_1, rocblas_error_2;
+    rocblas_local_handle handle;
+
+    if(batch_count < 0)
+    {
+        device_batch_vector<T> dx(10, 1, 10);
+        CHECK_HIP_ERROR(dx.memcheck());
+        device_vector<R> dr(10);
+        CHECK_HIP_ERROR(dr.memcheck());
+
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+        EXPECT_ROCBLAS_STATUS((func(handle, N, dx.ptr_on_device(), incx, batch_count, dr)),
+                              rocblas_status_invalid_size);
+        return;
+    }
+
+    // check to prevent undefined memory allocation error
+
+    if(N <= 0 || incx <= 0 || batch_count == 0)
+    {
+        device_batch_vector<T> dx(10, 1, 2);
+        CHECK_HIP_ERROR(dx.memcheck());
+        device_vector<R> dr(std::max(10, batch_count));
+        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+        CHECK_ROCBLAS_ERROR((func(handle, N, dx.ptr_on_device(), incx, batch_count, dr)));
+        return;
+    }
+
+    host_vector<R> hr1(batch_count);
+    CHECK_HIP_ERROR(hr1.memcheck());
+    host_vector<R> hr2(batch_count);
+    CHECK_HIP_ERROR(hr2.memcheck());
+    host_vector<R> cpu_result(batch_count);
+    CHECK_HIP_ERROR(cpu_result.memcheck());
+    device_vector<R> dr(batch_count);
+    CHECK_HIP_ERROR(dr.memcheck());
+
+    host_batch_vector<T> hx(N, incx, batch_count);
+    CHECK_HIP_ERROR(hx.memcheck());
+    device_batch_vector<T> dx(N, incx, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    //
+    // Initialize.
+    //
+    rocblas_init(hx, true);
+
+    //
+    // Copy data from host to device.
+    //
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+
+    double gpu_time_used, cpu_time_used;
+    if(arg.unit_check || arg.norm_check)
+    {
+        //
+        // GPU BLAS, rocblas_pointer_mode_host
+        //
+        {
+            CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+            CHECK_ROCBLAS_ERROR((func(handle, N, dx.ptr_on_device(), incx, batch_count, hr1)));
+        }
+
+        //
+        // GPU BLAS, rocblas_pointer_mode_device
+        //
+        {
+            CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+            CHECK_ROCBLAS_ERROR((func(handle, N, dx.ptr_on_device(), incx, batch_count, dr)));
+            CHECK_HIP_ERROR(hr2.transfer_from(dr));
+        }
+
+        //
+        // CPU BLAS
+        //
+        {
+            cpu_time_used = get_time_us();
+            for(rocblas_int batch_index = 0; batch_index < batch_count; ++batch_index)
+            {
+                CBLAS_FUNC(N, hx[batch_index], incx, cpu_result + batch_index);
+                //
+                // make index 1 based as in Fortran BLAS, not 0 based as in CBLAS
+                //
+                *(cpu_result + batch_index) += 1;
+            }
+            cpu_time_used = get_time_us() - cpu_time_used;
+        }
+
+        if(arg.unit_check)
+        {
+            unit_check_general<R>(batch_count, 1, 1, cpu_result, hr1);
+            unit_check_general<R>(batch_count, 1, 1, cpu_result, hr2);
+        }
+
+        if(arg.norm_check)
+        {
+            rocblas_error_1 = 0.0;
+            rocblas_error_2 = 0.0;
+            for(rocblas_int batch_index = 0; batch_index < batch_count; ++batch_index)
+            {
+                double a1       = double(hr1[batch_index]);
+                double a2       = double(hr2[batch_index]);
+                double c        = double(cpu_result[batch_index]);
+                rocblas_error_1 = std::max(rocblas_error_1, std::abs((c - a1) / c));
+                rocblas_error_2 = std::max(rocblas_error_2, std::abs((c - a2) / c));
+            }
+        }
+    }
+
+    if(arg.timing)
+    {
+        int number_cold_calls = 2;
+        int number_hot_calls  = 100;
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        for(int iter = 0; iter < number_cold_calls; iter++)
+        {
+            func(handle, N, dx.ptr_on_device(), incx, batch_count, hr2);
+        }
+
+        gpu_time_used = get_time_us(); // in microseconds
+
+        for(int iter = 0; iter < number_hot_calls; iter++)
+        {
+            func(handle, N, dx.ptr_on_device(), incx, batch_count, hr2);
+        }
+
+        gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
+
+        std::cout << "N,incx,batch_count,rocblas(us)";
+
+        if(arg.norm_check)
+            std::cout << ",CPU(us),error_host_ptr,error_dev_ptr";
+
+        std::cout << std::endl;
+        std::cout << N << "," << incx << "," << batch_count << "," << gpu_time_used;
+
+        if(arg.norm_check)
+            std::cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
+
+        std::cout << std::endl;
+    }
+}

--- a/clients/include/testing_reduction_strided_batched.hpp
+++ b/clients/include/testing_reduction_strided_batched.hpp
@@ -44,10 +44,10 @@ void template_testing_reduction_strided_batched_bad_arg(
         (func(handle, N, nullptr, incx, incx * N, batch_count, &h_rocblas_result)),
         rocblas_status_invalid_pointer);
 
-    EXPECT_ROCBLAS_STATUS((func(handle, N, dx, incx, incx * N, batch_count, nullptr)),
+    EXPECT_ROCBLAS_STATUS(func(handle, N, dx, incx, incx * N, batch_count, nullptr),
                           rocblas_status_invalid_pointer);
 
-    EXPECT_ROCBLAS_STATUS((func(nullptr, N, dx, incx, incx * N, batch_count, &h_rocblas_result)),
+    EXPECT_ROCBLAS_STATUS(func(nullptr, N, dx, incx, incx * N, batch_count, &h_rocblas_result),
                           rocblas_status_invalid_handle);
 }
 
@@ -108,7 +108,7 @@ void template_testing_reduction_strided_batched(
     //
     // Transfer host data to device.
     //
-    CHECK_HIP_ERROR((dx.transfer_from(hx)));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
 
     if(arg.unit_check || arg.norm_check)
     {
@@ -117,7 +117,7 @@ void template_testing_reduction_strided_batched(
         //
         {
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-            CHECK_ROCBLAS_ERROR((func(handle, N, dx, incx, stridex, batch_count, hr1)));
+            CHECK_ROCBLAS_ERROR(func(handle, N, dx, incx, stridex, batch_count, hr1));
         }
 
         //
@@ -125,11 +125,11 @@ void template_testing_reduction_strided_batched(
         //
         {
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-            CHECK_ROCBLAS_ERROR((func(handle, N, dx, incx, stridex, batch_count, dr)));
+            CHECK_ROCBLAS_ERROR(func(handle, N, dx, incx, stridex, batch_count, dr));
             //
             // Copy result back to host.
             //
-            CHECK_HIP_ERROR((hr2.transfer_from(dr)));
+            CHECK_HIP_ERROR(hr2.transfer_from(dr));
         }
 
         //

--- a/clients/include/testing_reduction_strided_batched.hpp
+++ b/clients/include/testing_reduction_strided_batched.hpp
@@ -1,0 +1,212 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "cblas_interface.hpp"
+#include "norm.hpp"
+#include "rocblas.hpp"
+#include "rocblas_init.hpp"
+#include "rocblas_math.hpp"
+#include "rocblas_random.hpp"
+#include "rocblas_test.hpp"
+#include "rocblas_vector.hpp"
+#include "unit.hpp"
+#include "utility.hpp"
+
+template <typename T, typename R>
+using rocblas_reduction_strided_batched_t = rocblas_status (*)(rocblas_handle handle,
+                                                               rocblas_int    n,
+                                                               const T*       x,
+                                                               rocblas_int    incx,
+                                                               rocblas_stride stridex,
+                                                               rocblas_int    batch_count,
+                                                               R*             result);
+
+template <typename T, typename R>
+void template_testing_reduction_strided_batched_bad_arg(
+    const Arguments& arg, rocblas_reduction_strided_batched_t<T, R> func)
+{
+    rocblas_int N = 100, incx = 1, batch_count = 5;
+
+    static const size_t safe_size = 100;
+
+    rocblas_local_handle handle;
+
+    //
+    // allocate memory on device
+    //
+    device_vector<T> dx(batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    R h_rocblas_result;
+
+    EXPECT_ROCBLAS_STATUS(
+        (func(handle, N, nullptr, incx, incx * N, batch_count, &h_rocblas_result)),
+        rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS((func(handle, N, dx, incx, incx * N, batch_count, nullptr)),
+                          rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS((func(nullptr, N, dx, incx, incx * N, batch_count, &h_rocblas_result)),
+                          rocblas_status_invalid_handle);
+}
+
+template <typename T, typename R>
+void template_testing_reduction_strided_batched(
+    const Arguments&                          arg,
+    rocblas_reduction_strided_batched_t<T, R> func,
+    void (*CBLAS_FUNC)(rocblas_int, const T*, rocblas_int, R*))
+{
+    rocblas_int    N = arg.N, incx = arg.incx, batch_count = arg.batch_count;
+    rocblas_stride stridex = arg.stride_x;
+
+    double               rocblas_error_1, rocblas_error_2;
+    rocblas_local_handle handle;
+    if(batch_count < 0)
+    {
+        device_strided_batch_vector<T> dx(10, 1, 10, 10);
+        CHECK_HIP_ERROR(dx.memcheck());
+        device_vector<R> dr(10);
+        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+        EXPECT_ROCBLAS_STATUS(func(handle, N, dx, incx, stridex, batch_count, dr),
+                              rocblas_status_invalid_size);
+        return;
+    }
+
+    // check to prevent undefined memory allocation error
+    if(N <= 0 || incx <= 0 || batch_count == 0)
+    {
+        device_strided_batch_vector<T> dx(10, 1, 10, 10);
+        CHECK_HIP_ERROR(dx.memcheck());
+        device_vector<R> dr(std::max(10, batch_count));
+        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+        CHECK_ROCBLAS_ERROR(func(handle, N, dx, incx, stridex, batch_count, dr));
+        return;
+    }
+
+    host_vector<R> hr1(batch_count);
+    CHECK_HIP_ERROR(hr1.memcheck());
+    host_vector<R> hr2(batch_count);
+    CHECK_HIP_ERROR(hr2.memcheck());
+    host_vector<R> cpu_result(batch_count);
+    CHECK_HIP_ERROR(cpu_result.memcheck());
+    device_strided_batch_vector<T> dx(N, incx, stridex, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+    host_strided_batch_vector<T> hx(N, incx, stridex, batch_count);
+    CHECK_HIP_ERROR(hx.memcheck());
+    device_vector<R> dr(batch_count);
+    CHECK_HIP_ERROR(dr.memcheck());
+    double gpu_time_used, cpu_time_used;
+
+    //
+    // Initialize hx
+    //
+    rocblas_init(hx, true);
+
+    //
+    // Transfer host data to device.
+    //
+    CHECK_HIP_ERROR((dx.transfer_from(hx)));
+
+    if(arg.unit_check || arg.norm_check)
+    {
+        //
+        // GPU BLAS, rocblas_pointer_mode_host
+        //
+        {
+            CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+            CHECK_ROCBLAS_ERROR((func(handle, N, dx, incx, stridex, batch_count, hr1)));
+        }
+
+        //
+        // GPU BLAS, rocblas_pointer_mode_device
+        //
+        {
+            CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
+            CHECK_ROCBLAS_ERROR((func(handle, N, dx, incx, stridex, batch_count, dr)));
+            //
+            // Copy result back to host.
+            //
+            CHECK_HIP_ERROR((hr2.transfer_from(dr)));
+        }
+
+        //
+        // COMPARE WITH CPU BLAS
+        //
+        {
+            //
+            // Time to execution
+            //
+            cpu_time_used = get_time_us();
+            for(rocblas_int batch_index = 0; batch_index < batch_count; ++batch_index)
+            {
+                CBLAS_FUNC(N, hx[batch_index], incx, cpu_result + batch_index);
+                *(cpu_result + batch_index) += 1;
+            }
+            cpu_time_used = get_time_us() - cpu_time_used;
+        }
+
+        //
+        // Check the results
+        //
+        if(arg.unit_check)
+        {
+            unit_check_general<R>(batch_count, 1, 1, cpu_result, hr1);
+            unit_check_general<R>(batch_count, 1, 1, cpu_result, hr2);
+        }
+
+        //
+        // Check the norm.
+        //
+        if(arg.norm_check)
+        {
+            rocblas_error_1 = 0.0;
+            rocblas_error_2 = 0.0;
+            for(rocblas_int batch_index = 0; batch_index < batch_count; ++batch_index)
+            {
+                double a1       = double(hr1[batch_index]);
+                double a2       = double(hr2[batch_index]);
+                double c        = double(cpu_result[batch_index]);
+                rocblas_error_1 = std::max(rocblas_error_1, std::abs((c - a1) / c));
+                rocblas_error_2 = std::max(rocblas_error_2, std::abs((c - a2) / c));
+            }
+        }
+    }
+
+    if(arg.timing)
+    {
+        int number_cold_calls = 2;
+        int number_hot_calls  = 100;
+        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+
+        for(int iter = 0; iter < number_cold_calls; iter++)
+        {
+            func(handle, N, dx, incx, stridex, batch_count, hr2);
+        }
+
+        gpu_time_used = get_time_us(); // in microseconds
+
+        for(int iter = 0; iter < number_hot_calls; iter++)
+        {
+            func(handle, N, dx, incx, stridex, batch_count, hr2);
+        }
+
+        gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
+
+        std::cout << "N,incx,stridex,batch_count,rocblas(us)";
+
+        if(arg.norm_check)
+            std::cout << ",CPU(us),error_host_ptr,error_dev_ptr";
+
+        std::cout << std::endl;
+        std::cout << N << "," << incx << "," << stridex << "," << batch_count << ","
+                  << gpu_time_used;
+
+        if(arg.norm_check)
+            std::cout << "," << cpu_time_used << "," << rocblas_error_1 << "," << rocblas_error_2;
+
+        std::cout << std::endl;
+    }
+}

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1368,8 +1368,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_dznrm2_strided_batched(rocblas_handle     
 /*! \brief BLAS Level 1 API
 
     \details
-    amax finds the first index of the element of maximum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+    amax finds the first index of the element of maximum magnitude of a vector x.
    vector
 
     @param[in]
@@ -1409,8 +1408,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamax(rocblas_handle                handl
 /*! \brief BLAS Level 1 API
 
     \details
-     amax_batched finds over a batch of vectors the first index of the element of maximum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+     amax_batched finds over a batch of vectors the first index of the element of maximum magnitude of a  vector x.
 
     @param[in]
     handle    rocblas_handle.
@@ -1463,8 +1461,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamax_batched(rocblas_handle             
 /*! \brief BLAS Level 1 API
 
     \details
-     amax_strided_batched finds over a strided batch of vectors the first index of the element of maximum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+     amax_strided_batched finds over a strided batch of vectors the first index of the element of maximum magnitude of a vector x.
 
     @param[in]
     handle    rocblas_handle.
@@ -1478,7 +1475,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamax_batched(rocblas_handle             
     incx      rocblas_int
               specifies the increment for the elements of each x_i. incx must be > 0.
     @param[in]
-    stridex   rocbla_stride
+    stridex   rocblas_stride
               specifies the pointer increment between batches for x. 
     @param[in]
     batch_count rocblas_int
@@ -1525,8 +1522,8 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamax_strided_batched(rocblas_handle     
 /*! \brief BLAS Level 1 API
 
     \details
-    amin finds the first index of the element of minimum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+    amin finds the first index of the element of minimum magnitude of a vector x.
+
    vector
 
     @param[in]
@@ -1566,8 +1563,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamin(rocblas_handle                handl
 /*! \brief BLAS Level 1 API
 
     \details
-    amin_batched finds over a batch of vectors the first index of the element of minimum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+    amin_batched finds over a batch of vectors the first index of the element of minimum magnitude of a vector x.
 
     @param[in]
     handle    rocblas_handle.
@@ -1620,8 +1616,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamin_batched(rocblas_handle             
 /*! \brief BLAS Level 1 API
 
     \details
-     amin_strided_batched finds over a strided batch of vectors the first index of the element of minimum magnitude of real vector x
-         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+     amin_strided_batched finds over a strided batch of vectors the first index of the element of minimum magnitude of a vector x.
 
     @param[in]
     handle    rocblas_handle.
@@ -1635,7 +1630,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamin_batched(rocblas_handle             
     incx      rocblas_int
               specifies the increment for the elements of each x_i. incx must be > 0.
     @param[in]
-    stridex   rocbla_stride
+    stridex   rocblas_stride
               specifies the pointer increment between batches for x. 
     @param[in]
     batch_count rocblas_int

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -1409,6 +1409,122 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamax(rocblas_handle                handl
 /*! \brief BLAS Level 1 API
 
     \details
+     amax_batched finds over a batch of vectors the first index of the element of maximum magnitude of real vector x
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    n         rocblas_int
+              number of elements in each vector x_i
+    @param[in]
+    x         array of pointers storing the different vector x_i on the GPU.
+    @param[in]
+    incx      rocblas_int
+              specifies the increment for the elements of each x_i. incx must be > 0.
+    @param[in]
+    batch_count rocblas_int
+              number of instances in the batch, must be > 0.
+    @param[out]
+    result
+              pointers to array of batch_count size for results. either on the host CPU or device GPU.
+              return is 0 if n, incx<=0.
+    ********************************************************************/
+
+ROCBLAS_EXPORT rocblas_status rocblas_isamax_batched(rocblas_handle     handle,
+                                                     rocblas_int        n,
+                                                     const float* const x[],
+                                                     rocblas_int        incx,
+                                                     rocblas_int        batch_count,
+                                                     rocblas_int*       result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_idamax_batched(rocblas_handle      handle,
+                                                     rocblas_int         n,
+                                                     const double* const x[],
+                                                     rocblas_int         incx,
+                                                     rocblas_int         batch_count,
+                                                     rocblas_int*        result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_icamax_batched(rocblas_handle                     handle,
+                                                     rocblas_int                        n,
+                                                     const rocblas_float_complex* const x[],
+                                                     rocblas_int                        incx,
+                                                     rocblas_int                        batch_count,
+                                                     rocblas_int*                       result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_izamax_batched(rocblas_handle                      handle,
+                                                     rocblas_int                         n,
+                                                     const rocblas_double_complex* const x[],
+                                                     rocblas_int                         incx,
+                                                     rocblas_int  batch_count,
+                                                     rocblas_int* result);
+
+/*! \brief BLAS Level 1 API
+
+    \details
+     amax_strided_batched finds over a strided batch of vectors the first index of the element of maximum magnitude of real vector x
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    n         rocblas_int
+              number of elements in each vector x_i
+    @param[in]
+    x         pointer to the first vector x_i on the GPU.
+    @param[in]
+    incx      rocblas_int
+              specifies the increment for the elements of each x_i. incx must be > 0.
+    @param[in]
+    stridex   rocbla_stride
+              specifies the pointer increment between batches for x. 
+    @param[in]
+    batch_count rocblas_int
+              number of instances in the batch
+    @param[out]
+    results
+              pointer to array for storing contiguous batch_count results. either on the host CPU or device GPU.
+              return is 0 if n <= 0, incx<=0.
+
+    ********************************************************************/
+
+ROCBLAS_EXPORT rocblas_status rocblas_isamax_strided_batched(rocblas_handle handle,
+                                                             rocblas_int    n,
+                                                             const float*   x,
+                                                             rocblas_int    incx,
+                                                             rocblas_stride stridex,
+                                                             rocblas_int    batch_count,
+                                                             rocblas_int*   result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_idamax_strided_batched(rocblas_handle handle,
+                                                             rocblas_int    n,
+                                                             const double*  x,
+                                                             rocblas_int    incx,
+                                                             rocblas_stride stridex,
+                                                             rocblas_int    batch_count,
+                                                             rocblas_int*   result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_icamax_strided_batched(rocblas_handle               handle,
+                                                             rocblas_int                  n,
+                                                             const rocblas_float_complex* x,
+                                                             rocblas_int                  incx,
+                                                             rocblas_stride               stridex,
+                                                             rocblas_int  batch_count,
+                                                             rocblas_int* result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_izamax_strided_batched(rocblas_handle                handle,
+                                                             rocblas_int                   n,
+                                                             const rocblas_double_complex* x,
+                                                             rocblas_int                   incx,
+                                                             rocblas_stride                stridex,
+                                                             rocblas_int  batch_count,
+                                                             rocblas_int* result);
+
+/*! \brief BLAS Level 1 API
+
+    \details
     amin finds the first index of the element of minimum magnitude of real vector x
          or the sum of magnitude of the real and imaginary parts of elements if x is a complex
    vector
@@ -1446,6 +1562,122 @@ ROCBLAS_EXPORT rocblas_status rocblas_izamin(rocblas_handle                handl
                                              const rocblas_double_complex* x,
                                              rocblas_int                   incx,
                                              rocblas_int*                  result);
+
+/*! \brief BLAS Level 1 API
+
+    \details
+    amin_batched finds over a batch of vectors the first index of the element of minimum magnitude of real vector x
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    n         rocblas_int
+              number of elements in each vector x_i
+    @param[in]
+    x         array of pointers storing the different vector x_i on the GPU.
+    @param[in]
+    incx      rocblas_int
+              specifies the increment for the elements of each x_i. incx must be > 0.
+    @param[in]
+    batch_count rocblas_int
+              number of instances in the batch, must be > 0.
+    @param[out]
+    result
+              pointers to array of batch_count size for results. either on the host CPU or device GPU.
+              return is 0 if n, incx<=0.
+    ********************************************************************/
+
+ROCBLAS_EXPORT rocblas_status rocblas_isamin_batched(rocblas_handle     handle,
+                                                     rocblas_int        n,
+                                                     const float* const x[],
+                                                     rocblas_int        incx,
+                                                     rocblas_int        batch_count,
+                                                     rocblas_int*       result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_idamin_batched(rocblas_handle      handle,
+                                                     rocblas_int         n,
+                                                     const double* const x[],
+                                                     rocblas_int         incx,
+                                                     rocblas_int         batch_count,
+                                                     rocblas_int*        result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_icamin_batched(rocblas_handle                     handle,
+                                                     rocblas_int                        n,
+                                                     const rocblas_float_complex* const x[],
+                                                     rocblas_int                        incx,
+                                                     rocblas_int                        batch_count,
+                                                     rocblas_int*                       result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_izamin_batched(rocblas_handle                      handle,
+                                                     rocblas_int                         n,
+                                                     const rocblas_double_complex* const x[],
+                                                     rocblas_int                         incx,
+                                                     rocblas_int  batch_count,
+                                                     rocblas_int* result);
+
+/*! \brief BLAS Level 1 API
+
+    \details
+     amin_strided_batched finds over a strided batch of vectors the first index of the element of minimum magnitude of real vector x
+         or the sum of magnitude of the real and imaginary parts of elements if x is a complex
+
+    @param[in]
+    handle    rocblas_handle.
+              handle to the rocblas library context queue.
+    @param[in]
+    n         rocblas_int
+              number of elements in each vector x_i
+    @param[in]
+    x         pointer to the first vector x_i on the GPU.
+    @param[in]
+    incx      rocblas_int
+              specifies the increment for the elements of each x_i. incx must be > 0.
+    @param[in]
+    stridex   rocbla_stride
+              specifies the pointer increment between batches for x. 
+    @param[in]
+    batch_count rocblas_int
+              number of instances in the batch
+    @param[out]
+    results
+              pointer to array for storing contiguous batch_count results. either on the host CPU or device GPU.
+              return is 0 if n <= 0, incx<=0.
+
+    ********************************************************************/
+
+ROCBLAS_EXPORT rocblas_status rocblas_isamin_strided_batched(rocblas_handle handle,
+                                                             rocblas_int    n,
+                                                             const float*   x,
+                                                             rocblas_int    incx,
+                                                             rocblas_stride stridex,
+                                                             rocblas_int    batch_count,
+                                                             rocblas_int*   result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_idamin_strided_batched(rocblas_handle handle,
+                                                             rocblas_int    n,
+                                                             const double*  x,
+                                                             rocblas_int    incx,
+                                                             rocblas_stride stridex,
+                                                             rocblas_int    batch_count,
+                                                             rocblas_int*   result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_icamin_strided_batched(rocblas_handle               handle,
+                                                             rocblas_int                  n,
+                                                             const rocblas_float_complex* x,
+                                                             rocblas_int                  incx,
+                                                             rocblas_stride               stridex,
+                                                             rocblas_int  batch_count,
+                                                             rocblas_int* result);
+
+ROCBLAS_EXPORT rocblas_status rocblas_izamin_strided_batched(rocblas_handle                handle,
+                                                             rocblas_int                   n,
+                                                             const rocblas_double_complex* x,
+                                                             rocblas_int                   incx,
+                                                             rocblas_stride                stridex,
+                                                             rocblas_int  batch_count,
+                                                             rocblas_int* result);
 
 /*! \brief BLAS Level 1 API
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -137,8 +137,12 @@ set( rocblas_auxiliary_source
 )
 
 set( rocblas_blas1_source
-  blas1/rocblas_amin.cpp
-  blas1/rocblas_amax.cpp
+  blas1/rocblas_iamin.cpp
+  blas1/rocblas_iamin_batched.cpp
+  blas1/rocblas_iamin_strided_batched.cpp
+  blas1/rocblas_iamax.cpp
+  blas1/rocblas_iamax_batched.cpp
+  blas1/rocblas_iamax_strided_batched.cpp
   blas1/rocblas_asum.cpp
   blas1/rocblas_asum_batched.cpp
   blas1/rocblas_asum_strided_batched.cpp

--- a/library/src/blas1/reduction_strided_batched.h
+++ b/library/src/blas1/reduction_strided_batched.h
@@ -170,6 +170,8 @@ size_t rocblas_reduction_kernel_workspace_size(rocblas_int n, rocblas_int batch_
 {
     if(n <= 0)
         n = 1; // allow for return value of empty set
+    if(batch_count <= 0)
+        batch_count = 1;
     auto blocks = rocblas_reduction_kernel_block_count(n, NB);
     return sizeof(To) * (blocks + 1) * batch_count;
 }

--- a/library/src/blas1/rocblas_amax.cpp
+++ b/library/src/blas1/rocblas_amax.cpp
@@ -1,6 +1,0 @@
-/* ************************************************************************
- * Copyright 2018-2019 Advanced Micro Devices, Inc.
- * ************************************************************************ */
-#define MAX_MIN max
-#define AMAX_AMIN_REDUCTION rocblas_reduce_amax
-#include "rocblas_amax_amin.h"

--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -2,6 +2,8 @@
  * Copyright 2018-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
+#include "rocblas_reduction_template.hpp"
+
 //!
 //! @brief Struct to define pair of value and index.
 //!

--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -34,7 +34,7 @@ struct rocblas_default_value<index_value_t<T>>
 //! @brief Struct-operator to fetch absolute value
 //!
 template <typename To>
-struct rocblas_fetch_index_value
+struct rocblas_fetch_amax_amin
 {
     template <typename Ti>
     __forceinline__ __host__ __device__ index_value_t<To> operator()(Ti x, rocblas_int index)
@@ -46,7 +46,7 @@ struct rocblas_fetch_index_value
 //!
 //! @brief Struct-operator to finalize the data.
 //!
-struct rocblas_finalize_index_value
+struct rocblas_finalize_amax_amin
 {
     template <typename To>
     __forceinline__ __host__ __device__ auto operator()(const index_value_t<To>& x)

--- a/library/src/blas1/rocblas_amax_amin.h
+++ b/library/src/blas1/rocblas_amax_amin.h
@@ -2,32 +2,21 @@
  * Copyright 2018-2019 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#include "rocblas_reduction_impl.hpp"
-
-#ifndef MAX_MIN
-#define MAX_MIN max
-#endif
-
-#ifndef AMAX_AMIN_REDUCTION
-#define AMAX_AMIN_REDUCTION rocblas_reduce_amax
-#endif
-
-#define QUOTE2(S) #S
-#define QUOTE(S) QUOTE2(S)
-
-#define JOIN2(A, B) A##B
-#define JOIN(A, B) JOIN2(A, B)
-
-// pair of value and index
+//!
+//! @brief Struct to define pair of value and index.
+//!
 template <typename T>
 struct index_value_t
 {
-    // important: index must come first, so that index_value_t* can be cast to rocblas_int*
+    //! @brief Important: index must come first, so that index_value_t* can be cast to rocblas_int*
     rocblas_int index;
-    T           value;
+    //! @brief The value.
+    T value;
 };
 
-// Specialization of default_value for index_value_t<T>
+//!
+//! @brief Struct-operator a default_value of index_value_t<T>
+//!
 template <typename T>
 struct rocblas_default_value<index_value_t<T>>
 {
@@ -39,9 +28,11 @@ struct rocblas_default_value<index_value_t<T>>
     }
 };
 
-// Fetch absolute value
+//!
+//! @brief Struct-operator to fetch absolute value
+//!
 template <typename To>
-struct rocblas_fetch_amax_amin
+struct rocblas_fetch_index_value
 {
     template <typename Ti>
     __forceinline__ __host__ __device__ index_value_t<To> operator()(Ti x, rocblas_int index)
@@ -50,43 +41,10 @@ struct rocblas_fetch_amax_amin
     }
 };
 
-// Replaces x with y if y.value < x.value or y.value == x.value and y.index < x.index
-struct rocblas_reduce_amax
-{
-    template <typename To>
-    __forceinline__ __host__ __device__ void operator()(index_value_t<To>& __restrict__ x,
-                                                        const index_value_t<To>& __restrict__ y)
-    {
-        // If y.index == -1 then y.value is invalid and should not be compared
-        if(y.index != -1)
-        {
-            if(x.index == -1 || y.value > x.value)
-                x = y; // if larger or smaller, update max/min and index
-            else if(y.index < x.index && x.value == y.value)
-                x.index = y.index; // if equal, choose smaller index
-        }
-    }
-};
-
-// Replaces x with y if y.value < x.value or y.value == x.value and y.index < x.index
-struct rocblas_reduce_amin
-{
-    template <typename To>
-    __forceinline__ __host__ __device__ void operator()(index_value_t<To>& __restrict__ x,
-                                                        const index_value_t<To>& __restrict__ y)
-    {
-        // If y.index == -1 then y.value is invalid and should not be compared
-        if(y.index != -1)
-        {
-            if(x.index == -1 || y.value < x.value)
-                x = y; // if larger or smaller, update max/min and index
-            else if(y.index < x.index && x.value == y.value)
-                x.index = y.index; // if equal, choose smaller index
-        }
-    }
-};
-
-struct rocblas_finalize_amax_amin
+//!
+//! @brief Struct-operator to finalize the data.
+//!
+struct rocblas_finalize_index_value
 {
     template <typename To>
     __forceinline__ __host__ __device__ auto operator()(const index_value_t<To>& x)
@@ -94,73 +52,3 @@ struct rocblas_finalize_amax_amin
         return x.index + 1;
     }
 };
-
-template <typename>
-static constexpr char rocblas_iamaxmin_name[] = "unknown";
-template <>
-static constexpr char rocblas_iamaxmin_name<float>[] = "rocblas_isa" QUOTE(MAX_MIN);
-template <>
-static constexpr char rocblas_iamaxmin_name<double>[] = "rocblas_ida" QUOTE(MAX_MIN);
-template <>
-static constexpr char rocblas_iamaxmin_name<rocblas_float_complex>[] = "rocblas_ica" QUOTE(MAX_MIN);
-template <>
-static constexpr char rocblas_iamaxmin_name<rocblas_double_complex>[]
-    = "rocblas_iza" QUOTE(MAX_MIN);
-
-// allocate workspace inside this API
-template <typename To, typename Ti>
-static rocblas_status rocblas_iamaxmin(
-    rocblas_handle handle, rocblas_int n, const Ti* x, rocblas_int incx, rocblas_int* result)
-{
-
-    static constexpr bool           isbatched     = false;
-    static constexpr rocblas_stride stridex_0     = 0;
-    static constexpr rocblas_int    batch_count_1 = 1;
-    static constexpr int            NB            = 1024;
-
-    return rocblas_reduction_impl<NB,
-                                  isbatched,
-                                  rocblas_fetch_amax_amin<To>,
-                                  AMAX_AMIN_REDUCTION,
-                                  rocblas_finalize_amax_amin,
-                                  index_value_t<To>>(handle,
-                                                     n,
-                                                     x,
-                                                     incx,
-                                                     stridex_0,
-                                                     batch_count_1,
-                                                     result,
-                                                     rocblas_iamaxmin_name<Ti>,
-                                                     "ia" QUOTE(MAX_MIN));
-}
-
-/*
- * ===========================================================================
- *    C wrapper
- * ===========================================================================
- */
-
-extern "C" {
-
-#ifdef IMPL
-#error IMPL IS ALREADY DEFINED
-#endif
-
-#define IMPL(name_, typei_, typew_)                                   \
-    rocblas_status name_(rocblas_handle handle,                       \
-                         rocblas_int    n,                            \
-                         const typei_*  x,                            \
-                         rocblas_int    incx,                         \
-                         rocblas_int*   results)                      \
-    {                                                                 \
-        return rocblas_iamaxmin<typew_>(handle, n, x, incx, results); \
-    }
-
-IMPL(JOIN(rocblas_isa, MAX_MIN), float, float);
-IMPL(JOIN(rocblas_ida, MAX_MIN), double, double);
-IMPL(JOIN(rocblas_ica, MAX_MIN), rocblas_float_complex, float);
-IMPL(JOIN(rocblas_iza, MAX_MIN), rocblas_double_complex, double);
-
-#undef IMPL
-
-} // extern "C"

--- a/library/src/blas1/rocblas_amin.cpp
+++ b/library/src/blas1/rocblas_amin.cpp
@@ -1,6 +1,0 @@
-/* ************************************************************************
- * Copyright 2018-2019 Advanced Micro Devices, Inc.
- * ************************************************************************ */
-#define MAX_MIN min
-#define AMAX_AMIN_REDUCTION rocblas_reduce_amin
-#include "rocblas_amax_amin.h"

--- a/library/src/blas1/rocblas_iamax.cpp
+++ b/library/src/blas1/rocblas_iamax.cpp
@@ -30,9 +30,9 @@ namespace
 
         return rocblas_reduction_impl<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amax,
-                                      rocblas_finalize_index_value,
+                                      rocblas_finalize_amax_amin,
                                       index_value_t<S>>(
             handle, n, x, incx, stridex_0, batch_count_1, result, rocblas_iamax_name<T>, "iamax");
     }

--- a/library/src/blas1/rocblas_iamax.cpp
+++ b/library/src/blas1/rocblas_iamax.cpp
@@ -1,0 +1,71 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblas_iamax.hpp"
+#include "rocblas_reduction_impl.hpp"
+
+namespace
+{
+    template <typename>
+    static constexpr char rocblas_iamax_name[] = "unknown";
+    template <>
+    static constexpr char rocblas_iamax_name<float>[] = "rocblas_isamax";
+    template <>
+    static constexpr char rocblas_iamax_name<double>[] = "rocblas_idamax";
+    template <>
+    static constexpr char rocblas_iamax_name<rocblas_float_complex>[] = "rocblas_icamax";
+    template <>
+    static constexpr char rocblas_iamax_name<rocblas_double_complex>[] = "rocblas_izamax";
+
+    // allocate workspace inside this API
+    template <typename S, typename T>
+    static rocblas_status rocblas_iamax_impl(
+        rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result)
+    {
+        static constexpr bool           isbatched     = false;
+        static constexpr rocblas_stride stridex_0     = 0;
+        static constexpr rocblas_int    batch_count_1 = 1;
+        static constexpr int            NB            = 1024;
+
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amax,
+                                      rocblas_finalize_index_value,
+                                      index_value_t<S>>(
+            handle, n, x, incx, stridex_0, batch_count_1, result, rocblas_iamax_name<T>, "iamax");
+    }
+
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
+
+#define IMPL(name_, typei_, typew_)                                     \
+    rocblas_status name_(rocblas_handle handle,                         \
+                         rocblas_int    n,                              \
+                         const typei_*  x,                              \
+                         rocblas_int    incx,                           \
+                         rocblas_int*   results)                        \
+    {                                                                   \
+        return rocblas_iamax_impl<typew_>(handle, n, x, incx, results); \
+    }
+
+IMPL(rocblas_isamax, float, float);
+IMPL(rocblas_idamax, double, double);
+IMPL(rocblas_icamax, rocblas_float_complex, float);
+IMPL(rocblas_izamax, rocblas_double_complex, double);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas1/rocblas_iamax.cpp
+++ b/library/src/blas1/rocblas_iamax.cpp
@@ -8,19 +8,19 @@
 namespace
 {
     template <typename>
-    static constexpr char rocblas_iamax_name[] = "unknown";
+    constexpr char rocblas_iamax_name[] = "unknown";
     template <>
-    static constexpr char rocblas_iamax_name<float>[] = "rocblas_isamax";
+    constexpr char rocblas_iamax_name<float>[] = "rocblas_isamax";
     template <>
-    static constexpr char rocblas_iamax_name<double>[] = "rocblas_idamax";
+    constexpr char rocblas_iamax_name<double>[] = "rocblas_idamax";
     template <>
-    static constexpr char rocblas_iamax_name<rocblas_float_complex>[] = "rocblas_icamax";
+    constexpr char rocblas_iamax_name<rocblas_float_complex>[] = "rocblas_icamax";
     template <>
-    static constexpr char rocblas_iamax_name<rocblas_double_complex>[] = "rocblas_izamax";
+    constexpr char rocblas_iamax_name<rocblas_double_complex>[] = "rocblas_izamax";
 
     // allocate workspace inside this API
     template <typename S, typename T>
-    static rocblas_status rocblas_iamax_impl(
+    rocblas_status rocblas_iamax_impl(
         rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result)
     {
         static constexpr bool           isbatched     = false;

--- a/library/src/blas1/rocblas_iamax.hpp
+++ b/library/src/blas1/rocblas_iamax.hpp
@@ -1,0 +1,45 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "rocblas_reduction_template.hpp"
+#include "rocblas_amax_amin.h"
+
+// Replaces x with y if y.value < x.value or y.value == x.value and y.index < x.index
+struct rocblas_reduce_amax
+{
+    template <typename To>
+    __forceinline__ __host__ __device__ void operator()(index_value_t<To>& __restrict__ x,
+                                                        const index_value_t<To>& __restrict__ y)
+    {
+        // If y.index == -1 then y.value is invalid and should not be compared
+        if(y.index != -1)
+        {
+            if(x.index == -1 || y.value > x.value)
+                x = y; // if larger or smaller, update max/min and index
+            else if(y.index < x.index && x.value == y.value)
+                x.index = y.index; // if equal, choose smaller index
+        }
+    }
+};
+
+template <rocblas_int NB, typename T, typename S>
+rocblas_status rocblas_iamax_template(rocblas_handle    handle,
+                                      rocblas_int       n,
+                                      const T*          x,
+                                      rocblas_int       shiftx,
+                                      rocblas_int       incx,
+                                      rocblas_int*      result,
+                                      index_value_t<S>* workspace)
+{
+    static constexpr bool           isbatched     = false;
+    static constexpr rocblas_stride stridex_0     = 0;
+    static constexpr rocblas_int    batch_count_1 = 1;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amax,
+                                      rocblas_finalize_index_value>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count_1, result, workspace);
+}

--- a/library/src/blas1/rocblas_iamax.hpp
+++ b/library/src/blas1/rocblas_iamax.hpp
@@ -3,7 +3,6 @@
  * ************************************************************************ */
 #pragma once
 
-#include "rocblas_reduction_template.hpp"
 #include "rocblas_amax_amin.h"
 
 // Replaces x with y if y.value < x.value or y.value == x.value and y.index < x.index

--- a/library/src/blas1/rocblas_iamax.hpp
+++ b/library/src/blas1/rocblas_iamax.hpp
@@ -37,8 +37,8 @@ rocblas_status rocblas_iamax_template(rocblas_handle    handle,
     static constexpr rocblas_int    batch_count_1 = 1;
     return rocblas_reduction_template<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amax,
-                                      rocblas_finalize_index_value>(
+                                      rocblas_finalize_amax_amin>(
         handle, n, x, shiftx, incx, stridex_0, batch_count_1, result, workspace);
 }

--- a/library/src/blas1/rocblas_iamax_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_batched.cpp
@@ -33,9 +33,9 @@ namespace
 
         return rocblas_reduction_impl<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amax,
-                                      rocblas_finalize_index_value,
+                                      rocblas_finalize_amax_amin,
                                       index_value_t<S>>(handle,
                                                         n,
                                                         x,

--- a/library/src/blas1/rocblas_iamax_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_batched.cpp
@@ -8,26 +8,24 @@
 namespace
 {
     template <typename>
-    static constexpr char rocblas_iamax_batched_name[] = "unknown";
+    constexpr char rocblas_iamax_batched_name[] = "unknown";
     template <>
-    static constexpr char rocblas_iamax_batched_name<float>[] = "rocblas_isamax_batched";
+    constexpr char rocblas_iamax_batched_name<float>[] = "rocblas_isamax_batched";
     template <>
-    static constexpr char rocblas_iamax_batched_name<double>[] = "rocblas_idamax_batched";
+    constexpr char rocblas_iamax_batched_name<double>[] = "rocblas_idamax_batched";
     template <>
-    static constexpr char rocblas_iamax_batched_name<rocblas_float_complex>[]
-        = "rocblas_icamax_batched";
+    constexpr char rocblas_iamax_batched_name<rocblas_float_complex>[] = "rocblas_icamax_batched";
     template <>
-    static constexpr char rocblas_iamax_batched_name<rocblas_double_complex>[]
-        = "rocblas_izamax_batched";
+    constexpr char rocblas_iamax_batched_name<rocblas_double_complex>[] = "rocblas_izamax_batched";
 
     // allocate workspace inside this API
     template <typename S, typename T>
-    static rocblas_status rocblas_iamax_batched_impl(rocblas_handle  handle,
-                                                     rocblas_int     n,
-                                                     const T* const* x,
-                                                     rocblas_int     incx,
-                                                     rocblas_int     batch_count,
-                                                     rocblas_int*    result)
+    rocblas_status rocblas_iamax_batched_impl(rocblas_handle  handle,
+                                              rocblas_int     n,
+                                              const T* const* x,
+                                              rocblas_int     incx,
+                                              rocblas_int     batch_count,
+                                              rocblas_int*    result)
     {
         static constexpr bool           isbatched = true;
         static constexpr int            NB        = 1024;

--- a/library/src/blas1/rocblas_iamax_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_batched.cpp
@@ -1,0 +1,84 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblas_iamax_batched.hpp"
+#include "rocblas_reduction_impl.hpp"
+
+namespace
+{
+    template <typename>
+    static constexpr char rocblas_iamax_batched_name[] = "unknown";
+    template <>
+    static constexpr char rocblas_iamax_batched_name<float>[] = "rocblas_isamax_batched";
+    template <>
+    static constexpr char rocblas_iamax_batched_name<double>[] = "rocblas_idamax_batched";
+    template <>
+    static constexpr char rocblas_iamax_batched_name<rocblas_float_complex>[]
+        = "rocblas_icamax_batched";
+    template <>
+    static constexpr char rocblas_iamax_batched_name<rocblas_double_complex>[]
+        = "rocblas_izamax_batched";
+
+    // allocate workspace inside this API
+    template <typename S, typename T>
+    static rocblas_status rocblas_iamax_batched_impl(rocblas_handle  handle,
+                                                     rocblas_int     n,
+                                                     const T* const* x,
+                                                     rocblas_int     incx,
+                                                     rocblas_int     batch_count,
+                                                     rocblas_int*    result)
+    {
+        static constexpr bool           isbatched = true;
+        static constexpr int            NB        = 1024;
+        static constexpr rocblas_stride stridex_0 = 0;
+
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amax,
+                                      rocblas_finalize_index_value,
+                                      index_value_t<S>>(handle,
+                                                        n,
+                                                        x,
+                                                        incx,
+                                                        stridex_0,
+                                                        batch_count,
+                                                        result,
+                                                        rocblas_iamax_batched_name<T>,
+                                                        "iamax_batched");
+    }
+
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
+
+#define IMPL(name_routine_, T_, S_)                                                      \
+    rocblas_status name_routine_(rocblas_handle   handle,                                \
+                                 rocblas_int      n,                                     \
+                                 const T_* const* x,                                     \
+                                 rocblas_int      incx,                                  \
+                                 rocblas_int      batch_count,                           \
+                                 rocblas_int*     results)                               \
+    {                                                                                    \
+        return rocblas_iamax_batched_impl<S_>(handle, n, x, incx, batch_count, results); \
+    }
+
+IMPL(rocblas_isamax_batched, float, float);
+IMPL(rocblas_idamax_batched, double, double);
+IMPL(rocblas_icamax_batched, rocblas_float_complex, float);
+IMPL(rocblas_izamax_batched, rocblas_double_complex, double);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas1/rocblas_iamax_batched.hpp
+++ b/library/src/blas1/rocblas_iamax_batched.hpp
@@ -19,8 +19,8 @@ rocblas_status rocblas_iamax_batched_template(rocblas_handle    handle,
     static constexpr rocblas_stride stridex_0 = 0;
     return rocblas_reduction_template<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amax,
-                                      rocblas_finalize_index_value>(
+                                      rocblas_finalize_amax_amin>(
         handle, n, x, shiftx, incx, stridex_0, batch_count, result, workspace);
 }

--- a/library/src/blas1/rocblas_iamax_batched.hpp
+++ b/library/src/blas1/rocblas_iamax_batched.hpp
@@ -1,0 +1,26 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "rocblas_iamax.hpp"
+
+template <rocblas_int NB, typename T, typename S>
+rocblas_status rocblas_iamax_batched_template(rocblas_handle    handle,
+                                              rocblas_int       n,
+                                              const T* const*   x,
+                                              rocblas_int       shiftx,
+                                              rocblas_int       incx,
+                                              rocblas_int       batch_count,
+                                              rocblas_int*      result,
+                                              index_value_t<S>* workspace)
+{
+    static constexpr bool           isbatched = true;
+    static constexpr rocblas_stride stridex_0 = 0;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amax,
+                                      rocblas_finalize_index_value>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count, result, workspace);
+}

--- a/library/src/blas1/rocblas_iamax_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_strided_batched.cpp
@@ -1,0 +1,88 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblas_iamax_strided_batched.hpp"
+#include "rocblas_reduction_impl.hpp"
+
+namespace
+{
+    template <typename>
+    static constexpr char rocblas_iamax_strided_batched_name[] = "unknown";
+    template <>
+    static constexpr char rocblas_iamax_strided_batched_name<float>[]
+        = "rocblas_isamax_strided_batched";
+    template <>
+    static constexpr char rocblas_iamax_strided_batched_name<double>[]
+        = "rocblas_idamax_strided_batched";
+    template <>
+    static constexpr char rocblas_iamax_strided_batched_name<rocblas_float_complex>[]
+        = "rocblas_icamax_strided_batched";
+    template <>
+    static constexpr char rocblas_iamax_strided_batched_name<rocblas_double_complex>[]
+        = "rocblas_izamax_strided_batched";
+
+    // allocate workspace inside this API
+    template <typename S, typename T>
+    static rocblas_status rocblas_iamax_strided_batched_impl(rocblas_handle handle,
+                                                             rocblas_int    n,
+                                                             const T*       x,
+                                                             rocblas_int    incx,
+                                                             rocblas_stride stridex,
+                                                             rocblas_int    batch_count,
+                                                             rocblas_int*   result)
+    {
+        static constexpr bool isbatched = true;
+        static constexpr int  NB        = 1024;
+
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amax,
+                                      rocblas_finalize_index_value,
+                                      index_value_t<S>>(handle,
+                                                        n,
+                                                        x,
+                                                        incx,
+                                                        stridex,
+                                                        batch_count,
+                                                        result,
+                                                        rocblas_iamax_strided_batched_name<T>,
+                                                        "iamax_strided_batched");
+    }
+
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
+
+#define IMPL(name_routine_, T_, S_)                             \
+    rocblas_status name_routine_(rocblas_handle handle,         \
+                                 rocblas_int    n,              \
+                                 const T_*      x,              \
+                                 rocblas_int    incx,           \
+                                 rocblas_stride stridex,        \
+                                 rocblas_int    batch_count,    \
+                                 rocblas_int*   results)        \
+    {                                                           \
+        return rocblas_iamax_strided_batched_impl<S_>(          \
+            handle, n, x, incx, stridex, batch_count, results); \
+    }
+
+IMPL(rocblas_isamax_strided_batched, float, float);
+IMPL(rocblas_idamax_strided_batched, double, double);
+IMPL(rocblas_icamax_strided_batched, rocblas_float_complex, float);
+IMPL(rocblas_izamax_strided_batched, rocblas_double_complex, double);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas1/rocblas_iamax_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_strided_batched.cpp
@@ -8,29 +8,27 @@
 namespace
 {
     template <typename>
-    static constexpr char rocblas_iamax_strided_batched_name[] = "unknown";
+    constexpr char rocblas_iamax_strided_batched_name[] = "unknown";
     template <>
-    static constexpr char rocblas_iamax_strided_batched_name<float>[]
-        = "rocblas_isamax_strided_batched";
+    constexpr char rocblas_iamax_strided_batched_name<float>[] = "rocblas_isamax_strided_batched";
     template <>
-    static constexpr char rocblas_iamax_strided_batched_name<double>[]
-        = "rocblas_idamax_strided_batched";
+    constexpr char rocblas_iamax_strided_batched_name<double>[] = "rocblas_idamax_strided_batched";
     template <>
-    static constexpr char rocblas_iamax_strided_batched_name<rocblas_float_complex>[]
+    constexpr char rocblas_iamax_strided_batched_name<rocblas_float_complex>[]
         = "rocblas_icamax_strided_batched";
     template <>
-    static constexpr char rocblas_iamax_strided_batched_name<rocblas_double_complex>[]
+    constexpr char rocblas_iamax_strided_batched_name<rocblas_double_complex>[]
         = "rocblas_izamax_strided_batched";
 
     // allocate workspace inside this API
     template <typename S, typename T>
-    static rocblas_status rocblas_iamax_strided_batched_impl(rocblas_handle handle,
-                                                             rocblas_int    n,
-                                                             const T*       x,
-                                                             rocblas_int    incx,
-                                                             rocblas_stride stridex,
-                                                             rocblas_int    batch_count,
-                                                             rocblas_int*   result)
+    rocblas_status rocblas_iamax_strided_batched_impl(rocblas_handle handle,
+                                                      rocblas_int    n,
+                                                      const T*       x,
+                                                      rocblas_int    incx,
+                                                      rocblas_stride stridex,
+                                                      rocblas_int    batch_count,
+                                                      rocblas_int*   result)
     {
         static constexpr bool isbatched = true;
         static constexpr int  NB        = 1024;

--- a/library/src/blas1/rocblas_iamax_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_strided_batched.cpp
@@ -35,9 +35,9 @@ namespace
 
         return rocblas_reduction_impl<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amax,
-                                      rocblas_finalize_index_value,
+                                      rocblas_finalize_amax_amin,
                                       index_value_t<S>>(handle,
                                                         n,
                                                         x,

--- a/library/src/blas1/rocblas_iamax_strided_batched.hpp
+++ b/library/src/blas1/rocblas_iamax_strided_batched.hpp
@@ -1,0 +1,26 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "rocblas_iamax.hpp"
+
+template <rocblas_int NB, typename T, typename S>
+rocblas_status rocblas_iamax_strided_batched_template(rocblas_handle    handle,
+                                                      rocblas_int       n,
+                                                      const T* const*   x,
+                                                      rocblas_int       shiftx,
+                                                      rocblas_int       incx,
+                                                      rocblas_stride    stridex,
+                                                      rocblas_int       batch_count,
+                                                      rocblas_int*      result,
+                                                      index_value_t<S>* workspace)
+{
+    static constexpr bool isbatched = true;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amax,
+                                      rocblas_finalize_index_value>(
+        handle, n, x, shiftx, incx, stridex, batch_count, result, workspace);
+}

--- a/library/src/blas1/rocblas_iamax_strided_batched.hpp
+++ b/library/src/blas1/rocblas_iamax_strided_batched.hpp
@@ -19,8 +19,8 @@ rocblas_status rocblas_iamax_strided_batched_template(rocblas_handle    handle,
     static constexpr bool isbatched = true;
     return rocblas_reduction_template<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amax,
-                                      rocblas_finalize_index_value>(
+                                      rocblas_finalize_amax_amin>(
         handle, n, x, shiftx, incx, stridex, batch_count, result, workspace);
 }

--- a/library/src/blas1/rocblas_iamin.cpp
+++ b/library/src/blas1/rocblas_iamin.cpp
@@ -30,9 +30,9 @@ namespace
 
         return rocblas_reduction_impl<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amin,
-                                      rocblas_finalize_index_value,
+                                      rocblas_finalize_amax_amin,
                                       index_value_t<S>>(
             handle, n, x, incx, stridex_0, batch_count_1, result, rocblas_iamin_name<T>, "iamin");
     }

--- a/library/src/blas1/rocblas_iamin.cpp
+++ b/library/src/blas1/rocblas_iamin.cpp
@@ -1,0 +1,71 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblas_iamin.hpp"
+#include "rocblas_reduction_impl.hpp"
+
+namespace
+{
+    template <typename>
+    static constexpr char rocblas_iamin_name[] = "unknown";
+    template <>
+    static constexpr char rocblas_iamin_name<float>[] = "rocblas_isamin";
+    template <>
+    static constexpr char rocblas_iamin_name<double>[] = "rocblas_idamin";
+    template <>
+    static constexpr char rocblas_iamin_name<rocblas_float_complex>[] = "rocblas_icamin";
+    template <>
+    static constexpr char rocblas_iamin_name<rocblas_double_complex>[] = "rocblas_izamin";
+
+    // allocate workspace inside this API
+    template <typename S, typename T>
+    static rocblas_status rocblas_iamin_impl(
+        rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result)
+    {
+        static constexpr bool           isbatched     = false;
+        static constexpr rocblas_stride stridex_0     = 0;
+        static constexpr rocblas_int    batch_count_1 = 1;
+        static constexpr int            NB            = 1024;
+
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amin,
+                                      rocblas_finalize_index_value,
+                                      index_value_t<S>>(
+            handle, n, x, incx, stridex_0, batch_count_1, result, rocblas_iamin_name<T>, "iamin");
+    }
+
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
+
+#define IMPL(name_, typei_, typew_)                                     \
+    rocblas_status name_(rocblas_handle handle,                         \
+                         rocblas_int    n,                              \
+                         const typei_*  x,                              \
+                         rocblas_int    incx,                           \
+                         rocblas_int*   results)                        \
+    {                                                                   \
+        return rocblas_iamin_impl<typew_>(handle, n, x, incx, results); \
+    }
+
+IMPL(rocblas_isamin, float, float);
+IMPL(rocblas_idamin, double, double);
+IMPL(rocblas_icamin, rocblas_float_complex, float);
+IMPL(rocblas_izamin, rocblas_double_complex, double);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas1/rocblas_iamin.cpp
+++ b/library/src/blas1/rocblas_iamin.cpp
@@ -8,19 +8,19 @@
 namespace
 {
     template <typename>
-    static constexpr char rocblas_iamin_name[] = "unknown";
+    constexpr char rocblas_iamin_name[] = "unknown";
     template <>
-    static constexpr char rocblas_iamin_name<float>[] = "rocblas_isamin";
+    constexpr char rocblas_iamin_name<float>[] = "rocblas_isamin";
     template <>
-    static constexpr char rocblas_iamin_name<double>[] = "rocblas_idamin";
+    constexpr char rocblas_iamin_name<double>[] = "rocblas_idamin";
     template <>
-    static constexpr char rocblas_iamin_name<rocblas_float_complex>[] = "rocblas_icamin";
+    constexpr char rocblas_iamin_name<rocblas_float_complex>[] = "rocblas_icamin";
     template <>
-    static constexpr char rocblas_iamin_name<rocblas_double_complex>[] = "rocblas_izamin";
+    constexpr char rocblas_iamin_name<rocblas_double_complex>[] = "rocblas_izamin";
 
     // allocate workspace inside this API
     template <typename S, typename T>
-    static rocblas_status rocblas_iamin_impl(
+    rocblas_status rocblas_iamin_impl(
         rocblas_handle handle, rocblas_int n, const T* x, rocblas_int incx, rocblas_int* result)
     {
         static constexpr bool           isbatched     = false;

--- a/library/src/blas1/rocblas_iamin.hpp
+++ b/library/src/blas1/rocblas_iamin.hpp
@@ -3,7 +3,6 @@
  * ************************************************************************ */
 #pragma once
 
-#include "rocblas_reduction_template.hpp"
 #include "rocblas_amax_amin.h"
 
 // Replaces x with y if y.value < x.value or y.value == x.value and y.index < x.index

--- a/library/src/blas1/rocblas_iamin.hpp
+++ b/library/src/blas1/rocblas_iamin.hpp
@@ -37,8 +37,8 @@ rocblas_status rocblas_iamin_template(rocblas_handle    handle,
     static constexpr rocblas_int    batch_count_1 = 1;
     return rocblas_reduction_template<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amin,
-                                      rocblas_finalize_index_value>(
+                                      rocblas_finalize_amax_amin>(
         handle, n, x, shiftx, incx, stridex_0, batch_count_1, result, workspace);
 }

--- a/library/src/blas1/rocblas_iamin.hpp
+++ b/library/src/blas1/rocblas_iamin.hpp
@@ -1,0 +1,45 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "rocblas_reduction_template.hpp"
+#include "rocblas_amax_amin.h"
+
+// Replaces x with y if y.value < x.value or y.value == x.value and y.index < x.index
+struct rocblas_reduce_amin
+{
+    template <typename To>
+    __forceinline__ __host__ __device__ void operator()(index_value_t<To>& __restrict__ x,
+                                                        const index_value_t<To>& __restrict__ y)
+    {
+        // If y.index == -1 then y.value is invalid and should not be compared
+        if(y.index != -1)
+        {
+            if(x.index == -1 || y.value < x.value)
+                x = y; // if larger or smaller, update max/min and index
+            else if(y.index < x.index && x.value == y.value)
+                x.index = y.index; // if equal, choose smaller index
+        }
+    }
+};
+
+template <rocblas_int NB, typename T, typename S>
+rocblas_status rocblas_iamin_template(rocblas_handle    handle,
+                                      rocblas_int       n,
+                                      const T*          x,
+                                      rocblas_int       shiftx,
+                                      rocblas_int       incx,
+                                      rocblas_int*      result,
+                                      index_value_t<S>* workspace)
+{
+    static constexpr bool           isbatched     = false;
+    static constexpr rocblas_stride stridex_0     = 0;
+    static constexpr rocblas_int    batch_count_1 = 1;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amin,
+                                      rocblas_finalize_index_value>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count_1, result, workspace);
+}

--- a/library/src/blas1/rocblas_iamin_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_batched.cpp
@@ -1,0 +1,83 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblas_iamin_batched.hpp"
+#include "rocblas_reduction_impl.hpp"
+
+namespace
+{
+    template <typename>
+    static constexpr char rocblas_iamin_batched_name[] = "unknown";
+    template <>
+    static constexpr char rocblas_iamin_batched_name<float>[] = "rocblas_isamin_batched";
+    template <>
+    static constexpr char rocblas_iamin_batched_name<double>[] = "rocblas_idamin_batched";
+    template <>
+    static constexpr char rocblas_iamin_batched_name<rocblas_float_complex>[]
+        = "rocblas_icamin_batched";
+    template <>
+    static constexpr char rocblas_iamin_batched_name<rocblas_double_complex>[]
+        = "rocblas_izamin_batched";
+
+    // allocate workspace inside this API
+    template <typename S, typename T>
+    static rocblas_status rocblas_iamin_batched_impl(rocblas_handle  handle,
+                                                     rocblas_int     n,
+                                                     const T* const* x,
+                                                     rocblas_int     incx,
+                                                     rocblas_int     batch_count,
+                                                     rocblas_int*    result)
+    {
+        static constexpr bool           isbatched = true;
+        static constexpr int            NB        = 1024;
+        static constexpr rocblas_stride stridex_0 = 0;
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amin,
+                                      rocblas_finalize_index_value,
+                                      index_value_t<S>>(handle,
+                                                        n,
+                                                        x,
+                                                        incx,
+                                                        stridex_0,
+                                                        batch_count,
+                                                        result,
+                                                        rocblas_iamin_batched_name<T>,
+                                                        "iamin_batched");
+    }
+
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
+
+#define IMPL(name_routine_, T_, S_)                                                      \
+    rocblas_status name_routine_(rocblas_handle   handle,                                \
+                                 rocblas_int      n,                                     \
+                                 const T_* const* x,                                     \
+                                 rocblas_int      incx,                                  \
+                                 rocblas_int      batch_count,                           \
+                                 rocblas_int*     results)                               \
+    {                                                                                    \
+        return rocblas_iamin_batched_impl<S_>(handle, n, x, incx, batch_count, results); \
+    }
+
+IMPL(rocblas_isamin_batched, float, float);
+IMPL(rocblas_idamin_batched, double, double);
+IMPL(rocblas_icamin_batched, rocblas_float_complex, float);
+IMPL(rocblas_izamin_batched, rocblas_double_complex, double);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas1/rocblas_iamin_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_batched.cpp
@@ -8,26 +8,24 @@
 namespace
 {
     template <typename>
-    static constexpr char rocblas_iamin_batched_name[] = "unknown";
+    constexpr char rocblas_iamin_batched_name[] = "unknown";
     template <>
-    static constexpr char rocblas_iamin_batched_name<float>[] = "rocblas_isamin_batched";
+    constexpr char rocblas_iamin_batched_name<float>[] = "rocblas_isamin_batched";
     template <>
-    static constexpr char rocblas_iamin_batched_name<double>[] = "rocblas_idamin_batched";
+    constexpr char rocblas_iamin_batched_name<double>[] = "rocblas_idamin_batched";
     template <>
-    static constexpr char rocblas_iamin_batched_name<rocblas_float_complex>[]
-        = "rocblas_icamin_batched";
+    constexpr char rocblas_iamin_batched_name<rocblas_float_complex>[] = "rocblas_icamin_batched";
     template <>
-    static constexpr char rocblas_iamin_batched_name<rocblas_double_complex>[]
-        = "rocblas_izamin_batched";
+    constexpr char rocblas_iamin_batched_name<rocblas_double_complex>[] = "rocblas_izamin_batched";
 
     // allocate workspace inside this API
     template <typename S, typename T>
-    static rocblas_status rocblas_iamin_batched_impl(rocblas_handle  handle,
-                                                     rocblas_int     n,
-                                                     const T* const* x,
-                                                     rocblas_int     incx,
-                                                     rocblas_int     batch_count,
-                                                     rocblas_int*    result)
+    rocblas_status rocblas_iamin_batched_impl(rocblas_handle  handle,
+                                              rocblas_int     n,
+                                              const T* const* x,
+                                              rocblas_int     incx,
+                                              rocblas_int     batch_count,
+                                              rocblas_int*    result)
     {
         static constexpr bool           isbatched = true;
         static constexpr int            NB        = 1024;

--- a/library/src/blas1/rocblas_iamin_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_batched.cpp
@@ -32,9 +32,9 @@ namespace
         static constexpr rocblas_stride stridex_0 = 0;
         return rocblas_reduction_impl<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amin,
-                                      rocblas_finalize_index_value,
+                                      rocblas_finalize_amax_amin,
                                       index_value_t<S>>(handle,
                                                         n,
                                                         x,

--- a/library/src/blas1/rocblas_iamin_batched.hpp
+++ b/library/src/blas1/rocblas_iamin_batched.hpp
@@ -20,8 +20,8 @@ rocblas_status rocblas_iamin_batched_template(rocblas_handle    handle,
     static constexpr rocblas_stride stridex_0 = 0;
     return rocblas_reduction_template<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amin,
-                                      rocblas_finalize_index_value>(
+                                      rocblas_finalize_amax_amin>(
         handle, n, x, shiftx, incx, stridex_0, batch_count, result, workspace);
 }

--- a/library/src/blas1/rocblas_iamin_batched.hpp
+++ b/library/src/blas1/rocblas_iamin_batched.hpp
@@ -1,0 +1,27 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "rocblas_iamin.hpp"
+
+// allocate workspace inside this API
+template <rocblas_int NB, typename T, typename S>
+rocblas_status rocblas_iamin_batched_template(rocblas_handle    handle,
+                                              rocblas_int       n,
+                                              const T* const*   x,
+                                              rocblas_int       shiftx,
+                                              rocblas_int       incx,
+                                              rocblas_int       batch_count,
+                                              rocblas_int*      result,
+                                              index_value_t<S>* workspace)
+{
+    static constexpr bool           isbatched = true;
+    static constexpr rocblas_stride stridex_0 = 0;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amin,
+                                      rocblas_finalize_index_value>(
+        handle, n, x, shiftx, incx, stridex_0, batch_count, result, workspace);
+}

--- a/library/src/blas1/rocblas_iamin_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_strided_batched.cpp
@@ -35,9 +35,9 @@ namespace
 
         return rocblas_reduction_impl<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amin,
-                                      rocblas_finalize_index_value,
+                                      rocblas_finalize_amax_amin,
                                       index_value_t<S>>(handle,
                                                         n,
                                                         x,

--- a/library/src/blas1/rocblas_iamin_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_strided_batched.cpp
@@ -8,29 +8,27 @@
 namespace
 {
     template <typename>
-    static constexpr char rocblas_iamin_strided_batched_name[] = "unknown";
+    constexpr char rocblas_iamin_strided_batched_name[] = "unknown";
     template <>
-    static constexpr char rocblas_iamin_strided_batched_name<float>[]
-        = "rocblas_isamin_strided_batched";
+    constexpr char rocblas_iamin_strided_batched_name<float>[] = "rocblas_isamin_strided_batched";
     template <>
-    static constexpr char rocblas_iamin_strided_batched_name<double>[]
-        = "rocblas_idamin_strided_batched";
+    constexpr char rocblas_iamin_strided_batched_name<double>[] = "rocblas_idamin_strided_batched";
     template <>
-    static constexpr char rocblas_iamin_strided_batched_name<rocblas_float_complex>[]
+    constexpr char rocblas_iamin_strided_batched_name<rocblas_float_complex>[]
         = "rocblas_icamin_strided_batched";
     template <>
-    static constexpr char rocblas_iamin_strided_batched_name<rocblas_double_complex>[]
+    constexpr char rocblas_iamin_strided_batched_name<rocblas_double_complex>[]
         = "rocblas_izamin_strided_batched";
 
     // allocate workspace inside this API
     template <typename S, typename T>
-    static rocblas_status rocblas_iamin_strided_batched_impl(rocblas_handle handle,
-                                                             rocblas_int    n,
-                                                             const T*       x,
-                                                             rocblas_int    incx,
-                                                             rocblas_stride stridex,
-                                                             rocblas_int    batch_count,
-                                                             rocblas_int*   result)
+    rocblas_status rocblas_iamin_strided_batched_impl(rocblas_handle handle,
+                                                      rocblas_int    n,
+                                                      const T*       x,
+                                                      rocblas_int    incx,
+                                                      rocblas_stride stridex,
+                                                      rocblas_int    batch_count,
+                                                      rocblas_int*   result)
     {
         static constexpr bool isbatched = true;
         static constexpr int  NB        = 1024;

--- a/library/src/blas1/rocblas_iamin_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_strided_batched.cpp
@@ -1,0 +1,88 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblas_iamin_strided_batched.hpp"
+#include "rocblas_reduction_impl.hpp"
+
+namespace
+{
+    template <typename>
+    static constexpr char rocblas_iamin_strided_batched_name[] = "unknown";
+    template <>
+    static constexpr char rocblas_iamin_strided_batched_name<float>[]
+        = "rocblas_isamin_strided_batched";
+    template <>
+    static constexpr char rocblas_iamin_strided_batched_name<double>[]
+        = "rocblas_idamin_strided_batched";
+    template <>
+    static constexpr char rocblas_iamin_strided_batched_name<rocblas_float_complex>[]
+        = "rocblas_icamin_strided_batched";
+    template <>
+    static constexpr char rocblas_iamin_strided_batched_name<rocblas_double_complex>[]
+        = "rocblas_izamin_strided_batched";
+
+    // allocate workspace inside this API
+    template <typename S, typename T>
+    static rocblas_status rocblas_iamin_strided_batched_impl(rocblas_handle handle,
+                                                             rocblas_int    n,
+                                                             const T*       x,
+                                                             rocblas_int    incx,
+                                                             rocblas_stride stridex,
+                                                             rocblas_int    batch_count,
+                                                             rocblas_int*   result)
+    {
+        static constexpr bool isbatched = true;
+        static constexpr int  NB        = 1024;
+
+        return rocblas_reduction_impl<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amin,
+                                      rocblas_finalize_index_value,
+                                      index_value_t<S>>(handle,
+                                                        n,
+                                                        x,
+                                                        incx,
+                                                        stridex,
+                                                        batch_count,
+                                                        result,
+                                                        rocblas_iamin_strided_batched_name<T>,
+                                                        "iamin_strided_batched");
+    }
+
+}
+
+/*
+ * ===========================================================================
+ *    C wrapper
+ * ===========================================================================
+ */
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL IS ALREADY DEFINED
+#endif
+
+#define IMPL(name_routine_, T_, S_)                             \
+    rocblas_status name_routine_(rocblas_handle handle,         \
+                                 rocblas_int    n,              \
+                                 const T_*      x,              \
+                                 rocblas_int    incx,           \
+                                 rocblas_stride stridex,        \
+                                 rocblas_int    batch_count,    \
+                                 rocblas_int*   results)        \
+    {                                                           \
+        return rocblas_iamin_strided_batched_impl<S_>(          \
+            handle, n, x, incx, stridex, batch_count, results); \
+    }
+
+IMPL(rocblas_isamin_strided_batched, float, float);
+IMPL(rocblas_idamin_strided_batched, double, double);
+IMPL(rocblas_icamin_strided_batched, rocblas_float_complex, float);
+IMPL(rocblas_izamin_strided_batched, rocblas_double_complex, double);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas1/rocblas_iamin_strided_batched.hpp
+++ b/library/src/blas1/rocblas_iamin_strided_batched.hpp
@@ -1,0 +1,27 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "rocblas_iamin.hpp"
+
+// allocate workspace inside this API
+template <rocblas_int NB, typename T, typename S>
+rocblas_status rocblas_iamin_strided_batched_template(rocblas_handle    handle,
+                                                      rocblas_int       n,
+                                                      const T* const*   x,
+                                                      rocblas_int       shiftx,
+                                                      rocblas_int       incx,
+                                                      rocblas_stride    stridex,
+                                                      rocblas_int       batch_count,
+                                                      rocblas_int*      result,
+                                                      index_value_t<S>* workspace)
+{
+    static constexpr bool isbatched = true;
+    return rocblas_reduction_template<NB,
+                                      isbatched,
+                                      rocblas_fetch_index_value<S>,
+                                      rocblas_reduce_amin,
+                                      rocblas_finalize_index_value>(
+        handle, n, x, shiftx, incx, stridex, batch_count, result, workspace);
+}

--- a/library/src/blas1/rocblas_iamin_strided_batched.hpp
+++ b/library/src/blas1/rocblas_iamin_strided_batched.hpp
@@ -20,8 +20,8 @@ rocblas_status rocblas_iamin_strided_batched_template(rocblas_handle    handle,
     static constexpr bool isbatched = true;
     return rocblas_reduction_template<NB,
                                       isbatched,
-                                      rocblas_fetch_index_value<S>,
+                                      rocblas_fetch_amax_amin<S>,
                                       rocblas_reduce_amin,
-                                      rocblas_finalize_index_value>(
+                                      rocblas_finalize_amax_amin>(
         handle, n, x, shiftx, incx, stridex, batch_count, result, workspace);
 }

--- a/library/src/blas1/rocblas_reduction_impl.hpp
+++ b/library/src/blas1/rocblas_reduction_impl.hpp
@@ -178,13 +178,7 @@ rocblas_status rocblas_reduction_impl(rocblas_handle handle,
         return rocblas_status_invalid_pointer;
     }
 
-    if(batch_count < 0)
-    {
-        return rocblas_status_invalid_size;
-    }
-
     size_t dev_bytes = rocblas_reduction_kernel_workspace_size<NB, Tw>(n, batch_count);
-
     if(handle->is_device_memory_size_query())
     {
         return handle->set_optimal_device_memory_size(dev_bytes);

--- a/library/src/blas1/rocblas_reduction_template.hpp
+++ b/library/src/blas1/rocblas_reduction_template.hpp
@@ -29,22 +29,28 @@ rocblas_status rocblas_reduction_template(rocblas_handle handle,
 {
 
     // Quick return if possible.
-    if(n <= 0 || incx <= 0 || (ISBATCHED && batch_count == 0))
+    if(n <= 0 || incx <= 0 || (ISBATCHED && batch_count <= 0))
     {
-        if(handle->is_device_memory_size_query())
+        if(n > 0 && incx > 0 && batch_count < 0)
         {
-            return rocblas_status_size_unchanged;
-        }
-        else if(rocblas_pointer_mode_device == handle->pointer_mode && batch_count > 0)
-        {
-            RETURN_IF_HIP_ERROR(hipMemset(results, 0, batch_count * sizeof(Tr)));
+            return rocblas_status_invalid_size;
         }
         else
         {
-
-            for(rocblas_int batch_index = 0; batch_index < batch_count; batch_index++)
+            if(handle->is_device_memory_size_query())
             {
-                results[batch_index] = Tr(0);
+                return rocblas_status_size_unchanged;
+            }
+            else if(rocblas_pointer_mode_device == handle->pointer_mode && batch_count > 0)
+            {
+                RETURN_IF_HIP_ERROR(hipMemset(results, 0, batch_count * sizeof(Tr)));
+            }
+            else
+            {
+                for(rocblas_int batch_index = 0; batch_index < batch_count; batch_index++)
+                {
+                    results[batch_index] = Tr(0);
+                }
             }
         }
         return rocblas_status_success;


### PR DESCRIPTION
resolves SWDEV-202341

Summary of proposed changes:
-  implemented batched and strided batched version of iamax / iamin with the use of rocblas_reduction_template and rocblas_reduction_impl.
-  created testing reduction template (that could be also used for asum / nrm2, maybe next refactoring)
