### PR TITLE
revert to build with old tensile client

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ rocBLAS build & installation helper script
            --hip-clang         Build library for amdgpu backend using hip-clang
            --build_dir         Specify name of output directory (default is ./build)
       -n | --no_tensile        Build subset of library that does not require Tensile
+      -s | --tensile-host      Build with Tensile host
       -r | --no-tensile-host   Do not build with Tensile host
       -u | --use-tag-only      Ignore Tensile version and just use the Tensile tag
            --skipldconf        Skip ld.so.conf entry
@@ -259,7 +260,7 @@ tensile_version=true
 build_clients=false
 build_cuda=false
 build_tensile=true
-build_tensile_host=true
+build_tensile_host=false
 cpu_ref_lib=blis
 build_release=true
 build_hip_clang=false
@@ -278,7 +279,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no_tensile,no-tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test_local_path:,cpu_ref_lib:,skipldconf --options nrhicdgul:a:o:f:b:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,no_tensile,tensile-host,no-tensile-host,use-tag-only,logic:,architecture:,cov:,fork:,branch:,build_dir:,test_local_path:,cpu_ref_lib:,skipldconf --options nsrhicdgul:a:o:f:b:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -329,6 +330,9 @@ while true; do
         shift 2 ;;
     -n|--no_tensile)
         build_tensile=false
+        shift ;;
+    -s|--tensile-host)
+        build_tensile_host=true
         shift ;;
     -r|--no-tensile-host)
         build_tensile_host=false


### PR DESCRIPTION
Resets the install.sh to build with the new tensile client to false so by default we build with the old client.

The pre_checkin tests passed locally on a vega20 machine. 
