### PR TITLE
Fix Usage of _Float16 to clang 9 or later

### DIFF
--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -48,7 +48,7 @@ typedef double rocblas_double;
 // Clang supports _Float16 on C11 and C++11
 // GCC does not currently support _Float16 on amd64
 /*! \brief Represents a 16 bit floating point number. */
-#if __clang__ && (__STDC_VERSION__ >= 201112L || __cplusplus >= 201103L)
+#if __clang_major__ >= 9 && (__STDC_VERSION__ >= 201112L || __cplusplus >= 201103L)
 typedef _Float16 rocblas_half;
 #else
 typedef struct


### PR DESCRIPTION
May need to be cherry-picked and applied to master, to fix SWDEV-216454
