### PR TITLE
Remove hip_hcc dependencies and replace with rocm-dev

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,17 +135,17 @@ install_packages( )
   # dependencies needed to build the rocblas library
   local library_dependencies_ubuntu=( "make" "cmake-curses-gui" "pkg-config"
                                       "python2.7" "python3" "python-yaml" "python3-yaml"
-                                      "llvm-6.0-dev" "hip_hcc" "rocm_smi64" "zlib1g-dev")
+                                      "llvm-6.0-dev" "rocm-dev" "zlib1g-dev")
   local library_dependencies_centos=( "epel-release"
                                       "make" "cmake3" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
                                       "gcc-c++" "llvm7.0-devel" "llvm7.0-static"
-                                      "hip_hcc" "rocm_smi64" "zlib-devel" )
+                                      "rocm-dev" "zlib-devel" )
   local library_dependencies_fedora=( "make" "cmake" "rpm-build"
                                       "python34" "PyYAML" "python3*-PyYAML"
-                                      "gcc-c++" "libcxx-devel" "hip_hcc" "rocm_smi64" "zlib-devel" )
+                                      "gcc-c++" "libcxx-devel" "rocm-dev" "zlib-devel" )
   local library_dependencies_sles=(   "make" "cmake" "python3-PyYAM"
-                                      "hip_hcc" "gcc-c++" "libcxxtools9" "rpm-build" )
+                                      "rocm-dev" "gcc-c++" "libcxxtools9" "rpm-build" "curl" )
 
   if [[ "${build_cuda}" == true ]]; then
     # Ideally, this could be cuda-cublas-dev, but the package name has a version number in it

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -124,8 +124,8 @@ add_subdirectory( src )
 # endif( )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3" )
+set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev (>= 2.5.27)" )
+set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev >= 2.5.27" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )


### PR DESCRIPTION
Old hip_hcc and rocm_smi64 packages will cause the installation to fail on rocm 3.0. Replacing with rocm-dev should fix this issue.