### PR TITLE
BLAS level 2 trmv routines (non batched, batched, strided batched)

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -49,6 +49,9 @@
 #include "testing_ger.hpp"
 #include "testing_syr.hpp"
 #include "testing_tbmv.hpp"
+#include "testing_trmv.hpp"
+#include "testing_trmv_batched.hpp"
+#include "testing_trmv_strided_batched.hpp"
 #include "type_dispatch.hpp"
 #include "utility.hpp"
 #include <algorithm>
@@ -203,6 +206,9 @@ struct perf_blas<
                 {"gemv", testing_gemv<T>},
                 {"gemv_batched", testing_gemv_batched<T>},
                 {"gemv_strided_batched", testing_gemv_strided_batched<T>},
+                {"trmv", testing_trmv<T>},
+                {"trmv_batched", testing_trmv_batched<T>},
+                {"trmv_strided_batched", testing_trmv_strided_batched<T>},
                 {"ger", testing_ger<T>},
                 {"syr", testing_syr<T>},
                 {"tbmv", testing_tbmv<T>},
@@ -290,6 +296,7 @@ struct perf_blas<T,
                 {"iamax", testing_iamax<T>},
                 {"iamin", testing_iamin<T>},
                 {"gemv", testing_gemv<T>},
+                {"trmv", testing_trmv<T>},
                 {"tbmv", testing_tbmv<T>},
 #if BUILD_WITH_TENSILE
                 {"gemm", testing_gemm<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -297,6 +297,8 @@ struct perf_blas<T,
                 {"iamin", testing_iamin<T>},
                 {"gemv", testing_gemv<T>},
                 {"trmv", testing_trmv<T>},
+                {"trmv_batched", testing_trmv_batched<T>},
+                {"trmv_strided_batched", testing_trmv_strided_batched<T>},
                 {"tbmv", testing_tbmv<T>},
 #if BUILD_WITH_TENSILE
                 {"gemm", testing_gemm<T>},

--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -212,6 +212,13 @@ def setdefaults(test):
         if all([x in test for x in ('stride_scale')]):
             test.setdefault('stride_c', int(test['stride_scale']) * 5)
 
+    elif test['function'] in ('trmv_strided_batched'):
+        if all([x in test for x in ('M', 'incx', 'stride_scale')]):
+            ldx = int(test['M'] * abs(test['incx']) * test['stride_scale'])
+            test.setdefault('stride_x', ldx)
+        if all([x in test for x in ('M', 'lda', 'stride_scale')]):
+            ldM = int(test['M'] * test['lda'] * test['stride_scale'])
+            test.setdefault('stride_a', ldM)
     elif test['function'] in ('gemv_strided_batched', 'ger_strided_batched', 'trsv_strided_batched'):
         if test['function'] in ('ger_strided_batched', 'trsv_strided_batched') or test['transA'] in ('T', 'C'):
             if all([x in test for x in ('M', 'incx', 'stride_scale')]):

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -60,6 +60,7 @@ set(rocblas_no_tensile_test_source
     blas1_gtest.cpp
     # blas2
     gemv_gtest.cpp
+    trmv_gtest.cpp
     tbmv_gtest.cpp
     ger_gtest.cpp
     syr_gtest.cpp
@@ -182,7 +183,7 @@ endif( )
 set( ROCBLAS_TEST_DATA "${PROJECT_BINARY_DIR}/staging/rocblas_gtest.data")
 add_custom_command( OUTPUT "${ROCBLAS_TEST_DATA}"
                     COMMAND ../common/rocblas_gentest.py -I ../include rocblas_gtest.yaml -o "${ROCBLAS_TEST_DATA}"
-                    DEPENDS ../common/rocblas_gentest.py rocblas_gtest.yaml ../include/rocblas_common.yaml known_bugs.yaml blas1_gtest.yaml gemm_gtest.yaml gemm_batched_gtest.yaml gemm_strided_batched_gtest.yaml gemv_gtest.yaml tbmv_gtest.yaml symv_gtest.yaml syr_gtest.yaml ger_gtest.yaml trsm_gtest.yaml trtri_gtest.yaml geam_gtest.yaml set_get_vector_gtest.yaml set_get_matrix_gtest.yaml trmm_gtest.yaml trsv_gtest.yaml logging_mode_gtest.yaml set_get_pointer_mode_gtest.yaml
+                    DEPENDS ../common/rocblas_gentest.py rocblas_gtest.yaml ../include/rocblas_common.yaml known_bugs.yaml blas1_gtest.yaml gemm_gtest.yaml gemm_batched_gtest.yaml gemm_strided_batched_gtest.yaml trmv_gtest.yaml gemv_gtest.yaml tbmv_gtest.yaml symv_gtest.yaml syr_gtest.yaml ger_gtest.yaml trsm_gtest.yaml trtri_gtest.yaml geam_gtest.yaml set_get_vector_gtest.yaml set_get_matrix_gtest.yaml trmm_gtest.yaml trsv_gtest.yaml logging_mode_gtest.yaml set_get_pointer_mode_gtest.yaml
                     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 add_custom_target( rocblas-test-data
                    DEPENDS "${ROCBLAS_TEST_DATA}" )

--- a/clients/gtest/rocblas_gtest.yaml
+++ b/clients/gtest/rocblas_gtest.yaml
@@ -7,6 +7,7 @@ include: symv_gtest.yaml
 include: syr_gtest.yaml
 include: ger_gtest.yaml
 include: tbmv_gtest.yaml
+include: trmv_gtest.yaml
 include: trmm_gtest.yaml
 include: trsm_gtest.yaml
 include: trtri_gtest.yaml

--- a/clients/gtest/trmv_gtest.cpp
+++ b/clients/gtest/trmv_gtest.cpp
@@ -1,0 +1,138 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "rocblas_data.hpp"
+#include "rocblas_datatype2string.hpp"
+#include "rocblas_test.hpp"
+#include "testing_trmv.hpp"
+#include "testing_trmv_batched.hpp"
+#include "testing_trmv_strided_batched.hpp"
+#include "type_dispatch.hpp"
+#include <cctype>
+#include <cstring>
+#include <type_traits>
+
+namespace
+{
+    // possible trmv test cases
+    enum trmv_test_type
+    {
+        TRMV,
+        TRMV_BATCHED,
+        TRMV_STRIDED_BATCHED,
+    };
+
+    //trmv test template
+    template <template <typename...> class FILTER, trmv_test_type TRMV_TYPE>
+    struct trmv_template : RocBLAS_Test<trmv_template<FILTER, TRMV_TYPE>, FILTER>
+    {
+        // Filter for which types apply to this suite
+        static bool type_filter(const Arguments& arg)
+        {
+            return rocblas_simple_dispatch<trmv_template::template type_filter_functor>(arg);
+        }
+
+        // Filter for which functions apply to this suite
+        static bool function_filter(const Arguments& arg)
+        {
+            switch(TRMV_TYPE)
+            {
+            case TRMV:
+                return !strcmp(arg.function, "trmv") || !strcmp(arg.function, "trmv_bad_arg");
+            case TRMV_BATCHED:
+                return !strcmp(arg.function, "trmv_batched")
+                       || !strcmp(arg.function, "trmv_batched_bad_arg");
+            case TRMV_STRIDED_BATCHED:
+                return !strcmp(arg.function, "trmv_strided_batched")
+                       || !strcmp(arg.function, "trmv_strided_batched_bad_arg");
+            }
+            return false;
+        }
+
+        // Google Test name suffix based on parameters
+        static std::string name_suffix(const Arguments& arg)
+        {
+            RocBLAS_TestName<trmv_template> name;
+
+            name << rocblas_datatype2string(arg.a_type) << '_' << (char)std::toupper(arg.transA)
+                 << '_' << arg.M << '_' << arg.N << '_' << arg.alpha << '_' << arg.lda;
+
+            if(TRMV_TYPE == TRMV_STRIDED_BATCHED)
+                name << '_' << arg.stride_a;
+
+            name << '_' << arg.incx;
+
+            if(TRMV_TYPE == TRMV_STRIDED_BATCHED)
+                name << '_' << arg.stride_x;
+
+            name << '_' << arg.beta << '_' << arg.incy;
+
+            if(TRMV_TYPE == TRMV_STRIDED_BATCHED)
+                name << '_' << arg.stride_y;
+
+            if(TRMV_TYPE == TRMV_STRIDED_BATCHED || TRMV_TYPE == TRMV_BATCHED)
+                name << '_' << arg.batch_count;
+
+            return std::move(name);
+        }
+    };
+
+    // By default, arbitrary type combinations are invalid.
+    // The unnamed second parameter is used for enable_if below.
+    template <typename, typename = void>
+    struct trmv_testing : rocblas_test_invalid
+    {
+    };
+
+    // When the condition in the second argument is satisfied, the type combination
+    // is valid. When the condition is false, this specialization does not apply.
+    template <typename T>
+    struct trmv_testing<
+        T,
+        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
+                                || std::is_same<T, rocblas_float_complex>{}
+                                || std::is_same<T, rocblas_double_complex>{}>::type>
+        : rocblas_test_valid
+    {
+        void operator()(const Arguments& arg)
+        {
+            if(!strcmp(arg.function, "trmv"))
+                testing_trmv<T>(arg);
+            else if(!strcmp(arg.function, "trmv_bad_arg"))
+                testing_trmv_bad_arg<T>(arg);
+            else if(!strcmp(arg.function, "trmv_batched"))
+                testing_trmv_batched<T>(arg);
+            else if(!strcmp(arg.function, "trmv_batched_bad_arg"))
+                testing_trmv_batched_bad_arg<T>(arg);
+            else if(!strcmp(arg.function, "trmv_strided_batched"))
+                testing_trmv_strided_batched<T>(arg);
+            else if(!strcmp(arg.function, "trmv_strided_batched_bad_arg"))
+                testing_trmv_strided_batched_bad_arg<T>(arg);
+            else
+                FAIL() << "Internal error: Test called with unknown function: " << arg.function;
+        }
+    };
+
+    using trmv = trmv_template<trmv_testing, TRMV>;
+    TEST_P(trmv, blas2)
+    {
+        rocblas_simple_dispatch<trmv_testing>(GetParam());
+    }
+    INSTANTIATE_TEST_CATEGORIES(trmv);
+
+    using trmv_batched = trmv_template<trmv_testing, TRMV_BATCHED>;
+    TEST_P(trmv_batched, blas2)
+    {
+        rocblas_simple_dispatch<trmv_testing>(GetParam());
+    }
+    INSTANTIATE_TEST_CATEGORIES(trmv_batched);
+
+    using trmv_strided_batched = trmv_template<trmv_testing, TRMV_STRIDED_BATCHED>;
+    TEST_P(trmv_strided_batched, blas2)
+    {
+        rocblas_simple_dispatch<trmv_testing>(GetParam());
+    }
+    INSTANTIATE_TEST_CATEGORIES(trmv_strided_batched);
+
+} // namespace

--- a/clients/gtest/trmv_gtest.yaml
+++ b/clients/gtest/trmv_gtest.yaml
@@ -1,0 +1,156 @@
+---
+include: rocblas_common.yaml
+include: known_bugs.yaml
+
+Definitions:
+  - &small_matrix_size_range
+    - { M:    -1, lda:    1, stride_a:       1 }
+    - { M:     1, lda:    0, stride_a:       1 }
+    - { M:     0, lda:    1, stride_a:       1 }
+    - { M:     1, lda:    -1, stride_a:       1 }
+    - { M:    10, lda:   10, stride_a:       100 }
+    - { M:    1, lda:   -1, stride_a:       1 }
+    - { M:    10, lda:    2, stride_a:      20 }
+    - { M:   100, lda:  200, stride_a:    40000 }
+
+  - &medium_matrix_size_range
+    - { M:   300, lda:  400, stride_a:   160000 }
+    - { M:   600, lda:  601, stride_a:   400000 }
+
+  - &large_matrix_size_range
+    - { M:  1000, lda: 1000, stride_a:  1000000 }
+    - { M:  2000, lda: 2000, stride_a:  4000000 }
+    - { M:  4011, lda: 4011, stride_a: 16088200 }
+    - { M:  8000, lda: 8000, stride_a: 64000000 }
+
+  - &incx_range
+    - [2, -2,1,-1,0,3,10]
+
+
+Tests:
+- name: trmv_bad_arg
+  category: pre_checkin
+  function: trmv_bad_arg
+  precision: *single_double_precisions
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+
+
+- name: trmv_small
+  category: quick
+  function: trmv
+  precision: *single_double_precisions_complex_real
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *small_matrix_size_range
+  incx: *incx_range
+
+- name: trmv_medium
+  category: pre_checkin
+  function: trmv
+  precision: *single_double_precisions_complex_real
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *medium_matrix_size_range
+  incx: *incx_range
+
+- name: trmv_large
+  category: nightly
+  function: trmv
+  precision: *single_double_precisions_complex_real
+  uplo: [L, U]
+  transA: [  N, T, C ]
+  diag: [N, U]
+  matrix_size: *large_matrix_size_range
+  incx: *incx_range
+
+- name: trmv_batched_bad_arg
+  category: pre_checkin
+  function: trmv_batched_bad_arg
+  precision: *single_double_precisions
+  uplo: [L, U]
+  transA: [  N, T, C ]
+  diag: [N, U]
+
+- name: trmv_batched_small
+  category: quick
+  function: trmv_batched
+  precision: *single_double_precisions
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *small_matrix_size_range
+  incx: *incx_range
+  batch_count: [ -1, 0, 1, 3 ]
+
+- name: trmv_batched_medium
+  category: pre_checkin
+  function: trmv_batched
+  precision: *single_double_precisions_complex_real
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *medium_matrix_size_range
+  incx: *incx_range
+  batch_count: [ 3 ]
+
+- name: trmv_batched_large
+  category: nightly
+  function: trmv_batched
+  precision: *single_double_precisions
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *large_matrix_size_range
+  incx: *incx_range
+  batch_count: [ 3 ]
+
+- name: trmv_strided_batched_bad_arg
+  category: pre_checkin
+  function: trmv_strided_batched_bad_arg
+  precision: *single_double_precisions
+  transA: N
+  uplo: [L]
+  transA: [  T ]
+  diag: [N]
+  stride_scale: [ 1 ]
+
+- name: trmv_strided_batched_small
+  category: quick
+  function: trmv_strided_batched
+  precision: *single_double_precisions
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *small_matrix_size_range
+  incx: *incx_range
+  batch_count: [ -1, 0, 1, 3 ]
+  stride_scale: [ 2 ]
+
+- name: trmv_strided_batched_medium
+  category: pre_checkin
+  function: trmv_strided_batched
+  precision: *single_double_precisions_complex_real
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *medium_matrix_size_range
+  incx: *incx_range
+  batch_count: [ 3 ]
+  stride_scale: [ 1.2 ]
+
+- name: trmv_strided_batched_large
+  category: nightly
+  function: trmv_strided_batched
+  precision: *single_double_precisions
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *large_matrix_size_range
+  incx: *incx_range
+  batch_count: [ 3 ]
+  stride_scale: [ 1.2 ]
+...

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -853,6 +853,48 @@ inline void cblas_trmv(rocblas_fill      uplo,
                 incx);
 }
 
+template <>
+inline void cblas_trmv(rocblas_fill                 uplo,
+                       rocblas_operation            transA,
+                       rocblas_diagonal             diag,
+                       rocblas_int                  m,
+                       const rocblas_float_complex* A,
+                       rocblas_int                  lda,
+                       rocblas_float_complex*       x,
+                       rocblas_int                  incx)
+{
+    cblas_ctrmv(CblasColMajor,
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
+                m,
+                A,
+                lda,
+                x,
+                incx);
+}
+
+template <>
+inline void cblas_trmv(rocblas_fill                  uplo,
+                       rocblas_operation             transA,
+                       rocblas_diagonal              diag,
+                       rocblas_int                   m,
+                       const rocblas_double_complex* A,
+                       rocblas_int                   lda,
+                       rocblas_double_complex*       x,
+                       rocblas_int                   incx)
+{
+    cblas_ztrmv(CblasColMajor,
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
+                m,
+                A,
+                lda,
+                x,
+                incx);
+}
+
 // symv
 template <typename T>
 void cblas_symv(rocblas_fill uplo,

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -93,6 +93,25 @@ constexpr double scal_gflop_count<rocblas_double_complex, double>(rocblas_int n)
  * ===========================================================================
  */
 
+/* \brief floating point counts of trmv */
+template <typename T>
+constexpr double trmv_gflop_count(rocblas_int m)
+{
+    return ((m * (m + 1))) / 1e9;
+}
+
+template <>
+constexpr double trmv_gflop_count<rocblas_float_complex>(rocblas_int m)
+{
+    return (2.0 * (m * (m + 1))) / 1e9;
+}
+
+template <>
+constexpr double trmv_gflop_count<rocblas_double_complex>(rocblas_int m)
+{
+    return (2.0 * (m * (m + 1))) / 1e9;
+}
+
 /* \brief floating point counts of GEMV */
 template <typename T>
 constexpr double gemv_gflop_count(rocblas_operation transA, rocblas_int m, rocblas_int n)

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -97,19 +97,19 @@ constexpr double scal_gflop_count<rocblas_double_complex, double>(rocblas_int n)
 template <typename T>
 constexpr double trmv_gflop_count(rocblas_int m)
 {
-    return ((m * (m + 1))) / 1e9;
+    return (m * m) / 1e9;
 }
 
 template <>
 constexpr double trmv_gflop_count<rocblas_float_complex>(rocblas_int m)
 {
-    return (2.0 * (m * (m + 1))) / 1e9;
+    return (2.0 * m * (2.0 * m + 1.0)) / 1e9;
 }
 
 template <>
 constexpr double trmv_gflop_count<rocblas_double_complex>(rocblas_int m)
 {
-    return (2.0 * (m * (m + 1))) / 1e9;
+    return (2.0 * m * (2.0 * m + 1.0)) / 1e9;
 }
 
 /* \brief floating point counts of GEMV */

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -1213,6 +1213,84 @@ static constexpr auto rocblas_gemv_batched<rocblas_float_complex> = rocblas_cgem
 template <>
 static constexpr auto rocblas_gemv_batched<rocblas_double_complex> = rocblas_zgemv_batched;
 
+// trmv
+template <typename T>
+rocblas_status (*rocblas_trmv)(rocblas_handle    handle,
+                               rocblas_fill      uplo,
+                               rocblas_operation transA,
+                               rocblas_diagonal  diag,
+                               rocblas_int       m,
+                               const T*          A,
+                               rocblas_int       lda,
+                               T*                x,
+                               rocblas_int       incx);
+
+template <>
+static constexpr auto rocblas_trmv<float> = rocblas_strmv;
+
+template <>
+static constexpr auto rocblas_trmv<double> = rocblas_dtrmv;
+
+template <>
+static constexpr auto rocblas_trmv<rocblas_float_complex> = rocblas_ctrmv;
+
+template <>
+static constexpr auto rocblas_trmv<rocblas_double_complex> = rocblas_ztrmv;
+
+// trmv_strided_batched
+template <typename T>
+rocblas_status (*rocblas_trmv_strided_batched)(rocblas_handle    handle,
+                                               rocblas_fill      uplo,
+                                               rocblas_operation transA,
+                                               rocblas_diagonal  diag,
+                                               rocblas_int       m,
+                                               const T*          A,
+                                               rocblas_int       lda,
+                                               rocblas_stride    stridea,
+                                               T*                x,
+                                               rocblas_stride    stridex,
+                                               rocblas_int       incx,
+                                               rocblas_int       batch_count);
+
+template <>
+static constexpr auto rocblas_trmv_strided_batched<float> = rocblas_strmv_strided_batched;
+
+template <>
+static constexpr auto rocblas_trmv_strided_batched<double> = rocblas_dtrmv_strided_batched;
+
+template <>
+static constexpr auto
+    rocblas_trmv_strided_batched<rocblas_float_complex> = rocblas_ctrmv_strided_batched;
+
+template <>
+static constexpr auto
+    rocblas_trmv_strided_batched<rocblas_double_complex> = rocblas_ztrmv_strided_batched;
+
+// trmv_batched
+template <typename T>
+rocblas_status (*rocblas_trmv_batched)(rocblas_handle    handle,
+                                       rocblas_fill      uplo,
+                                       rocblas_operation transA,
+                                       rocblas_diagonal  diag,
+                                       rocblas_int       m,
+                                       const T* const*   A,
+                                       rocblas_int       lda,
+                                       T* const*         x,
+                                       rocblas_int       incx,
+                                       rocblas_int       batch_count);
+
+template <>
+static constexpr auto rocblas_trmv_batched<float> = rocblas_strmv_batched;
+
+template <>
+static constexpr auto rocblas_trmv_batched<double> = rocblas_dtrmv_batched;
+
+template <>
+static constexpr auto rocblas_trmv_batched<rocblas_float_complex> = rocblas_ctrmv_batched;
+
+template <>
+static constexpr auto rocblas_trmv_batched<rocblas_double_complex> = rocblas_ztrmv_batched;
+
 // tbmv
 template <typename T>
 rocblas_status (*rocblas_tbmv)(rocblas_fill      uplo,

--- a/clients/include/rocblas_template.yaml
+++ b/clients/include/rocblas_template.yaml
@@ -56,6 +56,18 @@ Functions:
   rocblas_dgemv_strided_batched: { function: gemv_strided_batched, <<: *double_precision }
   rocblas_sgemv_batched: { function: gemv_batched, <<: *single_precision }
   rocblas_dgemv_batched: { function: gemv_batched, <<: *double_precision }
+  rocblas_strmv: { function: trmv, <<: *single_precision }
+  rocblas_dtrmv: { function: trmv, <<: *double_precision }
+  rocblas_ctrmv: { function: trmv, <<: *single_precision_complex }
+  rocblas_ztrmv: { function: trmv, <<: *double_precision_complex }
+  rocblas_strmv_strided_batched: { function: trmv_strided_batched, <<: *single_precision }
+  rocblas_dtrmv_strided_batched: { function: trmv_strided_batched, <<: *double_precision }
+  rocblas_ctrmv_strided_batched: { function: trmv_strided_batched, <<: *single_precision_complex }
+  rocblas_ztrmv_strided_batched: { function: trmv_strided_batched, <<: *double_precision_complex }
+  rocblas_strmv_batched: { function: trmv_batched, <<: *single_precision }
+  rocblas_dtrmv_batched: { function: trmv_batched, <<: *double_precision }
+  rocblas_ctrmv_batched: { function: trmv_batched, <<: *single_precision_complex }
+  rocblas_ztrmv_batched: { function: trmv_batched, <<: *double_precision_complex }
   rocblas_strsv: { function: trsv, <<: *single_precision }
   rocblas_dtrsv: { function: trsv, <<: *double_precision }
   rocblas_ssymv: { function: symv, <<: *single_precision }

--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -169,6 +169,8 @@ void testing_logging()
 
         rocblas_gemv<T>(handle, transA, m, n, &alpha, da, lda, dx, incx, &beta, dy, incy);
 
+        rocblas_trmv<T>(handle, uplo, transA, diag, m, da, lda, dx, incx);
+
         if(BUILD_WITH_TENSILE)
         {
             // BLAS3
@@ -469,6 +471,13 @@ void testing_logging()
                    << (void*)&alpha << "," << (void*)da << "," << lda << "," << (void*)dx << ","
                    << incx << "," << (void*)&beta << "," << (void*)dy << "," << incy << '\n';
     }
+
+    trace_ofs2 << replaceX<T>("rocblas_Xtrmv") << "," << uplo << "," << transA << "," << diag << ","
+               << m << "," << (void*)da << "," << lda << "," << (void*)dx << "," << incx << '\n';
+
+    bench_ofs2 << "./rocblas-bench -f trmv -r " << rocblas_precision_string<T> << " --uplo "
+               << uplo_letter << " --transposeA " << transA_letter << " --diag " << diag_letter
+               << " -m " << m << " --lda " << lda << " --incx " << incx << '\n';
 
     // BLAS3
 

--- a/clients/include/testing_trmv.hpp
+++ b/clients/include/testing_trmv.hpp
@@ -1,0 +1,229 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include "cblas_interface.hpp"
+#include "flops.hpp"
+#include "near.hpp"
+#include "norm.hpp"
+#include "rocblas.hpp"
+#include "rocblas_datatype2string.hpp"
+#include "rocblas_init.hpp"
+#include "rocblas_math.hpp"
+#include "rocblas_random.hpp"
+#include "rocblas_test.hpp"
+#include "rocblas_vector.hpp"
+#include "unit.hpp"
+#include "utility.hpp"
+
+template <typename T>
+void testing_trmv_bad_arg(const Arguments& arg)
+{
+    const rocblas_int       M      = 100;
+    const rocblas_int       lda    = 100;
+    const rocblas_int       incx   = 1;
+    const rocblas_operation transA = rocblas_operation_none;
+    const rocblas_fill      uplo   = rocblas_fill_lower;
+    const rocblas_diagonal  diag   = rocblas_diagonal_non_unit;
+
+    rocblas_local_handle handle;
+
+    size_t size_A = lda * size_t(M);
+    size_t size_x = M * size_t(incx);
+
+    host_vector<T> hA(size_A);
+    CHECK_HIP_ERROR(hA.memcheck());
+    host_vector<T> hx(size_x);
+    CHECK_HIP_ERROR(hx.memcheck());
+    device_vector<T> dA(size_A);
+    CHECK_HIP_ERROR(dA.memcheck());
+    device_vector<T> dx(size_x);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    //
+    // Initialize.
+    //
+    rocblas_init(hA, true);
+    rocblas_init(hx);
+
+    //
+    // Transfer.
+    //
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+
+    //
+    // Checks.
+    //
+    EXPECT_ROCBLAS_STATUS(rocblas_trmv<T>(handle, uplo, transA, diag, M, nullptr, lda, dx, incx),
+                          rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(rocblas_trmv<T>(handle, uplo, transA, diag, M, dA, lda, nullptr, incx),
+                          rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(rocblas_trmv<T>(nullptr, uplo, transA, diag, M, dA, lda, dx, incx),
+                          rocblas_status_invalid_handle);
+}
+
+template <typename T>
+void testing_trmv(const Arguments& arg)
+{
+    rocblas_int M = arg.M, lda = arg.lda, incx = arg.incx;
+
+    char char_uplo = arg.uplo, char_transA = arg.transA, char_diag = arg.diag;
+
+    rocblas_fill         uplo   = char2rocblas_fill(char_uplo);
+    rocblas_operation    transA = char2rocblas_operation(char_transA);
+    rocblas_diagonal     diag   = char2rocblas_diagonal(char_diag);
+    rocblas_local_handle handle;
+
+    if(M < 0 || lda < M || lda < 1 || !incx)
+    {
+        static const size_t safe_size = 100; // arbitrarily set to 100
+        device_vector<T>    dA1(safe_size);
+        CHECK_HIP_ERROR(dA1.memcheck());
+        device_vector<T> dx1(safe_size);
+        CHECK_HIP_ERROR(dx1.memcheck());
+
+        EXPECT_ROCBLAS_STATUS(rocblas_trmv<T>(handle, uplo, transA, diag, M, dA1, lda, dx1, incx),
+                              rocblas_status_invalid_size);
+
+        return;
+    }
+
+    if(M == 0)
+    {
+        EXPECT_ROCBLAS_STATUS(
+            rocblas_trmv<T>(handle, uplo, transA, diag, M, nullptr, lda, nullptr, incx),
+            rocblas_status_success);
+        return;
+    }
+
+    size_t size_A = lda * size_t(M);
+    size_t size_x, dim_x, abs_incx;
+    dim_x = M;
+
+    abs_incx = incx >= 0 ? incx : -incx;
+    size_x   = dim_x * abs_incx;
+
+    host_vector<T> hA(size_A);
+    CHECK_HIP_ERROR(hA.memcheck());
+    host_vector<T> hx(size_x);
+    CHECK_HIP_ERROR(hx.memcheck());
+    device_vector<T> dA(size_A);
+    CHECK_HIP_ERROR(dA.memcheck());
+    device_vector<T> dx(size_x);
+    CHECK_HIP_ERROR(dx.memcheck());
+    host_vector<T> hres(size_x);
+    CHECK_HIP_ERROR(hres.memcheck());
+
+    //
+    // Initialize.
+    //
+    rocblas_init(hA, true);
+    rocblas_init(hx, false);
+
+    //
+    // Transfer.
+    //
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
+    double rocblas_error;
+
+    /* =====================================================================
+     ROCBLAS
+     =================================================================== */
+    if(arg.unit_check || arg.norm_check)
+    {
+
+        //
+        // ROCBLAS
+        //
+        CHECK_ROCBLAS_ERROR(rocblas_trmv<T>(handle, uplo, transA, diag, M, dA, lda, dx, incx));
+        CHECK_HIP_ERROR(hres.transfer_from(dx));
+
+        //
+        // CPU BLAS
+        //
+        {
+            cpu_time_used = get_time_us();
+            cblas_trmv<T>(uplo, transA, diag, M, hA, lda, hx, incx);
+            cpu_time_used = get_time_us() - cpu_time_used;
+            cblas_gflops  = trmv_gflop_count<T>(M) / cpu_time_used * 1e6;
+        }
+
+        //
+        // Unit check.
+        //
+        if(arg.unit_check)
+        {
+            unit_check_general<T>(1, dim_x, abs_incx, hx, hres);
+        }
+
+        //
+        // Norm check.
+        //
+        if(arg.norm_check)
+        {
+            rocblas_error = norm_check_general<T>('F', 1, dim_x, abs_incx, hx, hres);
+        }
+    }
+
+    if(arg.timing)
+    {
+        //
+        // Warmup
+        //
+        {
+            int number_cold_calls = 2;
+            for(int iter = 0; iter < number_cold_calls; iter++)
+            {
+                rocblas_trmv<T>(handle, uplo, transA, diag, M, dA, lda, dx, incx);
+            }
+        }
+
+        //
+        // Go !
+        //
+        {
+            gpu_time_used        = get_time_us(); // in microseconds
+            int number_hot_calls = 100;
+            for(int iter = 0; iter < number_hot_calls; iter++)
+            {
+                rocblas_trmv<T>(handle, uplo, transA, diag, M, dA, lda, dx, incx);
+            }
+            gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
+        }
+
+        //
+        // Evaluate performance.
+        //
+        rocblas_gflops    = trmv_gflop_count<T>(M) / gpu_time_used * 1e6;
+        rocblas_bandwidth = (double((M * (M + 1)) / 2) * sizeof(T)) / gpu_time_used * 1e-3;
+
+        //
+        // Display.
+        //
+        std::cout << "M,lda,incx,uplo,transA,diag,rocblas-Gflops,rocblas-GB/s,";
+        if(arg.norm_check)
+        {
+            std::cout << "CPU-Gflops,norm_error";
+        }
+        std::cout << std::endl;
+        std::cout << M << "," << lda << "," << incx << "," << incx << "," << incx << "," << incx
+                  << "," << char_uplo << ',' << char_transA << ',' << char_diag << ','
+                  << rocblas_gflops << "," << rocblas_bandwidth << ",";
+
+        if(arg.norm_check)
+        {
+            std::cout << cblas_gflops << ',';
+            std::cout << rocblas_error;
+        }
+
+        std::cout << std::endl;
+    }
+}

--- a/clients/include/testing_trmv_batched.hpp
+++ b/clients/include/testing_trmv_batched.hpp
@@ -1,0 +1,280 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+
+
+ *
+ * ************************************************************************ */
+
+#include "cblas_interface.hpp"
+#include "flops.hpp"
+#include "near.hpp"
+#include "norm.hpp"
+#include "rocblas.hpp"
+#include "rocblas_datatype2string.hpp"
+#include "rocblas_init.hpp"
+#include "rocblas_math.hpp"
+#include "rocblas_random.hpp"
+#include "rocblas_test.hpp"
+#include "rocblas_vector.hpp"
+#include "unit.hpp"
+#include "utility.hpp"
+
+template <typename T>
+void testing_trmv_batched_bad_arg(const Arguments& arg)
+{
+    const rocblas_int       M           = 100;
+    const rocblas_int       lda         = 100;
+    const rocblas_int       incx        = 1;
+    const rocblas_int       batch_count = 1;
+    const rocblas_operation transA      = rocblas_operation_none;
+    const rocblas_fill      uplo        = rocblas_fill_lower;
+    const rocblas_diagonal  diag        = rocblas_diagonal_non_unit;
+
+    rocblas_local_handle handle;
+
+    size_t size_A = lda * size_t(M);
+
+    host_batch_vector<T> hA(size_A, 1, batch_count);
+    CHECK_HIP_ERROR(hA.memcheck());
+    host_batch_vector<T> hx(M, incx, batch_count);
+    CHECK_HIP_ERROR(hx.memcheck());
+
+    device_batch_vector<T> dA(batch_count, M * lda);
+    CHECK_HIP_ERROR(dA.memcheck());
+    device_batch_vector<T> dx(M, incx, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    //
+    // Initialize.
+    //
+    rocblas_init(hA, true);
+    rocblas_init(hx);
+
+    //
+    // Transfer.
+    //
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+
+    //
+    // Checks.
+    //
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_trmv_batched<T>(
+            handle, uplo, transA, diag, M, nullptr, lda, dx.ptr_on_device(), incx, batch_count),
+        rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_trmv_batched<T>(
+            handle, uplo, transA, diag, M, dA.ptr_on_device(), lda, nullptr, incx, batch_count),
+        rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(rocblas_trmv_batched<T>(nullptr,
+                                                  uplo,
+                                                  transA,
+                                                  diag,
+                                                  M,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dx.ptr_on_device(),
+                                                  incx,
+                                                  batch_count),
+                          rocblas_status_invalid_handle);
+}
+
+template <typename T>
+void testing_trmv_batched(const Arguments& arg)
+{
+    rocblas_int M = arg.M, lda = arg.lda, incx = arg.incx, batch_count = arg.batch_count;
+
+    char char_uplo = arg.uplo, char_transA = arg.transA, char_diag = arg.diag;
+
+    rocblas_fill      uplo   = char2rocblas_fill(char_uplo);
+    rocblas_operation transA = char2rocblas_operation(char_transA);
+    rocblas_diagonal  diag   = char2rocblas_diagonal(char_diag);
+
+    rocblas_local_handle handle;
+
+    if(M < 0 || lda < M || lda < 1 || !incx || batch_count < 0)
+    {
+        static const size_t    safe_size = 100; // arbitrarily set to 100
+        device_batch_vector<T> dA1(2, safe_size);
+        CHECK_HIP_ERROR(dA1.memcheck());
+        device_batch_vector<T> dx1(2, safe_size);
+        CHECK_HIP_ERROR(dx1.memcheck());
+
+        EXPECT_ROCBLAS_STATUS(rocblas_trmv_batched<T>(handle,
+                                                      uplo,
+                                                      transA,
+                                                      diag,
+                                                      M,
+                                                      dA1.ptr_on_device(),
+                                                      lda,
+                                                      dx1.ptr_on_device(),
+                                                      incx,
+                                                      batch_count),
+                              rocblas_status_invalid_size);
+
+        return;
+    }
+
+    if(!M || !batch_count)
+    {
+        EXPECT_ROCBLAS_STATUS(
+            rocblas_trmv_batched<T>(
+                handle, uplo, transA, diag, M, nullptr, lda, nullptr, incx, batch_count),
+            rocblas_status_success);
+        return;
+    }
+
+    size_t size_A   = lda * size_t(M);
+    size_t abs_incx = incx >= 0 ? incx : -incx;
+
+    host_batch_vector<T> hA(size_A, 1, batch_count);
+    CHECK_HIP_ERROR(hA.memcheck());
+
+    host_batch_vector<T> hx(M, incx, batch_count);
+    CHECK_HIP_ERROR(hx.memcheck());
+
+    host_batch_vector<T> hres(M, incx, batch_count);
+    CHECK_HIP_ERROR(hres.memcheck());
+
+    device_batch_vector<T> dA(batch_count, size_A);
+    CHECK_HIP_ERROR(dA.memcheck());
+
+    device_batch_vector<T> dx(M, incx, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    auto dA_on_device = dA.ptr_on_device();
+    auto dx_on_device = dx.ptr_on_device();
+
+    //
+    // Initialize.
+    //
+    rocblas_init(hA, true);
+    rocblas_init(hx);
+
+    //
+    // Transfer.
+    //
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+
+    double gpu_time_used, cpu_time_used, rocblas_gflops, cblas_gflops, rocblas_bandwidth,
+        rocblas_error;
+
+    /* =====================================================================
+     ROCBLAS
+     =================================================================== */
+    if(arg.unit_check || arg.norm_check)
+    {
+        //
+        // GPU BLAS
+        //
+        CHECK_ROCBLAS_ERROR(rocblas_trmv_batched<T>(
+            handle, uplo, transA, diag, M, dA_on_device, lda, dx_on_device, incx, batch_count));
+        CHECK_HIP_ERROR(hres.transfer_from(dx));
+
+        //
+        // CPU BLAS
+        //
+        {
+            cpu_time_used = get_time_us();
+            for(rocblas_int batch_index = 0; batch_index < batch_count; ++batch_index)
+            {
+                cblas_trmv<T>(uplo, transA, diag, M, hA[batch_index], lda, hx[batch_index], incx);
+            }
+
+            cpu_time_used = get_time_us() - cpu_time_used;
+            cblas_gflops  = (double(batch_count) * trmv_gflop_count<T>(M)) / cpu_time_used * 1e6;
+        }
+
+        //
+        // Unit check.
+        //
+        if(arg.unit_check)
+        {
+            unit_check_general<T>(1, M, batch_count, abs_incx, hx, hres);
+        }
+
+        //
+        // Norm check.
+        //
+        if(arg.norm_check)
+        {
+            rocblas_error = norm_check_general<T>('F', 1, M, batch_count, abs_incx, hx, hres);
+        }
+    }
+
+    if(arg.timing)
+    {
+
+        //
+        // Warmup
+        //
+        {
+            int number_cold_calls = 2;
+            for(int iter = 0; iter < number_cold_calls; iter++)
+            {
+                rocblas_trmv_batched<T>(handle,
+                                        uplo,
+                                        transA,
+                                        diag,
+                                        M,
+                                        dA_on_device,
+                                        lda,
+                                        dx_on_device,
+                                        incx,
+                                        batch_count);
+            }
+        }
+
+        //
+        // Go !
+        //
+        {
+            gpu_time_used        = get_time_us(); // in microseconds
+            int number_hot_calls = 100;
+            for(int iter = 0; iter < number_hot_calls; iter++)
+            {
+                rocblas_trmv_batched<T>(handle,
+                                        uplo,
+                                        transA,
+                                        diag,
+                                        M,
+                                        dA_on_device,
+                                        lda,
+                                        dx_on_device,
+                                        incx,
+                                        batch_count);
+            }
+            gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
+        }
+
+        //
+        // Evaluate performance.
+        //
+        rocblas_gflops    = (double(batch_count) * trmv_gflop_count<T>(M)) / gpu_time_used * 1e6;
+        rocblas_bandwidth = (double((M * (M + 1)) / 2) * double(batch_count) * double(sizeof(T)))
+                            / gpu_time_used * 1e-3;
+
+        //
+        // Display.
+        //
+        std::cout << "M,lda,incx,batch_count,uplo,transA,diag,rocblas-Gflops,rocblas-GB/s,";
+        if(arg.norm_check)
+        {
+            std::cout << "CPU-Gflops,norm_error";
+        }
+        std::cout << std::endl;
+        std::cout << M << "," << lda << "," << incx << "," << batch_count << "," << char_uplo << ','
+                  << char_transA << ',' << char_diag << ',' << rocblas_gflops << ","
+                  << rocblas_bandwidth << ",";
+        if(arg.norm_check)
+        {
+            std::cout << cblas_gflops << ',';
+            std::cout << rocblas_error;
+        }
+        std::cout << std::endl;
+    }
+}

--- a/clients/include/testing_trmv_strided_batched.hpp
+++ b/clients/include/testing_trmv_strided_batched.hpp
@@ -1,0 +1,290 @@
+/* ************************************************************************
+ * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include "cblas_interface.hpp"
+#include "flops.hpp"
+#include "near.hpp"
+#include "norm.hpp"
+#include "rocblas.hpp"
+#include "rocblas_datatype2string.hpp"
+#include "rocblas_init.hpp"
+#include "rocblas_math.hpp"
+#include "rocblas_random.hpp"
+#include "rocblas_test.hpp"
+#include "rocblas_vector.hpp"
+#include "unit.hpp"
+#include "utility.hpp"
+
+template <typename T>
+void testing_trmv_strided_batched_bad_arg(const Arguments& arg)
+{
+    const rocblas_int       M           = 100;
+    const rocblas_int       lda         = 100;
+    const rocblas_int       incx        = 1;
+    const rocblas_int       batch_count = 1;
+    const rocblas_stride    stride_a    = M * lda;
+    const rocblas_stride    stride_x    = M;
+    const rocblas_operation transA      = rocblas_operation_none;
+    const rocblas_fill      uplo        = rocblas_fill_lower;
+    const rocblas_diagonal  diag        = rocblas_diagonal_non_unit;
+
+    rocblas_local_handle handle;
+
+    size_t size_A = lda * size_t(M);
+
+    host_strided_batch_vector<T> hA(size_A, 1, stride_a, batch_count);
+    CHECK_HIP_ERROR(hA.memcheck());
+
+    host_strided_batch_vector<T> hx(M, incx, stride_x, batch_count);
+    CHECK_HIP_ERROR(hx.memcheck());
+
+    device_strided_batch_vector<T> dA(size_A, 1, stride_a, batch_count);
+    CHECK_HIP_ERROR(dA.memcheck());
+
+    device_strided_batch_vector<T> dx(M, incx, stride_x, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    //
+    // Initialize.
+    //
+    rocblas_init(hA, true);
+    rocblas_init(hx);
+
+    //
+    // Transfer.
+    //
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+
+    //
+    // Checks.
+    //
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_trmv_strided_batched<T>(
+            handle, uplo, transA, diag, M, nullptr, lda, stride_a, dx, incx, stride_x, batch_count),
+        rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_trmv_strided_batched<T>(
+            handle, uplo, transA, diag, M, dA, lda, stride_a, nullptr, incx, stride_x, batch_count),
+        rocblas_status_invalid_pointer);
+
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_trmv_strided_batched<T>(
+            nullptr, uplo, transA, diag, M, dA, lda, stride_a, dx, incx, stride_x, batch_count),
+        rocblas_status_invalid_handle);
+}
+
+template <typename T>
+void testing_trmv_strided_batched(const Arguments& arg)
+{
+    rocblas_int    M = arg.M, lda = arg.lda, incx = arg.incx, batch_count = arg.batch_count;
+    rocblas_stride stride_a = arg.stride_a, stride_x = arg.stride_x;
+
+    char char_uplo = arg.uplo, char_transA = arg.transA, char_diag = arg.diag;
+
+    rocblas_fill      uplo   = char2rocblas_fill(char_uplo);
+    rocblas_operation transA = char2rocblas_operation(char_transA);
+    rocblas_diagonal  diag   = char2rocblas_diagonal(char_diag);
+
+    rocblas_local_handle handle;
+
+    // argument sanity check before allocating invalid memory
+    if(M < 0 || lda < M || lda < 1 || !incx || batch_count < 0)
+    {
+        device_strided_batch_vector<T> dA1(10, 1, 10, 2);
+        CHECK_HIP_ERROR(dA1.memcheck());
+        device_strided_batch_vector<T> dx1(10, 1, 10, 2);
+        CHECK_HIP_ERROR(dx1.memcheck());
+
+        EXPECT_ROCBLAS_STATUS(rocblas_trmv_strided_batched<T>(handle,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              M,
+                                                              dA1,
+                                                              lda,
+                                                              stride_a,
+                                                              dx1,
+                                                              incx,
+                                                              stride_x,
+                                                              batch_count),
+                              rocblas_status_invalid_size);
+
+        return;
+    }
+
+    if(!M || !batch_count)
+    {
+        EXPECT_ROCBLAS_STATUS(rocblas_trmv_strided_batched<T>(handle,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              M,
+                                                              nullptr,
+                                                              lda,
+                                                              stride_a,
+                                                              nullptr,
+                                                              incx,
+                                                              stride_x,
+                                                              batch_count),
+                              rocblas_status_success);
+        return;
+    }
+
+    size_t size_A   = lda * size_t(M);
+    size_t abs_incx = incx >= 0 ? incx : -incx;
+
+    host_strided_batch_vector<T> hA(size_A, 1, stride_a, batch_count);
+    CHECK_HIP_ERROR(hA.memcheck());
+
+    host_strided_batch_vector<T> hx(M, incx, stride_x, batch_count);
+    CHECK_HIP_ERROR(hx.memcheck());
+
+    host_strided_batch_vector<T> hres(M, incx, stride_x, batch_count);
+    CHECK_HIP_ERROR(hres.memcheck());
+
+    device_strided_batch_vector<T> dA(size_A, 1, stride_a, batch_count);
+    CHECK_HIP_ERROR(dA.memcheck());
+
+    device_strided_batch_vector<T> dx(M, incx, stride_x, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+
+    //
+    // Initialize.
+    //
+    rocblas_init(hA, true);
+    rocblas_init(hx);
+
+    //
+    // Transfer.
+    //
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+
+    double gpu_time_used, cpu_time_used, rocblas_gflops, cblas_gflops, rocblas_bandwidth,
+        rocblas_error;
+
+    /* =====================================================================
+     ROCBLAS
+     =================================================================== */
+    if(arg.unit_check || arg.norm_check)
+    {
+        //
+        // GPU BLAS
+        //
+        CHECK_ROCBLAS_ERROR(rocblas_trmv_strided_batched<T>(
+            handle, uplo, transA, diag, M, dA, lda, stride_a, dx, incx, stride_x, batch_count));
+        CHECK_HIP_ERROR(hres.transfer_from(dx));
+
+        //
+        // CPU BLAS
+        //
+        {
+            cpu_time_used = get_time_us();
+            for(rocblas_int batch_index = 0; batch_index < batch_count; ++batch_index)
+            {
+                cblas_trmv<T>(uplo, transA, diag, M, hA[batch_index], lda, hx[batch_index], incx);
+            }
+
+            cpu_time_used = get_time_us() - cpu_time_used;
+            cblas_gflops  = (double(batch_count) * trmv_gflop_count<T>(M)) / cpu_time_used * 1e6;
+        }
+
+        //
+        // Unit check.
+        //
+        if(arg.unit_check)
+        {
+            unit_check_general<T>(1, M, batch_count, abs_incx, stride_x, hx, hres);
+        }
+
+        //
+        // Norm check.
+        //
+        if(arg.norm_check)
+        {
+            rocblas_error
+                = norm_check_general<T>('F', 1, M, batch_count, abs_incx, stride_x, hx, hres);
+        }
+    }
+
+    if(arg.timing)
+    {
+
+        //
+        // Warmup
+        //
+        {
+            int number_cold_calls = 2;
+            for(int iter = 0; iter < number_cold_calls; iter++)
+            {
+                rocblas_trmv_strided_batched<T>(handle,
+                                                uplo,
+                                                transA,
+                                                diag,
+                                                M,
+                                                dA,
+                                                lda,
+                                                stride_a,
+                                                dx,
+                                                incx,
+                                                stride_x,
+                                                batch_count);
+            }
+        }
+
+        //
+        // Go !
+        //
+        {
+            gpu_time_used        = get_time_us(); // in microseconds
+            int number_hot_calls = 100;
+            for(int iter = 0; iter < number_hot_calls; iter++)
+            {
+                rocblas_trmv_strided_batched<T>(handle,
+                                                uplo,
+                                                transA,
+                                                diag,
+                                                M,
+                                                dA,
+                                                lda,
+                                                stride_a,
+                                                dx,
+                                                incx,
+                                                stride_x,
+                                                batch_count);
+            }
+            gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
+        }
+
+        //
+        // Evaluate performance.
+        //
+        rocblas_gflops    = (double(batch_count) * trmv_gflop_count<T>(M)) / gpu_time_used * 1e6;
+        rocblas_bandwidth = (double((M * (M + 1)) / 2) * double(batch_count) * double(sizeof(T)))
+                            / gpu_time_used * 1e-3;
+
+        //
+        // Display.
+        //
+        std::cout << "M,lda,stride_a,incx,stride_x,batch_count, "
+                     "uplo,transA,diag,rocblas-Gflops,rocblas-GB/s,";
+        if(arg.norm_check)
+        {
+            std::cout << "CPU-Gflops,norm_error";
+        }
+        std::cout << std::endl;
+        std::cout << M << "," << lda << "," << stride_a << "," << incx << "," << stride_x << ","
+                  << batch_count << "," << char_uplo << ',' << char_transA << ',' << char_diag
+                  << ',' << rocblas_gflops << "," << rocblas_bandwidth << ",";
+        if(arg.norm_check)
+        {
+            std::cout << cblas_gflops << ',';
+            std::cout << rocblas_error;
+        }
+        std::cout << std::endl;
+    }
+}

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -3035,7 +3035,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle      
 
     where x is an n element vector and A is an n by n unit, or non-unit, upper or lower triangular matrix.
 
-    The vector x is overwritten on b.
+    The vector x is overwritten.
 
     @param[in]
     handle    [rocblas_handle]
@@ -3056,7 +3056,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle      
 
     @param[in]
     m         [rocblas_int]
-              m specifies the number of rows of b. m >= 0.
+              m specifies the number of rows of A. m >= 0.
 
     @param[in]
     A         device pointer storing matrix A,

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -3029,6 +3029,308 @@ ROCBLAS_EXPORT rocblas_status rocblas_zgemv_strided_batched(rocblas_handle      
 /*! \brief BLAS Level 2 API
 
     \details
+    trmv performs one of the matrix-vector operations
+
+         x = A*x or x = A**T*x,
+
+    where x is an n element vector and A is an n by n unit, or non-unit, upper or lower triangular matrix.
+
+    The vector x is overwritten on b.
+
+    @param[in]
+    handle    [rocblas_handle]
+              handle to the rocblas library context queue.
+
+    @param[in]
+    uplo    [rocblas_fill]
+            rocblas_fill_upper:  A is an upper triangular matrix.
+            rocblas_fill_lower:  A is a  lower triangular matrix.
+
+    @param[in]
+    transA     [rocblas_operation]
+
+    @param[in]
+    diag    [rocblas_diagonal]
+            rocblas_diagonal_unit:     A is assumed to be unit triangular.
+            rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
+
+    @param[in]
+    m         [rocblas_int]
+              m specifies the number of rows of b. m >= 0.
+
+    @param[in]
+    A         device pointer storing matrix A,
+              of dimension ( lda, m )
+
+    @param[in]
+    lda       [rocblas_int]
+              specifies the leading dimension of A.
+              lda = max( 1, m ).
+
+    @param[in]
+    x         device pointer storing vector x.
+
+    @param[in]
+    incx      [rocblas_int]
+              specifies the increment for the elements of x.
+
+    ********************************************************************/
+ROCBLAS_EXPORT rocblas_status rocblas_strmv(rocblas_handle    handle,
+                                            rocblas_fill      uplo,
+                                            rocblas_operation transA,
+                                            rocblas_diagonal  diag,
+                                            rocblas_int       m,
+                                            const float*      A,
+                                            rocblas_int       lda,
+                                            float*            x,
+                                            rocblas_int       incx);
+
+ROCBLAS_EXPORT rocblas_status rocblas_dtrmv(rocblas_handle    handle,
+                                            rocblas_fill      uplo,
+                                            rocblas_operation transA,
+                                            rocblas_diagonal  diag,
+                                            rocblas_int       m,
+                                            const double*     A,
+                                            rocblas_int       lda,
+                                            double*           x,
+                                            rocblas_int       incx);
+
+ROCBLAS_EXPORT rocblas_status rocblas_ctrmv(rocblas_handle               handle,
+                                            rocblas_fill                 uplo,
+                                            rocblas_operation            transA,
+                                            rocblas_diagonal             diag,
+                                            rocblas_int                  m,
+                                            const rocblas_float_complex* A,
+                                            rocblas_int                  lda,
+                                            rocblas_float_complex*       x,
+                                            rocblas_int                  incx);
+
+ROCBLAS_EXPORT rocblas_status rocblas_ztrmv(rocblas_handle                handle,
+                                            rocblas_fill                  uplo,
+                                            rocblas_operation             transA,
+                                            rocblas_diagonal              diag,
+                                            rocblas_int                   m,
+                                            const rocblas_double_complex* A,
+                                            rocblas_int                   lda,
+                                            rocblas_double_complex*       x,
+                                            rocblas_int                   incx);
+
+/*! \brief BLAS Level 2 API
+
+    \details
+    trmv_batched performs one of the matrix-vector operations
+
+         x_i = A_i*x_i or x_i = A**T*x_i, 0 \le i < batch_count
+
+    where x_i is an n element vector and A_i is an n by n (unit, or non-unit, upper or lower triangular matrix)
+
+    The vectors x_i are overwritten.
+
+    @param[in]
+    handle    [rocblas_handle]
+              handle to the rocblas library context queue.
+
+    @param[in]
+    uplo    [rocblas_fill]
+            rocblas_fill_upper:  A_i is an upper triangular matrix.
+            rocblas_fill_lower:  A_i is a  lower triangular matrix.
+
+    @param[in]
+    transA     [rocblas_operation]
+
+    @param[in]
+    diag    [rocblas_diagonal]
+            rocblas_diagonal_unit:     A_i is assumed to be unit triangular.
+            rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
+
+    @param[in]
+    m         [rocblas_int]
+              m specifies the number of rows of matrices A_i. m >= 0.
+
+    @param[in]
+    A         device pointer storing pointer of matrices A_i,
+              of dimension ( lda, m )
+
+    @param[in]
+    lda       [rocblas_int]
+              specifies the leading dimension of A_i.
+              lda >= max( 1, m ).
+
+    @param[in]
+    x         device pointer storing vectors x_i.
+
+    @param[in]
+    incx      [rocblas_int]
+              specifies the increment for the elements of vectors x_i.
+
+    @param[in]
+    batch_count [rocblas_int]
+              The number of batched matrices/vectors.
+
+
+    ********************************************************************/
+ROCBLAS_EXPORT rocblas_status rocblas_strmv_batched(rocblas_handle      handle,
+                                                    rocblas_fill        uplo,
+                                                    rocblas_operation   transA,
+                                                    rocblas_diagonal    diag,
+                                                    rocblas_int         m,
+                                                    const float* const* A,
+                                                    rocblas_int         lda,
+                                                    float* const*       x,
+                                                    rocblas_int         incx,
+                                                    rocblas_int         batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_dtrmv_batched(rocblas_handle       handle,
+                                                    rocblas_fill         uplo,
+                                                    rocblas_operation    transA,
+                                                    rocblas_diagonal     diag,
+                                                    rocblas_int          m,
+                                                    const double* const* A,
+                                                    rocblas_int          lda,
+                                                    double* const*       x,
+                                                    rocblas_int          incx,
+                                                    rocblas_int          batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_ctrmv_batched(rocblas_handle                      handle,
+                                                    rocblas_fill                        uplo,
+                                                    rocblas_operation                   transA,
+                                                    rocblas_diagonal                    diag,
+                                                    rocblas_int                         m,
+                                                    const rocblas_float_complex* const* A,
+                                                    rocblas_int                         lda,
+                                                    rocblas_float_complex* const*       x,
+                                                    rocblas_int                         incx,
+                                                    rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_ztrmv_batched(rocblas_handle                       handle,
+                                                    rocblas_fill                         uplo,
+                                                    rocblas_operation                    transA,
+                                                    rocblas_diagonal                     diag,
+                                                    rocblas_int                          m,
+                                                    const rocblas_double_complex* const* A,
+                                                    rocblas_int                          lda,
+                                                    rocblas_double_complex* const*       x,
+                                                    rocblas_int                          incx,
+                                                    rocblas_int batch_count);
+
+/*! \brief BLAS Level 2 API
+
+    \details
+    trmv_strided_batched performs one of the matrix-vector operations
+
+         x_i = A_i*x_i or x_i = A**T*x_i, 0 \le i < batch_count
+
+    where x_i is an n element vector and A_i is an n by n (unit, or non-unit, upper or lower triangular matrix)
+    with strides specifying how to retrieve $x_i$ (resp. $A_i$) from $x_{i-1}$ (resp. $A_i$).
+
+    The vectors x_i are overwritten.
+
+    @param[in]
+    handle    [rocblas_handle]
+              handle to the rocblas library context queue.
+
+    @param[in]
+    uplo    [rocblas_fill]
+            rocblas_fill_upper:  A_i is an upper triangular matrix.
+            rocblas_fill_lower:  A_i is a  lower triangular matrix.
+
+    @param[in]
+    transA     [rocblas_operation]
+
+    @param[in]
+    diag    [rocblas_diagonal]
+            rocblas_diagonal_unit:     A_i is assumed to be unit triangular.
+            rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
+
+    @param[in]
+    m         [rocblas_int]
+              m specifies the number of rows of matrices A_i. m >= 0.
+
+    @param[in]
+    A         device pointer of the matrix A_0,
+              of dimension ( lda, m )
+
+    @param[in]
+    lda       [rocblas_int]
+              specifies the leading dimension of A_i.
+              lda >= max( 1, m ).
+
+    @param[in]
+    stride_a  [rocblas_stride]
+              stride from the start of one A_i matrix to the next A_{i + 1}
+
+    @param[in]
+    x         device pointer storing the vector x_0.
+
+    @param[in]
+    incx      [rocblas_int]
+              specifies the increment for the elements of one vector x.
+
+    @param[in]
+    stride_x  [rocblas_stride]
+              stride from the start of one x_i vector to the next x_{i + 1}
+
+    @param[in]
+    batch_count [rocblas_int]
+              The number of batched matrices/vectors.
+
+
+    ********************************************************************/
+ROCBLAS_EXPORT rocblas_status rocblas_strmv_strided_batched(rocblas_handle    handle,
+                                                            rocblas_fill      uplo,
+                                                            rocblas_operation transA,
+                                                            rocblas_diagonal  diag,
+                                                            rocblas_int       m,
+                                                            const float*      A,
+                                                            rocblas_int       lda,
+                                                            rocblas_stride    stridea,
+                                                            float*            x,
+                                                            rocblas_int       incx,
+                                                            rocblas_stride    stridex,
+                                                            rocblas_int       batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_dtrmv_strided_batched(rocblas_handle    handle,
+                                                            rocblas_fill      uplo,
+                                                            rocblas_operation transA,
+                                                            rocblas_diagonal  diag,
+                                                            rocblas_int       m,
+                                                            const double*     A,
+                                                            rocblas_int       lda,
+                                                            rocblas_stride    stridea,
+                                                            double*           x,
+                                                            rocblas_int       incx,
+                                                            rocblas_stride    stridex,
+                                                            rocblas_int       batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_ctrmv_strided_batched(rocblas_handle               handle,
+                                                            rocblas_fill                 uplo,
+                                                            rocblas_operation            transA,
+                                                            rocblas_diagonal             diag,
+                                                            rocblas_int                  m,
+                                                            const rocblas_float_complex* A,
+                                                            rocblas_int                  lda,
+                                                            rocblas_stride               stridea,
+                                                            rocblas_float_complex*       x,
+                                                            rocblas_int                  incx,
+                                                            rocblas_stride               stridex,
+                                                            rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_ztrmv_strided_batched(rocblas_handle                handle,
+                                                            rocblas_fill                  uplo,
+                                                            rocblas_operation             transA,
+                                                            rocblas_diagonal              diag,
+                                                            rocblas_int                   m,
+                                                            const rocblas_double_complex* A,
+                                                            rocblas_int                   lda,
+                                                            rocblas_stride                stridea,
+                                                            rocblas_double_complex*       x,
+                                                            rocblas_int                   incx,
+                                                            rocblas_stride                stridex,
+                                                            rocblas_int batch_count);
+
+/*! \brief BLAS Level 2 API
+
+    \details
     xTBMV performs one of the matrix-vector operations
 
         x := A*x      or

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -129,6 +129,9 @@ set( rocblas_blas2_source
   blas2/rocblas_gemv.cpp
   blas2/rocblas_gemv_batched.cpp
   blas2/rocblas_gemv_strided_batched.cpp
+  blas2/rocblas_trmv.cpp
+  blas2/rocblas_trmv_batched.cpp
+  blas2/rocblas_trmv_strided_batched.cpp
   blas2/rocblas_ger.cpp
   blas2/rocblas_ger_batched.cpp
   blas2/rocblas_ger_strided_batched.cpp

--- a/library/src/blas2/rocblas_trmv.cpp
+++ b/library/src/blas2/rocblas_trmv.cpp
@@ -1,0 +1,171 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#include "rocblas_trmv.hpp"
+#include "handle.h"
+#include "logging.h"
+#include "rocblas.h"
+#include "utility.h"
+#include <algorithm>
+#include <cstdio>
+#include <tuple>
+
+namespace
+{
+    template <typename>
+    constexpr char rocblas_trmv_name[] = "unknown";
+    template <>
+    constexpr char rocblas_trmv_name<float>[] = "rocblas_strmv";
+    template <>
+    constexpr char rocblas_trmv_name<double>[] = "rocblas_dtrmv";
+    template <>
+    constexpr char rocblas_trmv_name<rocblas_float_complex>[] = "rocblas_ctrmv";
+    template <>
+    constexpr char rocblas_trmv_name<rocblas_double_complex>[] = "rocblas_ztrmv";
+
+    template <typename T>
+    rocblas_status rocblas_trmv_impl(rocblas_handle    handle,
+                                     rocblas_fill      uplo,
+                                     rocblas_operation transA,
+                                     rocblas_diagonal  diag,
+                                     rocblas_int       m,
+                                     const T*          A,
+                                     rocblas_int       lda,
+                                     T*                x,
+                                     rocblas_int       incx)
+    {
+        if(!handle)
+        {
+            return rocblas_status_invalid_handle;
+        }
+
+        auto layer_mode = handle->layer_mode;
+        if(layer_mode
+           & (rocblas_layer_mode_log_trace | rocblas_layer_mode_log_bench
+              | rocblas_layer_mode_log_profile))
+        {
+            auto uplo_letter   = rocblas_fill_letter(uplo);
+            auto transA_letter = rocblas_transpose_letter(transA);
+            auto diag_letter   = rocblas_diag_letter(diag);
+            if(layer_mode & rocblas_layer_mode_log_trace)
+            {
+                log_trace(handle, rocblas_trmv_name<T>, uplo, transA, diag, m, A, lda, x, incx);
+            }
+
+            if(layer_mode & rocblas_layer_mode_log_bench)
+            {
+                log_bench(handle,
+                          "./rocblas-bench",
+                          "-f",
+                          "trmv",
+                          "-r",
+                          rocblas_precision_string<T>,
+                          "--uplo",
+                          uplo_letter,
+                          "--transposeA",
+                          transA_letter,
+                          "--diag",
+                          diag_letter,
+                          "-m",
+                          m,
+                          "--lda",
+                          lda,
+                          "--incx",
+                          incx);
+            }
+
+            if(layer_mode & rocblas_layer_mode_log_profile)
+            {
+                log_profile(handle,
+                            rocblas_trmv_name<T>,
+                            "uplo",
+                            uplo_letter,
+                            "transA",
+                            transA_letter,
+                            "diag",
+                            diag_letter,
+                            "M",
+                            m,
+                            "lda",
+                            lda,
+                            "incx",
+                            incx);
+            }
+        }
+
+        if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
+        {
+            return rocblas_status_not_implemented;
+        }
+
+        if(m < 0 || lda < m || lda < 1 || !incx)
+        {
+            return rocblas_status_invalid_size;
+        }
+
+        //
+        // quick return if possible.
+        // return rocblas_status_size_unchanged if device memory size query
+        //
+        if(!m)
+        {
+            return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged
+                                                         : rocblas_status_success;
+        }
+
+        size_t dev_bytes = m * sizeof(T);
+        if(handle->is_device_memory_size_query())
+        {
+            return handle->set_optimal_device_memory_size(dev_bytes);
+        }
+
+        if(!A || !x)
+        {
+            return rocblas_status_invalid_pointer;
+        }
+
+        T* w = (T*)handle->device_malloc(dev_bytes);
+        if(!w)
+        {
+            return rocblas_status_memory_error;
+        }
+
+        return rocblas_trmv_template<T>(handle, uplo, transA, diag, m, A, lda, x, incx, w);
+    }
+
+} // namespace
+
+/*
+* ===========================================================================
+*    C wrapper
+* ===========================================================================
+*/
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL ALREADY DEFINED
+#endif
+
+#define IMPL(routine_name_, T_)                                                   \
+    rocblas_status routine_name_(rocblas_handle    handle,                        \
+                                 rocblas_fill      uplo,                          \
+                                 rocblas_operation transA,                        \
+                                 rocblas_diagonal  diag,                          \
+                                 rocblas_int       m,                             \
+                                 const T_*         A,                             \
+                                 rocblas_int       lda,                           \
+                                 T_*               x,                             \
+                                 rocblas_int       incx)                          \
+    {                                                                             \
+        return rocblas_trmv_impl(handle, uplo, transA, diag, m, A, lda, x, incx); \
+    }
+
+IMPL(rocblas_strmv, float);
+IMPL(rocblas_dtrmv, double);
+IMPL(rocblas_ctrmv, rocblas_float_complex);
+IMPL(rocblas_ztrmv, rocblas_double_complex);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas2/rocblas_trmv.cpp
+++ b/library/src/blas2/rocblas_trmv.cpp
@@ -130,7 +130,7 @@ namespace
             return rocblas_status_memory_error;
         }
 
-        return rocblas_trmv_template<T>(handle, uplo, transA, diag, m, A, lda, x, incx, w);
+        return rocblas_trmv_template(handle, uplo, transA, diag, m, A, lda, x, incx, w);
     }
 
 } // namespace

--- a/library/src/blas2/rocblas_trmv.hpp
+++ b/library/src/blas2/rocblas_trmv.hpp
@@ -22,6 +22,7 @@ rocblas_status rocblas_trmv_template(rocblas_handle    handle,
                                      rocblas_int       incx,
                                      W                 w)
 {
+    static constexpr rocblas_int    NB          = 512;
     static constexpr rocblas_int    batch_count = 1;
     static constexpr ptrdiff_t      offseta     = 0;
     static constexpr ptrdiff_t      offsetx     = 0;
@@ -29,20 +30,20 @@ rocblas_status rocblas_trmv_template(rocblas_handle    handle,
     static constexpr rocblas_stride stridea     = 0;
     static constexpr rocblas_stride stridew     = 0;
 
-    return trmv_template<512>(handle,
-                              uplo,
-                              transa,
-                              diag,
-                              m,
-                              a,
-                              offseta,
-                              lda,
-                              stridea,
-                              x,
-                              offsetx,
-                              incx,
-                              stridex,
-                              w,
-                              stridew,
-                              batch_count);
+    return trmv_template<NB>(handle,
+                             uplo,
+                             transa,
+                             diag,
+                             m,
+                             a,
+                             offseta,
+                             lda,
+                             stridea,
+                             x,
+                             offsetx,
+                             incx,
+                             stridex,
+                             w,
+                             stridew,
+                             batch_count);
 }

--- a/library/src/blas2/rocblas_trmv.hpp
+++ b/library/src/blas2/rocblas_trmv.hpp
@@ -1,0 +1,48 @@
+/* ************************************************************************
+ * Copyright 2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "handle.h"
+#include "logging.h"
+#include "rocblas.h"
+#include "trmv_template.hpp"
+#include "utility.h"
+#include <limits>
+
+template <typename T, typename A, typename X, typename W>
+rocblas_status rocblas_trmv_template(rocblas_handle    handle,
+                                     rocblas_fill      uplo,
+                                     rocblas_operation transa,
+                                     rocblas_diagonal  diag,
+                                     rocblas_int       m,
+                                     A                 a,
+                                     rocblas_int       lda,
+                                     X                 x,
+                                     rocblas_int       incx,
+                                     W                 w)
+{
+    static constexpr rocblas_int    batch_count = 1;
+    static constexpr ptrdiff_t      offseta     = 0;
+    static constexpr ptrdiff_t      offsetx     = 0;
+    static constexpr rocblas_stride stridex     = 0;
+    static constexpr rocblas_stride stridea     = 0;
+    static constexpr rocblas_stride stridew     = 0;
+
+    return trmv_template<512, T>(handle,
+                                 uplo,
+                                 transa,
+                                 diag,
+                                 m,
+                                 a,
+                                 offseta,
+                                 lda,
+                                 stridea,
+                                 x,
+                                 offsetx,
+                                 incx,
+                                 stridex,
+                                 w,
+                                 stridew,
+                                 batch_count);
+}

--- a/library/src/blas2/rocblas_trmv.hpp
+++ b/library/src/blas2/rocblas_trmv.hpp
@@ -10,7 +10,7 @@
 #include "utility.h"
 #include <limits>
 
-template <typename T, typename A, typename X, typename W>
+template <typename A, typename X, typename W>
 rocblas_status rocblas_trmv_template(rocblas_handle    handle,
                                      rocblas_fill      uplo,
                                      rocblas_operation transa,
@@ -29,20 +29,20 @@ rocblas_status rocblas_trmv_template(rocblas_handle    handle,
     static constexpr rocblas_stride stridea     = 0;
     static constexpr rocblas_stride stridew     = 0;
 
-    return trmv_template<512, T>(handle,
-                                 uplo,
-                                 transa,
-                                 diag,
-                                 m,
-                                 a,
-                                 offseta,
-                                 lda,
-                                 stridea,
-                                 x,
-                                 offsetx,
-                                 incx,
-                                 stridex,
-                                 w,
-                                 stridew,
-                                 batch_count);
+    return trmv_template<512>(handle,
+                              uplo,
+                              transa,
+                              diag,
+                              m,
+                              a,
+                              offseta,
+                              lda,
+                              stridea,
+                              x,
+                              offsetx,
+                              incx,
+                              stridex,
+                              w,
+                              stridew,
+                              batch_count);
 }

--- a/library/src/blas2/rocblas_trmv_batched.cpp
+++ b/library/src/blas2/rocblas_trmv_batched.cpp
@@ -1,0 +1,186 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#include "rocblas_trmv_batched.hpp"
+#include "handle.h"
+#include "logging.h"
+#include "rocblas.h"
+#include "utility.h"
+#include <algorithm>
+#include <cstdio>
+#include <tuple>
+
+namespace
+{
+    template <typename>
+    constexpr char rocblas_trmv_batched_name[] = "unknown";
+    template <>
+    constexpr char rocblas_trmv_batched_name<float>[] = "rocblas_strmv_batched";
+    template <>
+    constexpr char rocblas_trmv_batched_name<double>[] = "rocblas_dtrmv_batched";
+    template <>
+    constexpr char rocblas_trmv_batched_name<rocblas_float_complex>[] = "rocblas_ctrmv_batched";
+    template <>
+    constexpr char rocblas_trmv_batched_name<rocblas_double_complex>[] = "rocblas_ztrmv_batched";
+
+    template <typename T>
+    rocblas_status rocblas_trmv_batched_impl(rocblas_handle    handle,
+                                             rocblas_fill      uplo,
+                                             rocblas_operation transa,
+                                             rocblas_diagonal  diag,
+                                             rocblas_int       m,
+                                             const T* const*   a,
+                                             rocblas_int       lda,
+                                             T* const*         x,
+                                             rocblas_int       incx,
+                                             rocblas_int       batch_count)
+    {
+        if(!handle)
+        {
+            return rocblas_status_invalid_handle;
+        }
+
+        auto layer_mode = handle->layer_mode;
+        if(layer_mode
+           & (rocblas_layer_mode_log_trace | rocblas_layer_mode_log_bench
+              | rocblas_layer_mode_log_profile))
+        {
+            auto uplo_letter   = rocblas_fill_letter(uplo);
+            auto transa_letter = rocblas_transpose_letter(transa);
+            auto diag_letter   = rocblas_diag_letter(diag);
+            if(layer_mode & rocblas_layer_mode_log_trace)
+            {
+                log_trace(handle,
+                          rocblas_trmv_batched_name<T>,
+                          uplo,
+                          transa,
+                          diag,
+                          m,
+                          a,
+                          lda,
+                          x,
+                          incx,
+                          batch_count);
+            }
+
+            if(layer_mode & rocblas_layer_mode_log_bench)
+            {
+                log_bench(handle,
+                          "./rocblas-bench",
+                          "-f",
+                          "trmv_batched",
+                          "-r",
+                          rocblas_precision_string<T>,
+                          "--uplo",
+                          uplo_letter,
+                          "--transposeA",
+                          transa_letter,
+                          "--diag",
+                          diag_letter,
+                          "-m",
+                          m,
+                          "--lda",
+                          lda,
+                          "--incx",
+                          incx,
+                          "--batch_count",
+                          batch_count);
+            }
+
+            if(layer_mode & rocblas_layer_mode_log_profile)
+            {
+                log_profile(handle,
+                            rocblas_trmv_batched_name<T>,
+                            "uplo",
+                            uplo_letter,
+                            "transA",
+                            transa_letter,
+                            "diag",
+                            diag_letter,
+                            "M",
+                            m,
+                            "lda",
+                            lda,
+                            "incx",
+                            incx,
+                            "--batch_count",
+                            batch_count);
+            }
+        }
+
+        if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
+        {
+            return rocblas_status_not_implemented;
+        }
+
+        if(m < 0 || lda < m || lda < 1 || !incx || batch_count < 0)
+        {
+            return rocblas_status_invalid_size;
+        }
+
+        if(!m || !batch_count)
+        {
+            return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged
+                                                         : rocblas_status_success;
+        }
+
+        size_t dev_bytes = m * batch_count * sizeof(T);
+        if(handle->is_device_memory_size_query())
+        {
+            return handle->set_optimal_device_memory_size(dev_bytes);
+        }
+
+        if(!a || !x)
+        {
+            return rocblas_status_invalid_pointer;
+        }
+
+        T* w = (T*)handle->device_malloc(dev_bytes);
+        if(!w)
+        {
+            return rocblas_status_memory_error;
+        }
+
+        rocblas_stride stridew = m;
+        return rocblas_trmv_batched_template<T>(
+            handle, uplo, transa, diag, m, a, lda, x, incx, w, stridew, batch_count);
+    }
+
+} // namespace
+
+/*
+* ===========================================================================
+*    C wrapper
+* ===========================================================================
+*/
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL ALREADY DEFINED
+#endif
+
+#define IMPL(routine_name_, T_)                                           \
+    rocblas_status routine_name_(rocblas_handle    handle,                \
+                                 rocblas_fill      uplo,                  \
+                                 rocblas_operation transa,                \
+                                 rocblas_diagonal  diag,                  \
+                                 rocblas_int       m,                     \
+                                 const T_* const*  a,                     \
+                                 rocblas_int       lda,                   \
+                                 T_* const*        x,                     \
+                                 rocblas_int       incx,                  \
+                                 rocblas_int       batch_count)           \
+    {                                                                     \
+        return rocblas_trmv_batched_impl(                                 \
+            handle, uplo, transa, diag, m, a, lda, x, incx, batch_count); \
+    }
+
+IMPL(rocblas_strmv_batched, float);
+IMPL(rocblas_dtrmv_batched, double);
+IMPL(rocblas_ctrmv_batched, rocblas_float_complex);
+IMPL(rocblas_ztrmv_batched, rocblas_double_complex);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas2/rocblas_trmv_batched.cpp
+++ b/library/src/blas2/rocblas_trmv_batched.cpp
@@ -142,7 +142,7 @@ namespace
         }
 
         rocblas_stride stridew = m;
-        return rocblas_trmv_batched_template<T>(
+        return rocblas_trmv_batched_template(
             handle, uplo, transa, diag, m, a, lda, x, incx, w, stridew, batch_count);
     }
 

--- a/library/src/blas2/rocblas_trmv_batched.hpp
+++ b/library/src/blas2/rocblas_trmv_batched.hpp
@@ -7,7 +7,7 @@
 #include "rocblas.h"
 #include "trmv_template.hpp"
 
-template <typename T, typename A, typename X, typename W>
+template <typename A, typename X, typename W>
 rocblas_status rocblas_trmv_batched_template(rocblas_handle    handle,
                                              rocblas_fill      uplo,
                                              rocblas_operation transa,
@@ -27,20 +27,20 @@ rocblas_status rocblas_trmv_batched_template(rocblas_handle    handle,
     static constexpr ptrdiff_t      offseta = 0;
     static constexpr ptrdiff_t      offsetx = 0;
 
-    return trmv_template<NB, T>(handle,
-                                uplo,
-                                transa,
-                                diag,
-                                m,
-                                a,
-                                offseta,
-                                lda,
-                                stridea,
-                                x,
-                                offsetx,
-                                incx,
-                                stridex,
-                                w,
-                                stridew,
-                                batch_count);
+    return trmv_template<NB>(handle,
+                             uplo,
+                             transa,
+                             diag,
+                             m,
+                             a,
+                             offseta,
+                             lda,
+                             stridea,
+                             x,
+                             offsetx,
+                             incx,
+                             stridex,
+                             w,
+                             stridew,
+                             batch_count);
 }

--- a/library/src/blas2/rocblas_trmv_batched.hpp
+++ b/library/src/blas2/rocblas_trmv_batched.hpp
@@ -1,0 +1,46 @@
+/* ************************************************************************
+ * Copyright 2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "handle.h"
+#include "rocblas.h"
+#include "trmv_template.hpp"
+
+template <typename T, typename A, typename X, typename W>
+rocblas_status rocblas_trmv_batched_template(rocblas_handle    handle,
+                                             rocblas_fill      uplo,
+                                             rocblas_operation transa,
+                                             rocblas_diagonal  diag,
+                                             rocblas_int       m,
+                                             A                 a,
+                                             rocblas_int       lda,
+                                             X                 x,
+                                             rocblas_int       incx,
+                                             W                 w,
+                                             rocblas_stride    stridew,
+                                             rocblas_int       batch_count)
+{
+    static constexpr rocblas_int    NB      = 512;
+    static constexpr rocblas_stride stridex = 0;
+    static constexpr rocblas_stride stridea = 0;
+    static constexpr ptrdiff_t      offseta = 0;
+    static constexpr ptrdiff_t      offsetx = 0;
+
+    return trmv_template<NB, T>(handle,
+                                uplo,
+                                transa,
+                                diag,
+                                m,
+                                a,
+                                offseta,
+                                lda,
+                                stridea,
+                                x,
+                                offsetx,
+                                incx,
+                                stridex,
+                                w,
+                                stridew,
+                                batch_count);
+}

--- a/library/src/blas2/rocblas_trmv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_trmv_strided_batched.cpp
@@ -163,20 +163,20 @@ namespace
         }
 
         rocblas_stride stridew = m;
-        return rocblas_trmv_strided_batched_template<T>(handle,
-                                                        uplo,
-                                                        transa,
-                                                        diag,
-                                                        m,
-                                                        a,
-                                                        lda,
-                                                        stridea,
-                                                        x,
-                                                        incx,
-                                                        stridex,
-                                                        w,
-                                                        stridew,
-                                                        batch_count);
+        return rocblas_trmv_strided_batched_template(handle,
+                                                     uplo,
+                                                     transa,
+                                                     diag,
+                                                     m,
+                                                     a,
+                                                     lda,
+                                                     stridea,
+                                                     x,
+                                                     incx,
+                                                     stridex,
+                                                     w,
+                                                     stridew,
+                                                     batch_count);
     }
 
 } // namespace

--- a/library/src/blas2/rocblas_trmv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_trmv_strided_batched.cpp
@@ -1,0 +1,221 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#include "rocblas_trmv_strided_batched.hpp"
+#include "handle.h"
+#include "logging.h"
+#include "rocblas.h"
+#include "utility.h"
+#include <algorithm>
+#include <cstdio>
+#include <tuple>
+
+namespace
+{
+
+    template <typename>
+    constexpr char rocblas_trmv_strided_batched_name[] = "unknown";
+    template <>
+    constexpr char rocblas_trmv_strided_batched_name<float>[] = "rocblas_strmv_strided_batched";
+    template <>
+    constexpr char rocblas_trmv_strided_batched_name<double>[] = "rocblas_dtrmv_strided_batched";
+    template <>
+    constexpr char rocblas_trmv_strided_batched_name<rocblas_float_complex>[]
+        = "rocblas_ctrmv_strided_batched";
+    template <>
+    constexpr char rocblas_trmv_strided_batched_name<rocblas_double_complex>[]
+        = "rocblas_ztrmv_strided_batched";
+
+    template <typename T>
+    rocblas_status rocblas_trmv_strided_batched_impl(rocblas_handle    handle,
+                                                     rocblas_fill      uplo,
+                                                     rocblas_operation transa,
+                                                     rocblas_diagonal  diag,
+                                                     rocblas_int       m,
+                                                     const T*          a,
+                                                     rocblas_int       lda,
+                                                     rocblas_stride    stridea,
+                                                     T*                x,
+                                                     rocblas_int       incx,
+                                                     rocblas_stride    stridex,
+                                                     rocblas_int       batch_count)
+    {
+        if(!handle)
+        {
+            return rocblas_status_invalid_handle;
+        }
+
+        auto layer_mode = handle->layer_mode;
+        if(layer_mode
+           & (rocblas_layer_mode_log_trace | rocblas_layer_mode_log_bench
+              | rocblas_layer_mode_log_profile))
+        {
+            auto uplo_letter   = rocblas_fill_letter(uplo);
+            auto transa_letter = rocblas_transpose_letter(transa);
+            auto diag_letter   = rocblas_diag_letter(diag);
+            if(layer_mode & rocblas_layer_mode_log_trace)
+            {
+                log_trace(handle,
+                          rocblas_trmv_strided_batched_name<T>,
+                          uplo,
+                          transa,
+                          diag,
+                          m,
+                          a,
+                          lda,
+                          x,
+                          incx,
+
+                          "--stride_A",
+                          stridea,
+                          "--incx",
+                          incx,
+                          "--stride_x",
+                          stridex,
+
+                          batch_count);
+            }
+
+            if(layer_mode & rocblas_layer_mode_log_bench)
+            {
+                log_bench(handle,
+                          "./rocblas-bench",
+                          "-f",
+                          "trmv_strided_batched",
+                          "-r",
+                          rocblas_precision_string<T>,
+                          "--uplo",
+                          uplo_letter,
+                          "--transposeA",
+                          transa_letter,
+                          "--diag",
+                          diag_letter,
+                          "-m",
+                          m,
+                          "--lda",
+                          lda,
+                          "--stride_A",
+                          stridea,
+                          "--incx",
+                          incx,
+                          "--stride_x",
+                          stridex,
+                          "--batch_count",
+                          batch_count);
+            }
+
+            if(layer_mode & rocblas_layer_mode_log_profile)
+            {
+                log_profile(handle,
+                            rocblas_trmv_strided_batched_name<T>,
+                            "uplo",
+                            uplo_letter,
+                            "transA",
+                            transa_letter,
+                            "diag",
+                            diag_letter,
+                            "M",
+                            m,
+                            "lda",
+                            lda,
+                            "stride_A",
+                            stridea,
+                            "incx",
+                            incx,
+                            "stride_x",
+                            stridex,
+                            "batch_count",
+                            batch_count);
+            }
+        }
+
+        if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
+        {
+            return rocblas_status_not_implemented;
+        }
+
+        if(m < 0 || lda < m || lda < 1 || !incx || batch_count < 0)
+        {
+            return rocblas_status_invalid_size;
+        }
+
+        if(!m || !batch_count)
+        {
+            return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged
+                                                         : rocblas_status_success;
+        }
+
+        size_t dev_bytes = m * batch_count * sizeof(T);
+        if(handle->is_device_memory_size_query())
+        {
+            return handle->set_optimal_device_memory_size(dev_bytes);
+        }
+
+        if(!a || !x)
+        {
+            return rocblas_status_invalid_pointer;
+        }
+
+        T* w = (T*)handle->device_malloc(dev_bytes);
+        if(!w)
+        {
+            return rocblas_status_memory_error;
+        }
+
+        rocblas_stride stridew = m;
+        return rocblas_trmv_strided_batched_template<T>(handle,
+                                                        uplo,
+                                                        transa,
+                                                        diag,
+                                                        m,
+                                                        a,
+                                                        lda,
+                                                        stridea,
+                                                        x,
+                                                        incx,
+                                                        stridex,
+                                                        w,
+                                                        stridew,
+                                                        batch_count);
+    }
+
+} // namespace
+
+/*
+* ===========================================================================
+*    C wrapper
+* ===========================================================================
+*/
+
+extern "C" {
+
+#ifdef IMPL
+#error IMPL ALREADY DEFINED
+#endif
+
+#define IMPL(routine_name_, T_)                                                             \
+    rocblas_status routine_name_(rocblas_handle    handle,                                  \
+                                 rocblas_fill      uplo,                                    \
+                                 rocblas_operation transA,                                  \
+                                 rocblas_diagonal  diag,                                    \
+                                 rocblas_int       m,                                       \
+                                 const T_*         A,                                       \
+                                 rocblas_int       lda,                                     \
+                                 rocblas_stride    stridea,                                 \
+                                 T_*               x,                                       \
+                                 rocblas_int       incx,                                    \
+                                 rocblas_stride    stridex,                                 \
+                                 rocblas_int       batch_count)                             \
+    {                                                                                       \
+        return rocblas_trmv_strided_batched_impl(                                           \
+            handle, uplo, transA, diag, m, A, lda, stridea, x, incx, stridex, batch_count); \
+    }
+
+IMPL(rocblas_strmv_strided_batched, float);
+IMPL(rocblas_dtrmv_strided_batched, double);
+IMPL(rocblas_ctrmv_strided_batched, rocblas_float_complex);
+IMPL(rocblas_ztrmv_strided_batched, rocblas_double_complex);
+
+#undef IMPL
+
+} // extern "C"

--- a/library/src/blas2/rocblas_trmv_strided_batched.hpp
+++ b/library/src/blas2/rocblas_trmv_strided_batched.hpp
@@ -1,0 +1,45 @@
+/* ************************************************************************
+ * Copyright 2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "handle.h"
+#include "rocblas.h"
+#include "trmv_template.hpp"
+
+template <typename T, typename A, typename X, typename W>
+rocblas_status rocblas_trmv_strided_batched_template(rocblas_handle    handle,
+                                                     rocblas_fill      uplo,
+                                                     rocblas_operation transa,
+                                                     rocblas_diagonal  diag,
+                                                     rocblas_int       m,
+                                                     A                 a,
+                                                     rocblas_int       lda,
+                                                     rocblas_stride    stridea,
+                                                     X                 x,
+                                                     rocblas_int       incx,
+                                                     rocblas_stride    stridex,
+                                                     W                 w,
+                                                     rocblas_stride    stridew,
+                                                     rocblas_int       batch_count)
+{
+    static constexpr rocblas_int NB      = 512;
+    static constexpr ptrdiff_t   offseta = 0;
+    static constexpr ptrdiff_t   offsetx = 0;
+    return trmv_template<NB, T>(handle,
+                                uplo,
+                                transa,
+                                diag,
+                                m,
+                                a,
+                                offseta,
+                                lda,
+                                stridea,
+                                x,
+                                offsetx,
+                                incx,
+                                stridex,
+                                w,
+                                stridew,
+                                batch_count);
+}

--- a/library/src/blas2/rocblas_trmv_strided_batched.hpp
+++ b/library/src/blas2/rocblas_trmv_strided_batched.hpp
@@ -7,7 +7,7 @@
 #include "rocblas.h"
 #include "trmv_template.hpp"
 
-template <typename T, typename A, typename X, typename W>
+template <typename A, typename X, typename W>
 rocblas_status rocblas_trmv_strided_batched_template(rocblas_handle    handle,
                                                      rocblas_fill      uplo,
                                                      rocblas_operation transa,
@@ -26,20 +26,20 @@ rocblas_status rocblas_trmv_strided_batched_template(rocblas_handle    handle,
     static constexpr rocblas_int NB      = 512;
     static constexpr ptrdiff_t   offseta = 0;
     static constexpr ptrdiff_t   offsetx = 0;
-    return trmv_template<NB, T>(handle,
-                                uplo,
-                                transa,
-                                diag,
-                                m,
-                                a,
-                                offseta,
-                                lda,
-                                stridea,
-                                x,
-                                offsetx,
-                                incx,
-                                stridex,
-                                w,
-                                stridew,
-                                batch_count);
+    return trmv_template<NB>(handle,
+                             uplo,
+                             transa,
+                             diag,
+                             m,
+                             a,
+                             offseta,
+                             lda,
+                             stridea,
+                             x,
+                             offsetx,
+                             incx,
+                             stridex,
+                             w,
+                             stridew,
+                             batch_count);
 }

--- a/library/src/blas2/trmv_device.hpp
+++ b/library/src/blas2/trmv_device.hpp
@@ -1,0 +1,205 @@
+/* ************************************************************************
+ * Copyright 2016-2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+#include "utility.h"
+
+template <rocblas_int NB, typename T>
+__device__ void trmvn_kernel_calc(rocblas_fill     uplo,
+                                  rocblas_diagonal diag,
+                                  rocblas_int      m,
+                                  const T*         A,
+                                  rocblas_int      lda,
+                                  T*               x,
+                                  rocblas_int      incx,
+                                  T*               w)
+{
+    ptrdiff_t   tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    rocblas_int tx  = hipThreadIdx_x;
+    if(tid < m)
+    {
+        A += tid;
+        T res = x[tid * incx];
+        if(diag == rocblas_diagonal_non_unit)
+        {
+            res *= A[tid * lda];
+        }
+        if(rocblas_fill_upper == uplo)
+        {
+            for(rocblas_int col = tid + 1; col < m; ++col)
+            {
+                res += A[col * lda] * x[col * incx];
+            }
+        }
+        else
+        {
+            for(rocblas_int col = 0; col < tid; ++col)
+            {
+                res += A[col * lda] * x[col * incx];
+            }
+        }
+        w[tid] = res;
+    }
+}
+
+template <rocblas_int NB, typename T>
+__device__ void trmvc_kernel_calc(rocblas_fill     uplo,
+                                  rocblas_diagonal diag,
+                                  rocblas_int      m,
+                                  const T*         A,
+                                  rocblas_int      lda,
+                                  T*               x,
+                                  rocblas_int      incx,
+                                  T*               w)
+{
+    ptrdiff_t   tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    rocblas_int tx  = hipThreadIdx_x;
+
+    if(tid < m)
+    {
+        A += tid * lda;
+        T res = x[tid * incx];
+        if(diag == rocblas_diagonal_non_unit)
+        {
+            res *= conj(A[tid]);
+        }
+        if(rocblas_fill_upper == uplo)
+        {
+            for(rocblas_int row = 0; row < tid; ++row)
+            {
+                res += conj(A[row]) * x[row * incx];
+            }
+        }
+        else
+        {
+            for(rocblas_int row = tid + 1; row < m; ++row)
+            {
+                res += conj(A[row]) * x[row * incx];
+            }
+        }
+        w[tid] = res;
+    }
+}
+
+template <rocblas_int NB, typename T>
+__device__ void trmvt_kernel_calc(rocblas_fill     uplo,
+                                  rocblas_diagonal diag,
+                                  rocblas_int      m,
+                                  const T*         A,
+                                  rocblas_int      lda,
+                                  T*               x,
+                                  rocblas_int      incx,
+                                  T*               w)
+{
+    ptrdiff_t   tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    rocblas_int tx  = hipThreadIdx_x;
+
+    T           res;
+    rocblas_int row;
+
+    if(tid < m)
+    {
+        A += tid * lda;
+        T res = x[tid * incx];
+        if(diag == rocblas_diagonal_non_unit)
+        {
+            res *= A[tid];
+        }
+
+        if(rocblas_fill_upper == uplo)
+        {
+            for(rocblas_int row = 0; row < tid; ++row)
+            {
+                res += A[row] * x[row * incx];
+            }
+        }
+        else
+        {
+            for(rocblas_int row = tid + 1; row < m; ++row)
+            {
+                res += A[row] * x[row * incx];
+            }
+        }
+        w[tid] = res;
+    }
+}
+
+template <rocblas_int NB, typename A, typename X, typename W>
+__global__ void trmvn_kernel(rocblas_fill     uplo,
+                             rocblas_diagonal diag,
+                             rocblas_int      m,
+                             A                a,
+                             ptrdiff_t        shifta,
+                             rocblas_int      lda,
+                             rocblas_stride   stridea,
+                             X                x,
+                             ptrdiff_t        shiftx,
+                             rocblas_int      incx,
+                             rocblas_stride   stridex,
+                             W                w,
+                             rocblas_stride   stridew)
+{
+    static constexpr ptrdiff_t shiftw = 0;
+    trmvn_kernel_calc<NB>(uplo,
+                          diag,
+                          m,
+                          load_ptr_batch(a, hipBlockIdx_y, shifta, stridea),
+                          lda,
+                          load_ptr_batch(x, hipBlockIdx_y, shiftx, stridex),
+                          incx,
+                          load_ptr_batch(w, hipBlockIdx_y, shiftw, stridew));
+}
+
+template <rocblas_int NB, typename A, typename X, typename W>
+__global__ void trmvt_kernel(rocblas_fill     uplo,
+                             rocblas_diagonal diag,
+                             rocblas_int      m,
+                             A                a,
+                             ptrdiff_t        shifta,
+                             rocblas_int      lda,
+                             rocblas_stride   stridea,
+                             X                x,
+                             ptrdiff_t        shiftx,
+                             rocblas_int      incx,
+                             rocblas_stride   stridex,
+                             W                w,
+                             rocblas_stride   stridew)
+{
+    static constexpr ptrdiff_t shiftw = 0;
+    trmvt_kernel_calc<NB>(uplo,
+                          diag,
+                          m,
+                          load_ptr_batch(a, hipBlockIdx_y, shifta, stridea),
+                          lda,
+                          load_ptr_batch(x, hipBlockIdx_y, shiftx, stridex),
+                          incx,
+                          load_ptr_batch(w, hipBlockIdx_y, shiftw, stridew));
+}
+
+template <rocblas_int NB, typename A, typename X, typename W>
+__global__ void trmvc_kernel(rocblas_fill     uplo,
+                             rocblas_diagonal diag,
+                             rocblas_int      m,
+                             A                a,
+                             ptrdiff_t        shifta,
+                             rocblas_int      lda,
+                             rocblas_stride   stridea,
+                             X                x,
+                             ptrdiff_t        shiftx,
+                             rocblas_int      incx,
+                             rocblas_stride   stridex,
+                             W                w,
+                             rocblas_stride   stridew)
+{
+    static constexpr ptrdiff_t shiftw = 0;
+    trmvc_kernel_calc<NB>(uplo,
+                          diag,
+                          m,
+                          load_ptr_batch(a, hipBlockIdx_y, shifta, stridea),
+                          lda,
+                          load_ptr_batch(x, hipBlockIdx_y, shiftx, stridex),
+                          incx,
+                          load_ptr_batch(w, hipBlockIdx_y, shiftw, stridew));
+}

--- a/library/src/blas2/trmv_template.hpp
+++ b/library/src/blas2/trmv_template.hpp
@@ -6,7 +6,7 @@
 #include "../blas1/rocblas_copy.hpp"
 #include "trmv_device.hpp"
 
-template <rocblas_int NB, typename T, typename A, typename X, typename W>
+template <rocblas_int NB, typename A, typename X, typename W>
 rocblas_status trmv_template(rocblas_handle    handle,
                              rocblas_fill      uplo,
                              rocblas_operation transa,
@@ -117,7 +117,7 @@ rocblas_status trmv_template(rocblas_handle    handle,
     {
         static constexpr rocblas_int offsetw = 0;
         static constexpr rocblas_int incw    = 1;
-        return rocblas_copy_template<1024>(
+        return rocblas_copy_template<NB>(
             handle, m, w, offsetw, incw, stridew, x, offsetx, incx, stridex, batch_count);
     }
 }

--- a/library/src/blas2/trmv_template.hpp
+++ b/library/src/blas2/trmv_template.hpp
@@ -1,0 +1,123 @@
+/* ************************************************************************
+ * Copyright 2019 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+
+#include "../blas1/rocblas_copy.hpp"
+#include "trmv_device.hpp"
+
+template <rocblas_int NB, typename T, typename A, typename X, typename W>
+rocblas_status trmv_template(rocblas_handle    handle,
+                             rocblas_fill      uplo,
+                             rocblas_operation transa,
+                             rocblas_diagonal  diag,
+                             rocblas_int       m,
+                             A                 a,
+                             ptrdiff_t         offseta,
+                             rocblas_int       lda,
+                             rocblas_stride    stridea,
+                             X                 x,
+                             ptrdiff_t         offsetx,
+                             rocblas_int       incx,
+                             rocblas_stride    stridex,
+                             W                 w,
+                             rocblas_stride    stridew,
+                             rocblas_int       batch_count)
+{
+    //
+    // quick return
+    //
+    if(!m || !batch_count)
+    {
+        return rocblas_status_success;
+    }
+
+    hipStream_t rocblas_stream = handle->rocblas_stream;
+
+    ptrdiff_t shiftx = incx < 0 ? offsetx + ptrdiff_t(incx) * (1 - m) : offsetx;
+
+    dim3 trmv_grid((m - 1) / NB + 1, batch_count);
+    dim3 trmv_threads(NB);
+    switch(transa)
+    {
+    case rocblas_operation_none:
+    {
+        hipLaunchKernelGGL((trmvn_kernel<NB>),
+                           trmv_grid,
+                           trmv_threads,
+                           0,
+                           rocblas_stream,
+                           uplo,
+                           diag,
+                           m,
+                           a,
+                           offseta,
+                           lda,
+                           stridea,
+                           x,
+                           shiftx,
+                           incx,
+                           stridex,
+                           w,
+                           stridew);
+        break;
+    }
+
+    case rocblas_operation_transpose:
+    {
+        hipLaunchKernelGGL((trmvt_kernel<NB>),
+                           trmv_grid,
+                           trmv_threads,
+                           0,
+                           rocblas_stream,
+                           uplo,
+                           diag,
+                           m,
+                           a,
+                           offseta,
+                           lda,
+                           stridea,
+                           x,
+                           shiftx,
+                           incx,
+                           stridex,
+                           w,
+                           stridew);
+        break;
+    }
+
+    case rocblas_operation_conjugate_transpose:
+    {
+        hipLaunchKernelGGL((trmvc_kernel<NB>),
+                           trmv_grid,
+                           trmv_threads,
+                           0,
+                           rocblas_stream,
+                           uplo,
+                           diag,
+                           m,
+                           a,
+                           offseta,
+                           lda,
+                           stridea,
+                           x,
+                           shiftx,
+                           incx,
+                           stridex,
+                           w,
+                           stridew);
+
+        break;
+    }
+    }
+
+    //
+    // Copy workspace to x.
+    //
+    {
+        static constexpr rocblas_int offsetw = 0;
+        static constexpr rocblas_int incw    = 1;
+        return rocblas_copy_template<1024>(
+            handle, m, w, offsetw, incw, stridew, x, offsetx, incx, stridex, batch_count);
+    }
+}


### PR DESCRIPTION
SWDEV-211980

CLIENT SIDE /////////////////

-1/ modified:   clients/benchmarks/client.cpp
adding trmv headers and add references to trmv routines

-2/ modified:   clients/common/rocblas_gentest.py
adding default values of strides for the trmv strided batched routine

-3 /  modified:   clients/gtest/CMakeLists.txt
Reference the trmv_gtest.yaml file

-4 / modified:   clients/gtest/rocblas_gtest.yaml
Include the rocblas_trmv.yaml file

-5/  modified:   clients/include/cblas_interface.hpp
Add complex types for the cblas trmv routine.

-6 /  modified:   clients/include/flops.hpp
Add flop counts for the non-batched trmv routine.

-7/  modified:   clients/include/rocblas.hpp
add headers of the trmv routines.
 
-8 / modified:   clients/include/rocblas_template.yaml
Add trmv routines
   
-9/ modified:   clients/include/testing_logging.hpp
Add non batched trmv, why referencing batched routines with gemm only ?...

-10/   modified:   library/src/CMakeLists.txt
Adding the 3 cpp files to compile.
   
-12/     new: clients/gtest/trmv_gtest.cpp
Add trmv template for tests

-13/     new: clients/gtest/trmv_gtest.yaml
Definition of the tests

-14/  new: clients/include/testing_trmv.hpp
Testing the non batched  rocblas_trmv

-15/  new: clients/include/testing_trmv_batched.hpp
Testing the non batched  rocblas_trmv_batched

-16/ new: clients/include/testing_trmv_strided_batched.hpp
Testing the non batched  rocblas_trmv_strided_batched

 LIBRARY SIDE /////////

-1/ modified:   library/include/rocblas-functions.h
Headers and documentation of trmv routines.

-2/  new: library/src/blas2/rocblas_trmv.cpp
implementation C API + rocblas_trmv_impl
        
-3/ new: library/src/blas2/rocblas_trmv.hpp
definition of rocblas_trmv_template
        
-4/ new: library/src/blas2/rocblas_trmv_batched.cpp
implementation C API + rocblas_trmv_batched_impl
        
-5/ new: library/src/blas2/rocblas_trmv_batched.hpp
defintion of rocblas_trmv_batched_template     
    
-6/ new: library/src/blas2/rocblas_trmv_strided_batched.cpp
implementation C API +  rocblas_trmv_batched_impl

-7/  new: library/src/blas2/rocblas_trmv_strided_batched.hpp
defintion of rocblas_trmv_batched_strided_template     

KERNELS //////////

-8/ new: library/src/blas2/trmv_device.hpp
Kernel definitions, there is room for improvements.
How to remove the extra-memory? Would need a lot of synchronization.
The functionality is implemented, but far to be optimal.

-9/ new: library/src/blas2/trmv_template.hpp
Template definition for calling kernels defined in trmv_device.hpp.
