### PR TITLE
Add flag to install version-specific rocm-dev

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ rocBLAS build & installation helper script
       -r | --no-tensile-host   Do not build with Tensile host
       -u | --use-tag-only      Ignore Tensile version and just use the Tensile tag
            --skipldconf        Skip ld.so.conf entry
-      -v | --rocm-dev           Set specific rocm-dev version
+      -v | --rocm-dev          Set specific rocm-dev version
 EOF
 #          --prefix            Specify an alternate CMAKE_INSTALL_PREFIX for cmake
 #          --cuda              Build library for cuda backend


### PR DESCRIPTION
Cherry pick of PR #1040. Had to fix merge conflict, so it doesn't appear as a cherry-pick. This needs to be in the master-rocm-3.2 branch as the point release packages will be available starting in rocm 3.2