### PR TITLE
SWDEV-208995

### DIFF
--- a/clients/gtest/trsm_gtest.yaml
+++ b/clients/gtest/trsm_gtest.yaml
@@ -187,7 +187,7 @@ Tests:
   matrix_size: *medium_matrix_size_range
   alpha: *alpha_range
 
-- name: trsm_medium
+- name: trsm_medium_extra
   category: pre_checkin
   function: trsm
   precision: *single_double_precisions

--- a/clients/gtest/trsm_gtest.yaml
+++ b/clients/gtest/trsm_gtest.yaml
@@ -12,6 +12,9 @@ Definitions:
     - { M:   600, N:   500, lda:   600, ldb:   600 }
     - { M:   800, N:   700, lda:   801, ldb:   701 }
 
+  - &medium_matrix_size_extra
+    - { M:   256, N:   14848, lda:   256, ldb:   256 }
+
   - &large_matrix_size_range
     - { M:   640, N:   640, lda:   960, ldb:   960 }
     - { M:  1000, N:  1000, lda:  1000, ldb:  1000 }
@@ -70,7 +73,6 @@ Definitions:
     - { M:   128, N:   44544, lda:   128, ldb:   128 }
     - { M:   128, N:   53632, lda:   128, ldb:   128 }
     - { M:   256, N:    2048, lda:   256, ldb:   256 }
-    - { M:   256, N:   14848, lda:   256, ldb:   256 }
     - { M:   256, N:   29696, lda:   256, ldb:   256 }
     - { M:   256, N:   44544, lda:   256, ldb:   256 }
     - { M:   256, N:   53504, lda:   256, ldb:   256 }
@@ -184,6 +186,17 @@ Tests:
   diag: [N, U]
   matrix_size: *medium_matrix_size_range
   alpha: *alpha_range
+
+- name: trsm_medium
+  category: pre_checkin
+  function: trsm
+  precision: *single_double_precisions
+  side: [L]
+  uplo: [L]
+  transA: [N]
+  diag: [U]
+  matrix_size: *medium_matrix_size_extra
+  alpha: [ 1 ]
 
 - name: trsm_medium_complex
   category: pre_checkin


### PR DESCRIPTION
[SWDEV-208995](http://ontrack-internal.amd.com/browse/SWDEV-208995).

Moves a test from nightly to pre-checkin, I'm guessing to check for lda/ldb edge case. @leekillough please let me know if this is what was intended from the ticket or not because it wasn't 100% clear to me.