### PR TITLE
Fix uninitialized variables and order of initializer lists

### DIFF
--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -36,9 +36,9 @@ public:
     //! @remark Must wrap constructor and destructor in functions to allow Google Test macros to work
     //!
     explicit device_vector(rocblas_int n, rocblas_int inc)
-        : m_n(n)
+        : d_vector<T, PAD, U>(n * std::abs(inc))
+        , m_n(n)
         , m_inc(inc)
-        , d_vector<T, PAD, U>(n * std::abs(inc))
     {
         this->m_data = this->device_vector_setup();
     }
@@ -49,9 +49,9 @@ public:
     //! @remark Must wrap constructor and destructor in functions to allow Google Test macros to work
     //!
     explicit device_vector(size_t s)
-        : m_n(s)
+        : d_vector<T, PAD, U>(s)
+        , m_n(s)
         , m_inc(1)
-        , d_vector<T, PAD, U>(s)
     {
         this->m_data = this->device_vector_setup();
     }

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -86,8 +86,8 @@ void testing_dot_batched(const Arguments& arg)
     rocblas_int incy        = arg.incy;
     rocblas_int batch_count = arg.batch_count;
 
-    double               rocblas_error_1;
-    double               rocblas_error_2;
+    double               rocblas_error_1 = 0;
+    double               rocblas_error_2 = 0;
     rocblas_local_handle handle;
 
     // check to prevent undefined memmory allocation error

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -102,8 +102,8 @@ void testing_dot_strided_batched(const Arguments& arg)
     size_t         size_x      = N * size_t(abs_incx);
     size_t         size_y      = N * size_t(abs_incy);
 
-    double               rocblas_error_1;
-    double               rocblas_error_2;
+    double               rocblas_error_1 = 0;
+    double               rocblas_error_2 = 0;
     rocblas_local_handle handle;
 
     // check to prevent undefined memmory allocation error


### PR DESCRIPTION
The `rocblas_error_*` were uninitialized.

The initializer lists were not in the same order as the bases/members they initialized.