### PR TITLE
take hot and cold iters from arg

### DIFF
--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -121,8 +121,8 @@ void testing_asum(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -141,8 +141,8 @@ void testing_asum_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -139,8 +139,8 @@ void testing_asum_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -144,8 +144,8 @@ void testing_axpy(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_axpy_batched.hpp
+++ b/clients/include/testing_axpy_batched.hpp
@@ -205,8 +205,8 @@ void testing_axpy_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         //

--- a/clients/include/testing_axpy_strided_batched.hpp
+++ b/clients/include/testing_axpy_strided_batched.hpp
@@ -207,8 +207,8 @@ void testing_axpy_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         //

--- a/clients/include/testing_copy.hpp
+++ b/clients/include/testing_copy.hpp
@@ -112,8 +112,8 @@ void testing_copy(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -122,8 +122,8 @@ void testing_copy_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -131,8 +131,8 @@ void testing_copy_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)
         {

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -157,7 +157,7 @@ void testing_dot(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -219,7 +219,7 @@ void testing_dot_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -232,7 +232,7 @@ void testing_dot_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_gbmv.hpp
+++ b/clients/include/testing_gbmv.hpp
@@ -242,7 +242,7 @@ void testing_gbmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_gbmv_batched.hpp
+++ b/clients/include/testing_gbmv_batched.hpp
@@ -348,7 +348,7 @@ void testing_gbmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_gbmv_strided_batched.hpp
+++ b/clients/include/testing_gbmv_strided_batched.hpp
@@ -390,7 +390,7 @@ void testing_gbmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_geam.hpp
+++ b/clients/include/testing_geam.hpp
@@ -363,8 +363,8 @@ void testing_geam(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 10;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -231,7 +231,7 @@ void testing_gemv(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_gemv_batched.hpp
+++ b/clients/include/testing_gemv_batched.hpp
@@ -303,8 +303,8 @@ void testing_gemv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_gemv_strided_batched.hpp
+++ b/clients/include/testing_gemv_strided_batched.hpp
@@ -378,8 +378,8 @@ void testing_gemv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -178,7 +178,7 @@ void testing_ger(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_ger_batched.hpp
+++ b/clients/include/testing_ger_batched.hpp
@@ -228,7 +228,7 @@ void testing_ger_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -285,7 +285,7 @@ void testing_ger_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hbmv.hpp
+++ b/clients/include/testing_hbmv.hpp
@@ -193,7 +193,7 @@ void testing_hbmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hbmv_batched.hpp
+++ b/clients/include/testing_hbmv_batched.hpp
@@ -304,7 +304,7 @@ void testing_hbmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hbmv_strided_batched.hpp
+++ b/clients/include/testing_hbmv_strided_batched.hpp
@@ -351,7 +351,7 @@ void testing_hbmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hemv.hpp
+++ b/clients/include/testing_hemv.hpp
@@ -191,7 +191,7 @@ void testing_hemv(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hemv_batched.hpp
+++ b/clients/include/testing_hemv_batched.hpp
@@ -303,7 +303,7 @@ void testing_hemv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hemv_strided_batched.hpp
+++ b/clients/include/testing_hemv_strided_batched.hpp
@@ -346,7 +346,7 @@ void testing_hemv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_her.hpp
+++ b/clients/include/testing_her.hpp
@@ -150,7 +150,7 @@ void testing_her(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_her2.hpp
+++ b/clients/include/testing_her2.hpp
@@ -175,7 +175,7 @@ void testing_her2(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_her2_batched.hpp
+++ b/clients/include/testing_her2_batched.hpp
@@ -200,7 +200,7 @@ void testing_her2_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_her2_strided_batched.hpp
+++ b/clients/include/testing_her2_strided_batched.hpp
@@ -279,7 +279,7 @@ void testing_her2_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_her2k.hpp
+++ b/clients/include/testing_her2k.hpp
@@ -258,7 +258,7 @@ void testing_her2k(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_her2k_batched.hpp
+++ b/clients/include/testing_her2k_batched.hpp
@@ -329,7 +329,7 @@ void testing_her2k_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_her2k_strided_batched.hpp
+++ b/clients/include/testing_her2k_strided_batched.hpp
@@ -445,7 +445,7 @@ void testing_her2k_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_her_batched.hpp
+++ b/clients/include/testing_her_batched.hpp
@@ -170,7 +170,7 @@ void testing_her_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_her_strided_batched.hpp
+++ b/clients/include/testing_her_strided_batched.hpp
@@ -187,7 +187,7 @@ void testing_her_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_herk.hpp
+++ b/clients/include/testing_herk.hpp
@@ -201,7 +201,7 @@ void testing_herk(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_herk_batched.hpp
+++ b/clients/include/testing_herk_batched.hpp
@@ -278,7 +278,7 @@ void testing_herk_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_herk_strided_batched.hpp
+++ b/clients/include/testing_herk_strided_batched.hpp
@@ -364,7 +364,7 @@ void testing_herk_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_hpmv.hpp
+++ b/clients/include/testing_hpmv.hpp
@@ -186,7 +186,7 @@ void testing_hpmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpmv_batched.hpp
+++ b/clients/include/testing_hpmv_batched.hpp
@@ -284,7 +284,7 @@ void testing_hpmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpmv_strided_batched.hpp
+++ b/clients/include/testing_hpmv_strided_batched.hpp
@@ -337,7 +337,7 @@ void testing_hpmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpr.hpp
+++ b/clients/include/testing_hpr.hpp
@@ -148,7 +148,7 @@ void testing_hpr(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpr2.hpp
+++ b/clients/include/testing_hpr2.hpp
@@ -167,7 +167,7 @@ void testing_hpr2(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpr2_batched.hpp
+++ b/clients/include/testing_hpr2_batched.hpp
@@ -188,7 +188,7 @@ void testing_hpr2_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpr2_strided_batched.hpp
+++ b/clients/include/testing_hpr2_strided_batched.hpp
@@ -269,7 +269,7 @@ void testing_hpr2_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpr_batched.hpp
+++ b/clients/include/testing_hpr_batched.hpp
@@ -159,7 +159,7 @@ void testing_hpr_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_hpr_strided_batched.hpp
+++ b/clients/include/testing_hpr_strided_batched.hpp
@@ -168,7 +168,7 @@ void testing_hpr_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -129,8 +129,8 @@ void testing_iamax_iamin(const Arguments& arg, rocblas_iamax_iamin_t<T> func)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -133,8 +133,8 @@ void testing_nrm2(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -143,7 +143,7 @@ void testing_nrm2_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -147,8 +147,8 @@ void testing_nrm2_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_reduction_batched.hpp
+++ b/clients/include/testing_reduction_batched.hpp
@@ -150,8 +150,8 @@ void template_testing_reduction_batched(
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_reduction_strided_batched.hpp
+++ b/clients/include/testing_reduction_strided_batched.hpp
@@ -168,8 +168,8 @@ void template_testing_reduction_strided_batched(
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -164,8 +164,8 @@ void testing_rot(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -237,7 +237,7 @@ void testing_rot_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         CHECK_HIP_ERROR(dx.transfer_from(hx));

--- a/clients/include/testing_rot_strided_batched.hpp
+++ b/clients/include/testing_rot_strided_batched.hpp
@@ -201,8 +201,8 @@ void testing_rot_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));

--- a/clients/include/testing_rotg.hpp
+++ b/clients/include/testing_rotg.hpp
@@ -142,7 +142,7 @@ void testing_rotg(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -211,7 +211,7 @@ void testing_rotg_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         // Device mode will be much quicker
         // (TODO: or is there another reason we are typically using host_mode for timing?)

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -204,7 +204,7 @@ void testing_rotg_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         // Device mode will be quicker
         // (TODO: or is there another reason we are typically using host_mode for timing?)

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -153,8 +153,8 @@ void testing_rotm(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));

--- a/clients/include/testing_rotm_batched.hpp
+++ b/clients/include/testing_rotm_batched.hpp
@@ -236,7 +236,7 @@ void testing_rotm_batched(const Arguments& arg)
 
         if(arg.timing)
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             int number_hot_calls  = arg.iters;
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
             CHECK_HIP_ERROR(dx.transfer_from(hx));

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -227,7 +227,7 @@ void testing_rotm_strided_batched(const Arguments& arg)
 
         if(arg.timing)
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             int number_hot_calls  = arg.iters;
             CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
             CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));

--- a/clients/include/testing_rotmg.hpp
+++ b/clients/include/testing_rotmg.hpp
@@ -102,7 +102,7 @@ void testing_rotmg(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_rotmg_batched.hpp
+++ b/clients/include/testing_rotmg_batched.hpp
@@ -254,7 +254,7 @@ void testing_rotmg_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -262,7 +262,7 @@ void testing_rotmg_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));

--- a/clients/include/testing_sbmv.hpp
+++ b/clients/include/testing_sbmv.hpp
@@ -203,7 +203,7 @@ void testing_sbmv(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_sbmv_batched.hpp
+++ b/clients/include/testing_sbmv_batched.hpp
@@ -321,7 +321,7 @@ void testing_sbmv_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_sbmv_strided_batched.hpp
+++ b/clients/include/testing_sbmv_strided_batched.hpp
@@ -376,7 +376,7 @@ void testing_sbmv_strided_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -131,7 +131,7 @@ void testing_scal(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -119,8 +119,8 @@ void testing_scal_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -122,7 +122,7 @@ void testing_scal_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_set_get_matrix.hpp
+++ b/clients/include/testing_set_get_matrix.hpp
@@ -96,7 +96,7 @@ void testing_set_get_matrix(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_timing_iterations = 1;
+        int number_timing_iterations = arg.iters;
         gpu_time_used                = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_timing_iterations; iter++)

--- a/clients/include/testing_set_get_matrix_async.hpp
+++ b/clients/include/testing_set_get_matrix_async.hpp
@@ -106,7 +106,7 @@ void testing_set_get_matrix_async(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_timing_iterations = 10;
+        int number_timing_iterations = arg.iters;
         gpu_time_used                = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_timing_iterations; iter++)

--- a/clients/include/testing_set_get_vector.hpp
+++ b/clients/include/testing_set_get_vector.hpp
@@ -96,7 +96,7 @@ void testing_set_get_vector(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_timing_iterations = 1;
+        int number_timing_iterations = arg.iters;
         gpu_time_used                = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_timing_iterations; iter++)

--- a/clients/include/testing_set_get_vector_async.hpp
+++ b/clients/include/testing_set_get_vector_async.hpp
@@ -102,7 +102,7 @@ void testing_set_get_vector_async(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_timing_iterations = 10;
+        int number_timing_iterations = arg.iters;
         gpu_time_used                = get_time_us(); // in microseconds
 
         for(int iter = 0; iter < number_timing_iterations; iter++)

--- a/clients/include/testing_spmv.hpp
+++ b/clients/include/testing_spmv.hpp
@@ -199,7 +199,7 @@ void testing_spmv(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_spmv_batched.hpp
+++ b/clients/include/testing_spmv_batched.hpp
@@ -292,7 +292,7 @@ void testing_spmv_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_spmv_strided_batched.hpp
+++ b/clients/include/testing_spmv_strided_batched.hpp
@@ -350,7 +350,7 @@ void testing_spmv_strided_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_spr.hpp
+++ b/clients/include/testing_spr.hpp
@@ -156,7 +156,7 @@ void testing_spr(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_spr2.hpp
+++ b/clients/include/testing_spr2.hpp
@@ -165,7 +165,7 @@ void testing_spr2(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_spr2_batched.hpp
+++ b/clients/include/testing_spr2_batched.hpp
@@ -183,7 +183,7 @@ void testing_spr2_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_spr2_strided_batched.hpp
+++ b/clients/include/testing_spr2_strided_batched.hpp
@@ -267,7 +267,7 @@ void testing_spr2_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_spr_batched.hpp
+++ b/clients/include/testing_spr_batched.hpp
@@ -167,7 +167,7 @@ void testing_spr_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_spr_strided_batched.hpp
+++ b/clients/include/testing_spr_strided_batched.hpp
@@ -176,7 +176,7 @@ void testing_spr_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -125,8 +125,8 @@ void testing_swap(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -137,8 +137,8 @@ void testing_swap_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = 100;
+        int number_cold_calls = arg.cold_iters;
+        int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -151,7 +151,7 @@ void testing_swap_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_symv.hpp
+++ b/clients/include/testing_symv.hpp
@@ -209,7 +209,7 @@ void testing_symv(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_symv_batched.hpp
+++ b/clients/include/testing_symv_batched.hpp
@@ -324,7 +324,7 @@ void testing_symv_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_symv_strided_batched.hpp
+++ b/clients/include/testing_symv_strided_batched.hpp
@@ -371,7 +371,7 @@ void testing_symv_strided_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_syr.hpp
+++ b/clients/include/testing_syr.hpp
@@ -154,7 +154,7 @@ void testing_syr(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_syr2.hpp
+++ b/clients/include/testing_syr2.hpp
@@ -169,7 +169,7 @@ void testing_syr2(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_syr2_batched.hpp
+++ b/clients/include/testing_syr2_batched.hpp
@@ -196,7 +196,7 @@ void testing_syr2_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_syr2_strided_batched.hpp
+++ b/clients/include/testing_syr2_strided_batched.hpp
@@ -296,7 +296,7 @@ void testing_syr2_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_syr2k.hpp
+++ b/clients/include/testing_syr2k.hpp
@@ -275,7 +275,7 @@ void testing_syr2k(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_syr2k_batched.hpp
+++ b/clients/include/testing_syr2k_batched.hpp
@@ -339,7 +339,7 @@ void testing_syr2k_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_syr2k_strided_batched.hpp
+++ b/clients/include/testing_syr2k_strided_batched.hpp
@@ -461,7 +461,7 @@ void testing_syr2k_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_syr_batched.hpp
+++ b/clients/include/testing_syr_batched.hpp
@@ -187,7 +187,7 @@ void testing_syr_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_syr_strided_batched.hpp
+++ b/clients/include/testing_syr_strided_batched.hpp
@@ -201,7 +201,7 @@ void testing_syr_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 

--- a/clients/include/testing_syrk.hpp
+++ b/clients/include/testing_syrk.hpp
@@ -217,7 +217,7 @@ void testing_syrk(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_syrk_batched.hpp
+++ b/clients/include/testing_syrk_batched.hpp
@@ -259,7 +259,7 @@ void testing_syrk_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_syrk_strided_batched.hpp
+++ b/clients/include/testing_syrk_strided_batched.hpp
@@ -362,7 +362,7 @@ void testing_syrk_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));

--- a/clients/include/testing_tbmv.hpp
+++ b/clients/include/testing_tbmv.hpp
@@ -140,7 +140,7 @@ void testing_tbmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_tbmv_batched.hpp
+++ b/clients/include/testing_tbmv_batched.hpp
@@ -191,7 +191,7 @@ void testing_tbmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_tbmv_strided_batched.hpp
+++ b/clients/include/testing_tbmv_strided_batched.hpp
@@ -193,7 +193,7 @@ void testing_tbmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int iter = 0; iter < number_cold_calls; iter++)

--- a/clients/include/testing_tpmv.hpp
+++ b/clients/include/testing_tpmv.hpp
@@ -160,7 +160,7 @@ void testing_tpmv(const Arguments& arg)
         // Warmup
         //
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             for(int iter = 0; iter < number_cold_calls; iter++)
             {
                 rocblas_tpmv<T>(handle, uplo, transA, diag, M, dA, dx, incx);

--- a/clients/include/testing_tpmv_batched.hpp
+++ b/clients/include/testing_tpmv_batched.hpp
@@ -195,7 +195,7 @@ void testing_tpmv_batched(const Arguments& arg)
         // Warmup
         //
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             for(int iter = 0; iter < number_cold_calls; iter++)
             {
                 rocblas_tpmv_batched<T>(

--- a/clients/include/testing_tpmv_strided_batched.hpp
+++ b/clients/include/testing_tpmv_strided_batched.hpp
@@ -197,7 +197,7 @@ void testing_tpmv_strided_batched(const Arguments& arg)
         // Warmup
         //
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             for(int iter = 0; iter < number_cold_calls; iter++)
             {
                 rocblas_tpmv_strided_batched<T>(

--- a/clients/include/testing_trmv.hpp
+++ b/clients/include/testing_trmv.hpp
@@ -162,7 +162,7 @@ void testing_trmv(const Arguments& arg)
         // Warmup
         //
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             for(int iter = 0; iter < number_cold_calls; iter++)
             {
                 rocblas_trmv<T>(handle, uplo, transA, diag, M, dA, lda, dx, incx);

--- a/clients/include/testing_trmv_batched.hpp
+++ b/clients/include/testing_trmv_batched.hpp
@@ -201,7 +201,7 @@ void testing_trmv_batched(const Arguments& arg)
         // Warmup
         //
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             for(int iter = 0; iter < number_cold_calls; iter++)
             {
                 rocblas_trmv_batched<T>(handle,

--- a/clients/include/testing_trmv_strided_batched.hpp
+++ b/clients/include/testing_trmv_strided_batched.hpp
@@ -201,7 +201,7 @@ void testing_trmv_strided_batched(const Arguments& arg)
         // Warmup
         //
         {
-            int number_cold_calls = 2;
+            int number_cold_calls = arg.cold_iters;
             for(int iter = 0; iter < number_cold_calls; iter++)
             {
                 rocblas_trmv_strided_batched<T>(handle,

--- a/clients/include/testing_trsm.hpp
+++ b/clients/include/testing_trsm.hpp
@@ -219,7 +219,7 @@ void testing_trsm(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         // GPU rocBLAS

--- a/clients/include/testing_trsv.hpp
+++ b/clients/include/testing_trsv.hpp
@@ -187,7 +187,7 @@ void testing_trsv(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int i = 0; i < number_cold_calls; i++)

--- a/clients/include/testing_trsv_batched.hpp
+++ b/clients/include/testing_trsv_batched.hpp
@@ -247,7 +247,7 @@ void testing_trsv_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int i = 0; i < number_cold_calls; i++)

--- a/clients/include/testing_trsv_strided_batched.hpp
+++ b/clients/include/testing_trsv_strided_batched.hpp
@@ -263,7 +263,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
-        int number_cold_calls = 2;
+        int number_cold_calls = arg.cold_iters;
         int number_hot_calls  = arg.iters;
 
         for(int i = 0; i < number_cold_calls; i++)


### PR DESCRIPTION
* makes bench timing consistent using arg.iters and arg.cold_iters