### PR TITLE
Remove source gtest and unnecessary dependencies from dockerfile

### DIFF
--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -17,12 +17,8 @@ RUN yum install -y \
     git \
     cmake3 \
     make \
-    clang \
-    clang-devel \
     gcc-c++ \
     gcc-gfortran \
-    gtest-devel \ 
-    gtest \
     pkgconfig \
     python27 \
     python36 \

--- a/docker/dockerfile-build-sles
+++ b/docker/dockerfile-build-sles
@@ -22,7 +22,6 @@ RUN zypper refresh && zypper -n --no-gpg-checks install\
     gcc-fortran \
     make \
     cmake \
-    fftw3-devel \
     rpm-build \
     dpkg \
     python2-PyYAML \


### PR DESCRIPTION
This PR might solve rocSOLVER's CI failure, as it is picking up an old version of gtest when it installs rocblas from CI