### PR TITLE
fixing gemm_ex logic to avoid copies

### DIFF
--- a/library/src/blas_ex/rocblas_gemm_ex.hpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.hpp
@@ -660,8 +660,8 @@ rocblas_status gemm_ex_batched_template(rocblas_handle    handle,
     rocblas_stride    stride_i;
 
     if(!arch_lt906 && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{})
-       && ((ldc >= ldd && stride_c >= stride_d && m == ldd) || (ldc == ldd && stride_c == stride_d)
-           || batch_count == 1))
+       && ((ldc >= ldd && (stride_c >= stride_d || batch_count == 1) && m == ldd)
+           || (ldc == ldd && (stride_c == stride_d || batch_count == 1))))
     {
         c_in     = c;
         ldi      = ldc;

--- a/library/src/blas_ex/rocblas_gemm_ex.hpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.hpp
@@ -660,8 +660,8 @@ rocblas_status gemm_ex_batched_template(rocblas_handle    handle,
     rocblas_stride    stride_i;
 
     if(!arch_lt906 && (std::is_same<Ti, float>{} || std::is_same<Ti, double>{})
-       && ((ldc >= ldd && stride_c >= stride_d && m == ldd)
-           || (ldc == ldd && stride_c == stride_d)))
+       && ((ldc >= ldd && stride_c >= stride_d && m == ldd) || (ldc == ldd && stride_c == stride_d)
+           || batch_count == 1))
     {
         c_in     = c;
         ldi      = ldc;


### PR DESCRIPTION
resolves #SWDEV-213985

At this if statement, a normal trsm call would end up in the **if** section where no copies are done, instead now we are getting to the **else** portion. This is happening because stride_c is now explicitly being set to 0 (Actually Trsm’s stride_b when calling the template). Because the batch count is 1 the actual value for stride does not matter.

Previously we were setting this gemm_ex stride c to the supposedly correct size even though batch_count is 1. (Within rocblas_gemm_ex_impl)

Creating PR to run tests - Still testing regression 