### PR TITLE
In C routines, catch all C++ exceptions and convert them to rocblas_status

### DIFF
--- a/library/src/blas1/rocblas_asum.cpp
+++ b/library/src/blas1/rocblas_asum.cpp
@@ -53,9 +53,14 @@ extern "C" {
 #define IMPL(name_, typei_, typeo_)                                                               \
     rocblas_status name_(                                                                         \
         rocblas_handle handle, rocblas_int n, const typei_* x, rocblas_int incx, typeo_* results) \
+    try                                                                                           \
     {                                                                                             \
         constexpr rocblas_int NB = 512;                                                           \
         return rocblas_asum_impl<NB>(handle, n, x, incx, results);                                \
+    }                                                                                             \
+    catch(...)                                                                                    \
+    {                                                                                             \
+        return exception_to_rocblas_status();                                                     \
     }
 
 IMPL(rocblas_sasum, float, float);

--- a/library/src/blas1/rocblas_asum_batched.cpp
+++ b/library/src/blas1/rocblas_asum_batched.cpp
@@ -65,9 +65,14 @@ extern "C" {
                          rocblas_int         incx,                                     \
                          rocblas_int         batch_count,                              \
                          typeo_*             result)                                   \
+    try                                                                                \
     {                                                                                  \
         constexpr rocblas_int NB = 512;                                                \
         return rocblas_asum_batched_impl<NB>(handle, n, x, incx, batch_count, result); \
+    }                                                                                  \
+    catch(...)                                                                         \
+    {                                                                                  \
+        return exception_to_rocblas_status();                                          \
     }
 
 IMPL(rocblas_sasum_batched, float, float);

--- a/library/src/blas1/rocblas_asum_strided_batched.cpp
+++ b/library/src/blas1/rocblas_asum_strided_batched.cpp
@@ -71,10 +71,15 @@ extern "C" {
                          rocblas_stride stridex,                \
                          rocblas_int    batch_count,            \
                          typeo_*        results)                \
+    try                                                         \
     {                                                           \
         constexpr rocblas_int NB = 512;                         \
         return rocblas_asum_strided_batched_impl<NB>(           \
             handle, n, x, incx, stridex, batch_count, results); \
+    }                                                           \
+    catch(...)                                                  \
+    {                                                           \
+        return exception_to_rocblas_status();                   \
     }
 
 IMPL(rocblas_sasum_strided_batched, float, float);

--- a/library/src/blas1/rocblas_axpy.cpp
+++ b/library/src/blas1/rocblas_axpy.cpp
@@ -114,8 +114,13 @@ extern "C" {
                                  rocblas_int    incx,                                              \
                                  T_*            y,                                                 \
                                  rocblas_int    incy)                                              \
+    try                                                                                            \
     {                                                                                              \
         return rocblas_axpy_impl<256>(handle, n, alpha, x, incx, y, incy, #routine_name_, "axpy"); \
+    }                                                                                              \
+    catch(...)                                                                                     \
+    {                                                                                              \
+        return exception_to_rocblas_status();                                                      \
     }
 
 IMPL(rocblas_saxpy, float);

--- a/library/src/blas1/rocblas_axpy_batched.cpp
+++ b/library/src/blas1/rocblas_axpy_batched.cpp
@@ -123,9 +123,14 @@ extern "C" {
                                  T_* const       y[],                                         \
                                  rocblas_int     incy,                                        \
                                  rocblas_int     batch_count)                                 \
+    try                                                                                       \
     {                                                                                         \
         return rocblas_axpy_batched_impl<256>(                                                \
             handle, n, alpha, x, incx, y, incy, batch_count, #routine_name_, "axpy_batched"); \
+    }                                                                                         \
+    catch(...)                                                                                \
+    {                                                                                         \
+        return exception_to_rocblas_status();                                                 \
     }
 
 IMPL(rocblas_saxpy_batched, float);

--- a/library/src/blas1/rocblas_axpy_strided_batched.cpp
+++ b/library/src/blas1/rocblas_axpy_strided_batched.cpp
@@ -157,6 +157,7 @@ extern "C" {
                                  rocblas_int    incy,                          \
                                  rocblas_stride stridey,                       \
                                  rocblas_int    batch_count)                   \
+    try                                                                        \
     {                                                                          \
         return rocblas_axpy_strided_batched_impl<256>(handle,                  \
                                                       n,                       \
@@ -170,6 +171,10 @@ extern "C" {
                                                       batch_count,             \
                                                       #routine_name_,          \
                                                       "axpy_strided_batched"); \
+    }                                                                          \
+    catch(...)                                                                 \
+    {                                                                          \
+        return exception_to_rocblas_status();                                  \
     }
 
 IMPL(rocblas_saxpy_strided_batched, float);

--- a/library/src/blas1/rocblas_copy.cpp
+++ b/library/src/blas1/rocblas_copy.cpp
@@ -70,9 +70,14 @@ rocblas_status rocblas_scopy(rocblas_handle handle,
                              rocblas_int    incx,
                              float*         y,
                              rocblas_int    incy)
+try
 {
     constexpr int NB = 256;
     return rocblas_copy_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dcopy(rocblas_handle handle,
@@ -81,9 +86,14 @@ rocblas_status rocblas_dcopy(rocblas_handle handle,
                              rocblas_int    incx,
                              double*        y,
                              rocblas_int    incy)
+try
 {
     constexpr int NB = 256;
     return rocblas_copy_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_hcopy(rocblas_handle      handle,
@@ -92,9 +102,14 @@ rocblas_status rocblas_hcopy(rocblas_handle      handle,
                              rocblas_int         incx,
                              rocblas_half*       y,
                              rocblas_int         incy)
+try
 {
     constexpr int NB = 256;
     return rocblas_copy_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ccopy(rocblas_handle               handle,
@@ -103,9 +118,14 @@ rocblas_status rocblas_ccopy(rocblas_handle               handle,
                              rocblas_int                  incx,
                              rocblas_float_complex*       y,
                              rocblas_int                  incy)
+try
 {
     constexpr int NB = 256;
     return rocblas_copy_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zcopy(rocblas_handle                handle,
@@ -114,9 +134,14 @@ rocblas_status rocblas_zcopy(rocblas_handle                handle,
                              rocblas_int                   incx,
                              rocblas_double_complex*       y,
                              rocblas_int                   incy)
+try
 {
     constexpr int NB = 256;
     return rocblas_copy_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_copy_batched.cpp
+++ b/library/src/blas1/rocblas_copy_batched.cpp
@@ -87,9 +87,14 @@ rocblas_status rocblas_scopy_batched(rocblas_handle     handle,
                                      float* const       y[],
                                      rocblas_int        incy,
                                      rocblas_int        batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_batched_impl<NB>(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dcopy_batched(rocblas_handle      handle,
@@ -99,9 +104,14 @@ rocblas_status rocblas_dcopy_batched(rocblas_handle      handle,
                                      double* const       y[],
                                      rocblas_int         incy,
                                      rocblas_int         batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_batched_impl<NB>(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_hcopy_batched(rocblas_handle            handle,
@@ -111,9 +121,14 @@ rocblas_status rocblas_hcopy_batched(rocblas_handle            handle,
                                      rocblas_half* const       y[],
                                      rocblas_int               incy,
                                      rocblas_int               batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_batched_impl<NB>(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ccopy_batched(rocblas_handle                     handle,
@@ -123,9 +138,14 @@ rocblas_status rocblas_ccopy_batched(rocblas_handle                     handle,
                                      rocblas_float_complex* const       y[],
                                      rocblas_int                        incy,
                                      rocblas_int                        batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_batched_impl<NB>(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zcopy_batched(rocblas_handle                      handle,
@@ -135,9 +155,14 @@ rocblas_status rocblas_zcopy_batched(rocblas_handle                      handle,
                                      rocblas_double_complex* const       y[],
                                      rocblas_int                         incy,
                                      rocblas_int                         batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_batched_impl<NB>(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_copy_strided_batched.cpp
+++ b/library/src/blas1/rocblas_copy_strided_batched.cpp
@@ -112,10 +112,15 @@ rocblas_status rocblas_scopy_strided_batched(rocblas_handle handle,
                                              rocblas_int    incy,
                                              rocblas_stride stridey,
                                              rocblas_int    batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_strided_batched_impl<NB>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dcopy_strided_batched(rocblas_handle handle,
@@ -127,10 +132,15 @@ rocblas_status rocblas_dcopy_strided_batched(rocblas_handle handle,
                                              rocblas_int    incy,
                                              rocblas_stride stridey,
                                              rocblas_int    batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_strided_batched_impl<NB>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_hcopy_strided_batched(rocblas_handle      handle,
@@ -142,10 +152,15 @@ rocblas_status rocblas_hcopy_strided_batched(rocblas_handle      handle,
                                              rocblas_int         incy,
                                              rocblas_stride      stridey,
                                              rocblas_int         batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_strided_batched_impl<NB>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ccopy_strided_batched(rocblas_handle               handle,
@@ -157,10 +172,15 @@ rocblas_status rocblas_ccopy_strided_batched(rocblas_handle               handle
                                              rocblas_int                  incy,
                                              rocblas_stride               stridey,
                                              rocblas_int                  batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_strided_batched_impl<NB>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zcopy_strided_batched(rocblas_handle                handle,
@@ -172,10 +192,15 @@ rocblas_status rocblas_zcopy_strided_batched(rocblas_handle                handl
                                              rocblas_int                   incy,
                                              rocblas_stride                stridey,
                                              rocblas_int                   batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_copy_strided_batched_impl<NB>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_dot.cpp
+++ b/library/src/blas1/rocblas_dot.cpp
@@ -112,8 +112,13 @@ rocblas_status rocblas_sdot(rocblas_handle handle,
                             const float*   y,
                             rocblas_int    incy,
                             float*         result)
+try
 {
     return rocblas_dot_impl<false>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ddot(rocblas_handle handle,
@@ -123,8 +128,13 @@ rocblas_status rocblas_ddot(rocblas_handle handle,
                             const double*  y,
                             rocblas_int    incy,
                             double*        result)
+try
 {
     return rocblas_dot_impl<false>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_hdot(rocblas_handle      handle,
@@ -134,8 +144,13 @@ rocblas_status rocblas_hdot(rocblas_handle      handle,
                             const rocblas_half* y,
                             rocblas_int         incy,
                             rocblas_half*       result)
+try
 {
     return rocblas_dot_impl<false>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_bfdot(rocblas_handle          handle,
@@ -145,8 +160,13 @@ rocblas_status rocblas_bfdot(rocblas_handle          handle,
                              const rocblas_bfloat16* y,
                              rocblas_int             incy,
                              rocblas_bfloat16*       result)
+try
 {
     return rocblas_dot_impl<false, rocblas_bfloat16, float>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cdotu(rocblas_handle               handle,
@@ -156,8 +176,13 @@ rocblas_status rocblas_cdotu(rocblas_handle               handle,
                              const rocblas_float_complex* y,
                              rocblas_int                  incy,
                              rocblas_float_complex*       result)
+try
 {
     return rocblas_dot_impl<false>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdotu(rocblas_handle                handle,
@@ -167,8 +192,13 @@ rocblas_status rocblas_zdotu(rocblas_handle                handle,
                              const rocblas_double_complex* y,
                              rocblas_int                   incy,
                              rocblas_double_complex*       result)
+try
 {
     return rocblas_dot_impl<false>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cdotc(rocblas_handle               handle,
@@ -178,8 +208,13 @@ rocblas_status rocblas_cdotc(rocblas_handle               handle,
                              const rocblas_float_complex* y,
                              rocblas_int                  incy,
                              rocblas_float_complex*       result)
+try
 {
     return rocblas_dot_impl<true>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdotc(rocblas_handle                handle,
@@ -189,8 +224,13 @@ rocblas_status rocblas_zdotc(rocblas_handle                handle,
                              const rocblas_double_complex* y,
                              rocblas_int                   incy,
                              rocblas_double_complex*       result)
+try
 {
     return rocblas_dot_impl<true>(handle, n, x, incx, y, incy, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_dot_batched.cpp
+++ b/library/src/blas1/rocblas_dot_batched.cpp
@@ -117,8 +117,13 @@ rocblas_status rocblas_sdot_batched(rocblas_handle     handle,
                                     rocblas_int        incy,
                                     rocblas_int        batch_count,
                                     float*             results)
+try
 {
     return rocblas_dot_batched_impl<false>(handle, n, x, incx, y, incy, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ddot_batched(rocblas_handle      handle,
@@ -129,8 +134,13 @@ rocblas_status rocblas_ddot_batched(rocblas_handle      handle,
                                     rocblas_int         incy,
                                     rocblas_int         batch_count,
                                     double*             results)
+try
 {
     return rocblas_dot_batched_impl<false>(handle, n, x, incx, y, incy, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_hdot_batched(rocblas_handle            handle,
@@ -141,6 +151,7 @@ rocblas_status rocblas_hdot_batched(rocblas_handle            handle,
                                     rocblas_int               incy,
                                     rocblas_int               batch_count,
                                     rocblas_half*             result)
+try
 {
     return rocblas_dot_batched_impl<false>(handle,
                                            n,
@@ -151,6 +162,10 @@ rocblas_status rocblas_hdot_batched(rocblas_handle            handle,
                                            batch_count,
                                            (rocblas_half*)result);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 rocblas_status rocblas_bfdot_batched(rocblas_handle                handle,
                                      rocblas_int                   n,
@@ -160,9 +175,14 @@ rocblas_status rocblas_bfdot_batched(rocblas_handle                handle,
                                      rocblas_int                   incy,
                                      rocblas_int                   batch_count,
                                      rocblas_bfloat16*             result)
+try
 {
     return rocblas_dot_batched_impl<false, rocblas_bfloat16, float>(
         handle, n, x, incx, y, incy, batch_count, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cdotu_batched(rocblas_handle                     handle,
@@ -173,8 +193,13 @@ rocblas_status rocblas_cdotu_batched(rocblas_handle                     handle,
                                      rocblas_int                        incy,
                                      rocblas_int                        batch_count,
                                      rocblas_float_complex*             results)
+try
 {
     return rocblas_dot_batched_impl<false>(handle, n, x, incx, y, incy, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdotu_batched(rocblas_handle                      handle,
@@ -185,8 +210,13 @@ rocblas_status rocblas_zdotu_batched(rocblas_handle                      handle,
                                      rocblas_int                         incy,
                                      rocblas_int                         batch_count,
                                      rocblas_double_complex*             results)
+try
 {
     return rocblas_dot_batched_impl<false>(handle, n, x, incx, y, incy, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cdotc_batched(rocblas_handle                     handle,
@@ -197,8 +227,13 @@ rocblas_status rocblas_cdotc_batched(rocblas_handle                     handle,
                                      rocblas_int                        incy,
                                      rocblas_int                        batch_count,
                                      rocblas_float_complex*             results)
+try
 {
     return rocblas_dot_batched_impl<true>(handle, n, x, incx, y, incy, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdotc_batched(rocblas_handle                      handle,
@@ -209,8 +244,13 @@ rocblas_status rocblas_zdotc_batched(rocblas_handle                      handle,
                                      rocblas_int                         incy,
                                      rocblas_int                         batch_count,
                                      rocblas_double_complex*             results)
+try
 {
     return rocblas_dot_batched_impl<true>(handle, n, x, incx, y, incy, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_dot_strided_batched.cpp
+++ b/library/src/blas1/rocblas_dot_strided_batched.cpp
@@ -136,9 +136,14 @@ rocblas_status rocblas_sdot_strided_batched(rocblas_handle handle,
                                             rocblas_stride stridey,
                                             rocblas_int    batch_count,
                                             float*         results)
+try
 {
     return rocblas_dot_strided_batched_impl<false>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ddot_strided_batched(rocblas_handle handle,
@@ -151,9 +156,14 @@ rocblas_status rocblas_ddot_strided_batched(rocblas_handle handle,
                                             rocblas_stride stridey,
                                             rocblas_int    batch_count,
                                             double*        results)
+try
 {
     return rocblas_dot_strided_batched_impl<false>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_hdot_strided_batched(rocblas_handle      handle,
@@ -166,9 +176,14 @@ rocblas_status rocblas_hdot_strided_batched(rocblas_handle      handle,
                                             rocblas_stride      stridey,
                                             rocblas_int         batch_count,
                                             rocblas_half*       result)
+try
 {
     return rocblas_dot_strided_batched_impl<false>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_bfdot_strided_batched(rocblas_handle          handle,
@@ -181,9 +196,14 @@ rocblas_status rocblas_bfdot_strided_batched(rocblas_handle          handle,
                                              rocblas_stride          stridey,
                                              rocblas_int             batch_count,
                                              rocblas_bfloat16*       result)
+try
 {
     return rocblas_dot_strided_batched_impl<false, rocblas_bfloat16, float>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cdotu_strided_batched(rocblas_handle               handle,
@@ -196,9 +216,14 @@ rocblas_status rocblas_cdotu_strided_batched(rocblas_handle               handle
                                              rocblas_stride               stridey,
                                              rocblas_int                  batch_count,
                                              rocblas_float_complex*       results)
+try
 {
     return rocblas_dot_strided_batched_impl<false>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdotu_strided_batched(rocblas_handle                handle,
@@ -211,9 +236,14 @@ rocblas_status rocblas_zdotu_strided_batched(rocblas_handle                handl
                                              rocblas_stride                stridey,
                                              rocblas_int                   batch_count,
                                              rocblas_double_complex*       results)
+try
 {
     return rocblas_dot_strided_batched_impl<false>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cdotc_strided_batched(rocblas_handle               handle,
@@ -226,9 +256,15 @@ rocblas_status rocblas_cdotc_strided_batched(rocblas_handle               handle
                                              rocblas_stride               stridey,
                                              rocblas_int                  batch_count,
                                              rocblas_float_complex*       results)
+try
+
 {
     return rocblas_dot_strided_batched_impl<true>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdotc_strided_batched(rocblas_handle                handle,
@@ -241,9 +277,14 @@ rocblas_status rocblas_zdotc_strided_batched(rocblas_handle                handl
                                              rocblas_stride                stridey,
                                              rocblas_int                   batch_count,
                                              rocblas_double_complex*       results)
+try
 {
     return rocblas_dot_strided_batched_impl<true>(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, results);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_iamax.cpp
+++ b/library/src/blas1/rocblas_iamax.cpp
@@ -57,8 +57,13 @@ extern "C" {
                          const typei_*  x,                              \
                          rocblas_int    incx,                           \
                          rocblas_int*   results)                        \
+    try                                                                 \
     {                                                                   \
         return rocblas_iamax_impl<typew_>(handle, n, x, incx, results); \
+    }                                                                   \
+    catch(...)                                                          \
+    {                                                                   \
+        return exception_to_rocblas_status();                           \
     }
 
 IMPL(rocblas_isamax, float, float);

--- a/library/src/blas1/rocblas_iamax_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_batched.cpp
@@ -68,8 +68,13 @@ extern "C" {
                                  rocblas_int      incx,                                  \
                                  rocblas_int      batch_count,                           \
                                  rocblas_int*     results)                               \
+    try                                                                                  \
     {                                                                                    \
         return rocblas_iamax_batched_impl<S_>(handle, n, x, incx, batch_count, results); \
+    }                                                                                    \
+    catch(...)                                                                           \
+    {                                                                                    \
+        return exception_to_rocblas_status();                                            \
     }
 
 IMPL(rocblas_isamax_batched, float, float);

--- a/library/src/blas1/rocblas_iamax_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamax_strided_batched.cpp
@@ -71,9 +71,14 @@ extern "C" {
                                  rocblas_stride stridex,        \
                                  rocblas_int    batch_count,    \
                                  rocblas_int*   results)        \
+    try                                                         \
     {                                                           \
         return rocblas_iamax_strided_batched_impl<S_>(          \
             handle, n, x, incx, stridex, batch_count, results); \
+    }                                                           \
+    catch(...)                                                  \
+    {                                                           \
+        return exception_to_rocblas_status();                   \
     }
 
 IMPL(rocblas_isamax_strided_batched, float, float);

--- a/library/src/blas1/rocblas_iamin.cpp
+++ b/library/src/blas1/rocblas_iamin.cpp
@@ -57,8 +57,13 @@ extern "C" {
                          const typei_*  x,                              \
                          rocblas_int    incx,                           \
                          rocblas_int*   results)                        \
+    try                                                                 \
     {                                                                   \
         return rocblas_iamin_impl<typew_>(handle, n, x, incx, results); \
+    }                                                                   \
+    catch(...)                                                          \
+    {                                                                   \
+        return exception_to_rocblas_status();                           \
     }
 
 IMPL(rocblas_isamin, float, float);

--- a/library/src/blas1/rocblas_iamin_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_batched.cpp
@@ -67,8 +67,13 @@ extern "C" {
                                  rocblas_int      incx,                                  \
                                  rocblas_int      batch_count,                           \
                                  rocblas_int*     results)                               \
+    try                                                                                  \
     {                                                                                    \
         return rocblas_iamin_batched_impl<S_>(handle, n, x, incx, batch_count, results); \
+    }                                                                                    \
+    catch(...)                                                                           \
+    {                                                                                    \
+        return exception_to_rocblas_status();                                            \
     }
 
 IMPL(rocblas_isamin_batched, float, float);

--- a/library/src/blas1/rocblas_iamin_strided_batched.cpp
+++ b/library/src/blas1/rocblas_iamin_strided_batched.cpp
@@ -71,9 +71,14 @@ extern "C" {
                                  rocblas_stride stridex,        \
                                  rocblas_int    batch_count,    \
                                  rocblas_int*   results)        \
+    try                                                         \
     {                                                           \
         return rocblas_iamin_strided_batched_impl<S_>(          \
             handle, n, x, incx, stridex, batch_count, results); \
+    }                                                           \
+    catch(...)                                                  \
+    {                                                           \
+        return exception_to_rocblas_status();                   \
     }
 
 IMPL(rocblas_isamin_strided_batched, float, float);

--- a/library/src/blas1/rocblas_nrm2.cpp
+++ b/library/src/blas1/rocblas_nrm2.cpp
@@ -57,9 +57,14 @@ extern "C" {
 #define IMPL(name_, typei_, typeo_)                                                               \
     rocblas_status name_(                                                                         \
         rocblas_handle handle, rocblas_int n, const typei_* x, rocblas_int incx, typeo_* results) \
+    try                                                                                           \
     {                                                                                             \
         constexpr rocblas_int NB = 512;                                                           \
         return rocblas_nrm2_impl<NB>(handle, n, x, incx, results);                                \
+    }                                                                                             \
+    catch(...)                                                                                    \
+    {                                                                                             \
+        return exception_to_rocblas_status();                                                     \
     }
 
 IMPL(rocblas_snrm2, float, float);

--- a/library/src/blas1/rocblas_nrm2_batched.cpp
+++ b/library/src/blas1/rocblas_nrm2_batched.cpp
@@ -66,9 +66,14 @@ extern "C" {
                          rocblas_int         incx,                                     \
                          rocblas_int         batch_count,                              \
                          typeo_*             result)                                   \
+    try                                                                                \
     {                                                                                  \
         constexpr rocblas_int NB = 512;                                                \
         return rocblas_nrm2_batched_impl<NB>(handle, n, x, incx, batch_count, result); \
+    }                                                                                  \
+    catch(...)                                                                         \
+    {                                                                                  \
+        return exception_to_rocblas_status();                                          \
     }
 
 IMPL(rocblas_snrm2_batched, float, float);

--- a/library/src/blas1/rocblas_nrm2_strided_batched.cpp
+++ b/library/src/blas1/rocblas_nrm2_strided_batched.cpp
@@ -72,10 +72,15 @@ extern "C" {
                          rocblas_stride stridex,                \
                          rocblas_int    batch_count,            \
                          typeo_*        results)                \
+    try                                                         \
     {                                                           \
         constexpr rocblas_int NB = 512;                         \
         return rocblas_nrm2_strided_batched_impl<NB>(           \
             handle, n, x, incx, stridex, batch_count, results); \
+    }                                                           \
+    catch(...)                                                  \
+    {                                                           \
+        return exception_to_rocblas_status();                   \
     }
 
 IMPL(rocblas_snrm2_strided_batched, float, float);

--- a/library/src/blas1/rocblas_rot.cpp
+++ b/library/src/blas1/rocblas_rot.cpp
@@ -85,8 +85,13 @@ rocblas_status rocblas_srot(rocblas_handle handle,
                             rocblas_int    incy,
                             const float*   c,
                             const float*   s)
+try
 {
     return rocblas_rot_impl(handle, n, x, incx, y, incy, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_drot(rocblas_handle handle,
@@ -97,8 +102,13 @@ rocblas_status rocblas_drot(rocblas_handle handle,
                             rocblas_int    incy,
                             const double*  c,
                             const double*  s)
+try
 {
     return rocblas_rot_impl(handle, n, x, incx, y, incy, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_crot(rocblas_handle               handle,
@@ -109,8 +119,13 @@ rocblas_status rocblas_crot(rocblas_handle               handle,
                             rocblas_int                  incy,
                             const float*                 c,
                             const rocblas_float_complex* s)
+try
 {
     return rocblas_rot_impl(handle, n, x, incx, y, incy, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_csrot(rocblas_handle         handle,
@@ -121,8 +136,13 @@ rocblas_status rocblas_csrot(rocblas_handle         handle,
                              rocblas_int            incy,
                              const float*           c,
                              const float*           s)
+try
 {
     return rocblas_rot_impl(handle, n, x, incx, y, incy, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zrot(rocblas_handle                handle,
@@ -133,8 +153,13 @@ rocblas_status rocblas_zrot(rocblas_handle                handle,
                             rocblas_int                   incy,
                             const double*                 c,
                             const rocblas_double_complex* s)
+try
 {
     return rocblas_rot_impl(handle, n, x, incx, y, incy, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdrot(rocblas_handle          handle,
@@ -145,8 +170,13 @@ rocblas_status rocblas_zdrot(rocblas_handle          handle,
                              rocblas_int             incy,
                              const double*           c,
                              const double*           s)
+try
 {
     return rocblas_rot_impl(handle, n, x, incx, y, incy, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rot_batched.cpp
+++ b/library/src/blas1/rocblas_rot_batched.cpp
@@ -101,8 +101,13 @@ rocblas_status rocblas_srot_batched(rocblas_handle handle,
                                     const float*   c,
                                     const float*   s,
                                     rocblas_int    batch_count)
+try
 {
     return rocblas_rot_batched_impl(handle, n, x, incx, y, incy, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_drot_batched(rocblas_handle handle,
@@ -114,8 +119,13 @@ rocblas_status rocblas_drot_batched(rocblas_handle handle,
                                     const double*  c,
                                     const double*  s,
                                     rocblas_int    batch_count)
+try
 {
     return rocblas_rot_batched_impl(handle, n, x, incx, y, incy, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_crot_batched(rocblas_handle               handle,
@@ -127,8 +137,13 @@ rocblas_status rocblas_crot_batched(rocblas_handle               handle,
                                     const float*                 c,
                                     const rocblas_float_complex* s,
                                     rocblas_int                  batch_count)
+try
 {
     return rocblas_rot_batched_impl(handle, n, x, incx, y, incy, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_csrot_batched(rocblas_handle               handle,
@@ -140,8 +155,13 @@ rocblas_status rocblas_csrot_batched(rocblas_handle               handle,
                                      const float*                 c,
                                      const float*                 s,
                                      rocblas_int                  batch_count)
+try
 {
     return rocblas_rot_batched_impl(handle, n, x, incx, y, incy, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zrot_batched(rocblas_handle                handle,
@@ -153,8 +173,13 @@ rocblas_status rocblas_zrot_batched(rocblas_handle                handle,
                                     const double*                 c,
                                     const rocblas_double_complex* s,
                                     rocblas_int                   batch_count)
+try
 {
     return rocblas_rot_batched_impl(handle, n, x, incx, y, incy, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdrot_batched(rocblas_handle                handle,
@@ -166,8 +191,13 @@ rocblas_status rocblas_zdrot_batched(rocblas_handle                handle,
                                      const double*                 c,
                                      const double*                 s,
                                      rocblas_int                   batch_count)
+try
 {
     return rocblas_rot_batched_impl(handle, n, x, incx, y, incy, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rot_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rot_strided_batched.cpp
@@ -126,9 +126,14 @@ rocblas_status rocblas_srot_strided_batched(rocblas_handle handle,
                                             const float*   c,
                                             const float*   s,
                                             rocblas_int    batch_count)
+try
 {
     return rocblas_rot_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_drot_strided_batched(rocblas_handle handle,
@@ -142,9 +147,14 @@ rocblas_status rocblas_drot_strided_batched(rocblas_handle handle,
                                             const double*  c,
                                             const double*  s,
                                             rocblas_int    batch_count)
+try
 {
     return rocblas_rot_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_crot_strided_batched(rocblas_handle               handle,
@@ -158,9 +168,14 @@ rocblas_status rocblas_crot_strided_batched(rocblas_handle               handle,
                                             const float*                 c,
                                             const rocblas_float_complex* s,
                                             rocblas_int                  batch_count)
+try
 {
     return rocblas_rot_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_csrot_strided_batched(rocblas_handle         handle,
@@ -174,9 +189,14 @@ rocblas_status rocblas_csrot_strided_batched(rocblas_handle         handle,
                                              const float*           c,
                                              const float*           s,
                                              rocblas_int            batch_count)
+try
 {
     return rocblas_rot_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zrot_strided_batched(rocblas_handle                handle,
@@ -190,9 +210,14 @@ rocblas_status rocblas_zrot_strided_batched(rocblas_handle                handle
                                             const double*                 c,
                                             const rocblas_double_complex* s,
                                             rocblas_int                   batch_count)
+try
 {
     return rocblas_rot_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdrot_strided_batched(rocblas_handle          handle,
@@ -206,9 +231,14 @@ rocblas_status rocblas_zdrot_strided_batched(rocblas_handle          handle,
                                              const double*           c,
                                              const double*           s,
                                              rocblas_int             batch_count)
+try
 {
     return rocblas_rot_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotg.cpp
+++ b/library/src/blas1/rocblas_rotg.cpp
@@ -57,13 +57,23 @@ namespace
 extern "C" {
 
 rocblas_status rocblas_srotg(rocblas_handle handle, float* a, float* b, float* c, float* s)
+try
 {
     return rocblas_rotg_impl(handle, a, b, c, s);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 rocblas_status rocblas_drotg(rocblas_handle handle, double* a, double* b, double* c, double* s)
+try
 {
     return rocblas_rotg_impl(handle, a, b, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_crotg(rocblas_handle         handle,
@@ -71,8 +81,13 @@ rocblas_status rocblas_crotg(rocblas_handle         handle,
                              rocblas_float_complex* b,
                              float*                 c,
                              rocblas_float_complex* s)
+try
 {
     return rocblas_rotg_impl(handle, a, b, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zrotg(rocblas_handle          handle,
@@ -80,8 +95,13 @@ rocblas_status rocblas_zrotg(rocblas_handle          handle,
                              rocblas_double_complex* b,
                              double*                 c,
                              rocblas_double_complex* s)
+try
 {
     return rocblas_rotg_impl(handle, a, b, c, s);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotg_batched.cpp
+++ b/library/src/blas1/rocblas_rotg_batched.cpp
@@ -71,8 +71,13 @@ rocblas_status rocblas_srotg_batched(rocblas_handle handle,
                                      float* const   c[],
                                      float* const   s[],
                                      rocblas_int    batch_count)
+try
 {
     return rocblas_rotg_batched_impl(handle, a, b, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_drotg_batched(rocblas_handle handle,
@@ -81,8 +86,13 @@ rocblas_status rocblas_drotg_batched(rocblas_handle handle,
                                      double* const  c[],
                                      double* const  s[],
                                      rocblas_int    batch_count)
+try
 {
     return rocblas_rotg_batched_impl(handle, a, b, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_crotg_batched(rocblas_handle               handle,
@@ -91,8 +101,13 @@ rocblas_status rocblas_crotg_batched(rocblas_handle               handle,
                                      float* const                 c[],
                                      rocblas_float_complex* const s[],
                                      rocblas_int                  batch_count)
+try
 {
     return rocblas_rotg_batched_impl(handle, a, b, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zrotg_batched(rocblas_handle                handle,
@@ -101,8 +116,13 @@ rocblas_status rocblas_zrotg_batched(rocblas_handle                handle,
                                      double* const                 c[],
                                      rocblas_double_complex* const s[],
                                      rocblas_int                   batch_count)
+try
 {
     return rocblas_rotg_batched_impl(handle, a, b, c, s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotg_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rotg_strided_batched.cpp
@@ -80,9 +80,14 @@ rocblas_status rocblas_srotg_strided_batched(rocblas_handle handle,
                                              float*         s,
                                              rocblas_stride stride_s,
                                              rocblas_int    batch_count)
+try
 {
     return rocblas_rotg_strided_batched_impl(
         handle, a, stride_a, b, stride_b, c, stride_c, s, stride_s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_drotg_strided_batched(rocblas_handle handle,
@@ -95,9 +100,14 @@ rocblas_status rocblas_drotg_strided_batched(rocblas_handle handle,
                                              double*        s,
                                              rocblas_stride stride_s,
                                              rocblas_int    batch_count)
+try
 {
     return rocblas_rotg_strided_batched_impl(
         handle, a, stride_a, b, stride_b, c, stride_c, s, stride_s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_crotg_strided_batched(rocblas_handle         handle,
@@ -110,9 +120,14 @@ rocblas_status rocblas_crotg_strided_batched(rocblas_handle         handle,
                                              rocblas_float_complex* s,
                                              rocblas_stride         stride_s,
                                              rocblas_int            batch_count)
+try
 {
     return rocblas_rotg_strided_batched_impl(
         handle, a, stride_a, b, stride_b, c, stride_c, s, stride_s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zrotg_strided_batched(rocblas_handle          handle,
@@ -125,9 +140,14 @@ rocblas_status rocblas_zrotg_strided_batched(rocblas_handle          handle,
                                              rocblas_double_complex* s,
                                              rocblas_stride          stride_s,
                                              rocblas_int             batch_count)
+try
 {
     return rocblas_rotg_strided_batched_impl(
         handle, a, stride_a, b, stride_b, c, stride_c, s, stride_s, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotm.cpp
+++ b/library/src/blas1/rocblas_rotm.cpp
@@ -72,8 +72,13 @@ ROCBLAS_EXPORT rocblas_status rocblas_srotm(rocblas_handle handle,
                                             float*         y,
                                             rocblas_int    incy,
                                             const float*   param)
+try
 {
     return rocblas_rotm_impl(handle, n, x, incx, y, incy, param);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 ROCBLAS_EXPORT rocblas_status rocblas_drotm(rocblas_handle handle,
@@ -83,8 +88,13 @@ ROCBLAS_EXPORT rocblas_status rocblas_drotm(rocblas_handle handle,
                                             double*        y,
                                             rocblas_int    incy,
                                             const double*  param)
+try
 {
     return rocblas_rotm_impl(handle, n, x, incx, y, incy, param);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotm_batched.cpp
+++ b/library/src/blas1/rocblas_rotm_batched.cpp
@@ -87,8 +87,13 @@ ROCBLAS_EXPORT rocblas_status rocblas_srotm_batched(rocblas_handle     handle,
                                                     rocblas_int        incy,
                                                     const float* const param[],
                                                     rocblas_int        batch_count)
+try
 {
     return rocblas_rotm_batched_impl(handle, n, x, incx, y, incy, param, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 ROCBLAS_EXPORT rocblas_status rocblas_drotm_batched(rocblas_handle      handle,
@@ -99,8 +104,13 @@ ROCBLAS_EXPORT rocblas_status rocblas_drotm_batched(rocblas_handle      handle,
                                                     rocblas_int         incy,
                                                     const double* const param[],
                                                     rocblas_int         batch_count)
+try
 {
     return rocblas_rotm_batched_impl(handle, n, x, incx, y, incy, param, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotm_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rotm_strided_batched.cpp
@@ -123,9 +123,14 @@ ROCBLAS_EXPORT rocblas_status rocblas_srotm_strided_batched(rocblas_handle handl
                                                             const float*   param,
                                                             rocblas_stride stride_param,
                                                             rocblas_int    batch_count)
+try
 {
     return rocblas_rotm_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, param, stride_param, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 ROCBLAS_EXPORT rocblas_status rocblas_drotm_strided_batched(rocblas_handle handle,
@@ -139,9 +144,14 @@ ROCBLAS_EXPORT rocblas_status rocblas_drotm_strided_batched(rocblas_handle handl
                                                             const double*  param,
                                                             rocblas_stride stride_param,
                                                             rocblas_int    batch_count)
+try
 {
     return rocblas_rotm_strided_batched_impl(
         handle, n, x, incx, stride_x, y, incy, stride_y, param, stride_param, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotmg.cpp
+++ b/library/src/blas1/rocblas_rotmg.cpp
@@ -52,14 +52,24 @@ extern "C" {
 
 ROCBLAS_EXPORT rocblas_status rocblas_srotmg(
     rocblas_handle handle, float* d1, float* d2, float* x1, const float* y1, float* param)
+try
 {
     return rocblas_rotmg_impl(handle, d1, d2, x1, y1, param);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 ROCBLAS_EXPORT rocblas_status rocblas_drotmg(
     rocblas_handle handle, double* d1, double* d2, double* x1, const double* y1, double* param)
+try
 {
     return rocblas_rotmg_impl(handle, d1, d2, x1, y1, param);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotmg_batched.cpp
+++ b/library/src/blas1/rocblas_rotmg_batched.cpp
@@ -68,8 +68,13 @@ ROCBLAS_EXPORT rocblas_status rocblas_srotmg_batched(rocblas_handle     handle,
                                                      const float* const y1[],
                                                      float* const       param[],
                                                      rocblas_int        batch_count)
+try
 {
     return rocblas_rotmg_batched_impl(handle, d1, d2, x1, y1, param, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 ROCBLAS_EXPORT rocblas_status rocblas_drotmg_batched(rocblas_handle      handle,
@@ -79,8 +84,13 @@ ROCBLAS_EXPORT rocblas_status rocblas_drotmg_batched(rocblas_handle      handle,
                                                      const double* const y1[],
                                                      double* const       param[],
                                                      rocblas_int         batch_count)
+try
 {
     return rocblas_rotmg_batched_impl(handle, d1, d2, x1, y1, param, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_rotmg_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rotmg_strided_batched.cpp
@@ -112,6 +112,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_srotmg_strided_batched(rocblas_handle hand
                                                              float*         param,
                                                              rocblas_stride stride_param,
                                                              rocblas_int    batch_count)
+try
 {
     return rocblas_rotmg_strided_batched_impl(handle,
                                               d1,
@@ -126,6 +127,10 @@ ROCBLAS_EXPORT rocblas_status rocblas_srotmg_strided_batched(rocblas_handle hand
                                               stride_param,
                                               batch_count);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 ROCBLAS_EXPORT rocblas_status rocblas_drotmg_strided_batched(rocblas_handle handle,
                                                              double*        d1,
@@ -139,6 +144,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_drotmg_strided_batched(rocblas_handle hand
                                                              double*        param,
                                                              rocblas_stride stride_param,
                                                              rocblas_int    batch_count)
+try
 {
     return rocblas_rotmg_strided_batched_impl(handle,
                                               d1,
@@ -152,6 +158,10 @@ ROCBLAS_EXPORT rocblas_status rocblas_drotmg_strided_batched(rocblas_handle hand
                                               param,
                                               stride_param,
                                               batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_scal.cpp
+++ b/library/src/blas1/rocblas_scal.cpp
@@ -89,16 +89,26 @@ extern "C" {
 
 rocblas_status rocblas_sscal(
     rocblas_handle handle, rocblas_int n, const float* alpha, float* x, rocblas_int incx)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_impl<NB>(handle, n, alpha, x, incx);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 rocblas_status rocblas_dscal(
     rocblas_handle handle, rocblas_int n, const double* alpha, double* x, rocblas_int incx)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_impl<NB>(handle, n, alpha, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cscal(rocblas_handle               handle,
@@ -106,9 +116,14 @@ rocblas_status rocblas_cscal(rocblas_handle               handle,
                              const rocblas_float_complex* alpha,
                              rocblas_float_complex*       x,
                              rocblas_int                  incx)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_impl<NB>(handle, n, alpha, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zscal(rocblas_handle                handle,
@@ -116,9 +131,14 @@ rocblas_status rocblas_zscal(rocblas_handle                handle,
                              const rocblas_double_complex* alpha,
                              rocblas_double_complex*       x,
                              rocblas_int                   incx)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_impl<NB>(handle, n, alpha, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 // Scal with a real alpha & complex vector
@@ -127,9 +147,14 @@ rocblas_status rocblas_csscal(rocblas_handle         handle,
                               const float*           alpha,
                               rocblas_float_complex* x,
                               rocblas_int            incx)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_impl<NB>(handle, n, alpha, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdscal(rocblas_handle          handle,
@@ -137,9 +162,14 @@ rocblas_status rocblas_zdscal(rocblas_handle          handle,
                               const double*           alpha,
                               rocblas_double_complex* x,
                               rocblas_int             incx)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_impl<NB>(handle, n, alpha, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_scal_batched.cpp
+++ b/library/src/blas1/rocblas_scal_batched.cpp
@@ -100,9 +100,14 @@ rocblas_status rocblas_sscal_batched(rocblas_handle handle,
                                      float* const   x[],
                                      rocblas_int    incx,
                                      rocblas_int    batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_batched_impl<NB>(handle, n, alpha, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dscal_batched(rocblas_handle handle,
@@ -111,9 +116,14 @@ rocblas_status rocblas_dscal_batched(rocblas_handle handle,
                                      double* const  x[],
                                      rocblas_int    incx,
                                      rocblas_int    batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_batched_impl<NB>(handle, n, alpha, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cscal_batched(rocblas_handle               handle,
@@ -122,9 +132,14 @@ rocblas_status rocblas_cscal_batched(rocblas_handle               handle,
                                      rocblas_float_complex* const x[],
                                      rocblas_int                  incx,
                                      rocblas_int                  batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_batched_impl<NB>(handle, n, alpha, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zscal_batched(rocblas_handle                handle,
@@ -133,9 +148,14 @@ rocblas_status rocblas_zscal_batched(rocblas_handle                handle,
                                      rocblas_double_complex* const x[],
                                      rocblas_int                   incx,
                                      rocblas_int                   batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_batched_impl<NB>(handle, n, alpha, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 // Scal with a real alpha & complex vector
@@ -145,9 +165,14 @@ rocblas_status rocblas_csscal_batched(rocblas_handle               handle,
                                       rocblas_float_complex* const x[],
                                       rocblas_int                  incx,
                                       rocblas_int                  batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_batched_impl<NB>(handle, n, alpha, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdscal_batched(rocblas_handle                handle,
@@ -156,9 +181,14 @@ rocblas_status rocblas_zdscal_batched(rocblas_handle                handle,
                                       rocblas_double_complex* const x[],
                                       rocblas_int                   incx,
                                       rocblas_int                   batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_batched_impl<NB>(handle, n, alpha, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_scal_strided_batched.cpp
+++ b/library/src/blas1/rocblas_scal_strided_batched.cpp
@@ -117,9 +117,14 @@ rocblas_status rocblas_sscal_strided_batched(rocblas_handle handle,
                                              rocblas_int    incx,
                                              rocblas_stride stridex,
                                              rocblas_int    batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_strided_batched_impl<NB>(handle, n, alpha, x, incx, stridex, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dscal_strided_batched(rocblas_handle handle,
@@ -129,9 +134,14 @@ rocblas_status rocblas_dscal_strided_batched(rocblas_handle handle,
                                              rocblas_int    incx,
                                              rocblas_stride stridex,
                                              rocblas_int    batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_strided_batched_impl<NB>(handle, n, alpha, x, incx, stridex, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cscal_strided_batched(rocblas_handle               handle,
@@ -141,9 +151,14 @@ rocblas_status rocblas_cscal_strided_batched(rocblas_handle               handle
                                              rocblas_int                  incx,
                                              rocblas_stride               stridex,
                                              rocblas_int                  batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_strided_batched_impl<NB>(handle, n, alpha, x, incx, stridex, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zscal_strided_batched(rocblas_handle                handle,
@@ -153,9 +168,14 @@ rocblas_status rocblas_zscal_strided_batched(rocblas_handle                handl
                                              rocblas_int                   incx,
                                              rocblas_stride                stridex,
                                              rocblas_int                   batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_strided_batched_impl<NB>(handle, n, alpha, x, incx, stridex, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 // Scal with a real alpha & complex vector
@@ -166,9 +186,14 @@ rocblas_status rocblas_csscal_strided_batched(rocblas_handle         handle,
                                               rocblas_int            incx,
                                               rocblas_stride         stridex,
                                               rocblas_int            batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_strided_batched_impl<NB>(handle, n, alpha, x, incx, stridex, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zdscal_strided_batched(rocblas_handle          handle,
@@ -178,9 +203,14 @@ rocblas_status rocblas_zdscal_strided_batched(rocblas_handle          handle,
                                               rocblas_int             incx,
                                               rocblas_stride          stridex,
                                               rocblas_int             batch_count)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_scal_strided_batched_impl<NB>(handle, n, alpha, x, incx, stridex, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap.cpp
+++ b/library/src/blas1/rocblas_swap.cpp
@@ -68,16 +68,26 @@ extern "C" {
 
 rocblas_status rocblas_sswap(
     rocblas_handle handle, rocblas_int n, float* x, rocblas_int incx, float* y, rocblas_int incy)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 rocblas_status rocblas_dswap(
     rocblas_handle handle, rocblas_int n, double* x, rocblas_int incx, double* y, rocblas_int incy)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cswap(rocblas_handle         handle,
@@ -86,9 +96,14 @@ rocblas_status rocblas_cswap(rocblas_handle         handle,
                              rocblas_int            incx,
                              rocblas_float_complex* y,
                              rocblas_int            incy)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zswap(rocblas_handle          handle,
@@ -97,9 +112,14 @@ rocblas_status rocblas_zswap(rocblas_handle          handle,
                              rocblas_int             incx,
                              rocblas_double_complex* y,
                              rocblas_int             incy)
+try
 {
     constexpr rocblas_int NB = 256;
     return rocblas_swap_impl<NB>(handle, n, x, incx, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap_batched.cpp
+++ b/library/src/blas1/rocblas_swap_batched.cpp
@@ -92,8 +92,13 @@ rocblas_status rocblas_sswap_batched(rocblas_handle handle,
                                      float*         y[],
                                      rocblas_int    incy,
                                      rocblas_int    batch_count)
+try
 {
     return rocblas_swap_batched_impl(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dswap_batched(rocblas_handle handle,
@@ -103,8 +108,13 @@ rocblas_status rocblas_dswap_batched(rocblas_handle handle,
                                      double*        y[],
                                      rocblas_int    incy,
                                      rocblas_int    batch_count)
+try
 {
     return rocblas_swap_batched_impl(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cswap_batched(rocblas_handle         handle,
@@ -114,8 +124,13 @@ rocblas_status rocblas_cswap_batched(rocblas_handle         handle,
                                      rocblas_float_complex* y[],
                                      rocblas_int            incy,
                                      rocblas_int            batch_count)
+try
 {
     return rocblas_swap_batched_impl(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zswap_batched(rocblas_handle          handle,
@@ -125,8 +140,13 @@ rocblas_status rocblas_zswap_batched(rocblas_handle          handle,
                                      rocblas_double_complex* y[],
                                      rocblas_int             incy,
                                      rocblas_int             batch_count)
+try
 {
     return rocblas_swap_batched_impl(handle, n, x, incx, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas1/rocblas_swap_strided_batched.cpp
+++ b/library/src/blas1/rocblas_swap_strided_batched.cpp
@@ -113,9 +113,14 @@ rocblas_status rocblas_sswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    incy,
                                              rocblas_stride stridey,
                                              rocblas_int    batch_count)
+try
 {
     return rocblas_swap_strided_batched_impl(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
@@ -127,9 +132,14 @@ rocblas_status rocblas_dswap_strided_batched(rocblas_handle handle,
                                              rocblas_int    incy,
                                              rocblas_stride stridey,
                                              rocblas_int    batch_count)
+try
 {
     return rocblas_swap_strided_batched_impl(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
@@ -141,9 +151,14 @@ rocblas_status rocblas_cswap_strided_batched(rocblas_handle         handle,
                                              rocblas_int            incy,
                                              rocblas_stride         stridey,
                                              rocblas_int            batch_count)
+try
 {
     return rocblas_swap_strided_batched_impl(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
@@ -155,9 +170,14 @@ rocblas_status rocblas_zswap_strided_batched(rocblas_handle          handle,
                                              rocblas_int             incy,
                                              rocblas_stride          stridey,
                                              rocblas_int             batch_count)
+try
 {
     return rocblas_swap_strided_batched_impl(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv.cpp
+++ b/library/src/blas2/rocblas_gemv.cpp
@@ -154,8 +154,13 @@ rocblas_status rocblas_sgemv(rocblas_handle    handle,
                              const float*      beta,
                              float*            y,
                              rocblas_int       incy)
+try
 {
     return rocblas_gemv_impl(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dgemv(rocblas_handle    handle,
@@ -170,8 +175,13 @@ rocblas_status rocblas_dgemv(rocblas_handle    handle,
                              const double*     beta,
                              double*           y,
                              rocblas_int       incy)
+try
 {
     return rocblas_gemv_impl(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cgemv(rocblas_handle               handle,
@@ -186,8 +196,13 @@ rocblas_status rocblas_cgemv(rocblas_handle               handle,
                              const rocblas_float_complex* beta,
                              rocblas_float_complex*       y,
                              rocblas_int                  incy)
+try
 {
     return rocblas_gemv_impl(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zgemv(rocblas_handle                handle,
@@ -202,8 +217,13 @@ rocblas_status rocblas_zgemv(rocblas_handle                handle,
                              const rocblas_double_complex* beta,
                              rocblas_double_complex*       y,
                              rocblas_int                   incy)
+try
 {
     return rocblas_gemv_impl(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv_batched.cpp
+++ b/library/src/blas2/rocblas_gemv_batched.cpp
@@ -180,9 +180,14 @@ rocblas_status rocblas_sgemv_batched(rocblas_handle     handle,
                                      float* const       y[],
                                      rocblas_int        incy,
                                      rocblas_int        batch_count)
+try
 {
     return rocblas_gemv_batched_impl(
         handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dgemv_batched(rocblas_handle      handle,
@@ -198,9 +203,14 @@ rocblas_status rocblas_dgemv_batched(rocblas_handle      handle,
                                      double* const       y[],
                                      rocblas_int         incy,
                                      rocblas_int         batch_count)
+try
 {
     return rocblas_gemv_batched_impl(
         handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cgemv_batched(rocblas_handle                     handle,
@@ -216,9 +226,14 @@ rocblas_status rocblas_cgemv_batched(rocblas_handle                     handle,
                                      rocblas_float_complex* const       y[],
                                      rocblas_int                        incy,
                                      rocblas_int                        batch_count)
+try
 {
     return rocblas_gemv_batched_impl(
         handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zgemv_batched(rocblas_handle                      handle,
@@ -234,9 +249,14 @@ rocblas_status rocblas_zgemv_batched(rocblas_handle                      handle,
                                      rocblas_double_complex* const       y[],
                                      rocblas_int                         incy,
                                      rocblas_int                         batch_count)
+try
 {
     return rocblas_gemv_batched_impl(
         handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_gemv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_gemv_strided_batched.cpp
@@ -201,6 +201,7 @@ rocblas_status rocblas_sgemv_strided_batched(rocblas_handle    handle,
                                              rocblas_int       incy,
                                              rocblas_stride    stridey,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_gemv_strided_batched_impl(handle,
                                              transA,
@@ -218,6 +219,10 @@ rocblas_status rocblas_sgemv_strided_batched(rocblas_handle    handle,
                                              incy,
                                              stridey,
                                              batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dgemv_strided_batched(rocblas_handle    handle,
@@ -236,6 +241,7 @@ rocblas_status rocblas_dgemv_strided_batched(rocblas_handle    handle,
                                              rocblas_int       incy,
                                              rocblas_stride    stridey,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_gemv_strided_batched_impl(handle,
                                              transA,
@@ -253,6 +259,10 @@ rocblas_status rocblas_dgemv_strided_batched(rocblas_handle    handle,
                                              incy,
                                              stridey,
                                              batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cgemv_strided_batched(rocblas_handle               handle,
@@ -271,6 +281,7 @@ rocblas_status rocblas_cgemv_strided_batched(rocblas_handle               handle
                                              rocblas_int                  incy,
                                              rocblas_stride               stridey,
                                              rocblas_int                  batch_count)
+try
 {
     return rocblas_gemv_strided_batched_impl(handle,
                                              transA,
@@ -289,6 +300,10 @@ rocblas_status rocblas_cgemv_strided_batched(rocblas_handle               handle
                                              stridey,
                                              batch_count);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                handle,
                                              rocblas_operation             transA,
@@ -306,6 +321,7 @@ rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                handl
                                              rocblas_int                   incy,
                                              rocblas_stride                stridey,
                                              rocblas_int                   batch_count)
+try
 {
     return rocblas_gemv_strided_batched_impl(handle,
                                              transA,
@@ -323,6 +339,10 @@ rocblas_status rocblas_zgemv_strided_batched(rocblas_handle                handl
                                              incy,
                                              stridey,
                                              batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_ger.cpp
+++ b/library/src/blas2/rocblas_ger.cpp
@@ -110,8 +110,13 @@ rocblas_status rocblas_sger(rocblas_handle handle,
                             rocblas_int    incy,
                             float*         A,
                             rocblas_int    lda)
+try
 {
     return rocblas_ger_impl(handle, m, n, alpha, x, incx, y, incy, A, lda);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dger(rocblas_handle handle,
@@ -124,8 +129,13 @@ rocblas_status rocblas_dger(rocblas_handle handle,
                             rocblas_int    incy,
                             double*        A,
                             rocblas_int    lda)
+try
 {
     return rocblas_ger_impl(handle, m, n, alpha, x, incx, y, incy, A, lda);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_ger_batched.cpp
+++ b/library/src/blas2/rocblas_ger_batched.cpp
@@ -138,8 +138,13 @@ rocblas_status rocblas_sger_batched(rocblas_handle     handle,
                                     float* const       A[],
                                     rocblas_int        lda,
                                     rocblas_int        batch_count)
+try
 {
     return rocblas_ger_batched_impl(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dger_batched(rocblas_handle      handle,
@@ -153,8 +158,13 @@ rocblas_status rocblas_dger_batched(rocblas_handle      handle,
                                     double* const       A[],
                                     rocblas_int         lda,
                                     rocblas_int         batch_count)
+try
 {
     return rocblas_ger_batched_impl(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_ger_strided_batched.cpp
+++ b/library/src/blas2/rocblas_ger_strided_batched.cpp
@@ -178,9 +178,14 @@ rocblas_status rocblas_sger_strided_batched(rocblas_handle handle,
                                             rocblas_int    lda,
                                             rocblas_stride strideA,
                                             rocblas_int    batch_count)
+try
 {
     return rocblas_ger_strided_batched_impl(
         handle, m, n, alpha, x, incx, stridex, y, incy, stridey, A, lda, strideA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dger_strided_batched(rocblas_handle handle,
@@ -197,9 +202,14 @@ rocblas_status rocblas_dger_strided_batched(rocblas_handle handle,
                                             rocblas_int    lda,
                                             rocblas_stride strideA,
                                             rocblas_int    batch_count)
+try
 {
     return rocblas_ger_strided_batched_impl(
         handle, m, n, alpha, x, incx, stridex, y, incy, stridey, A, lda, strideA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_syr.cpp
+++ b/library/src/blas2/rocblas_syr.cpp
@@ -102,8 +102,13 @@ rocblas_status rocblas_ssyr(rocblas_handle handle,
                             rocblas_int    incx,
                             float*         A,
                             rocblas_int    lda)
+try
 {
     return rocblas_syr_impl(handle, uplo, n, alpha, x, incx, A, lda);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dsyr(rocblas_handle handle,
@@ -114,8 +119,13 @@ rocblas_status rocblas_dsyr(rocblas_handle handle,
                             rocblas_int    incx,
                             double*        A,
                             rocblas_int    lda)
+try
 {
     return rocblas_syr_impl(handle, uplo, n, alpha, x, incx, A, lda);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_syr_batched.cpp
+++ b/library/src/blas2/rocblas_syr_batched.cpp
@@ -122,8 +122,13 @@ rocblas_status rocblas_ssyr_batched(rocblas_handle     handle,
                                     float* const       A[],
                                     rocblas_int        lda,
                                     rocblas_int        batch_count)
+try
 {
     return rocblas_syr_batched_impl(handle, uplo, n, alpha, x, 0, incx, A, 0, lda, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dsyr_batched(rocblas_handle      handle,
@@ -135,8 +140,13 @@ rocblas_status rocblas_dsyr_batched(rocblas_handle      handle,
                                     double* const       A[],
                                     rocblas_int         lda,
                                     rocblas_int         batch_count)
+try
 {
     return rocblas_syr_batched_impl(handle, uplo, n, alpha, x, 0, incx, A, 0, lda, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_syr_strided_batched.cpp
+++ b/library/src/blas2/rocblas_syr_strided_batched.cpp
@@ -144,9 +144,14 @@ rocblas_status rocblas_ssyr_strided_batched(rocblas_handle handle,
                                             rocblas_int    lda,
                                             rocblas_stride strideA,
                                             rocblas_int    batch_count)
+try
 {
     return rocblas_syr_strided_batched_impl(
         handle, uplo, n, alpha, x, 0, incx, stridex, A, 0, lda, strideA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dsyr_strided_batched(rocblas_handle handle,
@@ -160,9 +165,14 @@ rocblas_status rocblas_dsyr_strided_batched(rocblas_handle handle,
                                             rocblas_int    lda,
                                             rocblas_stride strideA,
                                             rocblas_int    batch_count)
+try
 {
     return rocblas_syr_strided_batched_impl(
         handle, uplo, n, alpha, x, 0, incx, stridex, A, 0, lda, strideA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_tbmv.cpp
+++ b/library/src/blas2/rocblas_tbmv.cpp
@@ -137,8 +137,13 @@ rocblas_status rocblas_stbmv(rocblas_handle    handle,
                              rocblas_int       lda,
                              float*            x,
                              rocblas_int       incx)
+try
 {
     return rocblas_tbmv_impl(handle, uplo, transA, diag, m, k, A, lda, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtbmv(rocblas_handle    handle,
@@ -151,8 +156,13 @@ rocblas_status rocblas_dtbmv(rocblas_handle    handle,
                              rocblas_int       lda,
                              double*           x,
                              rocblas_int       incx)
+try
 {
     return rocblas_tbmv_impl(handle, uplo, transA, diag, m, k, A, lda, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ctbmv(rocblas_handle               handle,
@@ -165,8 +175,13 @@ rocblas_status rocblas_ctbmv(rocblas_handle               handle,
                              rocblas_int                  lda,
                              rocblas_float_complex*       x,
                              rocblas_int                  incx)
+try
 {
     return rocblas_tbmv_impl(handle, uplo, transA, diag, m, k, A, lda, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_ztbmv(rocblas_handle                handle,
@@ -179,8 +194,13 @@ rocblas_status rocblas_ztbmv(rocblas_handle                handle,
                              rocblas_int                   lda,
                              rocblas_double_complex*       x,
                              rocblas_int                   incx)
+try
 {
     return rocblas_tbmv_impl(handle, uplo, transA, diag, m, k, A, lda, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_trsv.cpp
+++ b/library/src/blas2/rocblas_trsv.cpp
@@ -157,8 +157,13 @@ rocblas_status rocblas_strsv(rocblas_handle    handle,
                              rocblas_int       lda,
                              float*            x,
                              rocblas_int       incx)
+try
 {
     return rocblas_trsv_ex_impl<STRSV_BLOCK>(handle, uplo, transA, diag, m, A, lda, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrsv(rocblas_handle    handle,
@@ -170,8 +175,13 @@ rocblas_status rocblas_dtrsv(rocblas_handle    handle,
                              rocblas_int       lda,
                              double*           x,
                              rocblas_int       incx)
+try
 {
     return rocblas_trsv_ex_impl<DTRSV_BLOCK>(handle, uplo, transA, diag, m, A, lda, x, incx);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_trsv_ex(rocblas_handle    handle,
@@ -186,7 +196,7 @@ rocblas_status rocblas_trsv_ex(rocblas_handle    handle,
                                const void*       invA,
                                rocblas_int       invA_size,
                                rocblas_datatype  compute_type)
-
+try
 {
     switch(compute_type)
     {
@@ -219,6 +229,10 @@ rocblas_status rocblas_trsv_ex(rocblas_handle    handle,
     default:
         return rocblas_status_not_implemented;
     }
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_trsv_batched.cpp
+++ b/library/src/blas2/rocblas_trsv_batched.cpp
@@ -176,9 +176,14 @@ rocblas_status rocblas_strsv_batched(rocblas_handle     handle,
                                      rocblas_int        incx,
 
                                      rocblas_int batch_count)
+try
 {
     return rocblas_trsv_batched_ex_impl<STRSV_BLOCK>(
         handle, uplo, transA, diag, m, A, lda, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrsv_batched(rocblas_handle      handle,
@@ -191,9 +196,14 @@ rocblas_status rocblas_dtrsv_batched(rocblas_handle      handle,
                                      double* const       x[],
                                      rocblas_int         incx,
                                      rocblas_int         batch_count)
+try
 {
     return rocblas_trsv_batched_ex_impl<DTRSV_BLOCK>(
         handle, uplo, transA, diag, m, A, lda, x, incx, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_trsv_batched_ex(rocblas_handle    handle,
@@ -209,7 +219,7 @@ rocblas_status rocblas_trsv_batched_ex(rocblas_handle    handle,
                                        const void*       invA,
                                        rocblas_int       invA_size,
                                        rocblas_datatype  compute_type)
-
+try
 {
     switch(compute_type)
     {
@@ -244,6 +254,10 @@ rocblas_status rocblas_trsv_batched_ex(rocblas_handle    handle,
     default:
         return rocblas_status_not_implemented;
     }
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas2/rocblas_trsv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_trsv_strided_batched.cpp
@@ -192,9 +192,14 @@ rocblas_status rocblas_strsv_strided_batched(rocblas_handle    handle,
                                              rocblas_int       incx,
                                              rocblas_stride    stride_x,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_trsv_strided_batched_ex_impl<STRSV_BLOCK>(
         handle, uplo, transA, diag, m, A, lda, stride_A, x, incx, stride_x, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrsv_strided_batched(rocblas_handle    handle,
@@ -209,9 +214,14 @@ rocblas_status rocblas_dtrsv_strided_batched(rocblas_handle    handle,
                                              rocblas_int       incx,
                                              rocblas_stride    stride_x,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_trsv_strided_batched_ex_impl<DTRSV_BLOCK>(
         handle, uplo, transA, diag, m, A, lda, stride_A, x, incx, stride_x, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_trsv_strided_batched_ex(rocblas_handle    handle,
@@ -229,7 +239,7 @@ rocblas_status rocblas_trsv_strided_batched_ex(rocblas_handle    handle,
                                                const void*       invA,
                                                rocblas_int       invA_size,
                                                rocblas_datatype  compute_type)
-
+try
 {
     switch(compute_type)
     {
@@ -268,6 +278,10 @@ rocblas_status rocblas_trsv_strided_batched_ex(rocblas_handle    handle,
     default:
         return rocblas_status_not_implemented;
     }
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/Tensile/gemm.cpp
+++ b/library/src/blas3/Tensile/gemm.cpp
@@ -186,9 +186,14 @@ rocblas_status rocblas_hgemm(rocblas_handle      handle,
                              const rocblas_half* beta,
                              rocblas_half*       C,
                              rocblas_int         ld_c)
+try
 {
     return rocblas_gemm_impl(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_sgemm(rocblas_handle    handle,
@@ -205,9 +210,14 @@ rocblas_status rocblas_sgemm(rocblas_handle    handle,
                              const float*      beta,
                              float*            C,
                              rocblas_int       ld_c)
+try
 {
     return rocblas_gemm_impl(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dgemm(rocblas_handle    handle,
@@ -224,9 +234,14 @@ rocblas_status rocblas_dgemm(rocblas_handle    handle,
                              const double*     beta,
                              double*           C,
                              rocblas_int       ld_c)
+try
 {
     return rocblas_gemm_impl(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cgemm(rocblas_handle               handle,
@@ -243,9 +258,14 @@ rocblas_status rocblas_cgemm(rocblas_handle               handle,
                              const rocblas_float_complex* beta,
                              rocblas_float_complex*       C,
                              rocblas_int                  ld_c)
+try
 {
     return rocblas_gemm_impl(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zgemm(rocblas_handle                handle,
@@ -262,9 +282,14 @@ rocblas_status rocblas_zgemm(rocblas_handle                handle,
                              const rocblas_double_complex* beta,
                              rocblas_double_complex*       C,
                              rocblas_int                   ld_c)
+try
 {
     return rocblas_gemm_impl(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************

--- a/library/src/blas3/Tensile/gemm_batched.cpp
+++ b/library/src/blas3/Tensile/gemm_batched.cpp
@@ -191,9 +191,14 @@ rocblas_status rocblas_hgemm_batched(rocblas_handle            handle,
                                      rocblas_half* const       C[],
                                      rocblas_int               ld_c,
                                      rocblas_int               b_c)
+try
 {
     return rocblas_gemm_batched_impl<rocblas_half>(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c, b_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_sgemm_batched(rocblas_handle     handle,
@@ -211,9 +216,14 @@ rocblas_status rocblas_sgemm_batched(rocblas_handle     handle,
                                      float* const       C[],
                                      rocblas_int        ld_c,
                                      rocblas_int        b_c)
+try
 {
     return rocblas_gemm_batched_impl<float>(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c, b_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dgemm_batched(rocblas_handle      handle,
@@ -231,9 +241,14 @@ rocblas_status rocblas_dgemm_batched(rocblas_handle      handle,
                                      double* const       C[],
                                      rocblas_int         ld_c,
                                      rocblas_int         b_c)
+try
 {
     return rocblas_gemm_batched_impl<double>(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c, b_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cgemm_batched(rocblas_handle                     handle,
@@ -251,9 +266,14 @@ rocblas_status rocblas_cgemm_batched(rocblas_handle                     handle,
                                      rocblas_float_complex* const       C[],
                                      rocblas_int                        ld_c,
                                      rocblas_int                        b_c)
+try
 {
     return rocblas_gemm_batched_impl<rocblas_float_complex>(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c, b_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_zgemm_batched(rocblas_handle                      handle,
@@ -271,9 +291,14 @@ rocblas_status rocblas_zgemm_batched(rocblas_handle                      handle,
                                      rocblas_double_complex* const       C[],
                                      rocblas_int                         ld_c,
                                      rocblas_int                         b_c)
+try
 {
     return rocblas_gemm_batched_impl<rocblas_double_complex>(
         handle, trans_a, trans_b, m, n, k, alpha, A, ld_a, B, ld_b, beta, C, ld_c, b_c);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************

--- a/library/src/blas3/Tensile/gemm_strided_batched.cpp
+++ b/library/src/blas3/Tensile/gemm_strided_batched.cpp
@@ -231,6 +231,7 @@ rocblas_status rocblas_hgemm_strided_batched(rocblas_handle      handle,
                                              rocblas_int         ld_c,
                                              rocblas_stride      stride_c,
                                              rocblas_int         batch_count)
+try
 {
     return rocblas_gemm_strided_batched_impl(handle,
                                              trans_a,
@@ -251,7 +252,10 @@ rocblas_status rocblas_hgemm_strided_batched(rocblas_handle      handle,
                                              stride_c,
                                              batch_count);
 }
-
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 rocblas_status rocblas_sgemm_strided_batched(rocblas_handle    handle,
                                              rocblas_operation trans_a,
                                              rocblas_operation trans_b,
@@ -270,6 +274,7 @@ rocblas_status rocblas_sgemm_strided_batched(rocblas_handle    handle,
                                              rocblas_int       ld_c,
                                              rocblas_stride    stride_c,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_gemm_strided_batched_impl(handle,
                                              trans_a,
@@ -289,6 +294,10 @@ rocblas_status rocblas_sgemm_strided_batched(rocblas_handle    handle,
                                              ld_c,
                                              stride_c,
                                              batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dgemm_strided_batched(rocblas_handle    handle,
@@ -309,6 +318,7 @@ rocblas_status rocblas_dgemm_strided_batched(rocblas_handle    handle,
                                              rocblas_int       ld_c,
                                              rocblas_stride    stride_c,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_gemm_strided_batched_impl(handle,
                                              trans_a,
@@ -328,6 +338,10 @@ rocblas_status rocblas_dgemm_strided_batched(rocblas_handle    handle,
                                              ld_c,
                                              stride_c,
                                              batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_cgemm_strided_batched(rocblas_handle               handle,
@@ -348,6 +362,7 @@ rocblas_status rocblas_cgemm_strided_batched(rocblas_handle               handle
                                              rocblas_int                  ld_c,
                                              rocblas_stride               stride_c,
                                              rocblas_int                  batch_count)
+try
 {
     return rocblas_gemm_strided_batched_impl(handle,
                                              trans_a,
@@ -368,6 +383,10 @@ rocblas_status rocblas_cgemm_strided_batched(rocblas_handle               handle
                                              stride_c,
                                              batch_count);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 rocblas_status rocblas_zgemm_strided_batched(rocblas_handle                handle,
                                              rocblas_operation             trans_a,
@@ -387,6 +406,7 @@ rocblas_status rocblas_zgemm_strided_batched(rocblas_handle                handl
                                              rocblas_int                   ld_c,
                                              rocblas_stride                stride_c,
                                              rocblas_int                   batch_count)
+try
 {
     return rocblas_gemm_strided_batched_impl(handle,
                                              trans_a,
@@ -406,6 +426,10 @@ rocblas_status rocblas_zgemm_strided_batched(rocblas_handle                handl
                                              ld_c,
                                              stride_c,
                                              batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************

--- a/library/src/blas3/rocblas_geam.cpp
+++ b/library/src/blas3/rocblas_geam.cpp
@@ -625,9 +625,14 @@ rocblas_status rocblas_sgeam(rocblas_handle    handle,
                              rocblas_int       ldb,
                              float*            C,
                              rocblas_int       ldc)
+try
 {
     return rocblas_geam_template<float>(
         handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dgeam(rocblas_handle    handle,
@@ -643,9 +648,14 @@ rocblas_status rocblas_dgeam(rocblas_handle    handle,
                              rocblas_int       ldb,
                              double*           C,
                              rocblas_int       ldc)
+try
 {
     return rocblas_geam_template<double>(
         handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trmm.cpp
+++ b/library/src/blas3/rocblas_trmm.cpp
@@ -185,8 +185,13 @@ rocblas_status rocblas_strmm(rocblas_handle    handle,
                              rocblas_int       lda,
                              float*            c,
                              rocblas_int       ldc)
+try
 {
     return rocblas_trmm_impl(handle, side, uplo, transa, diag, m, n, alpha, a, lda, c, ldc);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrmm(rocblas_handle    handle,
@@ -201,8 +206,13 @@ rocblas_status rocblas_dtrmm(rocblas_handle    handle,
                              rocblas_int       lda,
                              double*           c,
                              rocblas_int       ldc)
+try
 {
     return rocblas_trmm_impl(handle, side, uplo, transa, diag, m, n, alpha, a, lda, c, ldc);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trsm.cpp
+++ b/library/src/blas3/rocblas_trsm.cpp
@@ -247,9 +247,14 @@ rocblas_status rocblas_strsm(rocblas_handle    handle,
                              rocblas_int       lda,
                              float*            B,
                              rocblas_int       ldb)
+try
 {
     return rocblas_trsm_ex_impl<STRSM_BLOCK>(
         handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrsm(rocblas_handle    handle,
@@ -264,9 +269,14 @@ rocblas_status rocblas_dtrsm(rocblas_handle    handle,
                              rocblas_int       lda,
                              double*           B,
                              rocblas_int       ldb)
+try
 {
     return rocblas_trsm_ex_impl<DTRSM_BLOCK>(
         handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_trsm_ex(rocblas_handle    handle,
@@ -284,6 +294,7 @@ rocblas_status rocblas_trsm_ex(rocblas_handle    handle,
                                const void*       invA,
                                rocblas_int       invA_size,
                                rocblas_datatype  compute_type)
+try
 {
     switch(compute_type)
     {
@@ -322,6 +333,10 @@ rocblas_status rocblas_trsm_ex(rocblas_handle    handle,
     default:
         return rocblas_status_not_implemented;
     }
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trsm_batched.cpp
+++ b/library/src/blas3/rocblas_trsm_batched.cpp
@@ -253,9 +253,14 @@ rocblas_status rocblas_strsm_batched(rocblas_handle     handle,
                                      float*             B[],
                                      rocblas_int        ldb,
                                      rocblas_int        batch_count)
+try
 {
     return rocblas_trsm_batched_ex_impl<STRSM_BLOCK>(
         handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrsm_batched(rocblas_handle      handle,
@@ -271,9 +276,14 @@ rocblas_status rocblas_dtrsm_batched(rocblas_handle      handle,
                                      double*             B[],
                                      rocblas_int         ldb,
                                      rocblas_int         batch_count)
+try
 {
     return rocblas_trsm_batched_ex_impl<DTRSM_BLOCK>(
         handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_trsm_batched_ex(rocblas_handle    handle,
@@ -292,6 +302,7 @@ rocblas_status rocblas_trsm_batched_ex(rocblas_handle    handle,
                                        const void*       invA,
                                        rocblas_int       invA_size,
                                        rocblas_datatype  compute_type)
+try
 {
     switch(compute_type)
     {
@@ -332,6 +343,10 @@ rocblas_status rocblas_trsm_batched_ex(rocblas_handle    handle,
     default:
         return rocblas_status_not_implemented;
     }
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trsm_strided_batched.cpp
+++ b/library/src/blas3/rocblas_trsm_strided_batched.cpp
@@ -268,6 +268,7 @@ rocblas_status rocblas_strsm_strided_batched(rocblas_handle    handle,
                                              rocblas_int       ldb,
                                              rocblas_stride    stride_B,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_trsm_strided_batched_ex_impl<STRSM_BLOCK>(handle,
                                                              side,
@@ -285,6 +286,10 @@ rocblas_status rocblas_strsm_strided_batched(rocblas_handle    handle,
                                                              stride_B,
                                                              batch_count);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 rocblas_status rocblas_dtrsm_strided_batched(rocblas_handle    handle,
                                              rocblas_side      side,
@@ -301,6 +306,7 @@ rocblas_status rocblas_dtrsm_strided_batched(rocblas_handle    handle,
                                              rocblas_int       ldb,
                                              rocblas_stride    stride_B,
                                              rocblas_int       batch_count)
+try
 {
     return rocblas_trsm_strided_batched_ex_impl<DTRSM_BLOCK>(handle,
                                                              side,
@@ -317,6 +323,10 @@ rocblas_status rocblas_dtrsm_strided_batched(rocblas_handle    handle,
                                                              ldb,
                                                              stride_B,
                                                              batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_trsm_strided_batched_ex(rocblas_handle    handle,
@@ -338,6 +348,7 @@ rocblas_status rocblas_trsm_strided_batched_ex(rocblas_handle    handle,
                                                rocblas_int       invA_size,
                                                rocblas_stride    stride_invA,
                                                rocblas_datatype  compute_type)
+try
 {
     switch(compute_type)
     {
@@ -384,6 +395,10 @@ rocblas_status rocblas_trsm_strided_batched_ex(rocblas_handle    handle,
     default:
         return rocblas_status_not_implemented;
     }
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trtri.cpp
+++ b/library/src/blas3/rocblas_trtri.cpp
@@ -101,9 +101,14 @@ rocblas_status rocblas_strtri(rocblas_handle   handle,
                               rocblas_int      lda,
                               float*           invA,
                               rocblas_int      ldinvA)
+try
 {
     constexpr rocblas_int NB = 16;
     return rocblas_trtri_impl<NB>(handle, uplo, diag, n, A, lda, invA, ldinvA);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrtri(rocblas_handle   handle,
@@ -114,9 +119,14 @@ rocblas_status rocblas_dtrtri(rocblas_handle   handle,
                               rocblas_int      lda,
                               double*          invA,
                               rocblas_int      ldinvA)
+try
 {
     constexpr rocblas_int NB = 16;
     return rocblas_trtri_impl<NB>(handle, uplo, diag, n, A, lda, invA, ldinvA);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trtri_batched.cpp
+++ b/library/src/blas3/rocblas_trtri_batched.cpp
@@ -141,9 +141,14 @@ rocblas_status rocblas_strtri_batched(rocblas_handle     handle,
                                       float*             invA[],
                                       rocblas_int        ldinvA,
                                       rocblas_int        batch_count)
+try
 {
     constexpr rocblas_int NB = 16;
     return rocblas_trtri_batched_impl<NB>(handle, uplo, diag, n, A, lda, invA, ldinvA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrtri_batched(rocblas_handle      handle,
@@ -155,9 +160,14 @@ rocblas_status rocblas_dtrtri_batched(rocblas_handle      handle,
                                       double*             invA[],
                                       rocblas_int         ldinvA,
                                       rocblas_int         batch_count)
+try
 {
     constexpr rocblas_int NB = 16;
     return rocblas_trtri_batched_impl<NB>(handle, uplo, diag, n, A, lda, invA, ldinvA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas3/rocblas_trtri_strided_batched.cpp
+++ b/library/src/blas3/rocblas_trtri_strided_batched.cpp
@@ -166,10 +166,15 @@ rocblas_status rocblas_strtri_strided_batched(rocblas_handle   handle,
                                               rocblas_int      ldinvA,
                                               rocblas_stride   bsinvA,
                                               rocblas_int      batch_count)
+try
 {
     constexpr rocblas_int NB = 16;
     return rocblas_trtri_strided_batched_impl<NB>(
         handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 rocblas_status rocblas_dtrtri_strided_batched(rocblas_handle   handle,
@@ -183,10 +188,15 @@ rocblas_status rocblas_dtrtri_strided_batched(rocblas_handle   handle,
                                               rocblas_int      ldinvA,
                                               rocblas_stride   bsinvA,
                                               rocblas_int      batch_count)
+try
 {
     constexpr rocblas_int NB = 16;
     return rocblas_trtri_strided_batched_impl<NB>(
         handle, uplo, diag, n, A, lda, bsa, invA, ldinvA, bsinvA, batch_count);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 } // extern "C"

--- a/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
@@ -34,6 +34,7 @@ extern "C" rocblas_status rocblas_gemm_batched_ex(rocblas_handle    handle,
                                                   rocblas_gemm_algo algo,
                                                   int32_t           solution_index,
                                                   uint32_t          flags)
+try
 {
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -276,4 +277,8 @@ extern "C" rocblas_status rocblas_gemm_batched_ex(rocblas_handle    handle,
                                           stride_d,
                                           batch_count,
                                           compute_type);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -32,6 +32,7 @@ extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle    handle,
                                           rocblas_gemm_algo algo,
                                           int32_t           solution_index,
                                           uint32_t          flags)
+try
 {
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -267,4 +268,8 @@ extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle    handle,
                                            stride_d,
                                            batch_count,
                                            compute_type);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }

--- a/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
@@ -38,6 +38,7 @@ extern "C" rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle    hand
                                                           rocblas_gemm_algo algo,
                                                           int32_t           solution_index,
                                                           uint32_t          flags)
+try
 {
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -299,4 +300,8 @@ extern "C" rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle    hand
                                            stride_d,
                                            batch_count,
                                            compute_type);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -117,6 +117,7 @@ void* _rocblas_handle::device_allocator(size_t size)
  * start device memory size queries
  ******************************************************************************/
 extern "C" rocblas_status rocblas_start_device_memory_size_query(rocblas_handle handle)
+try
 {
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -126,11 +127,16 @@ extern "C" rocblas_status rocblas_start_device_memory_size_query(rocblas_handle 
     handle->device_memory_query_size = 0;
     return rocblas_status_success;
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 /*******************************************************************************
  * stop device memory size queries
  ******************************************************************************/
 extern "C" rocblas_status rocblas_stop_device_memory_size_query(rocblas_handle handle, size_t* size)
+try
 {
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -142,11 +148,16 @@ extern "C" rocblas_status rocblas_stop_device_memory_size_query(rocblas_handle h
     handle->device_memory_size_query = false;
     return rocblas_status_success;
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 /*******************************************************************************
  * get the device memory size
  ******************************************************************************/
 extern "C" rocblas_status rocblas_get_device_memory_size(rocblas_handle handle, size_t* size)
+try
 {
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -155,11 +166,16 @@ extern "C" rocblas_status rocblas_get_device_memory_size(rocblas_handle handle, 
     *size = handle->device_memory_size;
     return rocblas_status_success;
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 /*******************************************************************************
  * set the device memory size
  ******************************************************************************/
 extern "C" rocblas_status rocblas_set_device_memory_size(rocblas_handle handle, size_t size)
+try
 {
     if(!handle)
         return rocblas_status_invalid_handle;
@@ -189,6 +205,10 @@ extern "C" rocblas_status rocblas_set_device_memory_size(rocblas_handle handle, 
         handle->device_memory_size = size;
     }
     return rocblas_status_success;
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -358,7 +358,11 @@ try
         std::rethrow_exception(e);
     return rocblas_status_success;
 }
-catch(std::bad_alloc)
+catch(const rocblas_status& status)
+{
+    return status;
+}
+catch(const std::bad_alloc&)
 {
     return rocblas_status_memory_error;
 }

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -351,10 +351,9 @@ inline std::ostream& operator<<(std::ostream& os, rocblas_half x)
 // Convert the current C++ exception to rocblas_status
 // This allows extern "C" functions to return this function in a catch(...) block
 // while converting all C++ exceptions to an equivalent rocblas_status here
-inline rocblas_status exception_to_rocblas_status()
+inline rocblas_status exception_to_rocblas_status(std::exception_ptr e = std::current_exception())
 try
 {
-    auto e = std::current_exception();
     if(e)
         std::rethrow_exception(e);
     return rocblas_status_success;

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -8,6 +8,7 @@
 #include "rocblas.h"
 #include <cmath>
 #include <complex>
+#include <exception>
 #include <hip/hip_runtime.h>
 #include <type_traits>
 
@@ -346,4 +347,25 @@ inline std::ostream& operator<<(std::ostream& os, rocblas_half x)
 {
     return os << float(x);
 }
+
+// Convert the current C++ exception to rocblas_status
+// This allows extern "C" functions to return this function in a catch(...) block
+// while converting all C++ exceptions to an equivalent rocblas_status here
+inline rocblas_status exception_to_rocblas_status()
+try
+{
+    auto e = std::current_exception();
+    if(e)
+        std::rethrow_exception(e);
+    return rocblas_status_success;
+}
+catch(std::bad_alloc)
+{
+    return rocblas_status_memory_error;
+}
+catch(...)
+{
+    return rocblas_status_internal_error;
+}
+
 #endif

--- a/library/src/rocblas_auxiliary.cpp
+++ b/library/src/rocblas_auxiliary.cpp
@@ -32,58 +32,68 @@ extern "C" rocblas_pointer_mode rocblas_pointer_to_mode(void* ptr)
  ******************************************************************************/
 extern "C" rocblas_status rocblas_get_pointer_mode(rocblas_handle        handle,
                                                    rocblas_pointer_mode* mode)
+try
 {
     // if handle not valid
     if(!handle)
-        return rocblas_status_invalid_pointer;
+        return rocblas_status_invalid_handle;
     *mode = handle->pointer_mode;
     if(handle->layer_mode & rocblas_layer_mode_log_trace)
         log_trace(handle, "rocblas_get_pointer_mode", *mode);
     return rocblas_status_success;
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
  * ! \brief set pointer mode to host or device
  ******************************************************************************/
 extern "C" rocblas_status rocblas_set_pointer_mode(rocblas_handle handle, rocblas_pointer_mode mode)
+try
 {
     // if handle not valid
     if(!handle)
-        return rocblas_status_invalid_pointer;
+        return rocblas_status_invalid_handle;
     if(handle->layer_mode & rocblas_layer_mode_log_trace)
         log_trace(handle, "rocblas_set_pointer_mode", mode);
     handle->pointer_mode = mode;
     return rocblas_status_success;
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
  * ! \brief create rocblas handle called before any rocblas library routines
  ******************************************************************************/
 extern "C" rocblas_status rocblas_create_handle(rocblas_handle* handle)
+try
 {
     // if handle not valid
     if(!handle)
         return rocblas_status_invalid_handle;
 
     // allocate on heap
-    try
-    {
-        *handle = new _rocblas_handle();
+    *handle = new _rocblas_handle();
 
-        if((*handle)->layer_mode & rocblas_layer_mode_log_trace)
-            log_trace(*handle, "rocblas_create_handle");
-    }
-    catch(...)
-    {
-        return rocblas_status_internal_error;
-    }
+    if((*handle)->layer_mode & rocblas_layer_mode_log_trace)
+        log_trace(*handle, "rocblas_create_handle");
+
     return rocblas_status_success;
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
  *! \brief release rocblas handle, will implicitly synchronize host and device
  ******************************************************************************/
 extern "C" rocblas_status rocblas_destroy_handle(rocblas_handle handle)
+try
 {
     // if handle not valid
     if(!handle)
@@ -91,15 +101,13 @@ extern "C" rocblas_status rocblas_destroy_handle(rocblas_handle handle)
     if(handle->layer_mode & rocblas_layer_mode_log_trace)
         log_trace(handle, "rocblas_destroy_handle");
     // call destructor
-    try
-    {
-        delete handle;
-    }
-    catch(rocblas_status status)
-    {
-        return status;
-    }
+    delete handle;
+
     return rocblas_status_success;
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -108,6 +116,7 @@ extern "C" rocblas_status rocblas_destroy_handle(rocblas_handle handle)
  *   stream_id must be created before this call
  ******************************************************************************/
 extern "C" rocblas_status rocblas_set_stream(rocblas_handle handle, hipStream_t stream_id)
+try
 {
     // if handle not valid
     if(!handle)
@@ -116,12 +125,17 @@ extern "C" rocblas_status rocblas_set_stream(rocblas_handle handle, hipStream_t 
         log_trace(handle, "rocblas_set_stream", stream_id);
     return handle->set_stream(stream_id);
 }
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
 
 /*******************************************************************************
  *! \brief   get rocblas stream used for all subsequent library function calls.
  *   If not set, all hip kernels will take the default NULL stream.
  ******************************************************************************/
 extern "C" rocblas_status rocblas_get_stream(rocblas_handle handle, hipStream_t* stream_id)
+try
 {
     // if handle not valid
     if(!handle)
@@ -129,6 +143,10 @@ extern "C" rocblas_status rocblas_get_stream(rocblas_handle handle, hipStream_t*
     if(handle->layer_mode & rocblas_layer_mode_log_trace)
         log_trace(handle, "rocblas_get_stream", *stream_id);
     return handle->get_stream(stream_id);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -299,7 +317,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -428,7 +446,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -471,7 +489,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -514,7 +532,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -691,7 +709,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -839,7 +857,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -886,7 +904,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 /*******************************************************************************
@@ -934,7 +952,7 @@ try
 }
 catch(...) // catch all exceptions
 {
-    return rocblas_status_internal_error;
+    return exception_to_rocblas_status();
 }
 
 // Convert rocblas_status to string


### PR DESCRIPTION
We currently allow C++ exceptions to escape into the rocBLAS C API, while we should only be returning `rocblas_status`. A C program has no way of handling the exceptions, which will always be fatal.

This change goes through every `extern "C"` routine returning `rocblas_status` and adds a _function_ ` try / catch(...)` block (_function_ meaning it's inserted outside the body of the function, to minimize merge conflicts), and calls an `exception_to_rocblas_status()` function to convert the current exception to `rocblas_status`.

C++11 added `std::exception_ptr`, `std::current_exception` and `std::rethrow_exception`, which allow us to catch any exception with `catch(...)`, and then process it inside another function with `std::current_exception()`, which can `std::rethrow_exception` the current exception inside another `try/catch` block, handling the mappings from C++ exceptions to `rocblas_status` all in one place.

In this change, if there is no current exception, `exception_to_rocblas_status()` returns `rocblas_status_success`. If there is a `std::bad_alloc` exception, it returns `rocblas_status_memory_error`. Otherwise, it returns `rocblas_status_internal_error`, because otherwise the exception would leak into the C API, which it is not prepared for.

Even though not all `extern "C"` routines currently throw exceptions, I have tried to add this `try / catch(...)` around all of the ones which return `rocblas_status`, so that exception leaks are not likely to occur. In the future, all `extern "C"` routines which return `rocblas_status` should use this paradigm.

There could be more clever ways of "wrapping" the C APIs with some kind of universal exception catcher and converter, but it's simpler and more readable simply to put `try / catch(...)` outside and around each separate `extern "C"` function.