### PR TITLE
Changing order of checks for L2 solvers.

### DIFF
--- a/clients/include/testing_tbsv.hpp
+++ b/clients/include/testing_tbsv.hpp
@@ -69,13 +69,13 @@ void testing_tbsv(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    bool invalidSize = N < 0 || K < 0 || lda < K + 1 || !incx;
-    if(invalidSize || !N)
+    bool invalid_size = N < 0 || K < 0 || lda < K + 1 || !incx;
+    if(invalid_size || !N)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
             rocblas_tbsv<T>(handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx),
-            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+            invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tbsv.hpp
+++ b/clients/include/testing_tbsv.hpp
@@ -69,19 +69,13 @@ void testing_tbsv(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    if(N < 0 || K < 0 || lda < K + 1 || !incx)
+    bool invalidSize = N < 0 || K < 0 || lda < K + 1 || !incx;
+    if(invalidSize || !N)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
             rocblas_tbsv<T>(handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx),
-            rocblas_status_invalid_size);
-        return;
-    }
-    if(N == 0)
-    {
-        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(
-            rocblas_tbsv<T>(handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx));
+            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tbsv_batched.hpp
+++ b/clients/include/testing_tbsv_batched.hpp
@@ -94,14 +94,14 @@ void testing_tbsv_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    bool invalidSize = N < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
-    if(invalidSize || !N || !batch_count)
+    bool invalid_size = N < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
             rocblas_tbsv_batched<T>(
                 handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx, batch_count),
-            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+            invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tbsv_batched.hpp
+++ b/clients/include/testing_tbsv_batched.hpp
@@ -94,24 +94,14 @@ void testing_tbsv_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    if(N < 0 || K < 0 || lda < K + 1 || !incx || batch_count <= 0)
+    bool invalidSize = N < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalidSize || !N || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(rocblas_tbsv_batched<T>(
-                handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx, batch_count));
-        else
-            EXPECT_ROCBLAS_STATUS(
-                rocblas_tbsv_batched<T>(
-                    handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx, batch_count),
-                rocblas_status_invalid_size);
-        return;
-    }
-    if(N == 0)
-    {
-        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_tbsv_batched<T>(
-            handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx, batch_count));
+        EXPECT_ROCBLAS_STATUS(
+            rocblas_tbsv_batched<T>(
+                handle, uplo, transA, diag, N, K, nullptr, lda, nullptr, incx, batch_count),
+            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tbsv_strided_batched.hpp
+++ b/clients/include/testing_tbsv_strided_batched.hpp
@@ -112,8 +112,8 @@ void testing_tbsv_strided_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    bool invalidSize = N < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
-    if(invalidSize || !N || !batch_count)
+    bool invalid_size = N < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(rocblas_tbsv_strided_batched<T>(handle,
@@ -129,7 +129,7 @@ void testing_tbsv_strided_batched(const Arguments& arg)
                                                               incx,
                                                               stride_x,
                                                               batch_count),
-                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+                              invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tbsv_strided_batched.hpp
+++ b/clients/include/testing_tbsv_strided_batched.hpp
@@ -112,56 +112,24 @@ void testing_tbsv_strided_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    if(N < 0 || K < 0 || lda < K + 1 || !incx || batch_count <= 0)
+    bool invalidSize = N < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalidSize || !N || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(rocblas_tbsv_strided_batched<T>(handle,
-                                                                uplo,
-                                                                transA,
-                                                                diag,
-                                                                N,
-                                                                K,
-                                                                nullptr,
-                                                                lda,
-                                                                stride_a,
-                                                                nullptr,
-                                                                incx,
-                                                                stride_x,
-                                                                batch_count));
-        else
-            EXPECT_ROCBLAS_STATUS(rocblas_tbsv_strided_batched<T>(handle,
-                                                                  uplo,
-                                                                  transA,
-                                                                  diag,
-                                                                  N,
-                                                                  K,
-                                                                  nullptr,
-                                                                  lda,
-                                                                  stride_a,
-                                                                  nullptr,
-                                                                  incx,
-                                                                  stride_x,
-                                                                  batch_count),
-                                  rocblas_status_invalid_size);
-        return;
-    }
-    if(N == 0)
-    {
-        CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        CHECK_ROCBLAS_ERROR(rocblas_tbsv_strided_batched<T>(handle,
-                                                            uplo,
-                                                            transA,
-                                                            diag,
-                                                            N,
-                                                            K,
-                                                            nullptr,
-                                                            lda,
-                                                            stride_a,
-                                                            nullptr,
-                                                            incx,
-                                                            stride_x,
-                                                            batch_count));
+        EXPECT_ROCBLAS_STATUS(rocblas_tbsv_strided_batched<T>(handle,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              N,
+                                                              K,
+                                                              nullptr,
+                                                              lda,
+                                                              stride_a,
+                                                              nullptr,
+                                                              incx,
+                                                              stride_x,
+                                                              batch_count),
+                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tpsv_batched.hpp
+++ b/clients/include/testing_tpsv_batched.hpp
@@ -71,14 +71,14 @@ void testing_tpsv_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    bool invalidSize = N < 0 || !incx || batch_count < 0;
-    if(invalidSize || !N || !batch_count)
+    bool invalid_size = N < 0 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
             rocblas_tpsv_batched<T>(
                 handle, uplo, transA, diag, N, nullptr, nullptr, incx, batch_count),
-            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+            invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tpsv_batched.hpp
+++ b/clients/include/testing_tpsv_batched.hpp
@@ -71,17 +71,14 @@ void testing_tpsv_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    if(N < 0 || !incx || batch_count <= 0)
+    bool invalidSize = N < 0 || !incx || batch_count < 0;
+    if(invalidSize || !N || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(rocblas_tpsv_batched<T>(
-                handle, uplo, transA, diag, N, nullptr, nullptr, incx, batch_count));
-        else
-            EXPECT_ROCBLAS_STATUS(
-                rocblas_tpsv_batched<T>(
-                    handle, uplo, transA, diag, N, nullptr, nullptr, incx, batch_count),
-                rocblas_status_invalid_size);
+        EXPECT_ROCBLAS_STATUS(
+            rocblas_tpsv_batched<T>(
+                handle, uplo, transA, diag, N, nullptr, nullptr, incx, batch_count),
+            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_tpsv_strided_batched.hpp
+++ b/clients/include/testing_tpsv_strided_batched.hpp
@@ -87,34 +87,22 @@ void testing_tpsv_strided_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    if(N < 0 || !incx || batch_count <= 0)
+    bool invalid_size = N < 0 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(rocblas_tpsv_strided_batched<T>(handle,
-                                                                uplo,
-                                                                transA,
-                                                                diag,
-                                                                N,
-                                                                nullptr,
-                                                                stride_ap,
-                                                                nullptr,
-                                                                incx,
-                                                                stride_x,
-                                                                batch_count));
-        else
-            EXPECT_ROCBLAS_STATUS(rocblas_tpsv_strided_batched<T>(handle,
-                                                                  uplo,
-                                                                  transA,
-                                                                  diag,
-                                                                  N,
-                                                                  nullptr,
-                                                                  stride_ap,
-                                                                  nullptr,
-                                                                  incx,
-                                                                  stride_x,
-                                                                  batch_count),
-                                  rocblas_status_invalid_size);
+        EXPECT_ROCBLAS_STATUS(rocblas_tpsv_strided_batched<T>(handle,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              N,
+                                                              nullptr,
+                                                              stride_ap,
+                                                              nullptr,
+                                                              incx,
+                                                              stride_x,
+                                                              batch_count),
+                              invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_trsv.hpp
+++ b/clients/include/testing_trsv.hpp
@@ -38,15 +38,9 @@ void testing_trsv(const Arguments& arg)
     // check here to prevent undefined memory allocation error
     if(M < 0 || lda < M || !incx)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dx_or_b(safe_size);
-        device_vector<T>    dA(safe_size);
-        CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
-        CHECK_DEVICE_ALLOCATION(dA.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
-            rocblas_trsv<T>(handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx),
+            rocblas_trsv<T>(handle, uplo, transA, diag, M, nullptr, lda, nullptr, incx),
             rocblas_status_invalid_size);
         return;
     }

--- a/clients/include/testing_trsv_batched.hpp
+++ b/clients/include/testing_trsv_batched.hpp
@@ -37,14 +37,14 @@ void testing_trsv_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    bool invalidSize = M < 0 || lda < M || !incx || batch_count < 0;
-    if(invalidSize || !M || !batch_count)
+    bool invalid_size = M < 0 || lda < M || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(
             rocblas_trsv_batched<T>(
                 handle, uplo, transA, diag, M, nullptr, lda, nullptr, incx, batch_count),
-            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+            invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_trsv_strided_batched.hpp
+++ b/clients/include/testing_trsv_strided_batched.hpp
@@ -39,42 +39,23 @@ void testing_trsv_strided_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    if(M < 0 || lda < M || !incx || batch_count <= 0)
+    bool invalidSize = M < 0 || lda < M || !incx || batch_count < 0;
+    if(invalidSize || !M || !batch_count)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dx_or_b(safe_size);
-        device_vector<T>    dA(safe_size);
-        CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
-        CHECK_DEVICE_ALLOCATION(dA.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(rocblas_trsv_strided_batched<T>(handle,
-                                                                uplo,
-                                                                transA,
-                                                                diag,
-                                                                M,
-                                                                dA,
-                                                                lda,
-                                                                stride_a,
-                                                                dx_or_b,
-                                                                incx,
-                                                                stride_x,
-                                                                batch_count));
-        else
-            EXPECT_ROCBLAS_STATUS(rocblas_trsv_strided_batched<T>(handle,
-                                                                  uplo,
-                                                                  transA,
-                                                                  diag,
-                                                                  M,
-                                                                  dA,
-                                                                  lda,
-                                                                  stride_a,
-                                                                  dx_or_b,
-                                                                  incx,
-                                                                  stride_x,
-                                                                  batch_count),
-                                  rocblas_status_invalid_size);
+        EXPECT_ROCBLAS_STATUS(rocblas_trsv_strided_batched<T>(handle,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              M,
+                                                              nullptr,
+                                                              lda,
+                                                              stride_a,
+                                                              nullptr,
+                                                              incx,
+                                                              stride_x,
+                                                              batch_count),
+                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_trsv_strided_batched.hpp
+++ b/clients/include/testing_trsv_strided_batched.hpp
@@ -39,8 +39,8 @@ void testing_trsv_strided_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // check here to prevent undefined memory allocation error
-    bool invalidSize = M < 0 || lda < M || !incx || batch_count < 0;
-    if(invalidSize || !M || !batch_count)
+    bool invalid_size = M < 0 || lda < M || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(rocblas_trsv_strided_batched<T>(handle,
@@ -55,7 +55,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
                                                               incx,
                                                               stride_x,
                                                               batch_count),
-                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+                              invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/library/src/blas2/rocblas_tbsv_batched.cpp
+++ b/library/src/blas2/rocblas_tbsv_batched.cpp
@@ -113,7 +113,7 @@ namespace
 
         if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
             return rocblas_status_invalid_value;
-        if(batch_count < 0 || ((n < 0 || k < 0 || lda < k + 1 || !incx) && batch_count > 0))
+        if(n < 0 || k < 0 || lda < k + 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
         if(!n || !batch_count)
             return rocblas_status_success;

--- a/library/src/blas2/rocblas_tbsv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_tbsv_strided_batched.cpp
@@ -125,7 +125,7 @@ namespace
 
         if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
             return rocblas_status_invalid_value;
-        if(batch_count < 0 || ((n < 0 || k < 0 || lda < k + 1 || !incx) && batch_count > 0))
+        if(n < 0 || k < 0 || lda < k + 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
         if(!n || !batch_count)
             return rocblas_status_success;

--- a/library/src/blas2/rocblas_tpsv_batched.cpp
+++ b/library/src/blas2/rocblas_tpsv_batched.cpp
@@ -100,7 +100,7 @@ namespace
 
         if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
             return rocblas_status_invalid_value;
-        if(batch_count < 0 || ((n < 0 || !incx) && batch_count > 0))
+        if(n < 0 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
         if(!n || !batch_count)
             return rocblas_status_success;

--- a/library/src/blas2/rocblas_tpsv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_tpsv_strided_batched.cpp
@@ -113,7 +113,7 @@ namespace
 
         if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
             return rocblas_status_invalid_value;
-        if(batch_count < 0 || ((n < 0 || !incx) && batch_count > 0))
+        if(n < 0 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
         if(!n || !batch_count)
             return rocblas_status_success;

--- a/library/src/blas2/rocblas_trsv.cpp
+++ b/library/src/blas2/rocblas_trsv.cpp
@@ -92,8 +92,6 @@ namespace
 
         if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
             return rocblas_status_not_implemented;
-        if(!A || !B)
-            return rocblas_status_invalid_pointer;
         if(m < 0 || lda < m || lda < 1 || !incx)
             return rocblas_status_invalid_size;
 
@@ -102,6 +100,9 @@ namespace
         if(!m)
             return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged
                                                          : rocblas_status_success;
+
+        if(!A || !B)
+            return rocblas_status_invalid_pointer;
 
         void* mem_x_temp;
         void* mem_x_temp_arr;

--- a/library/src/blas2/rocblas_trsv_batched.cpp
+++ b/library/src/blas2/rocblas_trsv_batched.cpp
@@ -109,9 +109,7 @@ namespace
             return rocblas_status_not_implemented;
         if(!A || !B)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-        if((m < 0 || lda < m || lda < 1 || !incx) && batch_count > 0)
+        if(m < 0 || lda < m || lda < 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
 
         // quick return if possible.

--- a/library/src/blas2/rocblas_trsv_batched.cpp
+++ b/library/src/blas2/rocblas_trsv_batched.cpp
@@ -107,16 +107,17 @@ namespace
 
         if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
             return rocblas_status_not_implemented;
-        if(!A || !B)
-            return rocblas_status_invalid_pointer;
         if(m < 0 || lda < m || lda < 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
 
         // quick return if possible.
         // return rocblas_status_size_unchanged if device memory size query
-        if(!m)
+        if(!m || !batch_count)
             return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged
                                                          : rocblas_status_success;
+
+        if(!A || !B)
+            return rocblas_status_invalid_pointer;
 
         void* mem_x_temp;
         void* mem_x_temp_arr;

--- a/library/src/blas2/rocblas_trsv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_trsv_strided_batched.cpp
@@ -122,16 +122,17 @@ namespace
 
         if(uplo != rocblas_fill_lower && uplo != rocblas_fill_upper)
             return rocblas_status_not_implemented;
-        if(!A || !B)
-            return rocblas_status_invalid_pointer;
         if(m < 0 || lda < m || lda < 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
 
         // quick return if possible.
         // return rocblas_status_size_unchanged if device memory size query
-        if(!m)
+        if(!m || !batch_count)
             return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged
                                                          : rocblas_status_success;
+
+        if(!A || !B)
+            return rocblas_status_invalid_pointer;
 
         void* mem_x_temp;
         void* mem_x_temp_arr;

--- a/library/src/blas2/rocblas_trsv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_trsv_strided_batched.cpp
@@ -124,9 +124,7 @@ namespace
             return rocblas_status_not_implemented;
         if(!A || !B)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-        if((m < 0 || lda < m || lda < 1 || !incx) && batch_count > 0)
+        if(m < 0 || lda < m || lda < 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
 
         // quick return if possible.


### PR DESCRIPTION
Changing the order of checks for tbsv, trsv, and tpsv.
Previously, if batch_count == 0 we did not return invalid_size for bad input args (such as M < 0). This is being changed here to match the rest of the library (i.e. do invalid_size checks first, then do quick return checks after, including batch == 0 checks).

Still waiting to build on my machine to test trsv changes.