### PR TITLE
Change pre-commit script and LICENSE.md to allow parsing of copyright dates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,7 +27,7 @@ for file in $(git diff-index --cached --name-only $against); do
 done
 
 # do the formatting
-for file in $(git diff-index --cached --name-only $against | grep -E '\.c$|\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$|\.txt$|\.yaml$|\.sh$|\.py$|\.cmake$|\.cmake\.in$|\.md$|\.rst$'); do
+for file in $(git diff-index --cached --name-only $against | grep -E '\.c$|\.h$|\.hpp$|\.cpp$|\.cl$|\.in$|\.txt$|\.yaml$|\.sh$|\.py$|\.pl$|\.cmake$|\.md$|\.rst$'); do
     if [[ -e $file ]]; then
         sed -i -e 's/[[:space:]]*$//' "$file" # Remove whitespace at end of lines
         sed -i -e '$a\' "$file" # Add missing newline to end of file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ if( BUILD_WITH_TENSILE )
     message (STATUS "using GIT Tensile fork=${tensile_fork} from branch=${tensile_tag}")
   endif()
   list(APPEND CMAKE_PREFIX_PATH ${VIRTUALENV_HOME_DIR})
-  find_package(Tensile 4.13.0 EXACT REQUIRED HIP LLVM OpenMP PATHS "${INSTALLED_TENSILE_PATH}")
+  find_package(Tensile 4.14.0 EXACT REQUIRED HIP LLVM OpenMP PATHS "${INSTALLED_TENSILE_PATH}")
 endif()
 
 # Find HCC/HIP dependencies

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright © 2016 Advanced Micro Devices, Inc.  
- 
+Copyright 2016-2019 Advanced Micro Devices, Inc.
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.


### PR DESCRIPTION
Simplify the pattern used to find files to reformat in `pre-commit`, making use of only one instance of `\.in$` instead of `\.cpp\.in$`, `\.hpp\.in$`, etc, since in this part of the script we're only removing whitespace at the end of lines and filling a missing newline at EOF (`clang-format` is done later with a different pattern).

Add `\.pl$` pattern for Perl scripts, and remove the Unicode copyright character from LICENSE.md, since it doesn't appear in any other files, and it makes the copyright dates harder to parse. This change also allows the `pre-commit` script to automatically adjust the copyright date range for `LICENSE.md`.
