### PR TITLE
add command line option of setting cold calls

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -926,6 +926,10 @@ try
          value<rocblas_int>(&arg.iters)->default_value(10),
          "Iterations to run inside timing loop")
 
+        ("cold_iters,j",
+         value<rocblas_int>(&arg.cold_iters)->default_value(2),
+         "Cold Iterations to run before entering the timing loop")
+
         ("algo",
          value<uint32_t>(&arg.algo)->default_value(0),
          "extended precision gemm algorithm")

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -72,6 +72,7 @@ struct Arguments
     rocblas_int unit_check;
     rocblas_int timing;
     rocblas_int iters;
+    rocblas_int cold_iters;
 
     uint32_t algo;
     int32_t  solution_index;
@@ -161,6 +162,7 @@ struct Arguments
         ROCBLAS_FORMAT_CHECK(unit_check);
         ROCBLAS_FORMAT_CHECK(timing);
         ROCBLAS_FORMAT_CHECK(iters);
+        ROCBLAS_FORMAT_CHECK(cold_iters);
         ROCBLAS_FORMAT_CHECK(algo);
         ROCBLAS_FORMAT_CHECK(solution_index);
         ROCBLAS_FORMAT_CHECK(flags);
@@ -311,6 +313,7 @@ private:
         PRINT(unit_check);
         PRINT(timing);
         PRINT(iters);
+        PRINT(cold_iters);
         PRINT(initialization);
         PRINT(known_bug_platforms);
         PRINT(c_noalias_d);

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -258,6 +258,7 @@ Arguments:
   - unit_check: rocblas_int
   - timing: rocblas_int
   - iters: rocblas_int
+  - colde_iters: rocblas_int
   - algo: c_uint
   - solution_index: c_int
   - flags: c_uint
@@ -327,6 +328,7 @@ Defaults:
   unit_check: 1
   timing: 0
   iters: 10
+  cold_iters: 2
   algo: 0
   solution_index: 0
   flags: 0

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -258,7 +258,7 @@ Arguments:
   - unit_check: rocblas_int
   - timing: rocblas_int
   - iters: rocblas_int
-  - colde_iters: rocblas_int
+  - cold_iters: rocblas_int
   - algo: c_uint
   - solution_index: c_int
   - flags: c_uint

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -251,7 +251,7 @@ void testing_gemm(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -259,7 +259,7 @@ void testing_gemm_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -613,7 +613,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         for(int b = 0; b < batch_count; b++)

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -537,7 +537,7 @@ void testing_gemm_ex(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -238,7 +238,7 @@ void testing_gemm_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -238,7 +238,7 @@ void testing_gemm_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = arg.iters;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -736,7 +736,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 


### PR DESCRIPTION

add parameter to the rocblas-bench to set the number of cold calls used for bench marking. 

this feature is enabled for the gemm tests.