### PR TITLE
Removing unnecessary template parameter in rocblas_copy_template

### DIFF
--- a/library/src/blas1/rocblas_copy.cpp
+++ b/library/src/blas1/rocblas_copy.cpp
@@ -49,7 +49,7 @@ namespace
         if(layer_mode & rocblas_layer_mode_log_profile)
             log_profile(handle, rocblas_copy_name<T>, "N", n, "incx", incx, "incy", incy);
 
-        return rocblas_copy_template<NB, T>(handle, n, x, 0, incx, 0, y, 0, incy, 0, 1);
+        return rocblas_copy_template<NB>(handle, n, x, 0, incx, 0, y, 0, incy, 0, 1);
     }
 
 } // namespace

--- a/library/src/blas1/rocblas_copy.hpp
+++ b/library/src/blas1/rocblas_copy.hpp
@@ -6,7 +6,7 @@
 #include "rocblas.h"
 #include "utility.h"
 
-template <typename T, typename U, typename V>
+template <typename U, typename V>
 __global__ void copy_kernel(rocblas_int    n,
                             const U        xa,
                             ptrdiff_t      shiftx,
@@ -21,14 +21,14 @@ __global__ void copy_kernel(rocblas_int    n,
     // bound
     if(tid < n)
     {
-        const T* x = load_ptr_batch(xa, hipBlockIdx_y, shiftx, stridex);
-        T*       y = load_ptr_batch(ya, hipBlockIdx_y, shifty, stridey);
+        const auto* x = load_ptr_batch(xa, hipBlockIdx_y, shiftx, stridex);
+        auto*       y = load_ptr_batch(ya, hipBlockIdx_y, shifty, stridey);
 
         y[tid * incy] = x[tid * incx];
     }
 }
 
-template <rocblas_int NB, typename T, typename U, typename V>
+template <rocblas_int NB, typename U, typename V>
 rocblas_status rocblas_copy_template(rocblas_handle handle,
                                      rocblas_int    n,
                                      U              x,
@@ -59,7 +59,7 @@ rocblas_status rocblas_copy_template(rocblas_handle handle,
     dim3 grid(blocks, batch_count);
     dim3 threads(NB);
 
-    hipLaunchKernelGGL((copy_kernel<T>),
+    hipLaunchKernelGGL(copy_kernel,
                        grid,
                        threads,
                        0,

--- a/library/src/blas1/rocblas_copy_batched.cpp
+++ b/library/src/blas1/rocblas_copy_batched.cpp
@@ -65,7 +65,7 @@ namespace
                         "batch_count",
                         batch_count);
 
-        return rocblas_copy_template<NB, T>(handle, n, x, 0, incx, 0, y, 0, incy, 0, batch_count);
+        return rocblas_copy_template<NB>(handle, n, x, 0, incx, 0, y, 0, incy, 0, batch_count);
     }
 
 } // namespace

--- a/library/src/blas1/rocblas_copy_strided_batched.cpp
+++ b/library/src/blas1/rocblas_copy_strided_batched.cpp
@@ -87,7 +87,7 @@ namespace
                         "batch_count",
                         batch_count);
 
-        return rocblas_copy_template<NB, T>(
+        return rocblas_copy_template<NB>(
             handle, n, x, 0, incx, stridex, y, 0, incy, stridey, batch_count);
     }
 

--- a/library/src/blas2/rocblas_tbmv.hpp
+++ b/library/src/blas2/rocblas_tbmv.hpp
@@ -292,7 +292,7 @@ rocblas_status rocblas_tbmv_template(rocblas_handle    handle,
     dim3 copy_grid(copy_blocks, batch_count);
     dim3 copy_threads(256);
 
-    hipLaunchKernelGGL((copy_kernel<T>),
+    hipLaunchKernelGGL(copy_kernel,
                        copy_grid,
                        copy_threads,
                        0,

--- a/library/src/blas3/rocblas_trmm.hpp
+++ b/library/src/blas3/rocblas_trmm.hpp
@@ -177,17 +177,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                     for(int i = ii + offd; i <= ii + isec - 1; i++)
                     {
                         PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                            (rocblas_copy_template<NB, T>)(handle,
-                                                           i - ii + 1 - offd,
-                                                           &a[ii - 1 + (i - 1) * lda],
-                                                           0,
-                                                           1,
-                                                           0,
-                                                           &dt2[i - ii],
-                                                           0,
-                                                           cb,
-                                                           0,
-                                                           1));
+                            (rocblas_copy_template<NB>)(handle,
+                                                        i - ii + 1 - offd,
+                                                        &a[ii - 1 + (i - 1) * lda],
+                                                        0,
+                                                        1,
+                                                        0,
+                                                        &dt2[i - ii],
+                                                        0,
+                                                        cb,
+                                                        0,
+                                                        1));
                     }
                     for(int jj = 1; jj <= n; jj += rb)
                     {
@@ -201,17 +201,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int j = jj; j <= jj + jsec - 1; j++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   isec,
-                                                                   &c[ii - 1 + (j - 1) * ldc],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   &dt1[j - jj],
-                                                                   0,
-                                                                   rb,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                isec,
+                                                                &c[ii - 1 + (j - 1) * ldc],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                &dt1[j - jj],
+                                                                0,
+                                                                rb,
+                                                                0,
+                                                                1));
                             }
                         }
                         else
@@ -219,17 +219,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int i = ii; i <= ii + isec - 1; i++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   jsec,
-                                                                   &c[i - 1 + (jj - 1) * ldc],
-                                                                   0,
-                                                                   ldc,
-                                                                   0,
-                                                                   &dt1[(i - ii) * ldt1],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                jsec,
+                                                                &c[i - 1 + (jj - 1) * ldc],
+                                                                0,
+                                                                ldc,
+                                                                0,
+                                                                &dt1[(i - ii) * ldt1],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                1));
                             }
                         }
                         //
@@ -304,17 +304,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &dt1[j - jj],
-                                                               0,
-                                                               rb,
-                                                               0,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &dt1[j - jj],
+                                                            0,
+                                                            rb,
+                                                            0,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                     }
                     //
@@ -371,17 +371,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int j = jj; j <= jj + jsec - 1; j++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   isec,
-                                                                   &c[ii - 1 + (j - 1) * ldc],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   &dt1[j - jj],
-                                                                   0,
-                                                                   rb,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                isec,
+                                                                &c[ii - 1 + (j - 1) * ldc],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                &dt1[j - jj],
+                                                                0,
+                                                                rb,
+                                                                0,
+                                                                1));
                             }
                         }
                         else
@@ -389,17 +389,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int i = ii; i <= ii + isec - 1; i++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   jsec,
-                                                                   &c[i - 1 + (jj - 1) * ldc],
-                                                                   0,
-                                                                   ldc,
-                                                                   0,
-                                                                   &dt1[(i - ii) * ldt1],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                jsec,
+                                                                &c[i - 1 + (jj - 1) * ldc],
+                                                                0,
+                                                                ldc,
+                                                                0,
+                                                                &dt1[(i - ii) * ldt1],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                1));
                             }
                         }
                         //
@@ -475,17 +475,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &dt1[j - jj],
-                                                               0,
-                                                               rb,
-                                                               0,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &dt1[j - jj],
+                                                            0,
+                                                            rb,
+                                                            0,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                     }
                     //
@@ -541,17 +541,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                     for(int i = ii; i <= ii + isec - 1 - offd; i++)
                     {
                         PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                            (rocblas_copy_template<NB, T>)(handle,
-                                                           ii + isec - i - offd,
-                                                           &a[i + offd - 1 + (i - 1) * lda],
-                                                           0,
-                                                           1,
-                                                           0,
-                                                           &dt2[i - ii + (i - ii + offd) * ldt2],
-                                                           0,
-                                                           cb,
-                                                           0,
-                                                           1));
+                            (rocblas_copy_template<NB>)(handle,
+                                                        ii + isec - i - offd,
+                                                        &a[i + offd - 1 + (i - 1) * lda],
+                                                        0,
+                                                        1,
+                                                        0,
+                                                        &dt2[i - ii + (i - ii + offd) * ldt2],
+                                                        0,
+                                                        cb,
+                                                        0,
+                                                        1));
                     }
                     for(int jj = 1; jj <= n; jj += rb)
                     {
@@ -565,17 +565,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int j = jj; j <= jj + jsec - 1; j++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   isec,
-                                                                   &c[ii - 1 + (j - 1) * ldc],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   &dt1[j - jj],
-                                                                   0,
-                                                                   rb,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                isec,
+                                                                &c[ii - 1 + (j - 1) * ldc],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                &dt1[j - jj],
+                                                                0,
+                                                                rb,
+                                                                0,
+                                                                1));
                             }
                         }
                         else
@@ -583,17 +583,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int i = ii; i <= ii + isec - 1; i++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   jsec,
-                                                                   &c[i - 1 + (jj - 1) * ldc],
-                                                                   0,
-                                                                   ldc,
-                                                                   0,
-                                                                   &dt1[(i - ii) * ldt1],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                jsec,
+                                                                &c[i - 1 + (jj - 1) * ldc],
+                                                                0,
+                                                                ldc,
+                                                                0,
+                                                                &dt1[(i - ii) * ldt1],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                1));
                             }
                         }
                         //
@@ -668,17 +668,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &dt1[j - jj],
-                                                               0,
-                                                               rb,
-                                                               0,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &dt1[j - jj],
+                                                            0,
+                                                            rb,
+                                                            0,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                     }
                     //
@@ -734,17 +734,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int j = jj; j <= jj + jsec - 1; j++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   isec,
-                                                                   &c[ii - 1 + (j - 1) * ldc],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   &dt1[j - jj],
-                                                                   0,
-                                                                   rb,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                isec,
+                                                                &c[ii - 1 + (j - 1) * ldc],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                &dt1[j - jj],
+                                                                0,
+                                                                rb,
+                                                                0,
+                                                                1));
                             }
                         }
                         else
@@ -752,17 +752,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                             for(int i = ii; i <= ii + isec - 1; i++)
                             {
                                 PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                    (rocblas_copy_template<NB, T>)(handle,
-                                                                   jsec,
-                                                                   &c[i - 1 + (jj - 1) * ldc],
-                                                                   0,
-                                                                   ldc,
-                                                                   0,
-                                                                   &dt1[(i - ii) * ldt1],
-                                                                   0,
-                                                                   1,
-                                                                   0,
-                                                                   1));
+                                    (rocblas_copy_template<NB>)(handle,
+                                                                jsec,
+                                                                &c[i - 1 + (jj - 1) * ldc],
+                                                                0,
+                                                                ldc,
+                                                                0,
+                                                                &dt1[(i - ii) * ldt1],
+                                                                0,
+                                                                1,
+                                                                0,
+                                                                1));
                             }
                         }
                         //
@@ -837,17 +837,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &dt1[j - jj],
-                                                               0,
-                                                               rb,
-                                                               0,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &dt1[j - jj],
+                                                            0,
+                                                            rb,
+                                                            0,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                     }
                     //
@@ -907,17 +907,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               &dt1[(j - jj) * ldt1],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            &dt1[(j - jj) * ldt1],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                         //
                         //                      C := alpha*T1*A + delta*C, triangular matrix
@@ -1032,17 +1032,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                     for(int j = jj + offd; j <= jj + jsec - 1; j++)
                     {
                         PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                            (rocblas_copy_template<NB, T>)(handle,
-                                                           j - jj + 1 - offd,
-                                                           &a[jj - 1 + (j - 1) * lda],
-                                                           0,
-                                                           1,
-                                                           0,
-                                                           &dt2[j - jj],
-                                                           0,
-                                                           cb,
-                                                           0,
-                                                           1));
+                            (rocblas_copy_template<NB>)(handle,
+                                                        j - jj + 1 - offd,
+                                                        &a[jj - 1 + (j - 1) * lda],
+                                                        0,
+                                                        1,
+                                                        0,
+                                                        &dt2[j - jj],
+                                                        0,
+                                                        cb,
+                                                        0,
+                                                        1));
                     }
                     for(int ii = 1; ii <= m; ii += rb)
                     {
@@ -1054,17 +1054,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               &dt1[(j - jj) * ldt1],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            &dt1[(j - jj) * ldt1],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                         //
                         //                      C := alpha*T1*T2 + delta*C, triangular matrix
@@ -1188,17 +1188,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               &dt1[(j - jj) * ldt1],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            &dt1[(j - jj) * ldt1],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                         //
                         //                      C := alpha*T1*A + delta*C, triangular matrix
@@ -1316,17 +1316,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                     for(int j = jj; j <= jj + jsec - 1 - offd; j++)
                     {
                         PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                            (rocblas_copy_template<NB, T>)(handle,
-                                                           jj + jsec - j - offd,
-                                                           &a[j + offd - 1 + (j - 1) * lda],
-                                                           0,
-                                                           1,
-                                                           0,
-                                                           &dt2[j - jj + (j - jj + offd) * ldt2],
-                                                           0,
-                                                           cb,
-                                                           0,
-                                                           1));
+                            (rocblas_copy_template<NB>)(handle,
+                                                        jj + jsec - j - offd,
+                                                        &a[j + offd - 1 + (j - 1) * lda],
+                                                        0,
+                                                        1,
+                                                        0,
+                                                        &dt2[j - jj + (j - jj + offd) * ldt2],
+                                                        0,
+                                                        cb,
+                                                        0,
+                                                        1));
                     }
                     for(int ii = 1; ii <= m; ii += rb)
                     {
@@ -1338,17 +1338,17 @@ rocblas_status rocblas_trmm_template(rocblas_handle    handle,
                         for(int j = jj; j <= jj + jsec - 1; j++)
                         {
                             PRINT_AND_RETURN_IF_ROCBLAS_ERROR(
-                                (rocblas_copy_template<NB, T>)(handle,
-                                                               isec,
-                                                               &c[ii - 1 + (j - 1) * ldc],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               &dt1[(j - jj) * ldt1],
-                                                               0,
-                                                               1,
-                                                               0,
-                                                               1));
+                                (rocblas_copy_template<NB>)(handle,
+                                                            isec,
+                                                            &c[ii - 1 + (j - 1) * ldc],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            &dt1[(j - jj) * ldt1],
+                                                            0,
+                                                            1,
+                                                            0,
+                                                            1));
                         }
                         //
                         //                      C := alpha*T1*T2 + delta*C, triangular matrix


### PR DESCRIPTION
Removing  a useless template parameter in rocblas_copy_template