### PR TITLE
Change CMake target hip::hip_hcc to hip::device

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -128,8 +128,6 @@ else()
     endif()
 endif()
 
-get_target_property( HIPHCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-
 if( CUDA_FOUND )
   target_include_directories( rocblas-bench
     PRIVATE
@@ -141,7 +139,7 @@ if( CUDA_FOUND )
 else( )
   # auto set in hip_common.h
   #target_compile_definitions( rocblas-bench PRIVATE __HIP_PLATFORM_HCC__ )
-  target_link_libraries( rocblas-bench PRIVATE ${HIPHCC_LOCATION} )
+  target_link_libraries( rocblas-bench PRIVATE hip::device )
 endif( )
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -198,8 +198,6 @@ else()
     endif()
 endif()
 
-get_target_property( HIPHCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-
 if( CUDA_FOUND )
   target_include_directories( rocblas-test
     PRIVATE
@@ -211,7 +209,7 @@ if( CUDA_FOUND )
 else( )
   # auto set in hip_common.h
   #target_compile_definitions( rocblas-test PRIVATE __HIP_PLATFORM_HCC__ )
-  target_link_libraries( rocblas-test PRIVATE ${HIPHCC_LOCATION})
+  target_link_libraries( rocblas-test PRIVATE hip::device )
 endif( )
 
 set( ROCBLAS_TEST_DATA "${PROJECT_BINARY_DIR}/staging/rocblas_gtest.data")

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Copyright 2016-2020 Advanced Micro Devices, Inc.
 # ########################################################################
 
-get_target_property( HIPHCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-
 set( rocblas_samples_common ../common/utility.cpp )
 
 set( THREADS_PREFER_PTHREAD_FLAG ON )
@@ -54,7 +52,7 @@ foreach( exe ${sample_list} )
 
     # auto set in hip_common.h
     #target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
-    target_link_libraries( ${exe} PRIVATE ${HIPHCC_LOCATION} )
+    target_link_libraries( ${exe} PRIVATE hip::device )
   endif( )
 
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )


### PR DESCRIPTION
hip::device is supported by both hip_hcc and hip_vdi, so switching to this new cmake target should fix issues on HIP-Clang CI when building tests.
https://github.com/ROCm-Developer-Tools/HIP/blob/master/CMakeLists.txt#L351 