### PR TITLE
FIxing tbmv testing.

### DIFF
--- a/clients/gtest/tbmv_gtest.yaml
+++ b/clients/gtest/tbmv_gtest.yaml
@@ -5,6 +5,7 @@ include: known_bugs.yaml
 Definitions:
   - &small_matrix_size_range
     - { M:    -1, K:     1, lda:    1  }
+    - { M:     0, K:     0, lda:    1 }
     - { M:     1, K:    -1, lda:    1  }
     - { M:     1, K:     1, lda:    0  }
     - { M:     4, K:     2, lda:    10 }
@@ -18,21 +19,22 @@ Definitions:
     - { M:     9, K:    15, lda:   20  }
     - { M:     9, K:    10, lda:   10  }
     - { M:   100, K:    60, lda:  200  }
+    - { M:    10, K:     7, lda:    8  }
 
   - &medium_matrix_size_range
     - { M:   63,  K:   8,   lda:  128 }
-    - { M:   65,  K:   8,   lda:  128 }
+    - { M:   65,  K:   8,   lda:   10 }
     - { M:   65,  K:   12,  lda:  128 }
     - { M:   65,  K:   32,  lda:  128 }
     - { M:   64,  K:   8,   lda:  128 }
     - { M:   64,  K:   45,  lda:  128 }
     - { M:   127, K:   8,   lda:  127 }
-    - { M:   127, K:   100, lda:  127 }
+    - { M:   127, K:   100, lda:  101 }
     - { M:   128, K:   5,   lda:  128 }
     - { M:   128, K:   8,   lda:  128 }
     - { M:   128, K:   20,  lda:  128 }
     - { M:   128, K:   40,  lda:  128 }
-    - { M:   128, K:   60,  lda:  128 }
+    - { M:   128, K:   60,  lda:   63 }
     - { M:   128, K:   63,  lda:  128 }
     - { M:   128, K:   64,  lda:  128 }
     - { M:   128, K:   100, lda:  128 }
@@ -41,14 +43,14 @@ Definitions:
     - { M:   512, K:   8,   lda:  512 }
     - { M:   512, K:   9,   lda:  512 }
     - { M:   512, K:   10,  lda:  512 }
-    - { M:   512, K:   20,  lda:  512 }
+    - { M:   512, K:   20,  lda:  511 }
     - { M:   300, K:   100, lda:  400 }
     - { M:   600, K:   500, lda:  601 }
 
   - &large_matrix_size_range
     - { M:  1000, K:  5,    lda: 1000 }
     - { M:  2000, K:  1999, lda: 2000 }
-    - { M:  4011, K:  512,  lda: 4011 }
+    - { M:  4011, K:  512,  lda: 550 }
 
   - &incx_range
     - { incx:  -5 }

--- a/clients/include/testing_tbmv.hpp
+++ b/clients/include/testing_tbmv.hpp
@@ -66,7 +66,7 @@ void testing_tbmv(const Arguments& arg)
     rocblas_local_handle handle;
 
     // argument sanity check before allocating invalid memory
-    if(M < 0 || K < 0 || lda < M || lda < 1 || !incx || K >= lda)
+    if(M < 0 || K < 0 || lda < K + 1 || !incx)
     {
         EXPECT_ROCBLAS_STATUS(
             rocblas_tbmv<T>(handle, uplo, transA, diag, M, K, nullptr, lda, nullptr, incx),
@@ -93,9 +93,8 @@ void testing_tbmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     // Initial Data on CPU
-    rocblas_seedrand();
-    rocblas_init<T>(hA, M, M, lda);
-    rocblas_init<T>(hx, 1, M, abs_incx);
+    rocblas_init<T>(hA, true);
+    rocblas_init<T>(hx, false);
     hx_gold = hx;
 
     // copy data from CPU to device

--- a/clients/include/testing_tbmv_batched.hpp
+++ b/clients/include/testing_tbmv_batched.hpp
@@ -87,13 +87,13 @@ void testing_tbmv_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // argument sanity check before allocating invalid memory
-    bool invalidSize = M < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
-    if(invalidSize || !M || !batch_count)
+    bool invalid_size = M < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
         EXPECT_ROCBLAS_STATUS(
             rocblas_tbmv_batched<T>(
                 handle, uplo, transA, diag, M, K, nullptr, lda, nullptr, incx, batch_count),
-            invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+            invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
 
         return;
     }

--- a/clients/include/testing_tbmv_strided_batched.hpp
+++ b/clients/include/testing_tbmv_strided_batched.hpp
@@ -103,8 +103,8 @@ void testing_tbmv_strided_batched(const Arguments& arg)
     rocblas_local_handle handle;
 
     // argument sanity check before allocating invalid memory
-    bool invalidSize = M < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
-    if(invalidSize || !M || !batch_count)
+    bool invalid_size = M < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
         EXPECT_ROCBLAS_STATUS(rocblas_tbmv_strided_batched<T>(handle,
                                                               uplo,
@@ -119,7 +119,7 @@ void testing_tbmv_strided_batched(const Arguments& arg)
                                                               incx,
                                                               stride_x,
                                                               batch_count),
-                              invalidSize ? rocblas_status_invalid_size : rocblas_status_success);
+                              invalid_size ? rocblas_status_invalid_size : rocblas_status_success);
 
         return;
     }

--- a/library/src/blas2/rocblas_tbmv.cpp
+++ b/library/src/blas2/rocblas_tbmv.cpp
@@ -88,7 +88,7 @@ namespace
                             incx);
         }
 
-        if(m < 0 || k < 0 || lda < m || lda < 1 || !incx || k >= lda)
+        if(m < 0 || k < 0 || lda < k + 1 || !incx)
             return rocblas_status_invalid_size;
 
         if(!m)

--- a/library/src/blas2/rocblas_tbmv_batched.cpp
+++ b/library/src/blas2/rocblas_tbmv_batched.cpp
@@ -104,7 +104,7 @@ namespace
                             batch_count);
         }
 
-        if(m < 0 || k < 0 || lda < m || lda < 1 || !incx || k >= lda || batch_count < 0)
+        if(m < 0 || k < 0 || lda < k + 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
         if(!m || !batch_count)
             return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged

--- a/library/src/blas2/rocblas_tbmv_strided_batched.cpp
+++ b/library/src/blas2/rocblas_tbmv_strided_batched.cpp
@@ -116,7 +116,7 @@ namespace
                             batch_count);
         }
 
-        if(m < 0 || k < 0 || lda < m || lda < 1 || !incx || k >= lda || batch_count < 0)
+        if(m < 0 || k < 0 || lda < k + 1 || !incx || batch_count < 0)
             return rocblas_status_invalid_size;
         if(!m || !batch_count)
             return handle->is_device_memory_size_query() ? rocblas_status_size_unchanged


### PR DESCRIPTION
I noticed while going through to reduce tests that tbmv didn't have any tests for N > lda > k, which is a valid use case. The tests were broken for this case, so I added tests and fixed the testing suite for this.

Will be reducing the number of tests here in a future commit (along with many other functions).