### PR TITLE
Fix hip-clang header compilation tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ option( BUILD_VERBOSE "Output additional build information" OFF )
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build rocBLAS as a shared library" ON )
 
+option( BUILD_TESTING "Build tests for rocBLAS" ON )
+
 include( clients/cmake/build-options.cmake )
 
 # force library install path to lib (CentOS 7 defaults to lib64)

--- a/install.sh
+++ b/install.sh
@@ -358,6 +358,10 @@ pushd .
     cmake_client_options="${cmake_client_options} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON"
   fi
 
+  if ["${build_hip_clang}" == true ]; then
+      cmake_common_options="${cmake_common_options} -DRUN_HEADER_TESTING=OFF"
+  fi
+
   compiler="hcc"
   if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -206,9 +206,9 @@ rocm_export_targets(
 rocm_install_symlink_subdir( rocblas )
 
 #Control for enabling or disabling header testing
-option (RUN_HEADER_TESTING ON)
+option (RUN_HEADER_TESTING "Enable or disable header testing" ${BUILD_TESTING})
 
-if(BUILD_TESTING AND RUN_HEADER_TESTING)
+if(RUN_HEADER_TESTING)
 # Compilation tests to ensure that header files work independently,
 # and that public header files work across several languages
 add_custom_command(

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -205,11 +205,16 @@ rocm_export_targets(
 
 rocm_install_symlink_subdir( rocblas )
 
+#Control for enabling or disabling header testing
+option (RUN_HEADER_TESTING ON)
+
+if(BUILD_TESTING AND RUN_HEADER_TESTING)
 # Compilation tests to ensure that header files work independently,
 # and that public header files work across several languages
 add_custom_command(
   TARGET rocblas
   POST_BUILD
   COMMAND ${CMAKE_HOME_DIRECTORY}/header_compilation_tests.sh
-  WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
  )
+endif()


### PR DESCRIPTION
Fixes: [SWDEV-215697](http://ontrack-internal.amd.com/browse/SWDEV-215697)

Supercedes: [PR# 872](https://github.com/ROCmSoftwarePlatform/rocBLAS/pull/872)