### PR TITLE
Remove hipMalloc and hipFree warnings from samples

### DIFF
--- a/clients/samples/example_openmp.cpp
+++ b/clients/samples/example_openmp.cpp
@@ -59,8 +59,8 @@ int main()
     }
 
     // allocate memory on device
-    hipMalloc(&dx, N * NUM_THREADS * sizeof(float));
-    hipMalloc(&dy, N * NUM_THREADS * sizeof(float));
+    (hipMalloc)(&dx, N * NUM_THREADS * sizeof(float));
+    (hipMalloc)(&dy, N * NUM_THREADS * sizeof(float));
 
     // Initial Data on CPU
     srand(1);
@@ -129,8 +129,8 @@ int main()
 
     printf("%d    %8.2f         \n", (int)N * NUM_THREADS, gpu_time_used);
 
-    hipFree(dx);
-    hipFree(dy);
+    (hipFree)(dx);
+    (hipFree)(dy);
 
     // Destroy handle/streams
     for(rocblas_int i = 0; i < NUM_THREADS; i++)

--- a/clients/samples/example_scal_template.cpp
+++ b/clients/samples/example_scal_template.cpp
@@ -30,7 +30,7 @@ int main()
     rocblas_create_handle(&handle);
 
     // allocate memory on device
-    hipMalloc(&dx, N * sizeof(float));
+    (hipMalloc)(&dx, N * sizeof(float));
 
     // Initial Data on CPU
     srand(1);
@@ -72,7 +72,7 @@ int main()
 
     printf("%d    %8.2f        \n", (int)N, gpu_time_used);
 
-    hipFree(dx);
+    (hipFree)(dx);
     rocblas_destroy_handle(handle);
     return rocblas_status_success;
 }

--- a/clients/samples/example_sgemm.cpp
+++ b/clients/samples/example_sgemm.cpp
@@ -108,9 +108,9 @@ int main()
 
     // allocate memory on device
     float *da, *db, *dc;
-    CHECK_HIP_ERROR(hipMalloc(&da, size_a * sizeof(float)));
-    CHECK_HIP_ERROR(hipMalloc(&db, size_b * sizeof(float)));
-    CHECK_HIP_ERROR(hipMalloc(&dc, size_c * sizeof(float)));
+    CHECK_HIP_ERROR((hipMalloc)(&da, size_a * sizeof(float)));
+    CHECK_HIP_ERROR((hipMalloc)(&db, size_b * sizeof(float)));
+    CHECK_HIP_ERROR((hipMalloc)(&dc, size_c * sizeof(float)));
 
     // copy matrices from host to device
     CHECK_HIP_ERROR(hipMemcpy(da, ha.data(), sizeof(float) * size_a, hipMemcpyHostToDevice));
@@ -165,9 +165,9 @@ int main()
         std::cout << "PASS: max_relative_error = " << max_relative_error << std::endl;
     }
 
-    CHECK_HIP_ERROR(hipFree(da));
-    CHECK_HIP_ERROR(hipFree(db));
-    CHECK_HIP_ERROR(hipFree(dc));
+    CHECK_HIP_ERROR((hipFree)(da));
+    CHECK_HIP_ERROR((hipFree)(db));
+    CHECK_HIP_ERROR((hipFree)(dc));
     CHECK_ROCBLAS_ERROR(rocblas_destroy_handle(handle));
     return EXIT_SUCCESS;
 }

--- a/clients/samples/example_sgemm_strided_batched.cpp
+++ b/clients/samples/example_sgemm_strided_batched.cpp
@@ -541,9 +541,9 @@ int main(int argc, char* argv[])
 
     // allocate memory on device
     float *da, *db, *dc;
-    CHECK_HIP_ERROR(hipMalloc(&da, size_a * sizeof(float)));
-    CHECK_HIP_ERROR(hipMalloc(&db, size_b * sizeof(float)));
-    CHECK_HIP_ERROR(hipMalloc(&dc, size_c * sizeof(float)));
+    CHECK_HIP_ERROR((hipMalloc)(&da, size_a * sizeof(float)));
+    CHECK_HIP_ERROR((hipMalloc)(&db, size_b * sizeof(float)));
+    CHECK_HIP_ERROR((hipMalloc)(&dc, size_c * sizeof(float)));
 
     // copy matrices from host to device
     CHECK_HIP_ERROR(hipMemcpy(da, ha.data(), sizeof(float) * size_a, hipMemcpyHostToDevice));
@@ -624,9 +624,9 @@ int main(int argc, char* argv[])
         std::cout << "PASS, " << max_relative_error << std::endl;
     }
 
-    CHECK_HIP_ERROR(hipFree(da));
-    CHECK_HIP_ERROR(hipFree(db));
-    CHECK_HIP_ERROR(hipFree(dc));
+    CHECK_HIP_ERROR((hipFree)(da));
+    CHECK_HIP_ERROR((hipFree)(db));
+    CHECK_HIP_ERROR((hipFree)(dc));
     CHECK_ROCBLAS_ERROR(rocblas_destroy_handle(handle));
     return EXIT_SUCCESS;
 }

--- a/clients/samples/example_sscal.cpp
+++ b/clients/samples/example_sscal.cpp
@@ -31,7 +31,7 @@ int main()
     rocblas_create_handle(&handle);
 
     // allocate memory on device
-    hipMalloc(&dx, N * sizeof(float));
+    (hipMalloc)(&dx, N * sizeof(float));
 
     // Initial Data on CPU
     srand(1);
@@ -84,7 +84,7 @@ int main()
         printf("SSCAL TEST PASSES\n");
     }
 
-    hipFree(dx);
+    (hipFree)(dx);
     rocblas_destroy_handle(handle);
     return rocblas_status_success;
 }


### PR DESCRIPTION
This removes compilation warnings in the samples about `hipMalloc` and `hipFree` being deprecated.

Alternatively, we can `#undef` `hipMalloc` and `hipFree`, but we need to make sure it only applies to the samples, not to the main library or tests.
