### PR TITLE
Adding system requirements to install documentation

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -19,6 +19,13 @@ rocBLAS Debian packages can also be downloaded from the `rocBLAS releases tag <h
 Building from Source
 ********************
 
+Requirements
+````````````
+As a general rule, 32GB of system memory is required to build rocBLAS. This value may be lower
+depending on the target graphics card. This value may also increase as more functions are added to
+rocBLAS and dependencies such as Tensile grow.
+
+
 Download rocBLAS
 ````````````````
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -21,9 +21,9 @@ Building from Source
 
 Requirements
 ````````````
-As a general rule, 32GB of system memory is required to build rocBLAS. This value may be lower
-depending on the target graphics card. This value may also increase as more functions are added to
-rocBLAS and dependencies such as Tensile grow.
+As a general rule, 64GB of system memory is required for a full rocBLAS build. This value can be lower if
+rocBLAS is built with a different Tensile logic target (see the --logic command for ./install.sh). This value
+may also increase in the future as more functions are added to rocBLAS and dependencies such as Tensile grow.
 
 
 Download rocBLAS


### PR DESCRIPTION
Currently there doesn't seem to be any documentation on system memory requirements to build rocBLAS. This PR may not be 100% accurate so discussion is welcome on what the requirements _actually_ are.

Andrew mentioned that he was able to successfully build on a Vega20 with 24GB.