### PR TITLE
Use _Float16 only if clang >= 10 

### DIFF
--- a/library/include/rocblas-types.h
+++ b/library/include/rocblas-types.h
@@ -51,7 +51,7 @@ typedef double rocblas_double;
 // Clang supports _Float16 on C11 and C++11
 // GCC does not currently support _Float16 on amd64
 /*! \brief Represents a 16 bit floating point number. */
-#if __clang_major__ >= 9 && (__STDC_VERSION__ >= 201112L || __cplusplus >= 201103L)
+#if __clang_major__ >= 10 && (__STDC_VERSION__ >= 201112L || __cplusplus >= 201103L)
 typedef _Float16 rocblas_half;
 #else
 typedef struct


### PR DESCRIPTION
- This is due to clang++ 9.0.0 incompatibility, which causes problems for hipBLAS.
- Will need to propagated to master as well