### PR TITLE
update tensile init to only load valid modules

### DIFF
--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -359,7 +359,8 @@ namespace
                     path += "/" + processor;
             }
 
-            auto dir = path + "/*co";
+            // only load modules for the current architecture
+            auto dir = path + "/*" + processor + "*co";
 
             glob_t glob_result;
             int    g = glob(dir.c_str(), GLOB_TILDE_CHECK | GLOB_NOSORT, nullptr, &glob_result);


### PR DESCRIPTION

change in tensile host initialization to only load modules for the current architecture.

