### PR TITLE
Move quick-return and invalid-size into own function

### DIFF
--- a/clients/gtest/gbmv_gtest.cpp
+++ b/clients/gtest/gbmv_gtest.cpp
@@ -39,8 +39,7 @@ namespace
             switch(GBMV_TYPE)
             {
             case GBMV:
-                return !strcmp(arg.function, "gbmv") || !strcmp(arg.function, "gbmv_bad_arg")
-                       || !strcmp(arg.function, "gbmv_arg_check");
+                return !strcmp(arg.function, "gbmv") || !strcmp(arg.function, "gbmv_bad_arg");
             case GBMV_BATCHED:
                 return !strcmp(arg.function, "gbmv_batched")
                        || !strcmp(arg.function, "gbmv_batched_bad_arg");
@@ -55,18 +54,10 @@ namespace
         static std::string name_suffix(const Arguments& arg)
         {
             RocBLAS_TestName<gbmv_template> name;
-            name << rocblas_datatype2string(arg.a_type);
-            if(strstr(arg.function, "_bad_arg") != nullptr)
-            {
-                name << "_bad_arg";
-            }
-            if(strstr(arg.function, "_arg_check") != nullptr)
-            {
-                name << "_arg_check";
-            }
 
-            name << '_' << (char)std::toupper(arg.transA) << '_' << arg.M << '_' << arg.N << '_'
-                 << arg.KL << '_' << arg.KU << '_' << arg.alpha << '_' << arg.lda;
+            name << rocblas_datatype2string(arg.a_type) << '_' << (char)std::toupper(arg.transA)
+                 << '_' << arg.M << '_' << arg.N << '_' << arg.KL << '_' << arg.KU << '_'
+                 << arg.alpha << '_' << arg.lda;
 
             if(GBMV_TYPE == GBMV_STRIDED_BATCHED)
                 name << '_' << arg.stride_a;
@@ -110,8 +101,6 @@ namespace
                 testing_gbmv<T>(arg);
             else if(!strcmp(arg.function, "gbmv_bad_arg"))
                 testing_gbmv_bad_arg<T>(arg);
-            else if(!strcmp(arg.function, "gbmv_arg_check"))
-                testing_gbmv_arg_check<T>(arg);
             else if(!strcmp(arg.function, "gbmv_batched"))
                 testing_gbmv_batched<T>(arg);
             else if(!strcmp(arg.function, "gbmv_batched_bad_arg"))

--- a/clients/gtest/gbmv_gtest.cpp
+++ b/clients/gtest/gbmv_gtest.cpp
@@ -39,7 +39,8 @@ namespace
             switch(GBMV_TYPE)
             {
             case GBMV:
-                return !strcmp(arg.function, "gbmv") || !strcmp(arg.function, "gbmv_bad_arg");
+                return !strcmp(arg.function, "gbmv") || !strcmp(arg.function, "gbmv_bad_arg")
+                       || !strcmp(arg.function, "gbmv_arg_check");
             case GBMV_BATCHED:
                 return !strcmp(arg.function, "gbmv_batched")
                        || !strcmp(arg.function, "gbmv_batched_bad_arg");
@@ -54,10 +55,18 @@ namespace
         static std::string name_suffix(const Arguments& arg)
         {
             RocBLAS_TestName<gbmv_template> name;
+            name << rocblas_datatype2string(arg.a_type);
+            if(strstr(arg.function, "_bad_arg") != nullptr)
+            {
+                name << "_bad_arg";
+            }
+            if(strstr(arg.function, "_arg_check") != nullptr)
+            {
+                name << "_arg_check";
+            }
 
-            name << rocblas_datatype2string(arg.a_type) << '_' << (char)std::toupper(arg.transA)
-                 << '_' << arg.M << '_' << arg.N << '_' << arg.KL << '_' << arg.KU << '_'
-                 << arg.alpha << '_' << arg.lda;
+            name << '_' << (char)std::toupper(arg.transA) << '_' << arg.M << '_' << arg.N << '_'
+                 << arg.KL << '_' << arg.KU << '_' << arg.alpha << '_' << arg.lda;
 
             if(GBMV_TYPE == GBMV_STRIDED_BATCHED)
                 name << '_' << arg.stride_a;
@@ -101,6 +110,8 @@ namespace
                 testing_gbmv<T>(arg);
             else if(!strcmp(arg.function, "gbmv_bad_arg"))
                 testing_gbmv_bad_arg<T>(arg);
+            else if(!strcmp(arg.function, "gbmv_arg_check"))
+                testing_gbmv_arg_check<T>(arg);
             else if(!strcmp(arg.function, "gbmv_batched"))
                 testing_gbmv_batched<T>(arg);
             else if(!strcmp(arg.function, "gbmv_batched_bad_arg"))

--- a/clients/gtest/gbmv_gtest.yaml
+++ b/clients/gtest/gbmv_gtest.yaml
@@ -4,25 +4,10 @@ include: known_bugs.yaml
 
 Definitions:
   - &small_matrix_size_range
-    # Invalid Sizes
-    # - { M:    -1, N:     1, lda:    1, KL:  1, KU:  1 }
-    # - { M:     1, N:    -1, lda:    1, KL:  1, KU:  1 }
-    # - { M:    -1, N:    -1, lda:   -1, KL:  0, KU:  0 }
-    # - { M:     1, N:     1, lda:    0, KL:  0, KU:  0 }
-    # - { M:    10, N:    10, lda:    2, KL:  8, KU:  2 }
-    # - { M:    10, N:    10, lda:   10, KL: -1, KU:  5 }
-    # - { M:    10, N:    10, lda:   10, KL:  5, KU: -1 }
-    # - { M:    10, N:    10, lda:    5, KL:  3, KU:  2 }
-
     # lda > KL + KU + 1 && lda < M
     - { M:     2, N:     2, lda:    1, KL:  0, KU:  0 }
     - { M:    10, N:    10, lda:    9, KL:  3, KU:  2 }
     - { M:    10, N:     5, lda:    4, KL:  1, KU:  1 }
-
-    # Quick Return
-    # - { M:     0, N:    10, lda:   10, KL:  2, KU:  3 }
-    # - { M:     0, N:     1, lda:    1, KL:  0, KU:  0 }
-    # - { M:     1, N:     0, lda:    1, KL:  0, KU:  0 }
 
     # Regular Cases
     - { M:   100, N:   200, lda:  200, KL: 20, KU:  8 }
@@ -35,6 +20,23 @@ Definitions:
     - { M:    20, N:    30, lda:   50, KL: 14, KU: 14 }
     - { M:    20, N:    30, lda:   50, KL: 24, KU: 24 }
     - { M:    20, N:    20, lda:  100, KL: 40, KU: 40 }
+
+    # Special Cases
+  - &special_case_range
+    # Quick return
+    - { M: 0, N: 1, lda: 10, KL: 2, KU: 2, incx: 1, incy: 1 }
+    - { M: 1, N: 0, lda: 10, KL: 2, KU: 2, incx: 1, incy: 1 }
+    - { M: 0, N: 1, lda: 11, KL: 5, KU: 5, incx: 1, incy: 1 }
+
+    # invalid_arg checks
+    - { M: -1, N:  0, lda: 10, KL:  1, KU:  1, incx: 1, incy: 1 }
+    - { M:  0, N: -1, lda: 10, KL:  1, KU:  1, incx: 1, incy: 1 }
+    - { M:  0, N:  0, lda: 10, KL: -1, KU:  1, incx: 1, incy: 1 }
+    - { M:  0, N:  0, lda: 10, KL:  1, KU: -1, incx: 1, incy: 1 }
+    - { M:  0, N:  0, lda: 10, KL:  5, KU:  5, incx: 1, incy: 1 }
+    - { M:  0, N:  0, lda:  0, KL:  0, KU:  0, incx: 1, incy: 1 }
+    - { M:  0, N:  0, lda:  1, KL:  0, KU:  0, incx: 0, incy: 1 }
+    - { M:  0, N:  0, lda:  1, KL:  0, KU:  0, incx: 1, incy: 0 }
 
 
   - &medium_matrix_size_range
@@ -71,10 +73,11 @@ Tests:
   transA: N
 
 - name: gbmv_arg_check
-  category: pre_checkin
-  function: gbmv_arg_check
+  category: quick
+  function: gbmv
   precision: *single_double_precisions
   transA: N
+  matrix_size: *special_case_range
 
 - name: gbmv_NaN
   category: pre_checkin

--- a/clients/gtest/gbmv_gtest.yaml
+++ b/clients/gtest/gbmv_gtest.yaml
@@ -5,14 +5,14 @@ include: known_bugs.yaml
 Definitions:
   - &small_matrix_size_range
     # Invalid Sizes
-    - { M:    -1, N:     1, lda:    1, KL:  1, KU:  1 }
-    - { M:     1, N:    -1, lda:    1, KL:  1, KU:  1 }
-    - { M:    -1, N:    -1, lda:   -1, KL:  0, KU:  0 }
-    - { M:     1, N:     1, lda:    0, KL:  0, KU:  0 }
-    - { M:    10, N:    10, lda:    2, KL:  8, KU:  2 }
-    - { M:    10, N:    10, lda:   10, KL: -1, KU:  5 }
-    - { M:    10, N:    10, lda:   10, KL:  5, KU: -1 }
-    - { M:    10, N:    10, lda:    5, KL:  3, KU:  2 }
+    # - { M:    -1, N:     1, lda:    1, KL:  1, KU:  1 }
+    # - { M:     1, N:    -1, lda:    1, KL:  1, KU:  1 }
+    # - { M:    -1, N:    -1, lda:   -1, KL:  0, KU:  0 }
+    # - { M:     1, N:     1, lda:    0, KL:  0, KU:  0 }
+    # - { M:    10, N:    10, lda:    2, KL:  8, KU:  2 }
+    # - { M:    10, N:    10, lda:   10, KL: -1, KU:  5 }
+    # - { M:    10, N:    10, lda:   10, KL:  5, KU: -1 }
+    # - { M:    10, N:    10, lda:    5, KL:  3, KU:  2 }
 
     # lda > KL + KU + 1 && lda < M
     - { M:     2, N:     2, lda:    1, KL:  0, KU:  0 }
@@ -20,9 +20,9 @@ Definitions:
     - { M:    10, N:     5, lda:    4, KL:  1, KU:  1 }
 
     # Quick Return
-    - { M:     0, N:    10, lda:   10, KL:  2, KU:  3 }
-    - { M:     0, N:     1, lda:    1, KL:  0, KU:  0 }
-    - { M:     1, N:     0, lda:    1, KL:  0, KU:  0 }
+    # - { M:     0, N:    10, lda:   10, KL:  2, KU:  3 }
+    # - { M:     0, N:     1, lda:    1, KL:  0, KU:  0 }
+    # - { M:     1, N:     0, lda:    1, KL:  0, KU:  0 }
 
     # Regular Cases
     - { M:   100, N:   200, lda:  200, KL: 20, KU:  8 }
@@ -67,6 +67,12 @@ Tests:
 - name: gbmv_bad_arg
   category: pre_checkin
   function: gbmv_bad_arg
+  precision: *single_double_precisions
+  transA: N
+
+- name: gbmv_arg_check
+  category: pre_checkin
+  function: gbmv_arg_check
   precision: *single_double_precisions
   transA: N
 

--- a/clients/include/testing_gbmv.hpp
+++ b/clients/include/testing_gbmv.hpp
@@ -111,7 +111,8 @@ void testing_gbmv(const Arguments& arg)
     rocblas_local_handle handle;
 
     // argument sanity check before allocating invalid memory
-    if(M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0)
+    bool invalidSize = M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0;
+    if(invalidSize || !M || !N)
     {
         EXPECT_ROCBLAS_STATUS(rocblas_gbmv<T>(handle,
                                               transA,
@@ -127,29 +128,9 @@ void testing_gbmv(const Arguments& arg)
                                               nullptr,
                                               nullptr,
                                               incy),
-                              rocblas_status_invalid_size);
+                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
 
         return;
-    }
-
-    if(!M || !N)
-    {
-        CHECK_ROCBLAS_ERROR(rocblas_gbmv<T>(handle,
-                                            transA,
-                                            M,
-                                            N,
-                                            KL,
-                                            KU,
-                                            nullptr,
-                                            nullptr,
-                                            lda,
-                                            nullptr,
-                                            incx,
-                                            nullptr,
-                                            nullptr,
-                                            incy));
-        // We don't have to return here since *_vectors can handle size 0, so we can
-        // still do unit_checks and whatnot.
     }
 
     size_t size_A = lda * size_t(N);

--- a/clients/include/testing_gbmv.hpp
+++ b/clients/include/testing_gbmv.hpp
@@ -92,6 +92,63 @@ void testing_gbmv_bad_arg(const Arguments& arg)
 }
 
 template <typename T>
+void testing_gbmv_arg_check(const Arguments& arg)
+{
+    rocblas_local_handle handle;
+    rocblas_operation    transA = rocblas_operation_none;
+    T                    alpha;
+    T                    beta;
+    alpha = 0.0;
+    beta  = 1.0;
+
+    // quick returns
+    CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
+    CHECK_ROCBLAS_ERROR(rocblas_gbmv<T>(
+        handle, transA, 0, 1, 2, 2, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 1));
+    CHECK_ROCBLAS_ERROR(rocblas_gbmv<T>(
+        handle, transA, 1, 0, 2, 2, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 1));
+    CHECK_ROCBLAS_ERROR(rocblas_gbmv<T>(
+        handle, transA, 0, 1, 5, 5, nullptr, nullptr, 11, nullptr, 1, nullptr, nullptr, 1));
+
+    // invalid_arg checks
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, -1, 0, 1, 1, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 1),
+        rocblas_status_invalid_size);
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, 0, -1, 1, 1, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 1),
+        rocblas_status_invalid_size);
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, 0, 0, -1, 1, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 1),
+        rocblas_status_invalid_size);
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, 0, 0, 1, -1, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 1),
+        rocblas_status_invalid_size);
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, 0, 0, 5, 5, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 1),
+        rocblas_status_invalid_size);
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, 0, 0, 0, 0, nullptr, nullptr, 0, nullptr, 1, nullptr, nullptr, 1),
+        rocblas_status_invalid_size);
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, 0, 0, 1, 1, nullptr, nullptr, 10, nullptr, 0, nullptr, nullptr, 1),
+        rocblas_status_invalid_size);
+    EXPECT_ROCBLAS_STATUS(
+        rocblas_gbmv<T>(
+            handle, transA, 0, 0, 1, 1, nullptr, nullptr, 10, nullptr, 1, nullptr, nullptr, 0),
+        rocblas_status_invalid_size);
+
+    // TODO: See rocblas_gbmv.cpp comment on alpha==0 && beta==1 case.
+    // CHECK_ROCBLAS_ERROR(rocblas_gbmv<T>(handle, transA, 1, 1, 1, 1, &alpha, nullptr, 10, nullptr, 1, &beta, nullptr, 1));
+}
+
+template <typename T>
 void testing_gbmv(const Arguments& arg)
 {
     rocblas_int       M       = arg.M;

--- a/clients/include/testing_gbmv_batched.hpp
+++ b/clients/include/testing_gbmv_batched.hpp
@@ -168,37 +168,26 @@ void testing_gbmv_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // argument sanity check before allocating invalid memory
-    if(M <= 0 || N <= 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0
-       || batch_count <= 0)
+    bool invalidSize = M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || batch_count < 0
+                       || KL < 0 || KU < 0;
+    if(invalidSize || !M || !N || !batch_count)
     {
-        static constexpr size_t safe_size = 100; // arbitrarily set to 100
-        device_batch_vector<T>  dAA1(1, safe_size);
-        device_batch_vector<T>  dxA1(1, safe_size);
-        device_batch_vector<T>  dy_1A1(1, safe_size);
-
-        CHECK_HIP_ERROR(dAA1.memcheck());
-        CHECK_HIP_ERROR(dxA1.memcheck());
-        CHECK_HIP_ERROR(dy_1A1.memcheck());
-
         EXPECT_ROCBLAS_STATUS(rocblas_gbmv_batched<T>(handle,
                                                       transA,
                                                       M,
                                                       N,
                                                       KL,
                                                       KU,
-                                                      &h_alpha,
-                                                      dAA1.ptr_on_device(),
+                                                      nullptr,
+                                                      nullptr,
                                                       lda,
-                                                      dxA1.ptr_on_device(),
+                                                      nullptr,
                                                       incx,
-                                                      &h_beta,
-                                                      dy_1A1.ptr_on_device(),
+                                                      nullptr,
+                                                      nullptr,
                                                       incy,
                                                       batch_count),
-                              M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy
-                                      || batch_count < 0 || KL < 0 || KU < 0
-                                  ? rocblas_status_invalid_size
-                                  : rocblas_status_success);
+                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_gbmv_strided_batched.hpp
+++ b/clients/include/testing_gbmv_strided_batched.hpp
@@ -203,7 +203,9 @@ void testing_gbmv_strided_batched(const Arguments& arg)
     abs_incy = incy >= 0 ? incy : -incy;
 
     // argument sanity check before allocating invalid memory
-    if(M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0 || batch_count < 0)
+    bool invalidSize = M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0
+                       || batch_count < 0;
+    if(invalidSize || !M || !N || !batch_count)
     {
         EXPECT_ROCBLAS_STATUS(rocblas_gbmv_strided_batched<T>(handle,
                                                               transA,
@@ -211,45 +213,19 @@ void testing_gbmv_strided_batched(const Arguments& arg)
                                                               N,
                                                               KL,
                                                               KU,
-                                                              &h_alpha,
+                                                              nullptr,
                                                               nullptr,
                                                               lda,
                                                               stride_A,
                                                               nullptr,
                                                               incx,
                                                               stride_x,
-                                                              &h_beta,
+                                                              nullptr,
                                                               nullptr,
                                                               incy,
                                                               stride_y,
                                                               batch_count),
-                              rocblas_status_invalid_size);
-
-        return;
-    }
-
-    //quick return
-    if(!M || !N || !batch_count)
-    {
-        EXPECT_ROCBLAS_STATUS(rocblas_gbmv_strided_batched<T>(handle,
-                                                              transA,
-                                                              M,
-                                                              N,
-                                                              KL,
-                                                              KU,
-                                                              &h_alpha,
-                                                              nullptr,
-                                                              lda,
-                                                              stride_A,
-                                                              nullptr,
-                                                              incx,
-                                                              stride_x,
-                                                              &h_beta,
-                                                              nullptr,
-                                                              incy,
-                                                              stride_y,
-                                                              batch_count),
-                              rocblas_status_success);
+                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
 
         return;
     }

--- a/library/src/blas2/rocblas_gbmv.cpp
+++ b/library/src/blas2/rocblas_gbmv.cpp
@@ -139,6 +139,16 @@ namespace
         if(!m || !n)
             return rocblas_status_success;
 
+        // TODO: LAPACK does a alpha==0 && beta==1 quick return check here.
+        //       The following code is up for discussion if we want to include it here
+        //       or after the invalid_pointer check as we currently do (in rocblas_gbmv.hpp).
+
+        // if(handle->pointer_mode == rocblas_pointer_mode_host && alpha && beta)
+        // {
+        //     if(!*alpha && *beta == 1)
+        //         return rocblas_status_success;
+        // }
+
         if(!A || !x || !y || !alpha || !beta)
             return rocblas_status_invalid_pointer;
 


### PR DESCRIPTION
See [LWPMLSE-37](http://ontrack-internal.amd.com/browse/LWPMLSE-37).
A proposal for moving quick-return and invalid_size checks into their own function to reduce the explosion of repeated test cases.
This takes any useful quick return and invalid_size combinations and moves them to their own `testing_xxx_arg_check` function and out of the regular quick tests.
For example, this will remove testing all `incx`/`incy` and `alpha`/`beta` combinations when `M == -1`.

This draft only implements this for gbmv to help discussion. If everyone likes this I can move ahead with other functions.

Previously quick gbmv tests (not batched nor strided_batched) ran 10368 tests in around 15.8s. With this change quick gbmv tests run 5618 tests in around 10.8s. A 5s (or ~33%) improvement but will add up across the > 100 functions being tested.