### PR TITLE
Fix abs(0,0) to return 0 instead of NaN

### DIFF
--- a/library/include/rocblas-complex-types.h
+++ b/library/include/rocblas-complex-types.h
@@ -355,7 +355,7 @@ namespace std
     {
         T tr = rocblas_complex_num<T>::abs(z.x), ti = rocblas_complex_num<T>::abs(z.y);
         return tr > ti ? (ti /= tr, tr * rocblas_complex_num<T>::sqrt(ti * ti + 1))
-                       : (tr /= ti, ti * rocblas_complex_num<T>::sqrt(tr * tr + 1));
+                       : ti ? (tr /= ti, ti * rocblas_complex_num<T>::sqrt(tr * tr + 1)) : 0;
     }
 }
 


### PR DESCRIPTION
Fix complex `abs()` to return `0` instead of `NaN` when both the real and imaginary parts are 0.

