### PR TITLE
Updating strided_batched tests to use CHECK_DEVICE_ALLOCATION().

### DIFF
--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -23,7 +23,7 @@ void testing_asum_strided_batched_bad_arg(const Arguments& arg)
     real_t<T>      h_rocblas_result[1];
 
     device_strided_batch_vector<T> dx(N, incx, stridex, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     rocblas_local_handle handle;
     CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
@@ -57,9 +57,9 @@ void testing_asum_strided_batched(const Arguments& arg)
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         device_strided_batch_vector<T> dx(3, 1, 3, 3);
-        CHECK_HIP_ERROR(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
         device_vector<real_t<T>> dr(std::max(3, std::abs(batch_count)));
-        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_DEVICE_ALLOCATION(dr.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS(
@@ -76,10 +76,10 @@ void testing_asum_strided_batched(const Arguments& arg)
     host_strided_batch_vector<T> hx(N, incx, stridex, batch_count);
     CHECK_HIP_ERROR(hx.memcheck());
     device_strided_batch_vector<T> dx(N, incx, stridex, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     device_vector<real_t<T>> dr(batch_count);
-    CHECK_HIP_ERROR(dr.memcheck());
+    CHECK_DEVICE_ALLOCATION(dr.memcheck());
     host_vector<real_t<T>> hr1(batch_count);
     CHECK_HIP_ERROR(hr1.memcheck());
     host_vector<real_t<T>> hr(batch_count);

--- a/clients/include/testing_axpy_strided_batched.hpp
+++ b/clients/include/testing_axpy_strided_batched.hpp
@@ -27,8 +27,8 @@ void testing_axpy_strided_batched_bad_arg(const Arguments& arg)
 
     device_strided_batch_vector<T> dx(10, 1, 10, 2), dy(10, 1, 10, 2);
 
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_axpy_strided_batched<T>(
@@ -64,8 +64,8 @@ void testing_axpy_strided_batched(const Arguments& arg)
     {
         device_strided_batch_vector<T> dx(10, 1, 10, 2), dy(10, 1, 10, 2);
 
-        CHECK_HIP_ERROR(dx.memcheck());
-        CHECK_HIP_ERROR(dy.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
@@ -94,9 +94,9 @@ void testing_axpy_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dx(N, incx, stridex, batch_count),
         dy(N, incy, stridey, batch_count);
     device_vector<T> dalpha(1);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dalpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dalpha.memcheck());
 
     halpha[0] = h_alpha;
 

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -30,12 +30,8 @@ void testing_copy_strided_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
-
-    if(!dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_copy_strided_batched<T>(
                               handle, N, nullptr, incx, stride_x, dy, incy, stride_y, batch_count),
@@ -69,11 +65,8 @@ void testing_copy_strided_batched(const Arguments& arg)
         static const size_t safe_size = 100; //  arbitrarily set to 100
         device_vector<T>    dx(safe_size);
         device_vector<T>    dy(safe_size);
-        if(!dx || !dy)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_copy_strided_batched<T>(
                                   handle, N, dx, incx, stride_x, dy, incy, stride_y, batch_count),
@@ -85,11 +78,8 @@ void testing_copy_strided_batched(const Arguments& arg)
     // allocate memory on device
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
-    if(!dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(size_x);

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -31,11 +31,9 @@ void testing_dot_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T>     dx(size_x);
     device_vector<T>     dy(size_y);
     device_vector<T>     d_rocblas_result(1);
-    if(!dx || !dy || !d_rocblas_result)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_rocblas_result.memcheck());
 
     CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
@@ -113,12 +111,9 @@ void testing_dot_strided_batched(const Arguments& arg)
         device_vector<T>    dx(safe_size);
         device_vector<T>    dy(safe_size);
         device_vector<T>    d_rocblas_result(std::max(batch_count, 1));
-
-        if(!dx || !dy || !d_rocblas_result)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
+        CHECK_DEVICE_ALLOCATION(d_rocblas_result.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
@@ -149,11 +144,9 @@ void testing_dot_strided_batched(const Arguments& arg)
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
     device_vector<T> d_rocblas_result_2(batch_count);
-    if(!dx || !dy || !d_rocblas_result_2)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_rocblas_result_2.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(size_x);

--- a/clients/include/testing_gbmv_strided_batched.hpp
+++ b/clients/include/testing_gbmv_strided_batched.hpp
@@ -41,9 +41,9 @@ void testing_gbmv_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_vector<T> dA(size_A, 1, stride_A, batch_count),
         dx(N, incx, stride_x, batch_count), dy(M, incy, stride_y, batch_count);
 
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_gbmv_strided_batched<T>(handle,
                                                           transA,
@@ -205,14 +205,6 @@ void testing_gbmv_strided_batched(const Arguments& arg)
     // argument sanity check before allocating invalid memory
     if(M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0 || batch_count < 0)
     {
-        static constexpr size_t        safe_size = 100; // arbitrarily set to 100
-        device_strided_batch_vector<T> dA1(safe_size, 1, safe_size, 2),
-            dx1(safe_size, 1, safe_size, 2), dy1(safe_size, 1, safe_size, 2);
-
-        CHECK_HIP_ERROR(dA1.memcheck());
-        CHECK_HIP_ERROR(dx1.memcheck());
-        CHECK_HIP_ERROR(dy1.memcheck());
-
         EXPECT_ROCBLAS_STATUS(rocblas_gbmv_strided_batched<T>(handle,
                                                               transA,
                                                               M,
@@ -220,14 +212,14 @@ void testing_gbmv_strided_batched(const Arguments& arg)
                                                               KL,
                                                               KU,
                                                               &h_alpha,
-                                                              dA1,
+                                                              nullptr,
                                                               lda,
                                                               stride_A,
-                                                              dx1,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
                                                               &h_beta,
-                                                              dy1,
+                                                              nullptr,
                                                               incy,
                                                               stride_y,
                                                               batch_count),
@@ -239,14 +231,6 @@ void testing_gbmv_strided_batched(const Arguments& arg)
     //quick return
     if(!M || !N || !batch_count)
     {
-        static const size_t            safe_size = 100; // arbitrarily set to 100
-        device_strided_batch_vector<T> dA1(safe_size, 1, safe_size, 2),
-            dx1(safe_size, 1, safe_size, 2), dy1(safe_size, 1, safe_size, 2);
-
-        CHECK_HIP_ERROR(dA1.memcheck());
-        CHECK_HIP_ERROR(dx1.memcheck());
-        CHECK_HIP_ERROR(dy1.memcheck());
-
         EXPECT_ROCBLAS_STATUS(rocblas_gbmv_strided_batched<T>(handle,
                                                               transA,
                                                               M,
@@ -254,14 +238,14 @@ void testing_gbmv_strided_batched(const Arguments& arg)
                                                               KL,
                                                               KU,
                                                               &h_alpha,
-                                                              dA1,
+                                                              nullptr,
                                                               lda,
                                                               stride_A,
-                                                              dx1,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
                                                               &h_beta,
-                                                              dy1,
+                                                              nullptr,
                                                               incy,
                                                               stride_y,
                                                               batch_count),
@@ -294,12 +278,12 @@ void testing_gbmv_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dy_2(dim_y, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
     device_vector<T>               d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy_1.memcheck());
-    CHECK_HIP_ERROR(dy_2.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Initial Data on CPU
     rocblas_init<T>(hA, true);

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -52,11 +52,9 @@ void testing_gemm_strided_batched(const Arguments& arg)
         device_vector<T>    dA(safe_size);
         device_vector<T>    dB(safe_size);
         device_vector<T>    dC(safe_size);
-        if(!dA || !dB || !dC)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dB.memcheck());
+        CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_gemm_strided_batched<T>(handle,
                                                               transA,
@@ -102,11 +100,11 @@ void testing_gemm_strided_batched(const Arguments& arg)
     device_vector<T> dC(size_c);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
-    if((!dA && size_a) || (!dB && size_b) || (!dC && size_c) || !d_alpha || !d_beta)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dB.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hA(size_a);

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -62,11 +62,10 @@ void testing_gemm_strided_batched_ex_bad_arg(const Arguments& arg)
     device_vector<float> dB(safe_size);
     device_vector<float> dC(safe_size);
     device_vector<float> dD(safe_size);
-    if(!dA || !dB || !dC || !dD)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dB.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dD.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_gemm_strided_batched_ex(handle,
                                                           transA,
@@ -330,11 +329,10 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
         device_vector<Ti>   dB(safe_size);
         device_vector<To>   dC(safe_size);
         device_vector<To>   dD(safe_size);
-        if(!dA || !dB || !dC || !dD)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dB.memcheck());
+        CHECK_DEVICE_ALLOCATION(dC.memcheck());
+        CHECK_DEVICE_ALLOCATION(dD.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_gemm_strided_batched_ex(handle,
                                                               transA,
@@ -395,12 +393,12 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
     device_vector<To> dD(size_d);
     device_vector<Tc> d_alpha_Tc(1);
     device_vector<Tc> d_beta_Tc(1);
-    if((!dA && size_a) || (!dB && size_b) || (!dC && size_c) || (!dD && size_d) || !d_alpha_Tc
-       || !d_beta_Tc)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dB.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dD.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha_Tc.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta_Tc.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Ti> hA(size_a);

--- a/clients/include/testing_gemv_strided_batched.hpp
+++ b/clients/include/testing_gemv_strided_batched.hpp
@@ -43,11 +43,9 @@ void testing_gemv_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_gemv_strided_batched<T>(handle,
                                                           transA,
@@ -199,29 +197,19 @@ void testing_gemv_strided_batched(const Arguments& arg)
     // argument sanity check before allocating invalid memory
     if(M <= 0 || N <= 0 || lda < M || lda < 1 || !incx || !incy || batch_count <= 0)
     {
-        static constexpr size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>        dA1(safe_size);
-        device_vector<T>        dx1(safe_size);
-        device_vector<T>        dy1(safe_size);
-        if(!dA1 || !dx1 || !dy1)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
         EXPECT_ROCBLAS_STATUS(rocblas_gemv_strided_batched<T>(handle,
                                                               transA,
                                                               M,
                                                               N,
                                                               &h_alpha,
-                                                              dA1,
+                                                              nullptr,
                                                               lda,
                                                               stride_a,
-                                                              dx1,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
                                                               &h_beta,
-                                                              dy1,
+                                                              nullptr,
                                                               incy,
                                                               stride_y,
                                                               batch_count),
@@ -235,29 +223,19 @@ void testing_gemv_strided_batched(const Arguments& arg)
     //quick return
     if(!M || !N || !batch_count)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dA1(safe_size);
-        device_vector<T>    dx1(safe_size);
-        device_vector<T>    dy1(safe_size);
-        if(!dA1 || !dx1 || !dy1)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
         EXPECT_ROCBLAS_STATUS(rocblas_gemv_strided_batched<T>(handle,
                                                               transA,
                                                               M,
                                                               N,
                                                               &h_alpha,
-                                                              dA1,
+                                                              nullptr,
                                                               lda,
                                                               stride_a,
-                                                              dx1,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
                                                               &h_beta,
-                                                              dy1,
+                                                              nullptr,
                                                               incy,
                                                               stride_y,
                                                               batch_count),
@@ -283,11 +261,12 @@ void testing_gemv_strided_batched(const Arguments& arg)
     device_vector<T> dy_2(size_y);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
-    if((!dA && size_A) || (!dx && size_x) || ((!dy_1 || !dy_2) && size_y) || !d_alpha || !d_beta)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -40,11 +40,9 @@ void testing_ger_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T> dA_1(size_A);
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
-    if(!dA_1 || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS((rocblas_ger_strided_batched<T, CONJ>(handle,
                                                                 M,
@@ -133,27 +131,17 @@ void testing_ger_strided_batched(const Arguments& arg)
     // argument check before allocating invalid memory
     if(M <= 0 || N <= 0 || lda < M || lda < 1 || !incx || !incy || batch_count <= 0)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dA_1(safe_size);
-        device_vector<T>    dx(safe_size);
-        device_vector<T>    dy(safe_size);
-        if(!dA_1 || !dx || !dy)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
         EXPECT_ROCBLAS_STATUS((rocblas_ger_strided_batched<T, CONJ>(handle,
                                                                     M,
                                                                     N,
                                                                     &h_alpha,
-                                                                    dx,
+                                                                    nullptr,
                                                                     incx,
                                                                     stride_x,
-                                                                    dy,
+                                                                    nullptr,
                                                                     incy,
                                                                     stride_y,
-                                                                    dA_1,
+                                                                    nullptr,
                                                                     lda,
                                                                     stride_a,
                                                                     batch_count)),

--- a/clients/include/testing_hbmv_strided_batched.hpp
+++ b/clients/include/testing_hbmv_strided_batched.hpp
@@ -41,9 +41,9 @@ void testing_hbmv_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_vector<T> dA(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_hbmv_strided_batched<T>(handle,
                                                           uplo,
@@ -193,27 +193,19 @@ void testing_hbmv_strided_batched(const Arguments& arg)
     // argument sanity check before allocating invalid memory
     if(N <= 0 || K < 0 || lda <= K || !incx || !incy || batch_count <= 0)
     {
-        static const size_t            safe_size = 100; // arbitrarily set to 100
-        device_strided_batch_vector<T> dA1(safe_size, 1, safe_size, 2);
-        device_strided_batch_vector<T> dx1(safe_size, 1, safe_size, 2);
-        device_strided_batch_vector<T> dy1(safe_size, 1, safe_size, 2);
-        CHECK_HIP_ERROR(dA1.memcheck());
-        CHECK_HIP_ERROR(dx1.memcheck());
-        CHECK_HIP_ERROR(dy1.memcheck());
-
         EXPECT_ROCBLAS_STATUS(rocblas_hbmv_strided_batched<T>(handle,
                                                               uplo,
                                                               N,
                                                               K,
                                                               &h_alpha,
-                                                              dA1,
+                                                              nullptr,
                                                               lda,
                                                               stride_A,
-                                                              dx1,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
                                                               &h_beta,
-                                                              dy1,
+                                                              nullptr,
                                                               incy,
                                                               stride_y,
                                                               batch_count),
@@ -252,12 +244,12 @@ void testing_hbmv_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dy_2(N, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
     device_vector<T>               d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy_1.memcheck());
-    CHECK_HIP_ERROR(dy_2.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Initial Data on CPU
     rocblas_init<T>(hA, true);

--- a/clients/include/testing_hemv_strided_batched.hpp
+++ b/clients/include/testing_hemv_strided_batched.hpp
@@ -42,9 +42,9 @@ void testing_hemv_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_hemv_strided_batched<T>(handle,
                                                           uplo,
@@ -186,26 +186,18 @@ void testing_hemv_strided_batched(const Arguments& arg)
     // argument sanity check before allocating invalid memory
     if(N < 0 || lda < N || lda < 1 || !incx || !incy || batch_count <= 0)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dA1(safe_size);
-        device_vector<T>    dx1(safe_size);
-        device_vector<T>    dy1(safe_size);
-        CHECK_HIP_ERROR(dA1.memcheck());
-        CHECK_HIP_ERROR(dx1.memcheck());
-        CHECK_HIP_ERROR(dy1.memcheck());
-
         EXPECT_ROCBLAS_STATUS(rocblas_hemv_strided_batched<T>(handle,
                                                               uplo,
                                                               N,
                                                               &h_alpha,
-                                                              dA1,
+                                                              nullptr,
                                                               lda,
                                                               stride_A,
-                                                              dx1,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
                                                               &h_beta,
-                                                              dy1,
+                                                              nullptr,
                                                               incy,
                                                               stride_y,
                                                               batch_count),
@@ -239,12 +231,12 @@ void testing_hemv_strided_batched(const Arguments& arg)
     device_vector<T> dy_2(size_y);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy_1.memcheck());
-    CHECK_HIP_ERROR(dy_2.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_her2_strided_batched.hpp
+++ b/clients/include/testing_her2_strided_batched.hpp
@@ -38,9 +38,9 @@ void testing_her2_strided_batched_bad_arg()
     device_strided_batch_vector<T> dA_1(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS((rocblas_her2_strided_batched<T>)(handle,
                                                             rocblas_fill_full,
@@ -188,11 +188,11 @@ void testing_her2_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_her_strided_batched.hpp
+++ b/clients/include/testing_her_strided_batched.hpp
@@ -35,8 +35,8 @@ void testing_her_strided_batched_bad_arg()
     // allocate memory on device
     device_strided_batch_vector<T> dA_1(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_her_strided_batched<T>(handle,
                                                          rocblas_fill_full,
@@ -123,10 +123,10 @@ void testing_her_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dA_2(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_vector<real_t<T>>       d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_hpmv_strided_batched.hpp
+++ b/clients/include/testing_hpmv_strided_batched.hpp
@@ -41,9 +41,9 @@ void testing_hpmv_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_hpmv_strided_batched<T>(handle,
                                                           uplo,
@@ -228,12 +228,12 @@ void testing_hpmv_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dy_2(size_y, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
     device_vector<T>               d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy_1.memcheck());
-    CHECK_HIP_ERROR(dy_2.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Initial Data on CPU
     rocblas_init(hA, true);

--- a/clients/include/testing_hpr2_strided_batched.hpp
+++ b/clients/include/testing_hpr2_strided_batched.hpp
@@ -37,9 +37,9 @@ void testing_hpr2_strided_batched_bad_arg()
     device_strided_batch_vector<T> dA_1(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS((rocblas_hpr2_strided_batched<T>)(handle,
                                                             rocblas_fill_full,
@@ -180,11 +180,11 @@ void testing_hpr2_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_hpr_strided_batched.hpp
+++ b/clients/include/testing_hpr_strided_batched.hpp
@@ -104,10 +104,10 @@ void testing_hpr_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dA_2(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_vector<real_t<T>>       d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -27,11 +27,8 @@ void testing_nrm2_strided_batched_bad_arg(const Arguments& arg)
 
     device_vector<T>         dx(safe_size);
     device_vector<real_t<T>> d_rocblas_result(batch_count);
-    if(!dx || !d_rocblas_result)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_rocblas_result.memcheck());
 
     CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
@@ -63,9 +60,9 @@ void testing_nrm2_strided_batched(const Arguments& arg)
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         device_strided_batch_vector<T> dx(3, 1, 3, 3);
-        CHECK_HIP_ERROR(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
         device_vector<real_t<T>> dr(std::max(3, std::abs(batch_count)));
-        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_DEVICE_ALLOCATION(dr.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS(
@@ -84,11 +81,8 @@ void testing_nrm2_strided_batched(const Arguments& arg)
     // allocate memory on device
     device_vector<T>         dx(batch_count * size_x);
     device_vector<real_t<T>> d_rocblas_result_2(batch_count);
-    if(!dx || !d_rocblas_result_2)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_rocblas_result_2.memcheck());
 
     // Naming: dx is in GPU (device) memory. hx is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(batch_count * size_x);

--- a/clients/include/testing_reduction_strided_batched.hpp
+++ b/clients/include/testing_reduction_strided_batched.hpp
@@ -36,7 +36,7 @@ void template_testing_reduction_strided_batched_bad_arg(
     // allocate memory on device
     //
     device_vector<T> dx(batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     R h_rocblas_result;
 
@@ -67,9 +67,9 @@ void template_testing_reduction_strided_batched(
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         device_strided_batch_vector<T> dx(3, 1, 3, 3);
-        CHECK_HIP_ERROR(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
         device_vector<R> dr(std::max(3, std::abs(batch_count)));
-        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_DEVICE_ALLOCATION(dr.memcheck());
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS(func(handle, N, dx, incx, stridex, batch_count, dr),
                               (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
@@ -85,11 +85,11 @@ void template_testing_reduction_strided_batched(
     host_vector<R> cpu_result(batch_count);
     CHECK_HIP_ERROR(cpu_result.memcheck());
     device_strided_batch_vector<T> dx(N, incx, stridex, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
     host_strided_batch_vector<T> hx(N, incx, stridex, batch_count);
     CHECK_HIP_ERROR(hx.memcheck());
     device_vector<R> dr(batch_count);
-    CHECK_HIP_ERROR(dr.memcheck());
+    CHECK_DEVICE_ALLOCATION(dr.memcheck());
     double gpu_time_used, cpu_time_used;
 
     //

--- a/clients/include/testing_rot_strided_batched.hpp
+++ b/clients/include/testing_rot_strided_batched.hpp
@@ -29,11 +29,10 @@ void testing_rot_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T>     dy(safe_size);
     device_vector<U>     dc(1);
     device_vector<V>     ds(1);
-    if(!dx || !dy || !dc || !ds)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dc.memcheck());
+    CHECK_DEVICE_ALLOCATION(ds.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         (rocblas_rot_strided_batched<T, U, V>(
@@ -81,11 +80,10 @@ void testing_rot_strided_batched(const Arguments& arg)
         device_vector<T>    dy(safe_size);
         device_vector<U>    dc(1);
         device_vector<V>    ds(1);
-        if(!dx || !dy || !dc || !ds)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
+        CHECK_DEVICE_ALLOCATION(dc.memcheck());
+        CHECK_DEVICE_ALLOCATION(ds.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS((rocblas_rot_strided_batched<T, U, V>)(handle,
@@ -111,11 +109,10 @@ void testing_rot_strided_batched(const Arguments& arg)
     device_vector<T> dy(size_y);
     device_vector<U> dc(1);
     device_vector<V> ds(1);
-    if(!dx || !dy || !dc || !ds)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dc.memcheck());
+    CHECK_DEVICE_ALLOCATION(ds.memcheck());
 
     // Initial Data on CPU
     host_vector<T> hx(size_x);

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -28,11 +28,10 @@ void testing_rotg_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T>     db(batch_count * stride_b);
     device_vector<U>     dc(batch_count * stride_c);
     device_vector<T>     ds(batch_count * stride_s);
-    if(!da || !db || !dc || !ds)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(da.memcheck());
+    CHECK_DEVICE_ALLOCATION(db.memcheck());
+    CHECK_DEVICE_ALLOCATION(dc.memcheck());
+    CHECK_DEVICE_ALLOCATION(ds.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         (rocblas_rotg_strided_batched<T, U>(
@@ -79,11 +78,10 @@ void testing_rotg_strided_batched(const Arguments& arg)
         device_vector<T>    db(safe_size);
         device_vector<U>    dc(safe_size);
         device_vector<T>    ds(safe_size);
-        if(!da || !db || !dc || !ds)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(da.memcheck());
+        CHECK_DEVICE_ALLOCATION(db.memcheck());
+        CHECK_DEVICE_ALLOCATION(dc.memcheck());
+        CHECK_DEVICE_ALLOCATION(ds.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS(
@@ -162,6 +160,10 @@ void testing_rotg_strided_batched(const Arguments& arg)
             device_vector<T> db(size_b);
             device_vector<U> dc(size_c);
             device_vector<T> ds(size_s);
+            CHECK_DEVICE_ALLOCATION(da.memcheck());
+            CHECK_DEVICE_ALLOCATION(db.memcheck());
+            CHECK_DEVICE_ALLOCATION(dc.memcheck());
+            CHECK_DEVICE_ALLOCATION(ds.memcheck());
             CHECK_HIP_ERROR(hipMemcpy(da, ha, sizeof(T) * size_a, hipMemcpyHostToDevice));
             CHECK_HIP_ERROR(hipMemcpy(db, hb, sizeof(T) * size_b, hipMemcpyHostToDevice));
             CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U) * size_c, hipMemcpyHostToDevice));
@@ -203,7 +205,7 @@ void testing_rotg_strided_batched(const Arguments& arg)
     if(arg.timing)
     {
         int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_hot_calls  = arg.iters;
         // Device mode will be quicker
         // (TODO: or is there another reason we are typically using host_mode for timing?)
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
@@ -212,6 +214,10 @@ void testing_rotg_strided_batched(const Arguments& arg)
         device_vector<T> db(size_b);
         device_vector<U> dc(size_c);
         device_vector<T> ds(size_s);
+        CHECK_DEVICE_ALLOCATION(da.memcheck());
+        CHECK_DEVICE_ALLOCATION(db.memcheck());
+        CHECK_DEVICE_ALLOCATION(dc.memcheck());
+        CHECK_DEVICE_ALLOCATION(ds.memcheck());
         CHECK_HIP_ERROR(hipMemcpy(da, ha, sizeof(T) * size_a, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(db, hb, sizeof(T) * size_b, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U) * size_c, hipMemcpyHostToDevice));

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -29,11 +29,9 @@ void testing_rotm_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T>     dx(safe_size);
     device_vector<T>     dy(safe_size);
     device_vector<T>     dparam(safe_size);
-    if(!dx || !dy || !dparam)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dparam.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         (rocblas_rotm_strided_batched<T>(
@@ -93,11 +91,9 @@ void testing_rotm_strided_batched(const Arguments& arg)
         device_vector<T>    dx(safe_size);
         device_vector<T>    dy(safe_size);
         device_vector<T>    dparam(safe_size);
-        if(!dx || !dy || !dparam)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
+        CHECK_DEVICE_ALLOCATION(dparam.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS((rocblas_rotm_strided_batched<T>(handle,
@@ -123,11 +119,9 @@ void testing_rotm_strided_batched(const Arguments& arg)
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
     device_vector<T> dparam(size_param);
-    if(!dx || !dy || !dparam)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dparam.memcheck());
 
     // Initial Data on CPU
     host_vector<T> hx(size_x);
@@ -234,7 +228,7 @@ void testing_rotm_strided_batched(const Arguments& arg)
         if(arg.timing)
         {
             int number_cold_calls = 2;
-            int number_hot_calls  = 100;
+            int number_hot_calls  = arg.iters;
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
             CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
             CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -25,12 +25,11 @@ void testing_rotmg_strided_batched_bad_arg(const Arguments& arg)
     device_vector<T>     x1(safe_size);
     device_vector<T>     y1(safe_size);
     device_vector<T>     param(safe_size);
-
-    if(!d1 || !d2 || !x1 || !y1 || !param)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(d1.memcheck());
+    CHECK_DEVICE_ALLOCATION(d2.memcheck());
+    CHECK_DEVICE_ALLOCATION(x1.memcheck());
+    CHECK_DEVICE_ALLOCATION(y1.memcheck());
+    CHECK_DEVICE_ALLOCATION(param.memcheck());
 
     EXPECT_ROCBLAS_STATUS((rocblas_rotmg_strided_batched<T>(
                               nullptr, d1, 0, d2, 0, x1, 0, y1, 0, param, 0, batch_count)),
@@ -77,12 +76,11 @@ void testing_rotmg_strided_batched(const Arguments& arg)
         device_vector<T> x1(safe_size);
         device_vector<T> y1(safe_size);
         device_vector<T> params(safe_size);
-
-        if(!d1 || !d2 || !x1 || !y1 || !params)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(d1.memcheck());
+        CHECK_DEVICE_ALLOCATION(d2.memcheck());
+        CHECK_DEVICE_ALLOCATION(x1.memcheck());
+        CHECK_DEVICE_ALLOCATION(y1.memcheck());
+        CHECK_DEVICE_ALLOCATION(param.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS((rocblas_rotmg_strided_batched<T>(handle,
@@ -196,6 +194,11 @@ void testing_rotmg_strided_batched(const Arguments& arg)
             device_vector<T> dx1(size_x1);
             device_vector<T> dy1(size_y1);
             device_vector<T> dparams(size_param);
+            CHECK_DEVICE_ALLOCATION(d1.memcheck());
+            CHECK_DEVICE_ALLOCATION(d2.memcheck());
+            CHECK_DEVICE_ALLOCATION(x1.memcheck());
+            CHECK_DEVICE_ALLOCATION(y1.memcheck());
+            CHECK_DEVICE_ALLOCATION(param.memcheck());
 
             CHECK_HIP_ERROR(hipMemcpy(dd1, hd1, sizeof(T) * size_d1, hipMemcpyHostToDevice));
             CHECK_HIP_ERROR(hipMemcpy(dd2, hd2, sizeof(T) * size_d2, hipMemcpyHostToDevice));
@@ -260,7 +263,7 @@ void testing_rotmg_strided_batched(const Arguments& arg)
     if(arg.timing)
     {
         int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
@@ -269,6 +272,11 @@ void testing_rotmg_strided_batched(const Arguments& arg)
         device_vector<T> dx1(size_x1);
         device_vector<T> dy1(size_y1);
         device_vector<T> dparams(size_param);
+        CHECK_DEVICE_ALLOCATION(d1.memcheck());
+        CHECK_DEVICE_ALLOCATION(d2.memcheck());
+        CHECK_DEVICE_ALLOCATION(x1.memcheck());
+        CHECK_DEVICE_ALLOCATION(y1.memcheck());
+        CHECK_DEVICE_ALLOCATION(param.memcheck());
 
         CHECK_HIP_ERROR(hipMemcpy(dd1, hd1, sizeof(T) * size_d1, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dd2, hd2, sizeof(T) * size_d2, hipMemcpyHostToDevice));

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -80,7 +80,7 @@ void testing_rotmg_strided_batched(const Arguments& arg)
         CHECK_DEVICE_ALLOCATION(d2.memcheck());
         CHECK_DEVICE_ALLOCATION(x1.memcheck());
         CHECK_DEVICE_ALLOCATION(y1.memcheck());
-        CHECK_DEVICE_ALLOCATION(param.memcheck());
+        CHECK_DEVICE_ALLOCATION(params.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS((rocblas_rotmg_strided_batched<T>(handle,
@@ -194,11 +194,11 @@ void testing_rotmg_strided_batched(const Arguments& arg)
             device_vector<T> dx1(size_x1);
             device_vector<T> dy1(size_y1);
             device_vector<T> dparams(size_param);
-            CHECK_DEVICE_ALLOCATION(d1.memcheck());
-            CHECK_DEVICE_ALLOCATION(d2.memcheck());
-            CHECK_DEVICE_ALLOCATION(x1.memcheck());
-            CHECK_DEVICE_ALLOCATION(y1.memcheck());
-            CHECK_DEVICE_ALLOCATION(param.memcheck());
+            CHECK_DEVICE_ALLOCATION(dd1.memcheck());
+            CHECK_DEVICE_ALLOCATION(dd2.memcheck());
+            CHECK_DEVICE_ALLOCATION(dx1.memcheck());
+            CHECK_DEVICE_ALLOCATION(dy1.memcheck());
+            CHECK_DEVICE_ALLOCATION(dparams.memcheck());
 
             CHECK_HIP_ERROR(hipMemcpy(dd1, hd1, sizeof(T) * size_d1, hipMemcpyHostToDevice));
             CHECK_HIP_ERROR(hipMemcpy(dd2, hd2, sizeof(T) * size_d2, hipMemcpyHostToDevice));
@@ -272,11 +272,11 @@ void testing_rotmg_strided_batched(const Arguments& arg)
         device_vector<T> dx1(size_x1);
         device_vector<T> dy1(size_y1);
         device_vector<T> dparams(size_param);
-        CHECK_DEVICE_ALLOCATION(d1.memcheck());
-        CHECK_DEVICE_ALLOCATION(d2.memcheck());
-        CHECK_DEVICE_ALLOCATION(x1.memcheck());
-        CHECK_DEVICE_ALLOCATION(y1.memcheck());
-        CHECK_DEVICE_ALLOCATION(param.memcheck());
+        CHECK_DEVICE_ALLOCATION(dd1.memcheck());
+        CHECK_DEVICE_ALLOCATION(dd2.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx1.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy1.memcheck());
+        CHECK_DEVICE_ALLOCATION(dparams.memcheck());
 
         CHECK_HIP_ERROR(hipMemcpy(dd1, hd1, sizeof(T) * size_d1, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dd2, hd2, sizeof(T) * size_d2, hipMemcpyHostToDevice));

--- a/clients/include/testing_sbmv_strided_batched.hpp
+++ b/clients/include/testing_sbmv_strided_batched.hpp
@@ -43,11 +43,9 @@ void testing_sbmv_strided_batched_bad_arg()
     device_vector<T>    dA(safe_size);
     device_vector<T>    dx(safe_size);
     device_vector<T>    dy(safe_size);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_sbmv_strided_batched<T>(nullptr,
                                                           uplo,
@@ -212,11 +210,9 @@ void testing_sbmv_strided_batched(const Arguments& arg)
         device_vector<T>    dA(safe_size);
         device_vector<T>    dx(safe_size);
         device_vector<T>    dy(safe_size);
-        if(!dA || !dx || !dy)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_sbmv_strided_batched<T>(handle,
                                                               uplo,
@@ -244,6 +240,8 @@ void testing_sbmv_strided_batched(const Arguments& arg)
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     host_vector<T> hA(size_A);
     host_vector<T> hx(size_X);
@@ -260,11 +258,9 @@ void testing_sbmv_strided_batched(const Arguments& arg)
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_X);
     device_vector<T> dy(size_Y);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -31,11 +31,7 @@ void testing_scal_strided_batched(const Arguments& arg)
     {
         static const size_t safe_size = 100; // arbitrarily set to 100
         device_vector<T>    dx(safe_size);
-        if(!dx)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
@@ -65,11 +61,9 @@ void testing_scal_strided_batched(const Arguments& arg)
     device_vector<T> dx_1(size_x);
     device_vector<T> dx_2(size_x);
     device_vector<U> d_alpha(1);
-    if(!dx_1 || !dx_2 || !d_alpha)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dx_1, hx_1, sizeof(T) * size_x, hipMemcpyHostToDevice));
@@ -129,7 +123,7 @@ void testing_scal_strided_batched(const Arguments& arg)
     if(arg.timing)
     {
         int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)
@@ -182,11 +176,7 @@ void testing_scal_strided_batched_bad_arg(const Arguments& arg)
 
     // allocate memory on device
     device_vector<T> dx(size_x);
-    if(!dx)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         (rocblas_scal_strided_batched<T, U>)(handle, N, nullptr, dx, incx, stridex, batch_count),

--- a/clients/include/testing_spmv_strided_batched.hpp
+++ b/clients/include/testing_spmv_strided_batched.hpp
@@ -41,11 +41,9 @@ void testing_spmv_strided_batched_bad_arg()
     device_vector<T>    dA(safe_size);
     device_vector<T>    dx(safe_size);
     device_vector<T>    dy(safe_size);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_spmv_strided_batched<T>(nullptr,
                                                           uplo,
@@ -194,11 +192,9 @@ void testing_spmv_strided_batched(const Arguments& arg)
         device_vector<T>    dA(safe_size);
         device_vector<T>    dx(safe_size);
         device_vector<T>    dy(safe_size);
-        if(!dA || !dx || !dy)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_spmv_strided_batched<T>(handle,
                                                               uplo,
@@ -224,6 +220,8 @@ void testing_spmv_strided_batched(const Arguments& arg)
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     host_vector<T> hA(size_A);
     host_vector<T> hx(size_X);
@@ -240,11 +238,9 @@ void testing_spmv_strided_batched(const Arguments& arg)
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_X);
     device_vector<T> dy(size_Y);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_spr2_strided_batched.hpp
+++ b/clients/include/testing_spr2_strided_batched.hpp
@@ -36,9 +36,9 @@ void testing_spr2_strided_batched_bad_arg()
     device_strided_batch_vector<T> dA_1(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_spr2_strided_batched<T>(handle,
                                                           rocblas_fill_full,
@@ -179,11 +179,11 @@ void testing_spr2_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_spr_strided_batched.hpp
+++ b/clients/include/testing_spr_strided_batched.hpp
@@ -33,8 +33,8 @@ void testing_spr_strided_batched_bad_arg()
     // allocate memory on device
     device_strided_batch_vector<T> dA_1(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_spr_strided_batched<T>(
@@ -73,8 +73,6 @@ void testing_spr_strided_batched(const Arguments& arg)
     // argument check before allocating invalid memory
     if(N <= 0 || !incx || batch_count <= 0)
     {
-        static constexpr size_t safe_size = 100; // arbitrarily set to 100
-
         EXPECT_ROCBLAS_STATUS(
             rocblas_spr_strided_batched<T>(
                 handle, uplo, N, nullptr, nullptr, incx, stride_x, nullptr, stride_A, batch_count),
@@ -105,10 +103,10 @@ void testing_spr_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dA_2(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_vector<T>               d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -30,11 +30,8 @@ void testing_swap_strided_batched_bad_arg(const Arguments& arg)
     // allocate memory on device
     device_vector<T> dx(safe_size);
     device_vector<T> dy(safe_size);
-    if(!dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_swap_strided_batched<T>(
                               handle, N, nullptr, incx, stridex, dy, incy, stridey, batch_count),
@@ -65,11 +62,8 @@ void testing_swap_strided_batched(const Arguments& arg)
         static const size_t safe_size = 100; //  arbitrarily set to 100
         device_vector<T>    dx(safe_size);
         device_vector<T>    dy(safe_size);
-        if(!dx || !dy)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_swap_strided_batched<T>(
                                   handle, N, dx, incx, stridex, dy, incy, stridey, batch_count),
@@ -105,11 +99,8 @@ void testing_swap_strided_batched(const Arguments& arg)
     // allocate memory on device
     device_vector<T> dx(size_x * batch_count);
     device_vector<T> dy(size_y * batch_count);
-    if(!dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     size_t dataSizeX = sizeof(T) * size_x * batch_count;
     size_t dataSizeY = sizeof(T) * size_y * batch_count;
@@ -161,7 +152,7 @@ void testing_swap_strided_batched(const Arguments& arg)
     if(arg.timing)
     {
         int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_symv_strided_batched.hpp
+++ b/clients/include/testing_symv_strided_batched.hpp
@@ -41,11 +41,9 @@ void testing_symv_strided_batched_bad_arg()
     device_vector<T>    dA(safe_size);
     device_vector<T>    dx(safe_size);
     device_vector<T>    dy(safe_size);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_symv_strided_batched<T>(nullptr,
                                                           uplo,
@@ -202,11 +200,9 @@ void testing_symv_strided_batched(const Arguments& arg)
         device_vector<T>    dA(safe_size);
         device_vector<T>    dx(safe_size);
         device_vector<T>    dy(safe_size);
-        if(!dA || !dx || !dy)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_symv_strided_batched<T>(handle,
                                                               uplo,
@@ -233,6 +229,8 @@ void testing_symv_strided_batched(const Arguments& arg)
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     host_vector<T> hA(size_A);
     host_vector<T> hx(size_X);
@@ -249,11 +247,9 @@ void testing_symv_strided_batched(const Arguments& arg)
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_X);
     device_vector<T> dy(size_Y);
-    if(!dA || !dx || !dy)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_syr2_strided_batched.hpp
+++ b/clients/include/testing_syr2_strided_batched.hpp
@@ -39,9 +39,9 @@ void testing_syr2_strided_batched_bad_arg()
     device_strided_batch_vector<T> dA_1(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_syr2_strided_batched<T>(handle,
                                                           rocblas_fill_full,
@@ -159,27 +159,17 @@ void testing_syr2_strided_batched(const Arguments& arg)
     // argument check before allocating invalid memory
     if(N <= 0 || lda < N || lda < 1 || !incx || !incy || batch_count <= 0)
     {
-        static constexpr size_t safe_size = 100; // arbitrarily set to 100
-
-        device_strided_batch_vector<T> dA_1(safe_size, 1, safe_size, 1);
-        device_strided_batch_vector<T> dx(safe_size, 1, safe_size, 1);
-        device_strided_batch_vector<T> dy(safe_size, 1, safe_size, 1);
-
-        CHECK_HIP_ERROR(dA_1.memcheck());
-        CHECK_HIP_ERROR(dx.memcheck());
-        CHECK_HIP_ERROR(dy.memcheck());
-
         EXPECT_ROCBLAS_STATUS(rocblas_syr2_strided_batched<T>(handle,
                                                               uplo,
                                                               N,
                                                               &h_alpha,
-                                                              dx,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
-                                                              dy,
+                                                              nullptr,
                                                               incy,
                                                               stride_y,
-                                                              dA_1,
+                                                              nullptr,
                                                               lda,
                                                               stride_A,
                                                               batch_count),
@@ -206,11 +196,11 @@ void testing_syr2_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_syr_strided_batched.hpp
+++ b/clients/include/testing_syr_strided_batched.hpp
@@ -36,11 +36,8 @@ void testing_syr_strided_batched_bad_arg()
     // allocate memory on device
     device_vector<T> dA_1(size_A);
     device_vector<T> dx(size_x);
-    if(!dA_1 || !dx)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_syr_strided_batched<T>(
@@ -75,21 +72,20 @@ void testing_syr_strided_batched(const Arguments& arg)
     // argument check before allocating invalid memory
     if(N <= 0 || lda < N || lda < 1 || !incx || batch_count <= 0)
     {
-        static constexpr size_t safe_size = 100; // arbitrarily set to 100
-
-        device_vector<T> dA_1(safe_size);
-        device_vector<T> dx(safe_size);
-        if(!dA_1 || !dx)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
-        EXPECT_ROCBLAS_STATUS(
-            rocblas_syr_strided_batched<T>(
-                handle, uplo, N, &h_alpha, dx, incx, stridex, dA_1, lda, strideA, batch_count),
-            N < 0 || lda < N || lda < 1 || !incx || batch_count < 0 ? rocblas_status_invalid_size
-                                                                    : rocblas_status_success);
+        EXPECT_ROCBLAS_STATUS(rocblas_syr_strided_batched<T>(handle,
+                                                             uplo,
+                                                             N,
+                                                             &h_alpha,
+                                                             nullptr,
+                                                             incx,
+                                                             stridex,
+                                                             nullptr,
+                                                             lda,
+                                                             strideA,
+                                                             batch_count),
+                              N < 0 || lda < N || lda < 1 || !incx || batch_count < 0
+                                  ? rocblas_status_invalid_size
+                                  : rocblas_status_success);
         return;
     }
 
@@ -115,11 +111,10 @@ void testing_syr_strided_batched(const Arguments& arg)
     device_vector<T> dA_2(size_A);
     device_vector<T> dx(size_x);
     device_vector<T> d_alpha(1);
-    if(!dA_1 || !dA_2 || !dx || !d_alpha)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_tbmv_strided_batched.hpp
+++ b/clients/include/testing_tbmv_strided_batched.hpp
@@ -40,11 +40,8 @@ void testing_tbmv_strided_batched_bad_arg(const Arguments& arg)
     // allocate memory on device
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_x);
-    if(!dA || !dx)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_tbmv_strided_batched<T>(handle,
                                                           uplo,
@@ -108,15 +105,6 @@ void testing_tbmv_strided_batched(const Arguments& arg)
     // argument sanity check before allocating invalid memory
     if(M < 0 || K < 0 || lda < M || lda < 1 || !incx || K >= lda || batch_count <= 0)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dA1(safe_size);
-        device_vector<T>    dx1(safe_size);
-        if(!dA1 || !dx1)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
         EXPECT_ROCBLAS_STATUS(
             rocblas_tbmv_strided_batched<T>(handle,
                                             uplo,
@@ -124,10 +112,10 @@ void testing_tbmv_strided_batched(const Arguments& arg)
                                             diag,
                                             M,
                                             K,
-                                            dA1,
+                                            nullptr,
                                             lda,
                                             stride_A,
-                                            dx1,
+                                            nullptr,
                                             incx,
                                             stride_x,
                                             batch_count),
@@ -150,11 +138,8 @@ void testing_tbmv_strided_batched(const Arguments& arg)
 
     device_vector<T> dA(size_A);
     device_vector<T> dx(size_x);
-    if((!dA && size_A) || (!dx && size_x))
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_tpmv_strided_batched.hpp
+++ b/clients/include/testing_tpmv_strided_batched.hpp
@@ -33,16 +33,16 @@ void testing_tpmv_strided_batched_bad_arg(const Arguments& arg)
     size_t size_A = (M * (M + 1)) / 2;
 
     host_strided_batch_vector<T> hA(size_A, 1, stride_a, batch_count);
-    CHECK_HIP_ERROR(hA.memcheck());
+    CHECK_DEVICE_ALLOCATION(hA.memcheck());
 
     host_strided_batch_vector<T> hx(M, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(hx.memcheck());
+    CHECK_DEVICE_ALLOCATION(hx.memcheck());
 
     device_strided_batch_vector<T> dA(size_A, 1, stride_a, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
     device_strided_batch_vector<T> dx(M, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     //
     // Checks.
@@ -80,15 +80,18 @@ void testing_tpmv_strided_batched(const Arguments& arg)
     // argument sanity check before allocating invalid memory
     if(M < 0 || !incx || batch_count < 0)
     {
-        device_strided_batch_vector<T> dA1(10, 1, 10, 2);
-        CHECK_HIP_ERROR(dA1.memcheck());
-        device_strided_batch_vector<T> dx1(10, 1, 10, 2);
-        CHECK_HIP_ERROR(dx1.memcheck());
-
-        EXPECT_ROCBLAS_STATUS(
-            rocblas_tpmv_strided_batched<T>(
-                handle, uplo, transA, diag, M, dA1, stride_a, dx1, incx, stride_x, batch_count),
-            rocblas_status_invalid_size);
+        EXPECT_ROCBLAS_STATUS(rocblas_tpmv_strided_batched<T>(handle,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              M,
+                                                              nullptr,
+                                                              stride_a,
+                                                              nullptr,
+                                                              incx,
+                                                              stride_x,
+                                                              batch_count),
+                              rocblas_status_invalid_size);
 
         return;
     }
@@ -123,10 +126,10 @@ void testing_tpmv_strided_batched(const Arguments& arg)
     CHECK_HIP_ERROR(hres.memcheck());
 
     device_strided_batch_vector<T> dA(size_A, 1, stride_a, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
     device_strided_batch_vector<T> dx(M, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     //
     // Initialize.

--- a/clients/include/testing_trmv_strided_batched.hpp
+++ b/clients/include/testing_trmv_strided_batched.hpp
@@ -35,16 +35,16 @@ void testing_trmv_strided_batched_bad_arg(const Arguments& arg)
     size_t size_A = lda * size_t(M);
 
     host_strided_batch_vector<T> hA(size_A, 1, stride_a, batch_count);
-    CHECK_HIP_ERROR(hA.memcheck());
+    CHECK_DEVICE_ALLOCATION(hA.memcheck());
 
     host_strided_batch_vector<T> hx(M, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(hx.memcheck());
+    CHECK_DEVICE_ALLOCATION(hx.memcheck());
 
     device_strided_batch_vector<T> dA(size_A, 1, stride_a, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
     device_strided_batch_vector<T> dx(M, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     //
     // Checks.
@@ -82,20 +82,15 @@ void testing_trmv_strided_batched(const Arguments& arg)
     // argument sanity check before allocating invalid memory
     if(M < 0 || lda < M || lda < 1 || !incx || batch_count < 0)
     {
-        device_strided_batch_vector<T> dA1(10, 1, 10, 2);
-        CHECK_HIP_ERROR(dA1.memcheck());
-        device_strided_batch_vector<T> dx1(10, 1, 10, 2);
-        CHECK_HIP_ERROR(dx1.memcheck());
-
         EXPECT_ROCBLAS_STATUS(rocblas_trmv_strided_batched<T>(handle,
                                                               uplo,
                                                               transA,
                                                               diag,
                                                               M,
-                                                              dA1,
+                                                              nullptr,
                                                               lda,
                                                               stride_a,
-                                                              dx1,
+                                                              nullptr,
                                                               incx,
                                                               stride_x,
                                                               batch_count),
@@ -135,10 +130,10 @@ void testing_trmv_strided_batched(const Arguments& arg)
     CHECK_HIP_ERROR(hres.memcheck());
 
     device_strided_batch_vector<T> dA(size_A, 1, stride_a, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
     device_strided_batch_vector<T> dx(M, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     //
     // Initialize.

--- a/clients/include/testing_trsm_strided_batched.hpp
+++ b/clients/include/testing_trsm_strided_batched.hpp
@@ -49,6 +49,12 @@ void testing_trsm_strided_batched(const Arguments& arg)
     // check here to prevent undefined memory allocation error
     if(M < 0 || N < 0 || lda < K || ldb < M || batch_count <= 0)
     {
+        static const size_t safe_size = 100; // arbitrarily set to 100
+        device_vector<T>    dA(safe_size);
+        device_vector<T>    dXorB(safe_size);
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dXorB.memcheck());
+
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         rocblas_status status = rocblas_trsm_strided_batched<T>(handle,
                                                                 side,
@@ -58,10 +64,10 @@ void testing_trsm_strided_batched(const Arguments& arg)
                                                                 M,
                                                                 N,
                                                                 &alpha_h,
-                                                                nullptr,
+                                                                dA,
                                                                 lda,
                                                                 stride_a,
-                                                                nullptr,
+                                                                dXorB,
                                                                 ldb,
                                                                 stride_b,
                                                                 batch_count);

--- a/clients/include/testing_trsm_strided_batched_ex.hpp
+++ b/clients/include/testing_trsm_strided_batched_ex.hpp
@@ -56,11 +56,9 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
         device_vector<T>    dA(safe_size);
         device_vector<T>    dXorB(safe_size);
         device_vector<T>    dinvA(safe_size);
-        if(!dA || !dXorB)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dXorB.memcheck());
+        CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         rocblas_status status = rocblas_trsm_strided_batched_ex(handle,
@@ -111,12 +109,10 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
     device_vector<T> dXorB(size_B);
     device_vector<T> alpha_d(1);
     device_vector<T> dinvA(size_invA);
-
-    if(!dA || !dXorB || !alpha_d || !dinvA)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dXorB.memcheck());
+    CHECK_DEVICE_ALLOCATION(alpha_d.memcheck());
+    CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
     //  Random lower triangular matrices have condition number
     //  that grows exponentially with matrix size. Random full

--- a/clients/include/testing_trsv_strided_batched.hpp
+++ b/clients/include/testing_trsv_strided_batched.hpp
@@ -44,12 +44,8 @@ void testing_trsv_strided_batched(const Arguments& arg)
         static const size_t safe_size = 100; // arbitrarily set to 100
         device_vector<T>    dx_or_b(safe_size);
         device_vector<T>    dA(safe_size);
-
-        if(!dA || !dx_or_b)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         if(batch_count == 0)
@@ -105,6 +101,8 @@ void testing_trsv_strided_batched(const Arguments& arg)
     // allocate memory on device
     device_vector<T> dA(size_A);
     device_vector<T> dx_or_b(size_x);
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
     rocblas_init<T>(hA, M, M, lda, stride_a, batch_count);
 

--- a/clients/include/testing_trtri_strided_batched.hpp
+++ b/clients/include/testing_trtri_strided_batched.hpp
@@ -38,18 +38,9 @@ void testing_trtri_strided_batched(const Arguments& arg)
     // memory
     if(N <= 0 || lda < 0 || lda < N || batch_count <= 0)
     {
-        static constexpr size_t safe_size = 100;
-        device_vector<T>        dA(safe_size);
-        device_vector<T>        dinvA(safe_size);
-        if(!dA || !dinvA)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
-
         EXPECT_ROCBLAS_STATUS(
             rocblas_trtri_strided_batched<T>(
-                handle, uplo, diag, N, dA, lda, stride_a, dinvA, lda, stride_a, batch_count),
+                handle, uplo, diag, N, nullptr, lda, stride_a, nullptr, lda, stride_a, batch_count),
             N < 0 || lda < 0 || lda < N || batch_count < 0 ? rocblas_status_invalid_size
                                                            : rocblas_status_success);
         return;
@@ -101,11 +92,8 @@ void testing_trtri_strided_batched(const Arguments& arg)
 
     device_vector<T> dA(size_A);
     device_vector<T> dinvA(size_A);
-    if(!dA || !dinvA)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
     // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * size_A, hipMemcpyHostToDevice));

--- a/clients/include/testing_trtri_strided_batched.hpp
+++ b/clients/include/testing_trtri_strided_batched.hpp
@@ -38,9 +38,15 @@ void testing_trtri_strided_batched(const Arguments& arg)
     // memory
     if(N <= 0 || lda < 0 || lda < N || batch_count <= 0)
     {
+        static constexpr size_t safe_size = 100;
+        device_vector<T>        dA(safe_size);
+        device_vector<T>        dinvA(safe_size);
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
+
         EXPECT_ROCBLAS_STATUS(
             rocblas_trtri_strided_batched<T>(
-                handle, uplo, diag, N, nullptr, lda, stride_a, nullptr, lda, stride_a, batch_count),
+                handle, uplo, diag, N, dA, lda, stride_a, dinvA, lda, stride_a, batch_count),
             N < 0 || lda < 0 || lda < N || batch_count < 0 ? rocblas_status_invalid_size
                                                            : rocblas_status_success);
         return;


### PR DESCRIPTION
- Updating strided_batched tests to use `CHECK_DEVICE_ALLOCATION()` over `CHECK_HIP_ERROR()` when allocating memory on device.
- Updated some L2 and L3 strided_batched tests to pass in nullptrs when quick returning or returning invalid_value
- Updated some tests to use arg.iters for rocblas-bench.

Haven't locally tested the nullptr tests so will definitely wait for CI to pass.