### PR TITLE
Make Google Tests print type symbolically instead of numerically

### DIFF
--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -256,6 +256,12 @@ private:
         str << std::quoted(s);
     }
 
+    // rocblas_datatype output
+    static void print_value(std::ostream& os, const rocblas_datatype& d)
+    {
+        os << rocblas_datatype2string(d);
+    }
+
     // Function to print Arguments out to stream in YAML format
     // Google Tests uses this automatically to dump parameters
     friend std::ostream& operator<<(std::ostream& str, const Arguments& arg)

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -92,6 +92,12 @@ protected:
         print_value(os, s.c_str());
     }
 
+    // rocblas_datatype
+    static void print_value(std::ostream& os, const rocblas_datatype& d)
+    {
+        os << rocblas_datatype_string(d);
+    }
+
     /************************************************************************************
      * Print tuples
      ************************************************************************************/


### PR DESCRIPTION
Make Google tests print types as symbolic names instead of numbers.

This is a short-term fix.

PR #922 will incorporate this into its system, where all formatted IO is done in one place instead of scattered around.