### PR TITLE
Add final specifiers to enforce expectations about rocBLAS test class usage

### DIFF
--- a/clients/include/rocblas_test.hpp
+++ b/clients/include/rocblas_test.hpp
@@ -203,7 +203,7 @@ public:
 struct rocblas_test_valid
 {
     // Return true to indicate the type combination is valid, for filtering
-    explicit operator bool()
+    virtual explicit operator bool() final
     {
         return true;
     }
@@ -220,13 +220,13 @@ struct rocblas_test_valid
 struct rocblas_test_invalid
 {
     // Return false to indicate the type combination is invalid, for filtering
-    explicit operator bool()
+    virtual explicit operator bool() final
     {
         return false;
     }
 
     // If this specialization is actually called, print fatal error message
-    void operator()(const Arguments&)
+    virtual void operator()(const Arguments&) final
     {
         static constexpr char msg[] = "Internal error: Test called with invalid types\n";
 


### PR DESCRIPTION
Add `virtual` and `final` specifiers to some functions in `rocblas_test.hpp` to enforce class usage expectations, such as not overriding `operator bool()` in derived classes.

(This would detect and flag the TRMM case where `operator bool()` was still being overridden, even though it wasn't necessary anymore.)