### PR TITLE
Support and test K==0 in GEMM

### DIFF
--- a/clients/common/rocblas_gentest.py
+++ b/clients/common/rocblas_gentest.py
@@ -313,10 +313,10 @@ def setdefaults(test):
         test.setdefault('ldc', 0)
         test.setdefault('ldd', 0)
     else:
-        test.setdefault('lda', test['M'] if test['transA'].upper() == 'N' else
-                        test['K'])
-        test.setdefault('ldb', test['K'] if test['transB'].upper() == 'N' else
-                        test['N'])
+        test.setdefault('lda', test['M'] if test['transA'].upper() == 'N'
+                        else test['K'] if test['K'] != 0 else 1)
+        test.setdefault('ldb', test['K'] if test['K'] != 0 else 1
+                        if test['transB'].upper() == 'N' else test['N'])
         test.setdefault('ldc', test['M'])
         test.setdefault('ldd', test['M'])
         if test['batch_count'] > 0:

--- a/clients/gtest/gemm_batched_gtest.yaml
+++ b/clients/gtest/gemm_batched_gtest.yaml
@@ -328,7 +328,7 @@ Tests:
   transB: N
   batch_count: 1
 
-- name: gemm_zerok
+- name: gemm_batched_zerok
   category: quick
   function:
     gemm_batched: { <<: *half_single_double_precisions, <<: *complex_precisions }

--- a/clients/gtest/gemm_batched_gtest.yaml
+++ b/clients/gtest/gemm_batched_gtest.yaml
@@ -327,4 +327,20 @@ Tests:
   transA: N
   transB: N
   batch_count: 1
+
+- name: gemm_zerok
+  category: quick
+  function:
+    gemm_batched: { <<: *half_single_double_precisions, <<: *complex_precisions }
+    gemm_batched_ex: { <<: *real_precisions, <<: *complex_precisions }
+  transA_transB: *transA_transB_range
+  alpha_beta: *alpha_beta_range
+  K: 0
+  matrix_size:
+    - { M:  1,   N:  2 }
+    - { M:  3,   N:  5 }
+    - { M:  512, N:  100 }
+    - { M:  63,  N:  512 }
+  batch_count: 1
+
 ...

--- a/clients/gtest/gemm_gtest.yaml
+++ b/clients/gtest/gemm_gtest.yaml
@@ -2858,4 +2858,18 @@ Tests:
     - { M:  960, N: 1024, K: 1024 }
     - { M: 3840, N: 4096, K: 4096 }
 
+- name: gemm_zerok
+  category: quick
+  function:
+    gemm: { <<: *half_single_double_precisions, <<: *complex_precisions }
+    gemm_ex: { <<: *real_precisions, <<: *complex_precisions }
+  transA_transB: *transA_transB_range
+  alpha_beta: *alpha_beta_range
+  K: 0
+  matrix_size:
+    - { M:  1,   N:  2 }
+    - { M:  3,   N:  5 }
+    - { M:  512, N:  100 }
+    - { M:  63,  N:  512 }
+
 ...

--- a/clients/gtest/gemm_strided_batched_gtest.yaml
+++ b/clients/gtest/gemm_strided_batched_gtest.yaml
@@ -484,4 +484,20 @@ Tests:
   transA: N
   transB: N
   batch_count: 1
+
+- name: gemm_strided_batched_zerok
+  category: quick
+  function:
+    gemm_strided_batched: { <<: *half_single_double_precisions, <<: *complex_precisions }
+    gemm_strided_batched_ex: { <<: *real_precisions, <<: *complex_precisions }
+  transA_transB: *transA_transB_range
+  alpha_beta: *alpha_beta_range
+  K: 0
+  matrix_size:
+    - { M:  1,   N:  2 }
+    - { M:  3,   N:  5 }
+    - { M:  512, N:  100 }
+    - { M:  63,  N:  512 }
+  batch_count: 1
+
 ...

--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -128,16 +128,21 @@ namespace
         freeIndex[0].c = freeIndex[0].d = 0;
         freeIndex[1].c = freeIndex[1].d = 1;
 
+        // Tensile does not support 0-sized dimensions. For when k == 0, we still need to
+        // multiply C by beta, but not add any of the rank-0 dot products. As a workaround,
+        // we pass k = 1 and set alpha == 0, since alpha == 0 has the same effect as k == 0.
+        auto k = prob.k == 0 ? 1 : prob.k;
+
         // If A is transposed, swap the free and bound dimensions and their ranks
         if(prob.trans_a != rocblas_operation_none)
         {
-            a = {Tensile_Ti, {prob.k, prob.m, prob.batch_count}, {1, prob.ld_a, prob.stride_a}};
+            a = {Tensile_Ti, {k, prob.m, prob.batch_count}, {1, prob.ld_a, prob.stride_a}};
             freeIndex[0].i  = 1;
             boundIndex[0].a = 0;
         }
         else
         {
-            a = {Tensile_Ti, {prob.m, prob.k, prob.batch_count}, {1, prob.ld_a, prob.stride_a}};
+            a = {Tensile_Ti, {prob.m, k, prob.batch_count}, {1, prob.ld_a, prob.stride_a}};
             freeIndex[0].i  = 0;
             boundIndex[0].a = 1;
         }
@@ -149,13 +154,13 @@ namespace
         // If B is transposed, swap the free and bound dimensions and their ranks
         if(prob.trans_b != rocblas_operation_none)
         {
-            b = {Tensile_Ti, {prob.n, prob.k, prob.batch_count}, {1, prob.ld_b, prob.stride_b}};
+            b = {Tensile_Ti, {prob.n, k, prob.batch_count}, {1, prob.ld_b, prob.stride_b}};
             freeIndex[1].i  = 0;
             boundIndex[0].b = 1;
         }
         else
         {
-            b = {Tensile_Ti, {prob.k, prob.n, prob.batch_count}, {1, prob.ld_b, prob.stride_b}};
+            b = {Tensile_Ti, {k, prob.n, prob.batch_count}, {1, prob.ld_b, prob.stride_b}};
             freeIndex[1].i  = 1;
             boundIndex[0].b = 0;
         }
@@ -264,7 +269,11 @@ namespace
 
         // alpha and beta are stored by value in Tensile::TypedContractionInputs
         // alpha and beta are copied from host to Tensile::TypedContractionInputs
-        AlphaBeta<Ti, To, Tc>::copy(&inputs.alpha, problem.alpha);
+        // We set alpha = 0 if k == 0 (see above)
+        if(problem.k == 0)
+            memset(&inputs.alpha, 0, sizeof(inputs.alpha));
+        else
+            AlphaBeta<Ti, To, Tc>::copy(&inputs.alpha, problem.alpha);
         AlphaBeta<Ti, To, Tc>::copy(&inputs.beta, problem.beta);
 
         return inputs;


### PR DESCRIPTION
Resolves SWDEV-223351

Summary of proposed changes:

When `K == 0`, rocBLAS will set `K == 1` and `alpha == 0`, because Tensile does not support 0-sized dimensions right now.

Add `K == 0` tests, since they weren't being tested.

Change the computation of default `LDA` and `LDB` to use `1` if `K == 0`, because `0` is not a valid leading dimension.