### PR TITLE
blis generic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ get_os_id(OS_ID)
 message (STATUS "OS detected is ${OS_ID}")
 
 # Versioning via rocm-cmake
-set ( VERSION_STRING "2.12.0" )
+set ( VERSION_STRING "2.12.1" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,7 @@ rocBLASCI:
         platform.runCommand(this, command)
     }
 
+    rocblas.timeout.test = 600
     def testCommand =
     {
         platform, project->

--- a/install.sh
+++ b/install.sh
@@ -384,14 +384,14 @@ if [[ "${install_dependencies}" == true ]]; then
       cd extern/blis
       case "${ID}" in
           centos|rhel|sles)
-              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp generic
               ;;
           ubuntu)
-              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang auto
+              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang generic
               ;;
           *)
               echo "Unsupported OS for this script"
-              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+              ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp generic
               ;;
       esac
       make install
@@ -405,14 +405,14 @@ if [[ "${cpu_ref_lib}" == blis ]] && [[ ! -f "${build_dir}/deps/blis/lib/libblis
   cd extern/blis
   case "${ID}" in
     centos|rhel|sles)
-      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp generic
       ;;
     ubuntu)
-      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang auto
+      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp CC=/opt/rocm/hcc/bin/clang generic
       ;;
     *)
       echo "Unsupported OS for this script"
-      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp auto
+      ./configure --prefix=../../${build_dir}/deps/blis --enable-threading=openmp generic
       ;;
   esac
   make install


### PR DESCRIPTION
Fix for SWDEV-212579 and blis based testing on other CPUs by making blis configuration generic.
For 3.0 release branch integration.
