### PR TITLE
Package Dependency is changed to rocm-dev metapackage

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -125,7 +125,7 @@ add_subdirectory( src )
 
 # Package specific CPACK vars
 set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev (>= 2.5.27)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev (>= 2.5.27)" )
+set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev >= 2.5.27" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -124,8 +124,8 @@ add_subdirectory( src )
 # endif( )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3" )
+set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev (>= 2.5.27)" )
+set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev (>= 2.5.27)" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )


### PR DESCRIPTION
ROCm3.0 is changing package names to conform with debian naming conventions. As hip_hcc is being renamed, the dependency is now changed to rocm-dev. rocm-dev is meta package's name will be unchanged in ROCm3.0