### PR TITLE
Removing large stride_scale for large hpr tests.

### DIFF
--- a/clients/gtest/hpr_gtest.yaml
+++ b/clients/gtest/hpr_gtest.yaml
@@ -17,12 +17,10 @@ Definitions:
   - &medium_matrix_size_range
     - { N:  1000 }
     - { N:  2011 }
-    - { N:  3000 }
 
   - &large_matrix_size_range
-    - { N:  2000 }
+    - { N:  3000 }
     - { N:  4011 }
-    - { N:  8000 }
 
   - &alpha_range
     - { alpha:  2.0, alphai:  1.5 }
@@ -123,7 +121,7 @@ Tests:
   matrix_size: *medium_matrix_size_range
   incx: [ 2, -2 ]
   alpha_beta: *alpha_range
-  stride_scale: [ 1.0, 2.5 ]
+  stride_scale: [ 1.0 ]
   batch_count: [ 1, 3 ]
 
 - name: hpr_strided_large
@@ -134,7 +132,7 @@ Tests:
   matrix_size: *large_matrix_size_range
   incx: [ 1 ]
   alpha_beta: *alpha_range_small
-  stride_scale: [ 1.0, 2.5 ]
+  stride_scale: [ 1.0 ]
   batch_count: [ 1, 3 ]
 
 ...


### PR DESCRIPTION
I think the failing tests are from memory allocation failures. Reducing the size of stride_scale for large hpr tests, will wait to see if this passes CI.