### PR TITLE
restrict warnings to library

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -292,6 +292,8 @@ endif()
 
 set_target_properties( rocblas PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
 
+target_compile_definitions( rocblas PRIVATE ROCBLAS_LIBRARY_CHECKS )
+
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -316,6 +316,7 @@ private:
             return rocblas_status_size_unchanged;    \
     } while(0)
 
+#if defined(ROCBLAS_LIBRARY_CHECKS)
 // Warn about potentially unsafe and synchronizing uses of hipMalloc and hipFree
 #define hipMalloc(ptr, size)                                                                     \
     _Pragma(                                                                                     \
@@ -324,6 +325,7 @@ private:
 #define hipFree(ptr)                                                                               \
     _Pragma("GCC warning \"Direct use of hipFree in rocBLAS is deprecated; see CONTRIBUTING.md\"") \
         hipFree(ptr)
+#endif
 
 namespace rocblas
 {


### PR DESCRIPTION
allow limited warnings to apply to library build not clients or anything outside
