### PR TITLE
Make new Tensile client the default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ include( clients/cmake/build-options.cmake )
 # force library install path to lib (CentOS 7 defaults to lib64)
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for libraries" FORCE)
 
-option( BUILD_WITH_TENSILE_HOST "Use the new tensile client for gemm?" OFF )
+option( BUILD_WITH_TENSILE_HOST "Use the new tensile client for gemm?" ON )
 
 if( BUILD_WITH_TENSILE )
   set( Tensile_LOGIC "asm_full" CACHE STRING "Tensile to use which logic?")

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,6 @@ rocBLAS build & installation helper script
            --build_dir         Specify name of output directory (default is ./build)
       -n | --no_tensile        Build subset of library that does not require Tensile
       -r | --no-tensile-host   Do not build with Tensile host
-      -s | --tensile-host      Build with Tensile host
       -u | --use-tag-only      Ignore Tensile version and just use the Tensile tag
            --skipldconf        Skip ld.so.conf entry
 EOF
@@ -279,7 +278,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no_tensile,no-tensile-host,tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test_local_path:,cpu_ref_lib:,skipldconf --options nrshicdgul:a:o:f:b:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no_tensile,no-tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test_local_path:,cpu_ref_lib:,skipldconf --options nrhicdgul:a:o:f:b:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -333,9 +332,6 @@ while true; do
         shift ;;
     -r|--no-tensile-host)
         build_tensile_host=false
-        shift ;;
-    -s|--tensile-host)
-        build_tensile_host=true
         shift ;;
     --build_dir)
         build_dir=${2}

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ rocBLAS build & installation helper script
            --hip-clang         Build library for amdgpu backend using hip-clang
            --build_dir         Specify name of output directory (default is ./build)
       -n | --no_tensile        Build subset of library that does not require Tensile
+      -r | --no-tensile-host   Do not build with Tensile host
       -s | --tensile-host      Build with Tensile host
       -u | --use-tag-only      Ignore Tensile version and just use the Tensile tag
            --skipldconf        Skip ld.so.conf entry
@@ -259,7 +260,7 @@ tensile_version=true
 build_clients=false
 build_cuda=false
 build_tensile=true
-build_tensile_host=false
+build_tensile_host=true
 cpu_ref_lib=blis
 build_release=true
 build_hip_clang=false
@@ -278,7 +279,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no_tensile,tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test_local_path:,cpu_ref_lib:,skipldconf --options nshicdgul:a:o:f:b:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no_tensile,no-tensile-host,tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test_local_path:,cpu_ref_lib:,skipldconf --options nrshicdgul:a:o:f:b:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -329,6 +330,9 @@ while true; do
         shift 2 ;;
     -n|--no_tensile)
         build_tensile=false
+        shift ;;
+    -r|--no-tensile-host)
+        build_tensile_host=false
         shift ;;
     -s|--tensile-host)
         build_tensile_host=true
@@ -502,6 +506,10 @@ pushd .
   tensile_opt=""
   if [[ "${build_tensile}" == false ]]; then
     tensile_opt="${tensile_opt} -DBUILD_WITH_TENSILE=OFF"
+  fi
+
+  if [[ "${build_tensile_host}" == false ]]; then
+    tensile_opt="${tensile_opt} -DBUILD_WITH_TENSILE_HOST=OFF"
   fi
 
   if [[ "${build_tensile_host}" == true ]]; then

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -329,7 +329,8 @@ rocm_install_targets(
 
 if( BUILD_WITH_TENSILE )
   if( BUILD_WITH_TENSILE_HOST )
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/Tensile/library DESTINATION ${CMAKE_INSTALL_PREFIX}/rocblas/lib)
+    set( ROCBLAS_TENSILE_LIBRARY_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}rocblas/lib" CACHE PATH "path to tensile library" )
+    install(DIRECTORY ${CMAKE_BINARY_DIR}/Tensile/library DESTINATION ${ROCBLAS_TENSILE_LIBRARY_DIR})
   endif()
 endif()
 


### PR DESCRIPTION


Will enable the tensile new client by default

added -r / --no-tensile-host option to install.sh to build with old client.

Fixed a bug which prevented the packaging of the tensile library for getting installed.