### PR TITLE
update tensile init to only load valid modules (#1012)

### DIFF
--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -359,7 +359,8 @@ namespace
                     path += "/" + processor;
             }
 
-            auto dir = path + "/*co";
+            // only load modules for the current architecture
+            auto dir = path + "/*" + processor + "*co";
 
             glob_t glob_result;
             int    g = glob(dir.c_str(), GLOB_TILDE_CHECK | GLOB_NOSORT, nullptr, &glob_result);


### PR DESCRIPTION
Fixes SWDEV-224021, SWDEV-223629
Full rocblas-test passed in docker 1901-MIOpen2.2.x-92186831-py3-ub16.04-3.1.20066-f2ab87d-hip-stg-job730