### PR TITLE
hipclang fixes.

### DIFF
--- a/library/src/blas2/rocblas_sbmv.hpp
+++ b/library/src/blas2/rocblas_sbmv.hpp
@@ -233,7 +233,7 @@ rocblas_status rocblas_sbmv_template(rocblas_handle handle,
     {
         if(uplo == rocblas_fill_upper)
         {
-            hipLaunchKernelGGL(sbmv_kernel<true, sbmv_DIM_X, sbmv_DIM_Y>,
+            hipLaunchKernelGGL((sbmv_kernel<true, sbmv_DIM_X, sbmv_DIM_Y>),
                                grid,
                                threads,
                                0,
@@ -259,7 +259,7 @@ rocblas_status rocblas_sbmv_template(rocblas_handle handle,
         }
         else
         {
-            hipLaunchKernelGGL(sbmv_kernel<false, sbmv_DIM_X, sbmv_DIM_Y>,
+            hipLaunchKernelGGL((sbmv_kernel<false, sbmv_DIM_X, sbmv_DIM_Y>),
                                grid,
                                threads,
                                0,
@@ -292,7 +292,7 @@ rocblas_status rocblas_sbmv_template(rocblas_handle handle,
 
         if(uplo == rocblas_fill_upper)
         {
-            hipLaunchKernelGGL(sbmv_kernel<true, sbmv_DIM_X, sbmv_DIM_Y>,
+            hipLaunchKernelGGL((sbmv_kernel<true, sbmv_DIM_X, sbmv_DIM_Y>),
                                grid,
                                threads,
                                0,
@@ -318,7 +318,7 @@ rocblas_status rocblas_sbmv_template(rocblas_handle handle,
         }
         else
         {
-            hipLaunchKernelGGL(sbmv_kernel<false, sbmv_DIM_X, sbmv_DIM_Y>,
+            hipLaunchKernelGGL((sbmv_kernel<false, sbmv_DIM_X, sbmv_DIM_Y>),
                                grid,
                                threads,
                                0,

--- a/library/src/blas2/rocblas_spmv.hpp
+++ b/library/src/blas2/rocblas_spmv.hpp
@@ -204,7 +204,7 @@ rocblas_status rocblas_spmv_template(rocblas_handle handle,
     bool upper = uplo == rocblas_fill_upper;
     if(handle->pointer_mode == rocblas_pointer_mode_device)
     {
-        hipLaunchKernelGGL(spmv_kernel<spmv_DIM_X, spmv_DIM_Y>,
+        hipLaunchKernelGGL((spmv_kernel<spmv_DIM_X, spmv_DIM_Y>),
                            grid,
                            threads,
                            0,
@@ -233,7 +233,7 @@ rocblas_status rocblas_spmv_template(rocblas_handle handle,
         if(batch_count == 1 && !*alpha && *beta == 1)
             return rocblas_status_success;
 
-        hipLaunchKernelGGL(spmv_kernel<spmv_DIM_X, spmv_DIM_Y>,
+        hipLaunchKernelGGL((spmv_kernel<spmv_DIM_X, spmv_DIM_Y>),
                            grid,
                            threads,
                            0,

--- a/library/src/blas2/rocblas_symv.hpp
+++ b/library/src/blas2/rocblas_symv.hpp
@@ -194,7 +194,7 @@ rocblas_status rocblas_symv_template(rocblas_handle handle,
     bool upper = uplo == rocblas_fill_upper;
     if(handle->pointer_mode == rocblas_pointer_mode_device)
     {
-        hipLaunchKernelGGL(symv_kernel<symv_DIM_X, symv_DIM_Y>,
+        hipLaunchKernelGGL((symv_kernel<symv_DIM_X, symv_DIM_Y>),
                            grid,
                            threads,
                            0,
@@ -224,7 +224,7 @@ rocblas_status rocblas_symv_template(rocblas_handle handle,
         if(batch_count == 1 && !*alpha && *beta == 1)
             return rocblas_status_success;
 
-        hipLaunchKernelGGL(symv_kernel<symv_DIM_X, symv_DIM_Y>,
+        hipLaunchKernelGGL((symv_kernel<symv_DIM_X, symv_DIM_Y>),
                            grid,
                            threads,
                            0,


### PR DESCRIPTION
Noticed that a hip-clang build was broken in CI ([here](http://math-ci.rocm.amd.com/blue/organizations/jenkins/compute-rocm-dkms-no-npi-hipclang-int-bkc-3%2Fprecheckin%2FrocBLAS/detail/develop/15/pipeline/74)) this should fix it.