### PR TITLE
Adding RUNPATH to rocBLAS lib (#852)

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -207,6 +207,11 @@ add_library( rocblas
 
 add_library( roc::rocblas ALIAS rocblas )
 
+# RUNPATH is set only when ROCM_RPATH is defined in the ENV
+if( DEFINED ENV{ROCM_RPATH} )
+  set ( CMAKE_SHARED_LINKER_FLAGS " -Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}" )
+endif( )
+
 # Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
 if(TARGET hip::device)
 target_link_libraries( rocblas PRIVATE hip::device )


### PR DESCRIPTION
* The linker rpath will be set only if ROCM_RPATH is defined in the ENV
* Match the patching of master patch branches