### PR TITLE
Disabling build testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ option( BUILD_VERBOSE "Output additional build information" OFF )
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build rocBLAS as a shared library" ON )
 
+option( BUILD_TESTING "Build tests for rocBLAS" ON )
+
 include( clients/cmake/build-options.cmake )
 
 # force library install path to lib (CentOS 7 defaults to lib64)

--- a/install.sh
+++ b/install.sh
@@ -361,7 +361,7 @@ pushd .
   compiler="hcc"
   if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"
-    cmake_common_options="${cmake_common_options} -DTensile_COMPILER=hipcc -DBUILD_TESTING=OFF "
+    cmake_common_options="${cmake_common_options} -DTensile_COMPILER=hipcc"
   fi
 
   # Uncomment for cmake debugging

--- a/install.sh
+++ b/install.sh
@@ -361,7 +361,7 @@ pushd .
   compiler="hcc"
   if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"
-    cmake_common_options="${cmake_common_options} -DTensile_COMPILER=hipcc"
+    cmake_common_options="${cmake_common_options} -DTensile_COMPILER=hipcc -DBUILD_TESTING=OFF "
   fi
 
   # Uncomment for cmake debugging

--- a/install.sh
+++ b/install.sh
@@ -358,6 +358,10 @@ pushd .
     cmake_client_options="${cmake_client_options} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON"
   fi
 
+  if ["${build_hip_clang}" == true ]; then
+      cmake_common_options="${cmake_common_options} -DRUN_HEADER_TESTING=OFF"
+  fi
+
   compiler="hcc"
   if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -205,11 +205,16 @@ rocm_export_targets(
 
 rocm_install_symlink_subdir( rocblas )
 
+#Control for enabling or disabling header testing
+option (RUN_HEADER_TESTING ON)
+
+if(BUILD_TESTING AND RUN_HEADER_TESTING)
 # Compilation tests to ensure that header files work independently,
 # and that public header files work across several languages
 add_custom_command(
   TARGET rocblas
   POST_BUILD
   COMMAND ${CMAKE_HOME_DIRECTORY}/header_compilation_tests.sh
-  WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
  )
+endif()


### PR DESCRIPTION
hip-clang has issues with the BUILD_TESTING section. It is disabled with this PR.
