### PR TITLE
Do not run header compilation tests under hip-clang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -491,6 +491,10 @@ pushd .
     cmake_client_options="${cmake_client_options} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON -DLINK_BLIS=${LINK_BLIS}"
   fi
 
+  if ["${build_hip_clang}" == true ]; then
+      cmake_common_options="${cmake_common_options} -DRUN_HEADER_TESTING=OFF"
+  fi
+
   compiler="hcc"
   if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -297,7 +297,10 @@ rocm_export_targets(
 
 rocm_install_symlink_subdir( rocblas )
 
-if(BUILD_TESTING)
+#Control for enabling or disabling header testing
+option (RUN_HEADER_TESTING "Enable or disable header testing" ${BUILD_TESTING})
+
+if(RUN_HEADER_TESTING)
 # Compilation tests to ensure that header files work independently,
 # and that public header files work across several languages
 add_custom_command(


### PR DESCRIPTION
Same change as hip-clang branch; this needs to be a universal setting
