### PR TITLE
Not running tests when more memory is needed than available.

### DIFF
--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -48,11 +48,9 @@ ci: {
                         "rocm-docker":[]]
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = ["compute-rocm-dkms-no-npi":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
-                       "compute-rocm-dkms-no-npi-hipclang":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
-                       "rocm-docker":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]),
-                       "compute-rocm-dkms-no-npi-hipclang-int-bkc-2":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']])] 
-
+    def jobNameList = ["compute-rocm-dkms-no-npi":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
+                       "compute-rocm-dkms-no-npi-hipclang":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
+                       "rocm-docker":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']])]
     jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each 

--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -62,14 +62,11 @@ ci: {
     def propertyList = ["compute-rocm-dkms-no-npi":[pipelineTriggers([cron('0 1 * * 0')])], 
                         "compute-rocm-dkms-no-npi-hipclang":[pipelineTriggers([cron('0 1 * * 0')])],
                         "rocm-docker":[]]
-
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = ["compute-rocm-dkms-no-npi":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
-                       "compute-rocm-dkms-no-npi-hipclang":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
-                       "rocm-docker":([ubuntu16:['gfx900h'],ubuntu18:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]),
-                       "compute-rocm-dkms-no-npi-hipclang-int-bkc-2":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']])] 
-    
+    def jobNameList = ["compute-rocm-dkms-no-npi":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
+                       "compute-rocm-dkms-no-npi-hipclang":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
+                       "rocm-docker":([ubuntu16:['gfx900'],ubuntu18:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']])]
     jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each 

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -63,11 +63,9 @@ ci: {
                         "rocm-docker":[]]
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = ["compute-rocm-dkms-no-npi":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
-                       "compute-rocm-dkms-no-npi-hipclang":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
-                       "compute-rocm-dkms-no-npi-hipclang-int-bkc-2":([ubuntu16:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
-                       "rocm-docker":([ubuntu16:['gfx900h'],ubuntu18:['gfx900h'],centos7:['gfx906'],sles15sp1:['gfx906']])]
-    
+    def jobNameList = ["compute-rocm-dkms-no-npi":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
+                       "compute-rocm-dkms-no-npi-hipclang":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']]), 
+                       "rocm-docker":([ubuntu16:['gfx900'],ubuntu18:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']])]
     jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each 
@@ -91,7 +89,7 @@ ci: {
     {
         properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * *')])]))
         stage(urlJobName) {
-            runCI([ubuntu16:['gfx900h', 'gfx906']], urlJobName)
+            runCI([ubuntu16:['gfx900', 'gfx906']], urlJobName)
         }
     }
 }

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -58,16 +58,6 @@ double get_time_us_sync(hipStream_t stream)
 };
 
 /* ============================================================================================ */
-bool is_limited_memory(size_t needed_mem)
-{
-    size_t     free_mem  = 0;
-    size_t     total_mem = 0;
-    hipError_t err       = hipMemGetInfo(&free_mem, &total_mem);
-
-    return (err != hipSuccess || free_mem < needed_mem);
-}
-
-/* ============================================================================================ */
 /*  device query and print out their ID and name; return number of compute-capable devices. */
 rocblas_int query_device_property()
 {

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -58,6 +58,16 @@ double get_time_us_sync(hipStream_t stream)
 };
 
 /* ============================================================================================ */
+bool is_limited_memory(size_t needed_mem)
+{
+    size_t     free_mem  = 0;
+    size_t     total_mem = 0;
+    hipError_t err       = hipMemGetInfo(&free_mem, &total_mem);
+
+    return (err != hipSuccess || free_mem < needed_mem);
+}
+
+/* ============================================================================================ */
 /*  device query and print out their ID and name; return number of compute-capable devices. */
 rocblas_int query_device_property()
 {

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -25,6 +25,8 @@ public:
     bool showSuccesses; // Show each success.
     bool showInlineFailures; // Show each failure as it occurs.
     bool showEnvironment; // Show the setup of the global environment.
+    bool showInlineSkips; // Show when we skip a test.
+    int  skipped_tests; // Number of skipped tests.
 
     explicit ConfigurableEventListener(TestEventListener* theEventListener)
         : eventListener(theEventListener)
@@ -33,6 +35,8 @@ public:
         , showSuccesses(true)
         , showInlineFailures(true)
         , showEnvironment(true)
+        , showInlineSkips(true)
+        , skipped_tests(0)
     {
     }
 
@@ -77,6 +81,12 @@ public:
 
     void OnTestPartResult(const TestPartResult& result) override
     {
+        if(strcmp(result.message(), LIMITED_MEMORY_STRING))
+        {
+            skipped_tests++;
+            if(showInlineSkips)
+                printf("Skipped test due to limited memory environment.\n");
+        }
         eventListener->OnTestPartResult(result);
     }
 
@@ -111,6 +121,10 @@ public:
 
     void OnTestProgramEnd(const UnitTest& unit_test) override
     {
+        if(skipped_tests)
+        {
+            printf("[ SKIPPED  ] %d tests.\n", skipped_tests);
+        }
         eventListener->OnTestProgramEnd(unit_test);
     }
 };
@@ -259,7 +273,8 @@ int main(int argc, char** argv)
     auto listener       = new ConfigurableEventListener(default_printer);
     auto gtest_listener = getenv("GTEST_LISTENER");
     if(gtest_listener && !strcmp(gtest_listener, "NO_PASS_LINE_IN_LOG"))
-        listener->showTestNames = listener->showSuccesses = listener->showInlineFailures = false;
+        listener->showTestNames = listener->showSuccesses = listener->showInlineFailures
+            = listener->showInlineSkips                   = false;
     listeners.Append(listener);
 
     int status = RUN_ALL_TESTS();

--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -73,6 +73,15 @@ public:
         return d;
     }
 
+    bool check_available_memory(size_t batches = 1)
+    {
+        size_t     free_mem  = 0;
+        size_t     total_mem = 0;
+        hipError_t err       = hipMemGetInfo(&free_mem, &total_mem);
+
+        return (err == hipSuccess && free_mem >= (bytes * batches));
+    }
+
     void device_vector_check(T* d)
     {
 #ifdef GOOGLE_TEST

--- a/clients/include/device_strided_batch_vector.hpp
+++ b/clients/include/device_strided_batch_vector.hpp
@@ -79,7 +79,9 @@ public:
 
         if(valid_parameters)
         {
-            this->m_data = this->device_vector_setup();
+            m_enough_memory = this->check_available_memory();
+            if(m_enough_memory)
+                this->m_data = this->device_vector_setup();
         }
     }
 
@@ -210,7 +212,12 @@ public:
     //!
     hipError_t memcheck() const
     {
-        return ((bool)*this) ? hipSuccess : hipErrorOutOfMemory;
+        if(!m_enough_memory)
+            return hipErrorMemoryAllocation;
+        else if((bool)*this)
+            return hipSuccess;
+        else
+            return hipErrorOutOfMemory;
     }
 
 private:
@@ -220,6 +227,7 @@ private:
     rocblas_stride m_stride{};
     rocblas_int    m_batch_count{};
     T*             m_data{};
+    bool           m_enough_memory{};
 
     static size_t calculate_nmemb(
         rocblas_int n, rocblas_int inc, rocblas_stride stride, rocblas_int batch_count, storage st)

--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -40,7 +40,9 @@ public:
         , m_n(n)
         , m_inc(inc)
     {
-        this->m_data = this->device_vector_setup();
+        m_enough_memory = this->check_available_memory();
+        if(m_enough_memory)
+            this->m_data = this->device_vector_setup();
     }
 
     //!
@@ -53,7 +55,9 @@ public:
         , m_n(s)
         , m_inc(1)
     {
-        this->m_data = this->device_vector_setup();
+        m_enough_memory = this->check_available_memory();
+        if(m_enough_memory)
+            this->m_data = this->device_vector_setup();
     }
 
     //!
@@ -134,7 +138,12 @@ public:
 
     hipError_t memcheck() const
     {
-        return ((bool)*this) ? hipSuccess : hipErrorOutOfMemory;
+        if(!m_enough_memory)
+            return hipErrorMemoryAllocation;
+        else if((bool)*this)
+            return hipSuccess;
+        else
+            return hipErrorOutOfMemory;
     }
 
 private:
@@ -142,4 +151,5 @@ private:
     rocblas_int m_n{};
     rocblas_int m_inc{};
     T*          m_data{};
+    bool        m_enough_memory{};
 };

--- a/clients/include/rocblas_test.hpp
+++ b/clients/include/rocblas_test.hpp
@@ -26,6 +26,27 @@
 #define CHECK_HIP_ERROR2(ERROR) ASSERT_EQ(ERROR, hipSuccess)
 #define CHECK_HIP_ERROR(ERROR) CHECK_HIP_ERROR2(ERROR)
 
+#define CHECK_DEVICE_ALLOCATION(ERROR)            \
+    do                                            \
+    {                                             \
+        auto error = ERROR;                       \
+        if(error == hipErrorMemoryAllocation)     \
+        {                                         \
+            SUCCEED() << LIMITED_MEMORY_STRING;   \
+            return;                               \
+        }                                         \
+        else if(error != hipSuccess)              \
+        {                                         \
+            fprintf(stderr,                       \
+                    "error: '%s'(%d) at %s:%d\n", \
+                    hipGetErrorString(error),     \
+                    error,                        \
+                    __FILE__,                     \
+                    __LINE__);                    \
+            exit(EXIT_FAILURE);                   \
+        }                                         \
+    } while(0)
+
 #define EXPECT_ROCBLAS_STATUS ASSERT_EQ
 
 #else // GOOGLE_TEST
@@ -56,6 +77,8 @@ inline void rocblas_expect_status(rocblas_status status, rocblas_status expect)
             exit(EXIT_FAILURE);                   \
         }                                         \
     } while(0)
+
+#define CHECK_DEVICE_ALLOCATION(ERROR)
 
 #define EXPECT_ROCBLAS_STATUS rocblas_expect_status
 

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -135,27 +135,17 @@ void testing_gemm(const Arguments& arg)
     const auto size_B = size_t(ldb) * size_t(B_col);
     const auto size_C = size_t(ldc) * size_t(N);
 
-    // check memory info before allocation
-    size_t needed_mem = (size_A + size_B + size_C + 2) * sizeof(T);
-    if(is_limited_memory(needed_mem))
-    {
-#ifdef GOOGLE_TEST
-        SUCCEED() << LIMITED_MEMORY_STRING;
-#endif
-        return;
-    }
-
     // allocate memory on device
     device_vector<T> dA(size_A);
     device_vector<T> dB(size_B);
     device_vector<T> dC(size_C);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
-    if(!dA || !dB || !dC || !d_alpha || !d_beta)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dB.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(size_A);

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -135,6 +135,16 @@ void testing_gemm(const Arguments& arg)
     const auto size_B = size_t(ldb) * size_t(B_col);
     const auto size_C = size_t(ldc) * size_t(N);
 
+    // check memory info before allocation
+    size_t needed_mem = (size_A + size_B + size_C + 2) * sizeof(T);
+    if(is_limited_memory(needed_mem))
+    {
+#ifdef GOOGLE_TEST
+        SUCCEED() << LIMITED_MEMORY_STRING;
+#endif
+        return;
+    }
+
     // allocate memory on device
     device_vector<T> dA(size_A);
     device_vector<T> dB(size_B);

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -321,17 +321,6 @@ void testing_gemm_ex(const Arguments& arg)
     const size_t size_C = size_t(ldc) * size_t(N);
     const size_t size_D = size_t(ldd) * size_t(N);
 
-    // check memory info before allocation
-    size_t needed_mem
-        = (size_A + size_B) * sizeof(Ti) + (size_C + size_D) * sizeof(To) + (2) * sizeof(Tc);
-    if(is_limited_memory(needed_mem))
-    {
-#ifdef GOOGLE_TEST
-        SUCCEED() << LIMITED_MEMORY_STRING;
-#endif
-        return;
-    }
-
     // allocate memory on device
     device_vector<Ti> dA(size_A);
     device_vector<Ti> dB(size_B);
@@ -339,11 +328,12 @@ void testing_gemm_ex(const Arguments& arg)
     device_vector<To> dD(size_D);
     device_vector<Tc> d_alpha_Tc(1);
     device_vector<Tc> d_beta_Tc(1);
-    if(!dA || !dB || !dC || !dD || !d_alpha_Tc || !d_beta_Tc)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dB.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dD.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha_Tc.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta_Tc.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<Ti> hA(size_A);

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -321,6 +321,17 @@ void testing_gemm_ex(const Arguments& arg)
     const size_t size_C = size_t(ldc) * size_t(N);
     const size_t size_D = size_t(ldd) * size_t(N);
 
+    // check memory info before allocation
+    size_t needed_mem
+        = (size_A + size_B) * sizeof(Ti) + (size_C + size_D) * sizeof(To) + (2) * sizeof(Tc);
+    if(is_limited_memory(needed_mem))
+    {
+#ifdef GOOGLE_TEST
+        SUCCEED() << LIMITED_MEMORY_STRING;
+#endif
+        return;
+    }
+
     // allocate memory on device
     device_vector<Ti> dA(size_A);
     device_vector<Ti> dB(size_B);

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -102,27 +102,18 @@ void testing_ger(const Arguments& arg)
     host_vector<T> hx(M * abs_incx);
     host_vector<T> hy(N * abs_incy);
 
-    // check memory info before allocation
-    size_t needed_mem = (size_A + size_A + size_x + size_y + 1) * sizeof(T);
-    if(is_limited_memory(needed_mem))
-    {
-#ifdef GOOGLE_TEST
-        SUCCEED() << LIMITED_MEMORY_STRING;
-#endif
-        return;
-    }
-
     // allocate memory on device
     device_vector<T> dA_1(size_A);
     device_vector<T> dA_2(size_A);
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
     device_vector<T> d_alpha(1);
-    if(!dA_1 || !dA_2 || !dx || !dy || !d_alpha)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -102,6 +102,16 @@ void testing_ger(const Arguments& arg)
     host_vector<T> hx(M * abs_incx);
     host_vector<T> hy(N * abs_incy);
 
+    // check memory info before allocation
+    size_t needed_mem = (size_A + size_A + size_x + size_y + 1) * sizeof(T);
+    if(is_limited_memory(needed_mem))
+    {
+#ifdef GOOGLE_TEST
+        SUCCEED() << LIMITED_MEMORY_STRING;
+#endif
+        return;
+    }
+
     // allocate memory on device
     device_vector<T> dA_1(size_A);
     device_vector<T> dA_2(size_A);

--- a/clients/include/testing_ger_batched.hpp
+++ b/clients/include/testing_ger_batched.hpp
@@ -85,25 +85,16 @@ void testing_ger_batched(const Arguments& arg)
     size_t size_x   = M * abs_incx;
     size_t size_y   = N * abs_incy;
 
-    // check memory info before allocation
-    size_t needed_mem = (size_x + size_y + size_A + size_A) * batch_count * sizeof(T) + sizeof(T);
-    if(is_limited_memory(needed_mem))
-    {
-#ifdef GOOGLE_TEST
-        SUCCEED() << LIMITED_MEMORY_STRING;
-#endif
-        return;
-    }
-
     device_batch_vector<T> dy(N, incy, batch_count);
     device_batch_vector<T> dx(M, incx, batch_count);
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
     device_batch_vector<T> dA_2(size_A, 1, batch_count);
     device_vector<T>       d_alpha(1);
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     // Host-arrays of pointers to host memory

--- a/clients/include/testing_ger_batched.hpp
+++ b/clients/include/testing_ger_batched.hpp
@@ -25,17 +25,17 @@ void testing_ger_batched_bad_arg(const Arguments& arg)
     T                 alpha       = 0.6;
     const rocblas_int batch_count = 5;
 
+    size_t size_A = lda * size_t(N);
+
     rocblas_local_handle handle;
 
     // allocate memory on device
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dx(batch_count);
-    device_vector<T*, 0, T> dy(batch_count);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    device_batch_vector<T> dA(size_A, 1, batch_count);
+    device_batch_vector<T> dx(M, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS((rocblas_ger_batched<T, CONJ>(
                               handle, M, N, &alpha, nullptr, incx, dy, incy, dA, lda, batch_count)),
@@ -68,18 +68,10 @@ void testing_ger_batched(const Arguments& arg)
     if(M <= 0 || N <= 0 || lda < M || lda < 1 || !incx || !incy || batch_count <= 0)
     {
         static constexpr size_t safe_size = 100;
-        device_vector<T*, 0, T> dA(safe_size);
-        device_vector<T*, 0, T> dx(safe_size);
-        device_vector<T*, 0, T> dy(safe_size);
-        if(!dA || !dx || !dy)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
 
         EXPECT_ROCBLAS_STATUS(
             (rocblas_ger_batched<T, CONJ>(
-                handle, M, N, &h_alpha, dx, incx, dy, incy, dA, lda, batch_count)),
+                handle, M, N, &h_alpha, nullptr, incx, nullptr, incy, nullptr, lda, batch_count)),
 
             M < 0 || N < 0 || lda < M || lda < 1 || !incx || !incy || batch_count < 0
                 ? rocblas_status_invalid_size
@@ -93,49 +85,33 @@ void testing_ger_batched(const Arguments& arg)
     size_t size_x   = M * abs_incx;
     size_t size_y   = N * abs_incy;
 
-    //Device-arrays of pointers to device memory
-    device_vector<T*, 0, T> dy(batch_count);
-    device_vector<T*, 0, T> dx(batch_count);
-    device_vector<T*, 0, T> dA_1(batch_count);
-    device_vector<T*, 0, T> dA_2(batch_count);
-    device_vector<T>        d_alpha(1);
-    if(!dA_1 || !dA_2 || !dx || !dy || !d_alpha)
+    // check memory info before allocation
+    size_t needed_mem = (size_x + size_y + size_A + size_A) * batch_count * sizeof(T) + sizeof(T);
+    if(is_limited_memory(needed_mem))
     {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
+#ifdef GOOGLE_TEST
+        SUCCEED() << LIMITED_MEMORY_STRING;
+#endif
         return;
     }
+
+    device_batch_vector<T> dy(N, incy, batch_count);
+    device_batch_vector<T> dx(M, incx, batch_count);
+    device_batch_vector<T> dA_1(size_A, 1, batch_count);
+    device_batch_vector<T> dA_2(size_A, 1, batch_count);
+    device_vector<T>       d_alpha(1);
+    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_HIP_ERROR(dA_2.memcheck());
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     // Host-arrays of pointers to host memory
-    host_vector<T> hy[batch_count];
-    host_vector<T> hx[batch_count];
-    host_vector<T> hA_1[batch_count];
-    host_vector<T> hA_2[batch_count];
-    host_vector<T> hA_gold[batch_count];
-
-    for(int b = 0; b < batch_count; ++b)
-    {
-        hy[b]      = host_vector<T>(size_y);
-        hx[b]      = host_vector<T>(size_x);
-        hA_1[b]    = host_vector<T>(size_A);
-        hA_2[b]    = host_vector<T>(size_A);
-        hA_gold[b] = host_vector<T>(size_A);
-    }
-
-    // Host-arrays of pointers to device memory
-    // (intermediate arrays used for the transfers)
-    device_batch_vector<T> A_1(batch_count, size_A);
-    device_batch_vector<T> A_2(batch_count, size_A);
-    device_batch_vector<T> y(batch_count, size_y);
-    device_batch_vector<T> x(batch_count, size_x);
-
-    int last = batch_count - 1;
-    if((!y[last] && size_y) || (!x[last] && size_x) || ((!A_1[last] || !A_2[last]) && size_A)
-       || !d_alpha)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    host_batch_vector<T> hy(N, incy, batch_count);
+    host_batch_vector<T> hx(M, incx, batch_count);
+    host_batch_vector<T> hA_1(size_A, 1, batch_count);
+    host_batch_vector<T> hA_2(size_A, 1, batch_count);
+    host_batch_vector<T> hA_gold(size_A, 1, batch_count);
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
@@ -143,61 +119,51 @@ void testing_ger_batched(const Arguments& arg)
     double rocblas_error_2;
 
     // Initial Data on CPU
-    rocblas_seedrand();
+    rocblas_init(hA_1, true);
+    rocblas_init(hx, false);
+    rocblas_init(hy, false);
+    hA_2.copy_from(hA_1);
+    hA_gold.copy_from(hA_1);
 
-    for(int b = 0; b < batch_count; ++b)
-    {
-        if(lda >= M)
-        {
-            rocblas_init<T>(hA_1[b], M, N, lda);
-        }
-        rocblas_init<T>(hx[b], 1, M, abs_incx);
-        rocblas_init<T>(hy[b], 1, N, abs_incy);
-
-        // copy matrix is easy in STL; hA_gold = hA_1: save a copy in hA_gold which will be output of
-        // CPU BLAS
-        hA_gold[b] = hA_1[b];
-        hA_2[b]    = hA_1[b];
-    }
-
-    // copy data from CPU to device
-    // 1. Use intermediate arrays to access device memory from host
-    for(int b = 0; b < batch_count; ++b)
-    {
-        CHECK_HIP_ERROR(hipMemcpy(A_1[b], hA_1[b], sizeof(T) * size_A, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(x[b], hx[b], sizeof(T) * size_x, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(y[b], hy[b], sizeof(T) * size_y, hipMemcpyHostToDevice));
-    }
-
-    // 2. Copy intermediate arrays into device arrays
-    CHECK_HIP_ERROR(hipMemcpy(dA_1, A_1, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, x, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, y, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dA_1.transfer_from(hA_1));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
 
     if(arg.unit_check || arg.norm_check)
     {
         // copy data from CPU to device
-        for(int b = 0; b < batch_count; ++b)
-        {
-            CHECK_HIP_ERROR(hipMemcpy(A_2[b], hA_2[b], sizeof(T) * size_A, hipMemcpyHostToDevice));
-        }
-        CHECK_HIP_ERROR(hipMemcpy(dA_2, A_2, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(dA_2.transfer_from(hA_2));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR((rocblas_ger_batched<T, CONJ>(
-            handle, M, N, &h_alpha, dx, incx, dy, incy, dA_1, lda, batch_count)));
+        CHECK_ROCBLAS_ERROR((rocblas_ger_batched<T, CONJ>(handle,
+                                                          M,
+                                                          N,
+                                                          &h_alpha,
+                                                          dx.ptr_on_device(),
+                                                          incx,
+                                                          dy.ptr_on_device(),
+                                                          incy,
+                                                          dA_1.ptr_on_device(),
+                                                          lda,
+                                                          batch_count)));
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR((rocblas_ger_batched<T, CONJ>(
-            handle, M, N, d_alpha, dx, incx, dy, incy, dA_2, lda, batch_count)));
+        CHECK_ROCBLAS_ERROR((rocblas_ger_batched<T, CONJ>(handle,
+                                                          M,
+                                                          N,
+                                                          d_alpha,
+                                                          dx.ptr_on_device(),
+                                                          incx,
+                                                          dy.ptr_on_device(),
+                                                          incy,
+                                                          dA_2.ptr_on_device(),
+                                                          lda,
+                                                          batch_count)));
 
         // copy output from device to CPU
-        for(int b = 0; b < batch_count; ++b)
-        {
-            hipMemcpy(hA_1[b], A_1[b], sizeof(T) * size_A, hipMemcpyDeviceToHost);
-            hipMemcpy(hA_2[b], A_2[b], sizeof(T) * size_A, hipMemcpyDeviceToHost);
-        }
+        CHECK_HIP_ERROR(hA_1.transfer_from(dA_1));
+        CHECK_HIP_ERROR(hA_2.transfer_from(dA_2));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -241,16 +207,34 @@ void testing_ger_batched(const Arguments& arg)
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {
-            rocblas_ger_batched<T, CONJ>(
-                handle, M, N, &h_alpha, dx, incx, dy, incy, dA_1, lda, batch_count);
+            rocblas_ger_batched<T, CONJ>(handle,
+                                         M,
+                                         N,
+                                         &h_alpha,
+                                         dx.ptr_on_device(),
+                                         incx,
+                                         dy.ptr_on_device(),
+                                         incy,
+                                         dA_1.ptr_on_device(),
+                                         lda,
+                                         batch_count);
         }
 
         gpu_time_used = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_hot_calls; iter++)
         {
-            rocblas_ger_batched<T, CONJ>(
-                handle, M, N, &h_alpha, dx, incx, dy, incy, dA_1, lda, batch_count);
+            rocblas_ger_batched<T, CONJ>(handle,
+                                         M,
+                                         N,
+                                         &h_alpha,
+                                         dx.ptr_on_device(),
+                                         incx,
+                                         dy.ptr_on_device(),
+                                         incy,
+                                         dA_1.ptr_on_device(),
+                                         lda,
+                                         batch_count);
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -176,6 +176,16 @@ void testing_ger_strided_batched(const Arguments& arg)
     host_vector<T> hx(size_x);
     host_vector<T> hy(size_y);
 
+    // check memory info before allocation
+    size_t needed_mem = (size_A + size_A + size_x + 1) * sizeof(T);
+    if(is_limited_memory(needed_mem))
+    {
+#ifdef GOOGLE_TEST
+        SUCCEED() << LIMITED_MEMORY_STRING;
+#endif
+        return;
+    }
+
     // allocate memory on device
     device_vector<T> dA_1(size_A);
     device_vector<T> dA_2(size_A);

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -176,27 +176,17 @@ void testing_ger_strided_batched(const Arguments& arg)
     host_vector<T> hx(size_x);
     host_vector<T> hy(size_y);
 
-    // check memory info before allocation
-    size_t needed_mem = (size_A + size_A + size_x + 1) * sizeof(T);
-    if(is_limited_memory(needed_mem))
-    {
-#ifdef GOOGLE_TEST
-        SUCCEED() << LIMITED_MEMORY_STRING;
-#endif
-        return;
-    }
-
     // allocate memory on device
     device_vector<T> dA_1(size_A);
     device_vector<T> dA_2(size_A);
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
     device_vector<T> d_alpha(1);
-    if(((!dA_1 || !dA_2) && size_A) || (!dx && size_x) || (!dy && size_y) || !d_alpha)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_set_get_matrix_async.hpp
+++ b/clients/include/testing_set_get_matrix_async.hpp
@@ -64,6 +64,16 @@ void testing_set_get_matrix_async(const Arguments& arg)
     double rocblas_bandwidth, cpu_bandwidth;
     double rocblas_error = 0.0;
 
+    // check memory info before allocation
+    size_t needed_mem = (cols * size_t(ldc)) * sizeof(T);
+    if(is_limited_memory(needed_mem))
+    {
+#ifdef GOOGLE_TEST
+        SUCCEED() << LIMITED_MEMORY_STRING;
+#endif
+        return;
+    }
+
     // allocate memory on device
     device_vector<T> dc(cols * size_t(ldc));
     if(!dc)

--- a/clients/include/testing_set_get_matrix_async.hpp
+++ b/clients/include/testing_set_get_matrix_async.hpp
@@ -64,23 +64,9 @@ void testing_set_get_matrix_async(const Arguments& arg)
     double rocblas_bandwidth, cpu_bandwidth;
     double rocblas_error = 0.0;
 
-    // check memory info before allocation
-    size_t needed_mem = (cols * size_t(ldc)) * sizeof(T);
-    if(is_limited_memory(needed_mem))
-    {
-#ifdef GOOGLE_TEST
-        SUCCEED() << LIMITED_MEMORY_STRING;
-#endif
-        return;
-    }
-
     // allocate memory on device
     device_vector<T> dc(cols * size_t(ldc));
-    if(!dc)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dc.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_syr_batched.hpp
+++ b/clients/include/testing_syr_batched.hpp
@@ -31,13 +31,10 @@ void testing_syr_batched_bad_arg()
     size_t size_x   = N * abs_incx * batch_count;
 
     // allocate memory on device
-    device_vector<T*, 0, T> dx(batch_count);
-    device_vector<T*, 0, T> dA_1(batch_count);
-    if(!dx || !dA_1)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dA_1(size_A, 1, batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dA_1.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_syr_batched<T>(handle, uplo, N, &alpha, nullptr, incx, dA_1, lda, batch_count),
@@ -69,16 +66,9 @@ void testing_syr_batched(const Arguments& arg)
     {
         static const size_t safe_size = 100; // arbitrarily set to 100
 
-        device_vector<T*, 0, T> dx(std::max(1, batch_count));
-        device_vector<T*, 0, T> dA_1(std::max(1, batch_count));
-        if(!dx || !dA_1)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
         EXPECT_ROCBLAS_STATUS(
-            rocblas_syr_batched<T>(handle, uplo, N, &h_alpha, dx, incx, dA_1, lda, batch_count),
+            rocblas_syr_batched<T>(
+                handle, uplo, N, &h_alpha, nullptr, incx, nullptr, lda, batch_count),
             N < 0 || lda < N || lda < 1 || !incx || batch_count < 0 ? rocblas_status_invalid_size
                                                                     : rocblas_status_success);
         return;
@@ -92,29 +82,30 @@ void testing_syr_batched(const Arguments& arg)
     size_t size_x = size_t(N) * abs_incx;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA_1[batch_count];
-    host_vector<T> hA_2[batch_count];
-    host_vector<T> hA_gold[batch_count];
-    host_vector<T> hx[batch_count];
+    host_batch_vector<T> hA_1(size_A, 1, batch_count);
+    host_batch_vector<T> hA_2(size_A, 1, batch_count);
+    host_batch_vector<T> hA_gold(size_A, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
 
-    for(int i = 0; i < batch_count; i++)
+    // check memory info before allocation
+    size_t needed_mem = ((N * abs_incx) + size_A + size_A) * batch_count * sizeof(T) + sizeof(T);
+    if(is_limited_memory(needed_mem))
     {
-        hA_1[i]    = host_vector<T>(size_A);
-        hA_2[i]    = host_vector<T>(size_A);
-        hA_gold[i] = host_vector<T>(size_A);
-        hx[i]      = host_vector<T>(size_x);
+#ifdef GOOGLE_TEST
+        SUCCEED() << LIMITED_MEMORY_STRING;
+#endif
+        return;
     }
 
     // allocate memory on device
-    device_batch_vector<T> dA_1(batch_count, size_A);
-    device_batch_vector<T> dA_2(batch_count, size_A);
-    device_batch_vector<T> dx(batch_count, size_x);
+    device_batch_vector<T> dA_1(size_A, 1, batch_count);
+    device_batch_vector<T> dA_2(size_A, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
     device_vector<T>       d_alpha(1);
-    if(!dA_1 || !dA_2 || !dx || !d_alpha)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_HIP_ERROR(dA_2.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;
@@ -122,67 +113,48 @@ void testing_syr_batched(const Arguments& arg)
     double rocblas_error_2;
 
     // Initial Data on CPU
+    rocblas_init(hA_1, true);
+    rocblas_init(hx, false);
     rocblas_seedrand();
-    for(int i = 0; i < batch_count; i++)
-    {
-        if(lda >= N)
-        {
-            rocblas_init_symmetric<T>(hA_1[i], N, lda);
-        }
-        rocblas_init<T>(hx[i], 1, N, abs_incx);
-    }
 
-    // copy matrix is easy in STL; hA_gold = hA_1: save a copy in hA_gold which will be output of
-    // CPU BLAS
-    for(int i = 0; i < batch_count; i++)
-    {
-        hA_gold[i] = hA_1[i];
-        hA_2[i]    = hA_1[i];
-    }
+    hA_gold.copy_from(hA_1);
+    hA_2.copy_from(hA_1);
 
     // copy data from CPU to device
-    for(int i = 0; i < batch_count; i++)
-    {
-        CHECK_HIP_ERROR(hipMemcpy(dA_1[i], hA_1[i], sizeof(T) * size_A, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dA_2[i], hA_2[i], sizeof(T) * size_A, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dx[i], hx[i], sizeof(T) * size_x, hipMemcpyHostToDevice));
-    }
-
-    // vector pointers on gpu
-    device_vector<T*, 0, T> dx_pvec(batch_count);
-    device_vector<T*, 0, T> dA1_pvec(batch_count);
-    device_vector<T*, 0, T> dA2_pvec(batch_count);
-    if(!dx_pvec || !dA1_pvec || !dA2_pvec)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
-
-    // copy gpu vector pointers from host to device pointer array
-    CHECK_HIP_ERROR(hipMemcpy(dx_pvec, dx, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dA1_pvec, dA_1, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dA2_pvec, dA_2, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dA_1.transfer_from(hA_1));
+    CHECK_HIP_ERROR(dA_2.transfer_from(hA_2));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
 
     if(arg.unit_check || arg.norm_check)
     {
         // copy data from CPU to device
-        //CHECK_HIP_ERROR(hipMemcpy(dA_2, hA_2, sizeof(T) * lda * N, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_syr_batched<T>(
-            handle, uplo, N, &h_alpha, dx_pvec, incx, dA1_pvec, lda, batch_count));
+        CHECK_ROCBLAS_ERROR(rocblas_syr_batched<T>(handle,
+                                                   uplo,
+                                                   N,
+                                                   &h_alpha,
+                                                   dx.ptr_on_device(),
+                                                   incx,
+                                                   dA_1.ptr_on_device(),
+                                                   lda,
+                                                   batch_count));
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        CHECK_ROCBLAS_ERROR(rocblas_syr_batched<T>(
-            handle, uplo, N, d_alpha, dx_pvec, incx, dA2_pvec, lda, batch_count));
+        CHECK_ROCBLAS_ERROR(rocblas_syr_batched<T>(handle,
+                                                   uplo,
+                                                   N,
+                                                   d_alpha,
+                                                   dx.ptr_on_device(),
+                                                   incx,
+                                                   dA_2.ptr_on_device(),
+                                                   lda,
+                                                   batch_count));
 
         // copy output from device to CPU
-        for(int i = 0; i < batch_count; i++)
-        {
-            hipMemcpy(hA_1[i], dA_1[i], sizeof(T) * size_A, hipMemcpyDeviceToHost);
-            hipMemcpy(hA_2[i], dA_2[i], sizeof(T) * size_A, hipMemcpyDeviceToHost);
-        }
+        CHECK_HIP_ERROR(hA_1.transfer_from(dA_1));
+        CHECK_HIP_ERROR(hA_2.transfer_from(dA_2));
 
         // CPU BLAS
         cpu_time_used = get_time_us();
@@ -229,14 +201,30 @@ void testing_syr_batched(const Arguments& arg)
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {
-            rocblas_syr_batched<T>(handle, uplo, N, &h_alpha, dx, incx, dA_1, lda, batch_count);
+            rocblas_syr_batched<T>(handle,
+                                   uplo,
+                                   N,
+                                   &h_alpha,
+                                   dx.ptr_on_device(),
+                                   incx,
+                                   dA_1.ptr_on_device(),
+                                   lda,
+                                   batch_count);
         }
 
         gpu_time_used = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_hot_calls; iter++)
         {
-            rocblas_syr_batched<T>(handle, uplo, N, &h_alpha, dx, incx, dA_1, lda, batch_count);
+            rocblas_syr_batched<T>(handle,
+                                   uplo,
+                                   N,
+                                   &h_alpha,
+                                   dx.ptr_on_device(),
+                                   incx,
+                                   dA_1.ptr_on_device(),
+                                   lda,
+                                   batch_count);
         }
 
         gpu_time_used     = (get_time_us() - gpu_time_used) / number_hot_calls;

--- a/clients/include/testing_syr_batched.hpp
+++ b/clients/include/testing_syr_batched.hpp
@@ -87,25 +87,15 @@ void testing_syr_batched(const Arguments& arg)
     host_batch_vector<T> hA_gold(size_A, 1, batch_count);
     host_batch_vector<T> hx(N, incx, batch_count);
 
-    // check memory info before allocation
-    size_t needed_mem = ((N * abs_incx) + size_A + size_A) * batch_count * sizeof(T) + sizeof(T);
-    if(is_limited_memory(needed_mem))
-    {
-#ifdef GOOGLE_TEST
-        SUCCEED() << LIMITED_MEMORY_STRING;
-#endif
-        return;
-    }
-
     // allocate memory on device
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
     device_batch_vector<T> dA_2(size_A, 1, batch_count);
     device_batch_vector<T> dx(N, incx, batch_count);
     device_vector<T>       d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -56,9 +56,6 @@ rocblas_int query_device_property();
 /*  set current device to device_id */
 void set_device(rocblas_int device_id);
 
-/* checks available memory on GPU and returns true if needed_mem is greater */
-bool is_limited_memory(size_t needed_mem);
-
 /* ============================================================================================ */
 /*  timing: HIP only provides very limited timers function clock() and not general;
             rocblas sync CPU and device and use more accurate CPU timer*/

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -19,6 +19,9 @@
  * \brief provide common utilities
  */
 
+static constexpr char LIMITED_MEMORY_STRING[]
+    = "Error: Attempting to allocate more memory than available.";
+
 /* ============================================================================================ */
 /*! \brief  local handle which is automatically created and destroyed  */
 class rocblas_local_handle
@@ -52,6 +55,9 @@ rocblas_int query_device_property();
 
 /*  set current device to device_id */
 void set_device(rocblas_int device_id);
+
+/* checks available memory on GPU and returns true if needed_mem is greater */
+bool is_limited_memory(size_t needed_mem);
 
 /* ============================================================================================ */
 /*  timing: HIP only provides very limited timers function clock() and not general;


### PR DESCRIPTION
Potentially resolves [SWDEV-223558](http://ontrack-internal.amd.com/browse/SWDEV-223558) and [SWDEV-220984](http://ontrack-internal.amd.com/browse/SWDEV-220984).

Summary
------------
This allows tests to check how much memory will be allocated on the device, and compares this to how much memory is free. If the amount of memory to be allocated is greater, it immediately succeeds, and allows logging that a test was skipped.
This seems a little hacky, so any advice is appreciated.

Implementation
--------------------
In utility.cpp, I use `hipMemGetInfo` to query how much memory is available. In each test, I calculate how much memory is needed, and if it's  greater, I use googletest's SUCCESS with a unique message. In rocblas_gtest_main.cpp the listener detects this message and records the skipped test.

Example Output
---------
`[----------] Global test environment tear-down`
`[==========] 13697 tests from 2 test cases ran. (18047 ms total)`
`[  PASSED  ] 13697 tests.`
`[ SKIPPED  ] 592 tests.`

Alternatives
---------------
Alternatively, [GTEST_SKIP()](https://github.com/google/googletest/pull/1544) is a more elegant solution that I believe is available in a newer release of googletest (1.10.0) (we're currently using 1.8.0, not sure if it would be an issue to update).

Notes
-------
I only added the memory check for the functions noted in the two tickets. I also updated `ger_batched` and `syr_batched` to the new `device_batch_vector`s as well.
I haven't ran this on a V340L machine to see if it works, but it worked for my manual testing. Will do this and update.