### PR TITLE
add trmm complex functions rocblas_ctrmm and rocblas_ztrmm

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -353,6 +353,7 @@ struct perf_blas<T,
                 {"tbmv", testing_tbmv<T>},
                 {"tbmv_batched", testing_tbmv_batched<T>},
                 {"tbmv_strided_batched", testing_tbmv_strided_batched<T>},
+                {"trmm", testing_trmm<T>},
 #if BUILD_WITH_TENSILE
                 {"gemm", testing_gemm<T>},
                 {"gemm_batched", testing_gemm_batched<T>},

--- a/clients/gtest/trmm_gtest.cpp
+++ b/clients/gtest/trmm_gtest.cpp
@@ -24,8 +24,13 @@ namespace
     // When the condition in the second argument is satisfied, the type combination
     // is valid. When the condition is false, this specialization does not apply.
     template <typename T>
-    struct trmm_testing<T, std::enable_if_t<std::is_same<T, float>{} || std::is_same<T, double>{}>>
+    struct trmm_testing<
+        T,
+        typename std::enable_if<std::is_same<T, float>{} || std::is_same<T, double>{}
+                                || std::is_same<T, rocblas_float_complex>{}
+                                || std::is_same<T, rocblas_double_complex>{}>::type>
         : rocblas_test_valid
+
     {
         void operator()(const Arguments& arg)
         {

--- a/clients/gtest/trmm_gtest.yaml
+++ b/clients/gtest/trmm_gtest.yaml
@@ -18,7 +18,12 @@ Definitions:
     - { M:  1024, N:  1024, lda:  1024, ldb:  1024 }
     - { M:  2000, N:  2000, lda:  2000, ldb:  2000 }
 
-  - &alpha_range [ 1.0, -5.0 ]
+  - &alpha_range [ 1.0, -3.0 ]
+
+  - &complex_alpha_range
+    - { alpha:  2, alphai:  0 }
+    - { alpha:  0, alphai:  2 }
+    - { alpha:  1, alphai:  2 }
 
   - &testset1_small_matrix_size_range
     - { M:      256,  N:        256,    lda:    256,    ldb:    256     }
@@ -92,15 +97,25 @@ Definitions:
     - { M:  44928,  N: 384,  lda: 44928, ldb:   44928 }
     - { M:  53376,  N: 384,  lda: 53376, ldb:   53376 }
 
-
 Tests:
+- name: trmm_small
+  category: quick
+  function: trmm
+  precision: *single_double_precisions_complex
+  side: [L, R]
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *small_matrix_size_range
+  alpha_beta: *complex_alpha_range
+
 - name: trmm_small
   category: quick
   function: trmm
   precision: *single_double_precisions
   side: [L, R]
   uplo: [L, U]
-  transA: [N, C]
+  transA: [N, T, C]
   diag: [N, U]
   matrix_size: *small_matrix_size_range
   alpha: *alpha_range
@@ -115,6 +130,17 @@ Tests:
   diag: [N, U]
   matrix_size: *medium_matrix_size_range
   alpha: *alpha_range
+
+- name: trmm_medium
+  category: pre_checkin
+  function: trmm
+  precision: *single_double_precisions_complex
+  side: [L, R]
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *medium_matrix_size_range
+  alpha_beta: *complex_alpha_range
 
 - name: trmm_NaN
   category: pre_checkin
@@ -161,6 +187,17 @@ Tests:
   matrix_size: *large_matrix_size_range
   alpha: *alpha_range
 
+- name: trmm_large
+  category: nightly
+  function: trmm
+  precision: *single_double_precisions_complex
+  arguments:
+    - { side: L, uplo: L, transA: N, diag: N }
+    - { side: R, uplo: L, transA: T, diag: N }
+    - { side: L, uplo: U, transA: C, diag: N }
+  matrix_size: *large_matrix_size_range
+  alpha_beta: *complex_alpha_range
+
 - name: trmm_small
   category: quick
   function: trmm_ex
@@ -171,6 +208,17 @@ Tests:
   diag: [N, U]
   matrix_size: *small_matrix_size_range
   alpha: *alpha_range
+
+- name: trmm_small
+  category: quick
+  function: trmm_ex
+  precision: *single_double_precisions_complex
+  side: [L, R]
+  uplo: [L, U]
+  transA: [N, T, C]
+  diag: [N, U]
+  matrix_size: *small_matrix_size_range
+  alpha_beta: *complex_alpha_range
 
 - name: trmm_medium
   category: pre_checkin

--- a/clients/include/rocblas.hpp
+++ b/clients/include/rocblas.hpp
@@ -2067,6 +2067,12 @@ static constexpr auto rocblas_trmm<float> = rocblas_strmm;
 template <>
 static constexpr auto rocblas_trmm<double> = rocblas_dtrmm;
 
+template <>
+static constexpr auto rocblas_trmm<rocblas_float_complex> = rocblas_ctrmm;
+
+template <>
+static constexpr auto rocblas_trmm<rocblas_double_complex> = rocblas_ztrmm;
+
 // trsm
 template <typename T>
 rocblas_status (*rocblas_trsm)(rocblas_handle    handle,

--- a/clients/include/testing_trmm.hpp
+++ b/clients/include/testing_trmm.hpp
@@ -168,7 +168,6 @@ void testing_trmm(const Arguments& arg)
             auto err1     = std::abs(norm_check_general<T>('F', M, N, ldb, cpuB, hB_1));
             auto err2     = std::abs(norm_check_general<T>('F', M, N, ldb, cpuB, hB_2));
             rocblas_error = err1 > err2 ? err1 : err2;
-            rocblas_error = err1;
         }
     }
 

--- a/clients/include/unit.hpp
+++ b/clients/include/unit.hpp
@@ -409,4 +409,13 @@ inline void trsm_err_res_check(T max_error, rocblas_int M, T forward_tolerance, 
 #endif
 }
 
+template <typename T>
+double get_epsilon()
+{
+    if(std::is_same<T, rocblas_float_complex>{} || std::is_same<T, float>{})
+        return std::numeric_limits<float>::epsilon();
+    else if(std::is_same<T, rocblas_double_complex>{} || std::is_same<T, double>{})
+        return std::numeric_limits<double>::epsilon();
+}
+
 #endif

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -6432,6 +6432,32 @@ ROCBLAS_EXPORT rocblas_status rocblas_dtrmm(rocblas_handle    handle,
                                             double*           B,
                                             rocblas_int       ldb);
 
+ROCBLAS_EXPORT rocblas_status rocblas_ctrmm(rocblas_handle               handle,
+                                            rocblas_side                 side,
+                                            rocblas_fill                 uplo,
+                                            rocblas_operation            transA,
+                                            rocblas_diagonal             diag,
+                                            rocblas_int                  m,
+                                            rocblas_int                  n,
+                                            const rocblas_float_complex* alpha,
+                                            const rocblas_float_complex* A,
+                                            rocblas_int                  lda,
+                                            rocblas_float_complex*       B,
+                                            rocblas_int                  ldb);
+
+ROCBLAS_EXPORT rocblas_status rocblas_ztrmm(rocblas_handle                handle,
+                                            rocblas_side                  side,
+                                            rocblas_fill                  uplo,
+                                            rocblas_operation             transA,
+                                            rocblas_diagonal              diag,
+                                            rocblas_int                   m,
+                                            rocblas_int                   n,
+                                            const rocblas_double_complex* alpha,
+                                            const rocblas_double_complex* A,
+                                            rocblas_int                   lda,
+                                            rocblas_double_complex*       B,
+                                            rocblas_int                   ldb);
+
 /*! \brief BLAS Level 3 API
 
     \details

--- a/library/src/blas3/rocblas_trmm.cpp
+++ b/library/src/blas3/rocblas_trmm.cpp
@@ -215,6 +215,48 @@ catch(...)
     return exception_to_rocblas_status();
 }
 
+rocblas_status rocblas_ctrmm(rocblas_handle               handle,
+                             rocblas_side                 side,
+                             rocblas_fill                 uplo,
+                             rocblas_operation            transa,
+                             rocblas_diagonal             diag,
+                             rocblas_int                  m,
+                             rocblas_int                  n,
+                             const rocblas_float_complex* alpha,
+                             const rocblas_float_complex* a,
+                             rocblas_int                  lda,
+                             rocblas_float_complex*       c,
+                             rocblas_int                  ldc)
+try
+{
+    return rocblas_trmm_impl(handle, side, uplo, transa, diag, m, n, alpha, a, lda, c, ldc);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
+
+rocblas_status rocblas_ztrmm(rocblas_handle                handle,
+                             rocblas_side                  side,
+                             rocblas_fill                  uplo,
+                             rocblas_operation             transa,
+                             rocblas_diagonal              diag,
+                             rocblas_int                   m,
+                             rocblas_int                   n,
+                             const rocblas_double_complex* alpha,
+                             const rocblas_double_complex* a,
+                             rocblas_int                   lda,
+                             rocblas_double_complex*       c,
+                             rocblas_int                   ldc)
+try
+{
+    return rocblas_trmm_impl(handle, side, uplo, transa, diag, m, n, alpha, a, lda, c, ldc);
+}
+catch(...)
+{
+    return exception_to_rocblas_status();
+}
+
 } // extern "C"
 
 /* ============================================================================================ */


### PR DESCRIPTION
- add complex functions rocblas_ctrmm and rocblas_ztrmm
- added to internal rocBLAS function rocblas_copy_template  the argument rocblas_operation conjugate_transpose with default value rocblas_operation_none. This allows for a copy with conjugate. 
