### PR TITLE
Add flag to ignore Tensile version

### DIFF
--- a/.jenkins/Extended_TOT_Tensile.groovy
+++ b/.jenkins/Extended_TOT_Tensile.groovy
@@ -15,7 +15,7 @@ rocBLASCI:
 
     def rocblas = new rocProject('rocBLAS', 'Extended_TOT_Tensile')
     // customize for project
-    rocblas.paths.build_command = './install.sh -lasm_ci -cu -b develop'
+    rocblas.paths.build_command = './install.sh -lasm_ci -c --use-tag-only -b develop'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx900 && ubuntu', 'gfx906 && centos7'], rocblas)

--- a/.jenkins/Extended_TOT_Tensile.groovy
+++ b/.jenkins/Extended_TOT_Tensile.groovy
@@ -15,7 +15,7 @@ rocBLASCI:
 
     def rocblas = new rocProject('rocBLAS', 'Extended_TOT_Tensile')
     // customize for project
-    rocblas.paths.build_command = './install.sh -lasm_ci -c -b develop'
+    rocblas.paths.build_command = './install.sh -lasm_ci -cu -b develop'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx900 && ubuntu', 'gfx906 && centos7'], rocblas)

--- a/.jenkins/PreCheckin_TOT_Tensile.groovy
+++ b/.jenkins/PreCheckin_TOT_Tensile.groovy
@@ -15,7 +15,7 @@ rocBLASCI:
 
     def rocblas = new rocProject('rocBLAS', 'PreCheckin_TOT_Tensile')
     // customize for project
-    rocblas.paths.build_command = './install.sh -lasm_ci -c -b develop'
+    rocblas.paths.build_command = './install.sh -lasm_ci -cu -b develop'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx900 && ubuntu', 'gfx906 && centos7'], rocblas)

--- a/.jenkins/PreCheckin_TOT_Tensile.groovy
+++ b/.jenkins/PreCheckin_TOT_Tensile.groovy
@@ -15,7 +15,7 @@ rocBLASCI:
 
     def rocblas = new rocProject('rocBLAS', 'PreCheckin_TOT_Tensile')
     // customize for project
-    rocblas.paths.build_command = './install.sh -lasm_ci -cu -b develop'
+    rocblas.paths.build_command = './install.sh -lasm_ci -c --use-tag-only -b develop'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx900 && ubuntu', 'gfx906 && centos7'], rocblas)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,11 @@ if( BUILD_WITH_TENSILE )
     message (STATUS "using GIT Tensile fork=${tensile_fork} from branch=${tensile_tag}")
   endif()
   list(APPEND CMAKE_PREFIX_PATH ${VIRTUALENV_HOME_DIR})
-  find_package(Tensile 4.15.0 EXACT REQUIRED HIP LLVM OpenMP PATHS "${INSTALLED_TENSILE_PATH}")
+  if (SUPPRESS_TENSILE_VERSION)
+    find_package(Tensile 4.15.0 QUIET REQUIRED HIP LLVM OpenMP PATHS "${INSTALLED_TENSILE_PATH}")
+  else()
+    find_package(Tensile 4.15.0 EXACT REQUIRED HIP LLVM OpenMP PATHS "${INSTALLED_TENSILE_PATH}")
+  endif()
 endif()
 
 # Find HCC/HIP dependencies

--- a/install.sh
+++ b/install.sh
@@ -20,11 +20,11 @@ rocBLAS build & installation helper script
       -l | --logic             Set Tensile logic target, e.g., asm_full, asm_lite, etc.
       -a | --architecture      Set Tensile GPU architecture target, e.g. all, gfx000, gfx803, gfx900, gfx906, gfx908
       -o | --cov               Set Tensile code_object_version (V2 or V3)
-      -t | --test-local-path   Use a local path for Tensile instead of remote GIT repo
-           --cpu-ref-lib       Specify library to use for CPU reference code in testing (blis or lapack)
+      -t | --test_local_path   Use a local path for Tensile instead of remote GIT repo
+           --cpu_ref_lib       Specify library to use for CPU reference code in testing (blis or lapack)
            --hip-clang         Build library for amdgpu backend using hip-clang
-           --build-dir         Specify name of output directory (default is ./build)
-      -n | --no-tensile        Build subset of library that does not require Tensile
+           --build_dir         Specify name of output directory (default is ./build)
+      -n | --no_tensile        Build subset of library that does not require Tensile
       -s | --tensile-host      Build with Tensile host
       -u | --use-tag-only      Ignore Tensile version and just use the Tensile tag
            --skipldconf        Skip ld.so.conf entry
@@ -278,7 +278,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no-tensile,tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test-local-path:,cpu-ref-lib:,skipldconf --options nshicdgul:a:o:f:b:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no_tensile,tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test_local_path:,cpu_ref_lib:,skipldconf --options nshicdgul:a:o:f:b:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -324,22 +324,22 @@ while true; do
     -b|--branch)
         tensile_tag=${2}
         shift 2 ;;
-    -t|--test-local-path)
+    -t|--test_local_path)
         tensile_test_local_path=${2}
         shift 2 ;;
-    -n|--no-tensile)
+    -n|--no_tensile)
         build_tensile=false
         shift ;;
     -s|--tensile-host)
         build_tensile_host=true
         shift ;;
-    --build-dir)
+    --build_dir)
         build_dir=${2}
         shift 2;;
     --cuda)
         build_cuda=true
         shift ;;
-    --cpu-ref-lib)
+    --cpu_ref_lib)
         cpu_ref_lib=${2}
         shift 2 ;;
     --hip-clang)

--- a/install.sh
+++ b/install.sh
@@ -515,7 +515,7 @@ pushd .
     cmake_client_options="${cmake_client_options} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON -DLINK_BLIS=${LINK_BLIS}"
   fi
 
-  if ["${build_hip_clang}" == true ]; then
+  if [["${build_hip_clang}" == true ]]; then
       cmake_common_options="${cmake_common_options} -DRUN_HEADER_TESTING=OFF"
   fi
 


### PR DESCRIPTION
This PR adds a flag that allows the user to install an older version of Tensile without the install script returning an error code. Mostly, this is for CI purposes.