### PR TITLE
Remove pre-check for memory allocation.

### DIFF
--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -73,15 +73,6 @@ public:
         return d;
     }
 
-    bool check_available_memory(size_t batches = 1)
-    {
-        size_t     free_mem  = 0;
-        size_t     total_mem = 0;
-        hipError_t err       = hipMemGetInfo(&free_mem, &total_mem);
-
-        return (err == hipSuccess && free_mem >= (bytes * batches));
-    }
-
     void device_vector_check(T* d)
     {
 #ifdef GOOGLE_TEST

--- a/clients/include/device_batch_vector.hpp
+++ b/clients/include/device_batch_vector.hpp
@@ -208,7 +208,7 @@ public:
     //!
     hipError_t memcheck() const
     {
-        if((bool)*this)
+        if(*this)
             return hipSuccess;
         else
             return hipErrorOutOfMemory;

--- a/clients/include/device_strided_batch_vector.hpp
+++ b/clients/include/device_strided_batch_vector.hpp
@@ -79,9 +79,7 @@ public:
 
         if(valid_parameters)
         {
-            m_enough_memory = this->check_available_memory();
-            if(m_enough_memory)
-                this->m_data = this->device_vector_setup();
+            this->m_data = this->device_vector_setup();
         }
     }
 
@@ -212,9 +210,7 @@ public:
     //!
     hipError_t memcheck() const
     {
-        if(!m_enough_memory)
-            return hipErrorMemoryAllocation;
-        else if((bool)*this)
+        if((bool)*this)
             return hipSuccess;
         else
             return hipErrorOutOfMemory;
@@ -227,7 +223,6 @@ private:
     rocblas_stride m_stride{};
     rocblas_int    m_batch_count{};
     T*             m_data{};
-    bool           m_enough_memory{};
 
     static size_t calculate_nmemb(
         rocblas_int n, rocblas_int inc, rocblas_stride stride, rocblas_int batch_count, storage st)

--- a/clients/include/device_strided_batch_vector.hpp
+++ b/clients/include/device_strided_batch_vector.hpp
@@ -210,7 +210,7 @@ public:
     //!
     hipError_t memcheck() const
     {
-        if((bool)*this)
+        if(*this)
             return hipSuccess;
         else
             return hipErrorOutOfMemory;

--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -40,9 +40,7 @@ public:
         , m_n(n)
         , m_inc(inc)
     {
-        m_enough_memory = this->check_available_memory();
-        if(m_enough_memory)
-            this->m_data = this->device_vector_setup();
+        this->m_data = this->device_vector_setup();
     }
 
     //!
@@ -55,9 +53,7 @@ public:
         , m_n(s)
         , m_inc(1)
     {
-        m_enough_memory = this->check_available_memory();
-        if(m_enough_memory)
-            this->m_data = this->device_vector_setup();
+        this->m_data = this->device_vector_setup();
     }
 
     //!
@@ -138,9 +134,7 @@ public:
 
     hipError_t memcheck() const
     {
-        if(!m_enough_memory)
-            return hipErrorMemoryAllocation;
-        else if((bool)*this)
+        if((bool)*this)
             return hipSuccess;
         else
             return hipErrorOutOfMemory;
@@ -151,5 +145,4 @@ private:
     rocblas_int m_n{};
     rocblas_int m_inc{};
     T*          m_data{};
-    bool        m_enough_memory{};
 };

--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -134,7 +134,7 @@ public:
 
     hipError_t memcheck() const
     {
-        if((bool)*this)
+        if(*this)
             return hipSuccess;
         else
             return hipErrorOutOfMemory;

--- a/clients/include/rocblas_test.hpp
+++ b/clients/include/rocblas_test.hpp
@@ -26,25 +26,25 @@
 #define CHECK_HIP_ERROR2(ERROR) ASSERT_EQ(ERROR, hipSuccess)
 #define CHECK_HIP_ERROR(ERROR) CHECK_HIP_ERROR2(ERROR)
 
-#define CHECK_DEVICE_ALLOCATION(ERROR)                                        \
-    do                                                                        \
-    {                                                                         \
-        auto error = ERROR;                                                   \
-        if(error == hipErrorMemoryAllocation || error == hipErrorOutOfMemory) \
-        {                                                                     \
-            SUCCEED() << LIMITED_MEMORY_STRING;                               \
-            return;                                                           \
-        }                                                                     \
-        else if(error != hipSuccess)                                          \
-        {                                                                     \
-            fprintf(stderr,                                                   \
-                    "error: '%s'(%d) at %s:%d\n",                             \
-                    hipGetErrorString(error),                                 \
-                    error,                                                    \
-                    __FILE__,                                                 \
-                    __LINE__);                                                \
-            return;                                                           \
-        }                                                                     \
+#define CHECK_DEVICE_ALLOCATION(ERROR)            \
+    do                                            \
+    {                                             \
+        auto error = ERROR;                       \
+        if(error == hipErrorOutOfMemory)          \
+        {                                         \
+            SUCCEED() << LIMITED_MEMORY_STRING;   \
+            return;                               \
+        }                                         \
+        else if(error != hipSuccess)              \
+        {                                         \
+            fprintf(stderr,                       \
+                    "error: '%s'(%d) at %s:%d\n", \
+                    hipGetErrorString(error),     \
+                    error,                        \
+                    __FILE__,                     \
+                    __LINE__);                    \
+            return;                               \
+        }                                         \
     } while(0)
 
 #define EXPECT_ROCBLAS_STATUS ASSERT_EQ


### PR DESCRIPTION
- Removes the use of `hipMemGetInfo()` introduced in #1011 to query available device memory before allocation. This has been proven to be an unreliable way of getting available memory on the device. We shouldn't need this query since we're skipping tests on failed memory allocation as well.