### PR TITLE
Reducing size of large test cases for spr2 and spr.

### DIFF
--- a/clients/gtest/spr2_gtest.yaml
+++ b/clients/gtest/spr2_gtest.yaml
@@ -22,7 +22,6 @@ Definitions:
   - &large_matrix_size_range
     - { N:  2000 }
     - { N:  4011 }
-    - { N:  8000 }
 
   - &incx_incy_range
     - { incx:  1, incy:  1 }
@@ -125,7 +124,7 @@ Tests:
   matrix_size: *medium_matrix_size_range
   incx_incy: *incx_incy_range_small
   alpha: [ -0.5, 2.0 ]
-  stride_scale: [ 1.0, 2.5 ]
+  stride_scale: [ 1.0 ]
   batch_count: [ 1, 3 ]
 
 - name: spr2_strided_large
@@ -136,7 +135,7 @@ Tests:
   matrix_size: *large_matrix_size_range
   incx_incy: *incx_incy_range_small
   alpha: [ 1000.6 ]
-  stride_scale: [ 1.0, 2.5 ]
+  stride_scale: [ 1.0 ]
   batch_count: [ 1, 3 ]
 
 ...

--- a/clients/gtest/spr_gtest.yaml
+++ b/clients/gtest/spr_gtest.yaml
@@ -112,7 +112,7 @@ Tests:
   matrix_size: *medium_matrix_size_range
   incx: [ 2, -2 ]
   alpha: [ -0.5, 2.0 ]
-  stride_scale: [ 1.0, 2.5 ]
+  stride_scale: [ 1.0 ]
   batch_count: [ 1, 3 ]
 
 - name: spr_strided_large
@@ -123,7 +123,7 @@ Tests:
   matrix_size: *large_matrix_size_range
   incx: [ 1 ]
   alpha: [ 1000.6 ]
-  stride_scale: [ 1.0, 2.5 ]
+  stride_scale: [ 1.0 ]
   batch_count: [ 1, 3 ]
 
 ...


### PR DESCRIPTION
Just like hpr failed previously, some test cases for spr2 are too large for CI. Not sure how this wasn't caught by CI earlier.