### PR TITLE
Use C++14 std::enable_if_t to make code more compact

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -131,9 +131,9 @@ template <typename Ti, typename To, typename Tc>
 struct perf_gemm_ex<Ti,
                     To,
                     Tc,
-                    typename std::enable_if<!std::is_same<Ti, void>{}
-                                            && !(std::is_same<Ti, To>{} && std::is_same<Ti, Tc>{}
-                                                 && std::is_same<Ti, rocblas_bfloat16>{})>::type>
+                    std::enable_if_t<!std::is_same<Ti, void>{}
+                                     && !(std::is_same<Ti, To>{} && std::is_same<Ti, Tc>{}
+                                          && std::is_same<Ti, rocblas_bfloat16>{})>>
     : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
@@ -158,10 +158,9 @@ struct perf_gemm_strided_batched_ex<
     Ti,
     To,
     Tc,
-    typename std::enable_if<!std::is_same<Ti, void>{}
-                            && !(std::is_same<Ti, To>{} && std::is_same<Ti, Tc>{}
-                                 && std::is_same<Ti, rocblas_bfloat16>{})>::type>
-    : rocblas_test_valid
+    std::enable_if_t<!std::is_same<Ti, void>{}
+                     && !(std::is_same<Ti, To>{} && std::is_same<Ti, Tc>{}
+                          && std::is_same<Ti, rocblas_bfloat16>{})>> : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
     {
@@ -180,10 +179,7 @@ struct perf_blas : rocblas_test_invalid
 };
 
 template <typename T, typename U>
-struct perf_blas<
-    T,
-    U,
-    typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
     : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
@@ -250,8 +246,7 @@ struct perf_blas<
 };
 
 template <typename T, typename U>
-struct perf_blas<T, U, typename std::enable_if<std::is_same<T, rocblas_bfloat16>{}>::type>
-    : rocblas_test_valid
+struct perf_blas<T, U, std::enable_if_t<std::is_same<T, rocblas_bfloat16>{}>> : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
     {
@@ -263,8 +258,7 @@ struct perf_blas<T, U, typename std::enable_if<std::is_same<T, rocblas_bfloat16>
 };
 
 template <typename T, typename U>
-struct perf_blas<T, U, typename std::enable_if<std::is_same<T, rocblas_half>{}>::type>
-    : rocblas_test_valid
+struct perf_blas<T, U, std::enable_if_t<std::is_same<T, rocblas_half>{}>> : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
     {
@@ -284,9 +278,8 @@ struct perf_blas<T, U, typename std::enable_if<std::is_same<T, rocblas_half>{}>:
 template <typename T, typename U>
 struct perf_blas<T,
                  U,
-                 typename std::enable_if<std::is_same<T, rocblas_double_complex>{}
-                                         || std::is_same<T, rocblas_float_complex>{}>::type>
-    : rocblas_test_valid
+                 std::enable_if_t<std::is_same<T, rocblas_double_complex>{}
+                                  || std::is_same<T, rocblas_float_complex>{}>> : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
     {
@@ -343,17 +336,17 @@ struct perf_blas_rot<
     Ti,
     To,
     Tc,
-    typename std::enable_if<(
-        (std::is_same<Ti, float>{} && std::is_same<Ti, To>{} && std::is_same<To, Tc>{})
-        || (std::is_same<Ti, double>{} && std::is_same<Ti, To>{} && std::is_same<To, Tc>{})
-        || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{}
-            && std::is_same<Tc, rocblas_float_complex>{})
-        || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{}
-            && std::is_same<Tc, float>{})
-        || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{}
-            && std::is_same<Tc, rocblas_double_complex>{})
-        || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{}
-            && std::is_same<Tc, double>{}))>::type> : rocblas_test_valid
+    std::enable_if_t<(std::is_same<Ti, float>{} && std::is_same<Ti, To>{} && std::is_same<To, Tc>{})
+                     || (std::is_same<Ti, double>{} && std::is_same<Ti, To>{}
+                         && std::is_same<To, Tc>{})
+                     || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{}
+                         && std::is_same<Tc, rocblas_float_complex>{})
+                     || (std::is_same<Ti, rocblas_float_complex>{} && std::is_same<To, float>{}
+                         && std::is_same<Tc, float>{})
+                     || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{}
+                         && std::is_same<Tc, rocblas_double_complex>{})
+                     || (std::is_same<Ti, rocblas_double_complex>{} && std::is_same<To, double>{}
+                         && std::is_same<Tc, double>{})>> : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
     {
@@ -375,13 +368,12 @@ template <typename Ta, typename Tb>
 struct perf_blas_scal<
     Ta,
     Tb,
-    typename std::enable_if<
-        (std::is_same<Ta, double>{} && std::is_same<Tb, rocblas_double_complex>{})
-        || (std::is_same<Ta, float>{} && std::is_same<Tb, rocblas_float_complex>{})
-        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{})
-        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{})
-        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_float_complex>{})
-        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_double_complex>{})>::type>
+    std::enable_if_t<(std::is_same<Ta, double>{} && std::is_same<Tb, rocblas_double_complex>{})
+                     || (std::is_same<Ta, float>{} && std::is_same<Tb, rocblas_float_complex>{})
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{})
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{})
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_float_complex>{})
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, rocblas_double_complex>{})>>
     : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
@@ -404,11 +396,11 @@ template <typename Ta, typename Tb>
 struct perf_blas_rotg<
     Ta,
     Tb,
-    typename std::enable_if<
-        (std::is_same<Ta, rocblas_double_complex>{} && std::is_same<Tb, double>{})
-        || (std::is_same<Ta, rocblas_float_complex>{} && std::is_same<Tb, float>{})
-        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{})
-        || (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{})>::type> : rocblas_test_valid
+    std::enable_if_t<(std::is_same<Ta, rocblas_double_complex>{} && std::is_same<Tb, double>{})
+                     || (std::is_same<Ta, rocblas_float_complex>{} && std::is_same<Tb, float>{})
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{})
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{})>>
+    : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
     {

--- a/clients/gtest/README.md
+++ b/clients/gtest/README.md
@@ -117,10 +117,8 @@ In the partial specialization(s), create a functional `operator()` which takes a
 ```c++
  template <typename T>
  struct syr_testing<T,
-                    typename std::enable_if<
-                    std::is_same<T, float>::value ||
-                    std::is_same<T, double>::value
-                   >::type> : rocblas_test_valid
+                    std::enable_if_t<std::is_same<T, float>::value || std::is_same<T, double>::value>
+                   > : rocblas_test_valid
 {
     void operator()(const Arguments& arg)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -320,51 +320,46 @@ namespace
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function
-// clang-format off
-#define BLAS1_TESTING(NAME, ARG)                                               \
-struct blas1_##NAME                                                            \
-{                                                                              \
-    template <typename Ti, typename To = Ti, typename Tc = To, typename = void>\
-    struct testing : rocblas_test_invalid {};                                  \
-                                                                               \
-    template <typename Ti, typename To, typename Tc>                           \
-    struct testing<Ti,                                                         \
-                   To,                                                         \
-                   Tc,                                                         \
-                   typename std::enable_if<                                    \
-                       blas1_enabled<blas1::NAME, Ti, To, Tc>{}>::type>        \
-       : rocblas_test_valid                                                    \
-    {                                                                          \
-        void operator()(const Arguments& arg)                                  \
-        {                                                                      \
-            if(!strcmp(arg.function, #NAME))                                   \
-                testing_##NAME<ARG(Ti, To, Tc)>(arg);                          \
-            else if(!strcmp(arg.function, #NAME "_bad_arg"))                   \
-                testing_##NAME##_bad_arg<ARG(Ti, To, Tc)>(arg);                \
-            else                                                               \
-                FAIL() << "Internal error: Test called with unknown function: "\
-                       << arg.function;                                        \
-        }                                                                      \
-    };                                                                         \
-};                                                                             \
-                                                                               \
-using NAME = blas1_test_template<blas1_##NAME::template testing, blas1::NAME>; \
-                                                                               \
-template<>                                                                     \
-inline bool NAME::function_filter(const Arguments& arg)                        \
-{                                                                              \
-    return !strcmp(arg.function, #NAME) ||                                     \
-           !strcmp(arg.function, #NAME "_bad_arg");                            \
-}                                                                              \
-                                                                               \
-TEST_P(NAME, blas1)                                                            \
-{                                                                              \
-    CATCH_SIGNALS_AND_EXCEPTIONS_AS_FAILURES(rocblas_blas1_dispatch<blas1_##NAME::template testing>(GetParam())); \
-}                                                                              \
-                                                                               \
-INSTANTIATE_TEST_CATEGORIES(NAME)
-
-    // clang-format on
+#define BLAS1_TESTING(NAME, ARG)                                                               \
+    struct blas1_##NAME                                                                        \
+    {                                                                                          \
+        template <typename Ti, typename To = Ti, typename Tc = To, typename = void>            \
+        struct testing : rocblas_test_invalid                                                  \
+        {                                                                                      \
+        };                                                                                     \
+                                                                                               \
+        template <typename Ti, typename To, typename Tc>                                       \
+        struct testing<Ti, To, Tc, std::enable_if_t<blas1_enabled<blas1::NAME, Ti, To, Tc>{}>> \
+            : rocblas_test_valid                                                               \
+        {                                                                                      \
+            void operator()(const Arguments& arg)                                              \
+            {                                                                                  \
+                if(!strcmp(arg.function, #NAME))                                               \
+                    testing_##NAME<ARG(Ti, To, Tc)>(arg);                                      \
+                else if(!strcmp(arg.function, #NAME "_bad_arg"))                               \
+                    testing_##NAME##_bad_arg<ARG(Ti, To, Tc)>(arg);                            \
+                else                                                                           \
+                    FAIL() << "Internal error: Test called with unknown function: "            \
+                           << arg.function;                                                    \
+            }                                                                                  \
+        };                                                                                     \
+    };                                                                                         \
+                                                                                               \
+    using NAME = blas1_test_template<blas1_##NAME::template testing, blas1::NAME>;             \
+                                                                                               \
+    template <>                                                                                \
+    inline bool NAME::function_filter(const Arguments& arg)                                    \
+    {                                                                                          \
+        return !strcmp(arg.function, #NAME) || !strcmp(arg.function, #NAME "_bad_arg");        \
+    }                                                                                          \
+                                                                                               \
+    TEST_P(NAME, blas1)                                                                        \
+    {                                                                                          \
+        CATCH_SIGNALS_AND_EXCEPTIONS_AS_FAILURES(                                              \
+            rocblas_blas1_dispatch<blas1_##NAME::template testing>(GetParam()));               \
+    }                                                                                          \
+                                                                                               \
+    INSTANTIATE_TEST_CATEGORIES(NAME)
 
 #define ARG1(Ti, To, Tc) Ti
 #define ARG2(Ti, To, Tc) Ti, To

--- a/clients/gtest/gbmv_gtest.cpp
+++ b/clients/gtest/gbmv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2018-2019 Advanced Micro Devices, Inc.
+ * Copyright 2018-2020 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "rocblas_data.hpp"
@@ -80,7 +80,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct gbmv_testing : rocblas_test_invalid
     {
@@ -89,11 +89,10 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct gbmv_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
-                                || std::is_same<T, rocblas_float_complex>{}
-                                || std::is_same<T, rocblas_double_complex>{}>::type>
+    struct gbmv_testing<T,
+                        std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}
+                                         || std::is_same<T, rocblas_float_complex>{}
+                                         || std::is_same<T, rocblas_double_complex>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/geam_gtest.cpp
+++ b/clients/gtest/geam_gtest.cpp
@@ -14,7 +14,7 @@
 namespace
 {
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct geam_testing : rocblas_test_invalid
     {
@@ -23,9 +23,7 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct geam_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct geam_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/gemm_gtest.cpp
+++ b/clients/gtest/gemm_gtest.cpp
@@ -133,11 +133,11 @@ namespace
     // When Ti = To = Tc != void, this test applies.
     // When converted to bool, this functor returns true.
     template <typename T>
-    struct gemm_testing<T,
-                        T,
-                        T,
-                        typename std::enable_if<!std::is_same<T, void>{}
-                                                && !std::is_same<T, rocblas_bfloat16>{}>::type>
+    struct gemm_testing<
+        T,
+        T,
+        T,
+        std::enable_if_t<!std::is_same<T, void>{} && !std::is_same<T, rocblas_bfloat16>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)
@@ -199,9 +199,8 @@ namespace
         Ti,
         To,
         Tc,
-        typename std::enable_if<!std::is_same<Ti, void>{}
-                                && !(std::is_same<Ti, Tc>{}
-                                     && std::is_same<Ti, rocblas_bfloat16>{})>::type>
+        std::enable_if_t<!std::is_same<Ti, void>{}
+                         && !(std::is_same<Ti, Tc>{} && std::is_same<Ti, rocblas_bfloat16>{})>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -79,7 +79,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct gemv_testing : rocblas_test_invalid
     {
@@ -88,11 +88,10 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct gemv_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
-                                || std::is_same<T, rocblas_float_complex>{}
-                                || std::is_same<T, rocblas_double_complex>{}>::type>
+    struct gemv_testing<T,
+                        std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}
+                                         || std::is_same<T, rocblas_float_complex>{}
+                                         || std::is_same<T, rocblas_double_complex>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/ger_gtest.cpp
+++ b/clients/gtest/ger_gtest.cpp
@@ -87,7 +87,7 @@ namespace
     };
 
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct ger_testing : rocblas_test_invalid
     {
@@ -96,9 +96,7 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct ger_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct ger_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/hemv_gtest.cpp
+++ b/clients/gtest/hemv_gtest.cpp
@@ -79,7 +79,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct hemv_testing : rocblas_test_invalid
     {
@@ -89,8 +89,8 @@ namespace
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
     struct hemv_testing<T,
-                        typename std::enable_if<std::is_same<T, rocblas_float_complex>{}
-                                                || std::is_same<T, rocblas_double_complex>{}>::type>
+                        std::enable_if_t<std::is_same<T, rocblas_float_complex>{}
+                                         || std::is_same<T, rocblas_double_complex>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/logging_mode_gtest.cpp
+++ b/clients/gtest/logging_mode_gtest.cpp
@@ -14,7 +14,7 @@
 namespace
 {
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct logging_testing : rocblas_test_invalid
     {
@@ -23,9 +23,8 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct logging_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct logging_testing<T,
+                           std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/set_get_matrix_gtest.cpp
+++ b/clients/gtest/set_get_matrix_gtest.cpp
@@ -62,7 +62,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct set_get_matrix_testing : rocblas_test_invalid
     {
@@ -73,7 +73,7 @@ namespace
     template <typename T>
     struct set_get_matrix_testing<
         T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+        std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/set_get_vector_gtest.cpp
+++ b/clients/gtest/set_get_vector_gtest.cpp
@@ -60,7 +60,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct set_get_vector_testing : rocblas_test_invalid
     {
@@ -71,7 +71,7 @@ namespace
     template <typename T>
     struct set_get_vector_testing<
         T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+        std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/symv_gtest.cpp
+++ b/clients/gtest/symv_gtest.cpp
@@ -15,7 +15,7 @@
 namespace
 {
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct symv_testing : rocblas_test_invalid
     {
@@ -28,7 +28,7 @@ namespace
 template <typename T>
 struct symv_testing<
     T,
-    typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
     : rocblas_test_valid
 {
     void operator()(const Arguments& arg)

--- a/clients/gtest/syr_gtest.cpp
+++ b/clients/gtest/syr_gtest.cpp
@@ -83,7 +83,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct syr_testing : rocblas_test_invalid
     {
@@ -92,9 +92,7 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct syr_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct syr_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/tbmv_gtest.cpp
+++ b/clients/gtest/tbmv_gtest.cpp
@@ -80,7 +80,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct tbmv_testing : rocblas_test_invalid
     {
@@ -89,11 +89,10 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct tbmv_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
-                                || std::is_same<T, rocblas_float_complex>{}
-                                || std::is_same<T, rocblas_double_complex>{}>::type>
+    struct tbmv_testing<T,
+                        std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}
+                                         || std::is_same<T, rocblas_float_complex>{}
+                                         || std::is_same<T, rocblas_double_complex>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/trmm_gtest.cpp
+++ b/clients/gtest/trmm_gtest.cpp
@@ -15,7 +15,7 @@
 namespace
 {
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct trmm_testing : rocblas_test_invalid
     {
@@ -24,9 +24,7 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct trmm_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct trmm_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/trmv_gtest.cpp
+++ b/clients/gtest/trmv_gtest.cpp
@@ -75,7 +75,7 @@ namespace
     };
 
     // By default, arbitrary type combinations are invalid.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct trmv_testing : rocblas_test_invalid
     {
@@ -84,11 +84,10 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct trmv_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
-                                || std::is_same<T, rocblas_float_complex>{}
-                                || std::is_same<T, rocblas_double_complex>{}>::type>
+    struct trmv_testing<T,
+                        std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}
+                                         || std::is_same<T, rocblas_float_complex>{}
+                                         || std::is_same<T, rocblas_double_complex>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/trsm_gtest.cpp
+++ b/clients/gtest/trsm_gtest.cpp
@@ -87,7 +87,7 @@ namespace
     };
 
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct trsm_testing : rocblas_test_invalid
     {
@@ -96,9 +96,7 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct trsm_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct trsm_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/trsv_gtest.cpp
+++ b/clients/gtest/trsv_gtest.cpp
@@ -25,7 +25,7 @@ namespace
     };
 
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct trsv_testing : rocblas_test_invalid
     {
@@ -34,9 +34,7 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct trsv_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct trsv_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/trtri_gtest.cpp
+++ b/clients/gtest/trtri_gtest.cpp
@@ -17,7 +17,7 @@
 namespace
 {
     // By default, this test does not apply to any types.
-    // The unnamed second parameter is used for enable_if below.
+    // The unnamed second parameter is used for enable_if_t below.
     template <typename, typename = void>
     struct trtri_testing : rocblas_test_invalid
     {
@@ -26,9 +26,7 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct trtri_testing<
-        T,
-        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}>::type>
+    struct trtri_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
         : rocblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/include/norm.hpp
+++ b/clients/include/norm.hpp
@@ -124,7 +124,7 @@ inline void xaxpy(int*                    n,
 
 /* ============== Norm Check for General Matrix ============= */
 /*! \brief compare the norm error of two matrices hCPU & hGPU */
-template <typename T, typename std::enable_if<!is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 double norm_check_general(
     char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU)
 {
@@ -154,7 +154,7 @@ double norm_check_general(
     return error;
 }
 
-template <typename T, typename std::enable_if<is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
 double norm_check_general(
     char norm_type, rocblas_int M, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU)
 {
@@ -319,7 +319,7 @@ double norm_check_general(char        norm_type,
 
 /* ============== Norm Check for Symmetric Matrix ============= */
 /*! \brief compare the norm error of two hermitian/symmetric matrices hCPU & hGPU */
-template <typename T, typename std::enable_if<!is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 double norm_check_symmetric(
     char norm_type, char uplo, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU)
 {
@@ -346,7 +346,7 @@ double norm_check_symmetric(
     return error;
 }
 
-template <typename T, typename std::enable_if<is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
 double norm_check_symmetric(
     char norm_type, char uplo, rocblas_int N, rocblas_int lda, T* hCPU, T* hGPU)
 {

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -184,13 +184,13 @@ struct Arguments
     }
 
 private:
-    template <typename T, typename U, typename std::enable_if<!is_complex<T>, int>::type = 0>
+    template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
     static T convert_alpha_beta(U r, U i)
     {
         return T(r);
     }
 
-    template <typename T, typename U, typename std::enable_if<+is_complex<T>, int>::type = 0>
+    template <typename T, typename U, std::enable_if_t<+is_complex<T>, int> = 0>
     static T convert_alpha_beta(U r, U i)
     {
         return T(r, i);

--- a/clients/include/rocblas_math.hpp
+++ b/clients/include/rocblas_math.hpp
@@ -31,20 +31,19 @@ inline __host__ rocblas_bfloat16 float_to_bfloat16_truncate(float val)
 /* ============================================================================================ */
 /*! \brief  returns true if value is NaN */
 
-template <typename T, typename std::enable_if<std::is_integral<T>{}, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_integral<T>{}, int> = 0>
 inline bool rocblas_isnan(T)
 {
     return false;
 }
 
-template <typename T,
-          typename std::enable_if<!std::is_integral<T>{} && !is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<!std::is_integral<T>{} && !is_complex<T>, int> = 0>
 inline bool rocblas_isnan(T arg)
 {
     return std::isnan(arg);
 }
 
-template <typename T, typename std::enable_if<is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
 inline bool rocblas_isnan(const T& arg)
 {
     return rocblas_isnan(std::real(arg)) || rocblas_isnan(std::imag(arg));

--- a/clients/include/rocblas_random.hpp
+++ b/clients/include/rocblas_random.hpp
@@ -45,7 +45,7 @@ class rocblas_nan_rng
 
 public:
     // Random integer
-    template <typename T, typename std::enable_if<std::is_integral<T>{}, int>::type = 0>
+    template <typename T, std::enable_if_t<std::is_integral<T>{}, int> = 0>
     explicit operator T()
     {
         return std::uniform_int_distribution<T>{}(rocblas_rng);

--- a/docs/source/addtest.rst
+++ b/docs/source/addtest.rst
@@ -144,10 +144,8 @@ In the partial specialization(s), create a functional ``operator()`` which takes
 
     template <typename T>
     struct syr_testing<T,
-                       typename std::enable_if<
-                       std::is_same<T, float>::value ||
-                       std::is_same<T, double>::value
-                      >::type> : rocblas_test_valid
+                      std::enable_if_t<std::is_same<T, float>::value || std::is_same<T, double>::value>
+                      > : rocblas_test_valid
    {
        void operator()(const Arguments& arg)
        {

--- a/library/include/rocblas-complex-types.h
+++ b/library/include/rocblas-complex-types.h
@@ -101,7 +101,7 @@ public:
     }
 
     // Conversion from different complex (explicit)
-    template <typename U, typename std::enable_if<std::is_constructible<T, U>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_constructible<T, U>{}, int> = 0>
     __device__ __host__ explicit rocblas_complex_num(const rocblas_complex_num<U>& z)
         : x(z.x)
         , y(z.y)
@@ -125,37 +125,37 @@ public:
     }
 
     // complex-real operations
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     __device__ __host__ auto& operator+=(const U& rhs)
     {
         return (x += T(rhs)), *this;
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     __device__ __host__ auto& operator-=(const U& rhs)
     {
         return (x -= T(rhs)), *this;
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     __device__ __host__ auto& operator*=(const U& rhs)
     {
         return (x *= rhs), (y *= T(rhs)), *this;
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     __device__ __host__ auto& operator/=(const U& rhs)
     {
         return (x /= T(rhs)), (y /= T(rhs)), *this;
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     __device__ __host__ bool operator==(const U& rhs) const
     {
         return x == T(rhs) && y == 0;
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     __device__ __host__ bool operator!=(const U& rhs) const
     {
         return !(*this == rhs);
@@ -271,28 +271,28 @@ public:
     }
 
     // real-complex operations (complex-real is handled above)
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     friend __device__ __host__ rocblas_complex_num operator+(const U&                   lhs,
                                                              const rocblas_complex_num& rhs)
     {
         return {T(lhs) + rhs.x, rhs.y};
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     friend __device__ __host__ rocblas_complex_num operator-(const U&                   lhs,
                                                              const rocblas_complex_num& rhs)
     {
         return {T(lhs) - rhs.x, -rhs.y};
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     friend __device__ __host__ rocblas_complex_num operator*(const U&                   lhs,
                                                              const rocblas_complex_num& rhs)
     {
         return {T(lhs) * rhs.x, T(lhs) * rhs.y};
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     friend __device__ __host__ rocblas_complex_num operator/(const U&                   lhs,
                                                              const rocblas_complex_num& rhs)
     {
@@ -310,13 +310,13 @@ public:
         }
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     friend __device__ __host__ bool operator==(const U& lhs, const rocblas_complex_num& rhs)
     {
         return T(lhs) == rhs.x && 0 == rhs.y;
     }
 
-    template <typename U, typename std::enable_if<std::is_convertible<U, T>{}, int>::type = 0>
+    template <typename U, std::enable_if_t<std::is_convertible<U, T>{}, int> = 0>
     friend __device__ __host__ bool operator!=(const U& lhs, const rocblas_complex_num& rhs)
     {
         return !(lhs == rhs);

--- a/library/src/blas1/rocblas_rot.hpp
+++ b/library/src/blas1/rocblas_rot.hpp
@@ -9,7 +9,7 @@ template <typename T,
           typename T2,
           typename U,
           typename V,
-          typename std::enable_if<!is_complex<V>, int>::type = 0>
+          std::enable_if_t<!is_complex<V>, int> = 0>
 __global__ void rot_kernel(rocblas_int    n,
                            T2             x_in,
                            rocblas_int    offset_x,
@@ -40,11 +40,7 @@ __global__ void rot_kernel(rocblas_int    n,
     }
 }
 
-template <typename T,
-          typename T2,
-          typename U,
-          typename V,
-          typename std::enable_if<is_complex<V>, int>::type = 0>
+template <typename T, typename T2, typename U, typename V, std::enable_if_t<is_complex<V>, int> = 0>
 __global__ void rot_kernel(rocblas_int    n,
                            T2             x_in,
                            rocblas_int    offset_x,

--- a/library/src/blas1/rocblas_rotg.hpp
+++ b/library/src/blas1/rocblas_rotg.hpp
@@ -6,7 +6,7 @@
 #include "rocblas.h"
 #include "utility.h"
 
-template <typename T, typename U, typename std::enable_if<!is_complex<T>, int>::type = 0>
+template <typename T, typename U, std::enable_if_t<!is_complex<T>, int> = 0>
 __device__ __host__ void rocblas_rotg_calc(T& a, T& b, U& c, T& s)
 {
     T scale = rocblas_abs(a) + rocblas_abs(b);
@@ -36,7 +36,7 @@ __device__ __host__ void rocblas_rotg_calc(T& a, T& b, U& c, T& s)
     }
 }
 
-template <typename T, typename U, typename std::enable_if<is_complex<T>, int>::type = 0>
+template <typename T, typename U, std::enable_if_t<is_complex<T>, int> = 0>
 __device__ __host__ void rocblas_rotg_calc(T& a, T& b, U& c, T& s)
 {
     if(!rocblas_abs(a))

--- a/library/src/blas2/gemv_device.hpp
+++ b/library/src/blas2/gemv_device.hpp
@@ -11,7 +11,7 @@ template <rocblas_int DIM_X,
           rocblas_int DIM_Y,
           typename T,
           typename U,
-          typename std::enable_if<!std::is_same<T, rocblas_double_complex>{}, int>::type = 0>
+          std::enable_if_t<!std::is_same<T, rocblas_double_complex>{}, int> = 0>
 __device__ void gemvn_kernel_calc(rocblas_int m,
                                   rocblas_int n,
                                   U           alpha,

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -111,8 +111,8 @@ public:
     // Maximum size is accumulated in device_memory_query_size
     // Returns rocblas_status_size_increased or rocblas_status_size_unchanged
     template <typename... Ss,
-              typename = typename std::enable_if<
-                  sizeof...(Ss) && conjunction<std::is_constructible<size_t, Ss>...>{}>::type>
+              typename = std::enable_if_t<sizeof...(Ss)
+                                          && conjunction<std::is_constructible<size_t, Ss>...>{}>>
     rocblas_status set_optimal_device_memory_size(Ss... sizes)
     {
         if(!device_memory_size_query)
@@ -133,10 +133,8 @@ public:
 
     // Allocate one or more sizes
     template <typename... Ss,
-              typename std::enable_if<sizeof...(Ss)
-                                          && conjunction<std::is_constructible<size_t, Ss>...>{},
-                                      int>::type
-              = 0>
+              std::enable_if_t<sizeof...(Ss) && conjunction<std::is_constructible<size_t, Ss>...>{},
+                               int> = 0>
     auto device_malloc(Ss... sizes)
     {
         return _device_malloc<sizeof...(Ss)>(this, size_t(sizes)...);
@@ -241,8 +239,7 @@ private:
         }
 
         // Conversion to any pointer type, but only if N == 1
-        template <typename T,
-                  typename = typename std::enable_if<std::is_pointer<T>{} && N == 1>::type>
+        template <typename T, typename = std::enable_if_t<std::is_pointer<T>{} && N == 1>>
         explicit operator T() const
         {
             return T(pointers[0]);

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -135,14 +135,14 @@ protected:
      * Compute value hashes for (key1, value1, key2, value2, ...) tuples
      ************************************************************************************/
     // Workaround for compilers which don't implement C++14 enum hash (LWG 2148)
-    template <typename T, typename std::enable_if<std::is_enum<T>{}, int>::type = 0>
+    template <typename T, std::enable_if_t<std::is_enum<T>{}, int> = 0>
     static size_t hash(const T& x)
     {
         return std::hash<typename std::underlying_type<T>::type>{}(x);
     }
 
     // Default hash for non-enum types
-    template <typename T, typename std::enable_if<!std::is_enum<T>{}, int>::type = 0>
+    template <typename T, std::enable_if_t<!std::is_enum<T>{}, int> = 0>
     static size_t hash(const T& x)
     {
         return std::hash<T>{}(x);
@@ -378,13 +378,13 @@ inline float log_trace_scalar_value(const rocblas_half* value)
     return value ? float(*value) : std::numeric_limits<float>::quiet_NaN();
 }
 
-template <typename T, typename std::enable_if<!is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 inline T log_trace_scalar_value(const T* value)
 {
     return value ? *value : std::numeric_limits<T>::quiet_NaN();
 }
 
-template <typename T, typename std::enable_if<+is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<+is_complex<T>, int> = 0>
 inline T log_trace_scalar_value(const T* value)
 {
     return value ? *value
@@ -403,7 +403,7 @@ inline std::string log_bench_scalar_value(const char* name, const rocblas_half* 
     return ss.str();
 }
 
-template <typename T, typename std::enable_if<!is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 inline std::string log_bench_scalar_value(const char* name, const T* value)
 {
     std::stringstream ss;
@@ -411,7 +411,7 @@ inline std::string log_bench_scalar_value(const char* name, const T* value)
     return ss.str();
 }
 
-template <typename T, typename std::enable_if<+is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<+is_complex<T>, int> = 0>
 inline std::string log_bench_scalar_value(const char* name, const T* value)
 {
     std::stringstream ss;

--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -31,13 +31,13 @@ __device__ inline rocblas_half2
 
 // Conjugate a value. For most types, simply return argument; for
 // rocblas_float_complex and rocblas_double_complex, return std::conj(z)
-template <typename T, typename std::enable_if<!is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 __device__ __host__ inline T conj(const T& z)
 {
     return z;
 }
 
-template <typename T, typename std::enable_if<is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
 __device__ __host__ inline T conj(const T& z)
 {
     return std::conj(z);
@@ -311,14 +311,14 @@ constexpr rocblas_status get_rocblas_status_for_hip_status(hipError_t status)
 }
 
 // Absolute value
-template <typename T, typename std::enable_if<!is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 __device__ __host__ inline T rocblas_abs(T x)
 {
     return x < 0 ? -x : x;
 }
 
 // For complex, we have defined a __device__ __host__ compatible std::abs
-template <typename T, typename std::enable_if<is_complex<T>, int>::type = 0>
+template <typename T, std::enable_if_t<is_complex<T>, int> = 0>
 __device__ __host__ inline auto rocblas_abs(T x)
 {
     return std::abs(x);


### PR DESCRIPTION
`std::enable_if_t<...>` is more compact than `typename std::enable_if<...>::type`, and is in C++14. We build using `-std=c++14`.

This makes the templates smaller, and `clang-format` sometimes reduces them to single lines.

Turn off whitespace if you want to ignore most of the `clang-format` changes.
