### PR TITLE
Skip tests when cannot allocate enough memory.

### DIFF
--- a/clients/include/rocblas_test.hpp
+++ b/clients/include/rocblas_test.hpp
@@ -26,25 +26,25 @@
 #define CHECK_HIP_ERROR2(ERROR) ASSERT_EQ(ERROR, hipSuccess)
 #define CHECK_HIP_ERROR(ERROR) CHECK_HIP_ERROR2(ERROR)
 
-#define CHECK_DEVICE_ALLOCATION(ERROR)            \
-    do                                            \
-    {                                             \
-        auto error = ERROR;                       \
-        if(error == hipErrorMemoryAllocation)     \
-        {                                         \
-            SUCCEED() << LIMITED_MEMORY_STRING;   \
-            return;                               \
-        }                                         \
-        else if(error != hipSuccess)              \
-        {                                         \
-            fprintf(stderr,                       \
-                    "error: '%s'(%d) at %s:%d\n", \
-                    hipGetErrorString(error),     \
-                    error,                        \
-                    __FILE__,                     \
-                    __LINE__);                    \
-            exit(EXIT_FAILURE);                   \
-        }                                         \
+#define CHECK_DEVICE_ALLOCATION(ERROR)                                        \
+    do                                                                        \
+    {                                                                         \
+        auto error = ERROR;                                                   \
+        if(error == hipErrorMemoryAllocation || error == hipErrorOutOfMemory) \
+        {                                                                     \
+            SUCCEED() << LIMITED_MEMORY_STRING;                               \
+            return;                                                           \
+        }                                                                     \
+        else if(error != hipSuccess)                                          \
+        {                                                                     \
+            fprintf(stderr,                                                   \
+                    "error: '%s'(%d) at %s:%d\n",                             \
+                    hipGetErrorString(error),                                 \
+                    error,                                                    \
+                    __FILE__,                                                 \
+                    __LINE__);                                                \
+            return;                                                           \
+        }                                                                     \
     } while(0)
 
 #define EXPECT_ROCBLAS_STATUS ASSERT_EQ


### PR DESCRIPTION
From @zaliu:

For nightly, I got through the tests on this puny 8GB VRAM Vega 10, with only 2 skipped:
```
[----------] Global test environment tear-down
[==========] 514269 tests from 140 test cases ran. (27237522 ms total)
[  PASSED  ] 514269 tests.
[ SKIPPED  ] 2 tests.
rocBLAS version: 2.17.0.1990-4b4fbc51
```
Nice job!
