### PR TITLE
Trying to fix sles errors

### DIFF
--- a/docker/dockerfile-build-sles
+++ b/docker/dockerfile-build-sles
@@ -13,7 +13,7 @@ ARG user_uid
 # * rocblas-test: gfortran, googletest
 # * rocblas-bench: libboost-program-options-dev
 # * libhsakmt.so: libnuma1
-RUN zypper -n update && zypper -n install\
+RUN zypper refresh && zypper -n --no-gpg-checks install\
     rock-dkms \
     sudo \
     ca-certificates \


### PR DESCRIPTION
It looks like that zypper update is causing dependent system packages like systemd to be installed, which require a reboot, which isn't possible in a container. This results in the docker stage returning an error code. Other projects are not calling zypper update and thus do not error out when trying to install packages. 