### PR TITLE
Fix skipping tests

### DIFF
--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -81,7 +81,7 @@ public:
 
     void OnTestPartResult(const TestPartResult& result) override
     {
-        if(strcmp(result.message(), LIMITED_MEMORY_STRING))
+        if(strcmp(result.message(), LIMITED_MEMORY_STRING_GTEST) == 0)
         {
             skipped_tests++;
             if(showInlineSkips)

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -19,8 +19,15 @@
  * \brief provide common utilities
  */
 
+// Passed into gtest's SUCCEED macro when skipping a test.
 static constexpr char LIMITED_MEMORY_STRING[]
     = "Error: Attempting to allocate more memory than available.";
+
+// TODO: This is dependent on internal gtest behaviour.
+// Compared with result.message() when a test ended. Note that "Succeeded\n" is
+// added to the beginning of the message automatically by gtest, so this must be compared.
+static constexpr char LIMITED_MEMORY_STRING_GTEST[]
+    = "Succeeded\nError: Attempting to allocate more memory than available.";
 
 /* ============================================================================================ */
 /*! \brief  local handle which is automatically created and destroyed  */


### PR DESCRIPTION
Fix for commit 5a3b4689233375618e453b2b92238a1081a1c0f4.

The previous commit would print that tests were skipped for any failed tests due to an incorrect use of strcmp. This should be fixed here.