### PR TITLE
Add alarm to tests to detect hangs; reduce memory leaks in tests; improve rocblas_abort implementation; make sigsetjmp code conformant; add comments

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -60,6 +60,7 @@ endif( )
 
 set(rocblas_no_tensile_test_source
     rocblas_gtest_main.cpp
+    rocblas_test.cpp
     set_get_pointer_mode_gtest.cpp
     logging_mode_gtest.cpp
     ostream_threadsafety_gtest.cpp

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -4,14 +4,9 @@
 
 #include "rocblas_data.hpp"
 #include "rocblas_parse_data.hpp"
+#include "rocblas_test.hpp"
 #include "test_cleanup.hpp"
 #include "utility.hpp"
-#include <atomic>
-#include <cerrno>
-#include <csetjmp>
-#include <csignal>
-#include <cstdlib>
-#include <gtest/gtest.h>
 
 using namespace testing;
 
@@ -154,98 +149,6 @@ static void rocblas_set_listener()
     }
 
     listeners.Append(listener);
-}
-
-/*********************************************
- * Signal-handling for detecting test faults *
- *********************************************/
-// Id of the thread which is catching signals
-static volatile pthread_t rocblas_test_sighandler_tid;
-
-// sigjmp_buf describing stack frame to go back to
-static sigjmp_buf rocblas_sigjmp_buf;
-
-// Whether rocblas_sigjmp_buf is set and catching signals is enabled
-static volatile sig_atomic_t rocblas_sighandler_enabled = false;
-
-// Signal handler
-extern "C" void rocblas_test_signal_handler(int sig)
-{
-    int e = errno; // Save errno
-
-    // If the signal handler is disabled, restore this signal's disposition
-    // to default, and reraise the signal
-    if(!rocblas_sighandler_enabled)
-    {
-        signal(sig, SIG_DFL);
-        raise(sig);
-        errno = e; // Restore errno
-        return;
-    }
-
-    // If the thread receiving the signal is different from the thread
-    // catching signals, send the signal to the thread catching signals.
-    if(!pthread_equal(pthread_self(), rocblas_test_sighandler_tid))
-    {
-        pthread_kill(rocblas_test_sighandler_tid, sig);
-        sleep(1);
-        errno = e; // Restore errno
-        return;
-    }
-
-    // Jump back to the handler code
-    // Note: This bypasses stack unwinding, and may lead to memory leaks, but
-    // it is better than crashing. Throwing exceptions from signal handlers is
-    // poorly supported, and may result in recursive calls to std::terminate.
-    errno = e; // Restore errno
-    siglongjmp(rocblas_sigjmp_buf, sig);
-}
-
-// Set up signal handlers
-static void rocblas_test_sigaction()
-{
-    struct sigaction act;
-    sigfillset(&act.sa_mask);
-    act.sa_flags   = 0;
-    act.sa_handler = rocblas_test_signal_handler;
-
-    for(int sig : {SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGPIPE, SIGSEGV, SIGSYS, SIGUSR1, SIGUSR2})
-    {
-        sigaction(sig, &act, nullptr);
-    }
-}
-
-// Lambda wrapper which detects signals and exceptions in an invokable function
-void catch_signals_and_exceptions_as_failures(const std::function<void()>& test)
-{
-    // Save this thread's id, to detect signals in different threads
-    rocblas_test_sighandler_tid = pthread_self();
-
-    // Set up the return point
-    int sig = sigsetjmp(rocblas_sigjmp_buf, true);
-
-    // If this is a return, indicate the signal received
-    if(sig)
-    {
-        rocblas_sighandler_enabled = false;
-        FAIL() << "Received " << strsignal(sig) << " signal";
-    }
-    else
-    {
-        // Run the test function, catching signals and exceptions
-        // Disable the signal handler after running the test
-        rocblas_sighandler_enabled = true;
-        try
-        {
-            test();
-            rocblas_sighandler_enabled = false;
-        }
-        catch(...)
-        {
-            rocblas_sighandler_enabled = false;
-            FAIL() << "Received unhandled exception";
-        }
-    }
 }
 
 // Print Version

--- a/clients/gtest/rocblas_test.cpp
+++ b/clients/gtest/rocblas_test.cpp
@@ -1,0 +1,149 @@
+#include "rocblas_test.hpp"
+#include <cerrno>
+#include <csetjmp>
+#include <csignal>
+#include <cstdlib>
+#include <exception>
+#include <pthread.h>
+#include <unistd.h>
+
+/*********************************************
+ * Signal-handling for detecting test faults *
+ *********************************************/
+
+// State of the signal handler
+static struct
+{
+    // Whether sigjmp_buf is set and catching signals is enabled
+    volatile sig_atomic_t enabled;
+
+    // Id of the thread which is catching signals
+    volatile pthread_t tid;
+
+    // sigjmp_buf describing stack frame to go back to
+    sigjmp_buf sigjmp_buf;
+
+    // The signal which was received
+    volatile sig_atomic_t signal;
+} handler;
+
+// Signal handler (must have external "C" linkage)
+extern "C" void rocblas_test_signal_handler(int sig)
+{
+    int saved_errno = errno; // Save errno
+
+    // If the signal handler is disabled, because we're not in the middle of
+    // running a rocBLAS test, restore this signal's disposition to default,
+    // and reraise the signal
+    if(!handler.enabled)
+    {
+        signal(sig, SIG_DFL);
+        errno = saved_errno;
+        raise(sig);
+        return;
+    }
+
+    // If the thread receiving the signal is different from the thread
+    // catching signals, send the signal to the thread catching signals.
+    if(!pthread_equal(pthread_self(), handler.tid))
+    {
+        pthread_kill(handler.tid, sig);
+        errno = saved_errno;
+        return;
+    }
+
+    // If this is an alarm timeout, we abort
+    if(sig == SIGALRM)
+    {
+        static constexpr char msg[]
+            = "\nAborting tests due to an alarm timeout.\n\n"
+              "This could be due to a deadlock caused by mutexes being left locked\n"
+              "after a previous test's signal was caught and partially recovered from.\n";
+        // We must use write() because it's async-signal-safe and other IO might be blocked
+        write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        rocblas_abort();
+    }
+
+    // Jump back to the handler code after setting handler.signal
+    // Note: This bypasses stack unwinding, and may lead to memory leaks, but
+    // it is better than crashing.
+    handler.signal = sig;
+    errno          = saved_errno;
+    siglongjmp(handler.sigjmp_buf, true);
+}
+
+// Set up signal handlers
+void rocblas_test_sigaction()
+{
+    // Set up a separate stack in case stack overflows occur
+    alignas(64) static char stack_memory[SIGSTKSZ];
+    stack_t                 stack = {stack_memory, 0, sizeof(stack_memory)};
+
+    struct sigaction act;
+    sigfillset(&act.sa_mask);
+
+    // Signal handler above
+    act.sa_handler = rocblas_test_signal_handler;
+
+    // We use the stack if sigaltstack() returns success
+    act.sa_flags = !sigaltstack(&stack, nullptr) ? SA_ONSTACK : 0;
+
+    for(int sig : {SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGALRM, SIGSEGV, SIGSYS, SIGUSR1, SIGUSR2})
+        sigaction(sig, &act, nullptr);
+}
+
+// Number of seconds each test is allowed to take before all testing is killed.
+constexpr unsigned TEST_TIMEOUT = 600;
+
+// Lambda wrapper which detects signals and exceptions in an invokable function
+void catch_signals_and_exceptions_as_failures(std::function<void()> test, bool set_alarm)
+{
+    // Save the current handler (to allow nested calls to this function)
+    auto old_handler = handler;
+
+    // Set up the return point, and handle siglongjmp returning back to here
+    if(sigsetjmp(handler.sigjmp_buf, true))
+    {
+        FAIL() << "Received " << strsignal(handler.signal) << " signal";
+    }
+    else
+    {
+        // Test timeout can be overriden by the ROCBLAS_TEST_TIMEOUT environment variable
+        static const unsigned test_timeout = []() {
+            unsigned    timeout;
+            const char* env = getenv("ROCBLAS_TEST_TIMEOUT");
+            return env && sscanf(env, "%u", &timeout) == 1 ? timeout : TEST_TIMEOUT;
+        }();
+
+        // Alarm to detect deadlocks or hangs
+        if(set_alarm)
+            alarm(test_timeout);
+
+        // Save this thread's id, to detect signals in different threads
+        handler.tid = pthread_self();
+
+        // Enable the signal handler
+        handler.enabled = true;
+
+        // Run the test function, catching signals and exceptions
+        try
+        {
+            test();
+        }
+        catch(const std::exception& e)
+        {
+            FAIL() << "Received uncaught exception: " << e.what();
+        }
+        catch(...)
+        {
+            FAIL() << "Received uncaught exception";
+        }
+    }
+
+    // Cancel the alarm if it was set
+    if(set_alarm)
+        alarm(0);
+
+    // Restore the previous handler
+    handler = old_handler;
+}

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -15,7 +15,7 @@
 #include "unit.hpp"
 #include "utility.hpp"
 
-#define DEBUG_PRINT false
+#define DEBUG_PRINT 0
 
 /* ============================================================================================ */
 template <typename Ti, typename To, typename Tc>

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -15,7 +15,7 @@
 #include "unit.hpp"
 #include "utility.hpp"
 
-#define DEBUG_PRINT false
+#define DEBUG_PRINT 0
 
 /* ============================================================================================ */
 template <typename Ti, typename To, typename Tc>

--- a/clients/include/testing_trsm_batched.hpp
+++ b/clients/include/testing_trsm_batched.hpp
@@ -54,25 +54,20 @@ void testing_trsm_batched(const Arguments& arg)
         CHECK_DEVICE_ALLOCATION(dXorB.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        rocblas_status status = rocblas_trsm_batched<T>(handle,
-                                                        side,
-                                                        uplo,
-                                                        transA,
-                                                        diag,
-                                                        M,
-                                                        N,
-                                                        &alpha_h,
-                                                        dA.ptr_on_device(),
-                                                        lda,
-                                                        dXorB.ptr_on_device(),
-                                                        ldb,
-                                                        batch_count);
-
-        if(batch_count == 0) // || M == 0 || N == 0 || K == 0)
-            CHECK_ROCBLAS_ERROR(status);
-        else
-            EXPECT_ROCBLAS_STATUS(status, rocblas_status_invalid_size);
-
+        EXPECT_ROCBLAS_STATUS(rocblas_trsm_batched<T>(handle,
+                                                      side,
+                                                      uplo,
+                                                      transA,
+                                                      diag,
+                                                      M,
+                                                      N,
+                                                      &alpha_h,
+                                                      dA.ptr_on_device(),
+                                                      lda,
+                                                      dXorB.ptr_on_device(),
+                                                      ldb,
+                                                      batch_count),
+                              batch_count ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_trsm_batched_ex.hpp
+++ b/clients/include/testing_trsm_batched_ex.hpp
@@ -58,28 +58,23 @@ void testing_trsm_batched_ex(const Arguments& arg)
         CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        rocblas_status status = rocblas_trsm_batched_ex(handle,
-                                                        side,
-                                                        uplo,
-                                                        transA,
-                                                        diag,
-                                                        M,
-                                                        N,
-                                                        &alpha_h,
-                                                        dA.ptr_on_device(),
-                                                        lda,
-                                                        dXorB.ptr_on_device(),
-                                                        ldb,
-                                                        batch_count,
-                                                        dinvA.ptr_on_device(),
-                                                        TRSM_BLOCK * K,
-                                                        arg.compute_type);
-
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(status);
-        else
-            EXPECT_ROCBLAS_STATUS(status, rocblas_status_invalid_size);
-
+        EXPECT_ROCBLAS_STATUS(rocblas_trsm_batched_ex(handle,
+                                                      side,
+                                                      uplo,
+                                                      transA,
+                                                      diag,
+                                                      M,
+                                                      N,
+                                                      &alpha_h,
+                                                      dA.ptr_on_device(),
+                                                      lda,
+                                                      dXorB.ptr_on_device(),
+                                                      ldb,
+                                                      batch_count,
+                                                      dinvA.ptr_on_device(),
+                                                      TRSM_BLOCK * K,
+                                                      arg.compute_type),
+                              batch_count ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_trsm_strided_batched.hpp
+++ b/clients/include/testing_trsm_strided_batched.hpp
@@ -56,26 +56,22 @@ void testing_trsm_strided_batched(const Arguments& arg)
         CHECK_DEVICE_ALLOCATION(dXorB.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        rocblas_status status = rocblas_trsm_strided_batched<T>(handle,
-                                                                side,
-                                                                uplo,
-                                                                transA,
-                                                                diag,
-                                                                M,
-                                                                N,
-                                                                &alpha_h,
-                                                                dA,
-                                                                lda,
-                                                                stride_a,
-                                                                dXorB,
-                                                                ldb,
-                                                                stride_b,
-                                                                batch_count);
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(status);
-        else
-            EXPECT_ROCBLAS_STATUS(status, rocblas_status_invalid_size);
-
+        EXPECT_ROCBLAS_STATUS(rocblas_trsm_strided_batched<T>(handle,
+                                                              side,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              M,
+                                                              N,
+                                                              &alpha_h,
+                                                              dA,
+                                                              lda,
+                                                              stride_a,
+                                                              dXorB,
+                                                              ldb,
+                                                              stride_b,
+                                                              batch_count),
+                              batch_count ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_trsm_strided_batched_ex.hpp
+++ b/clients/include/testing_trsm_strided_batched_ex.hpp
@@ -61,31 +61,26 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
         CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        rocblas_status status = rocblas_trsm_strided_batched_ex(handle,
-                                                                side,
-                                                                uplo,
-                                                                transA,
-                                                                diag,
-                                                                M,
-                                                                N,
-                                                                &alpha_h,
-                                                                dA,
-                                                                lda,
-                                                                stride_A,
-                                                                dXorB,
-                                                                ldb,
-                                                                stride_B,
-                                                                batch_count,
-                                                                dinvA,
-                                                                TRSM_BLOCK * K,
-                                                                stride_invA,
-                                                                arg.compute_type);
-
-        if(batch_count == 0)
-            CHECK_ROCBLAS_ERROR(status);
-        else
-            EXPECT_ROCBLAS_STATUS(status, rocblas_status_invalid_size);
-
+        EXPECT_ROCBLAS_STATUS(rocblas_trsm_strided_batched_ex(handle,
+                                                              side,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              M,
+                                                              N,
+                                                              &alpha_h,
+                                                              dA,
+                                                              lda,
+                                                              stride_A,
+                                                              dXorB,
+                                                              ldb,
+                                                              stride_B,
+                                                              batch_count,
+                                                              dinvA,
+                                                              TRSM_BLOCK * K,
+                                                              stride_invA,
+                                                              arg.compute_type),
+                              batch_count ? rocblas_status_invalid_size : rocblas_status_success);
         return;
     }
 

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -29,13 +29,31 @@
 // This must come after the header #includes above, to avoid poisoning system headers.
 //
 // This is only enabled for rocblas-test and rocblas-bench.
+//
+// If you are here because of a poisoned identifier error, here is the rationale for each
+// included identifier:
+//
+// cout, stdout: rocblas_cout should be used instead, for thread-safe and atomic line buffering
+// cerr, stderr: rocblas_cerr should be used instead, for thread-safe and atomic line buffering
+// clog: C++ stream which should not be used
+// gets: Always unsafe; buffer-overflows; removed from later versions of the language; use fgets
+// puts, putchar, fputs, printf, fprintf, vprintf, vfprintf: Use rocblas_cout or rocblas_cerr
+// sprintf, vsprintf: Possible buffer overflows; us snprintf or vsnprintf instead
+// strerror: Thread-unsafe; use snprintf / dprintf with %m or strerror_* alternatives
+// strtok: Thread-unsafe; use strtok_r
+// gmtime, ctime, asctime, localtime: Thread-unsafe
+// tmpnam: Thread-unsafe; use mkstemp or related functions instead
+// putenv: Use setenv instead
+// clearenv, fcloseall, ecvt, fcvt: Miscellaneous thread-unsafe functions
+// sleep: Might interact with signals by using alarm(); use nanosleep() instead
+// abort: Does not abort as cleanly as rocblas_abort, and can be caught by a signal handler
 
 #if defined(GOOGLE_TEST) || defined(ROCBLAS_BENCH)
 #undef stdout
 #undef stderr
 #pragma GCC poison cout cerr clog stdout stderr gets puts putchar fputs fprintf printf sprintf    \
     vfprintf vprintf vsprintf perror strerror strtok gmtime ctime asctime localtime tmpnam putenv \
-        clearenv fcloseall ecvt fcvt
+        clearenv fcloseall ecvt fcvt sleep abort
 #else
 // Suppress warnings about hipMalloc(), hipFree() except in rocblas-test and rocblas-bench
 #undef hipMalloc

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -12476,18 +12476,18 @@ ROCBLAS_EXPORT rocblas_status rocblas_zsyrkx_strided_batched(rocblas_handle     
             when  side == rocblas_side_left  and
             is  n  when  side == rocblas_side_right.
 
-	    When uplo == rocblas_fill_upper the  leading  k by k
-           upper triangular part of the array  A must contain the upper
-           triangular matrix  and the strictly lower triangular part of
-           A is not referenced.
+        When uplo == rocblas_fill_upper the  leading  k by k
+        upper triangular part of the array  A must contain the upper
+        triangular matrix  and the strictly lower triangular part of
+        A is not referenced.
 
-           When uplo == rocblas_fill_lower the  leading  k by k
-           lower triangular part of the array  A must contain the lower
-           triangular matrix  and the strictly upper triangular part of
-           A is not referenced.
+        When uplo == rocblas_fill_lower the  leading  k by k
+        lower triangular part of the array  A must contain the lower
+        triangular matrix  and the strictly upper triangular part of
+        A is not referenced.
 
-           Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
-           A  are not referenced either,  but are assumed to be  unity.
+        Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
+        A  are not referenced either,  but are assumed to be  unity.
 
     @param[in]
     lda     [rocblas_int]
@@ -12621,18 +12621,18 @@ ROCBLAS_EXPORT rocblas_status rocblas_ztrmm(rocblas_handle                handle
             when  side == rocblas_side_left  and
             is  n  when  side == rocblas_side_right.
 
-	    When uplo == rocblas_fill_upper the  leading  k by k
-           upper triangular part of the array  A must contain the upper
-           triangular matrix  and the strictly lower triangular part of
-           A is not referenced.
+        When uplo == rocblas_fill_upper the  leading  k by k
+        upper triangular part of the array  A must contain the upper
+        triangular matrix  and the strictly lower triangular part of
+        A is not referenced.
 
-           When uplo == rocblas_fill_lower the  leading  k by k
-           lower triangular part of the array  A must contain the lower
-           triangular matrix  and the strictly upper triangular part of
-           A is not referenced.
+        When uplo == rocblas_fill_lower the  leading  k by k
+        lower triangular part of the array  A must contain the lower
+        triangular matrix  and the strictly upper triangular part of
+        A is not referenced.
 
-           Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
-           A_i  are not referenced either,  but are assumed to be  unity.
+        Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
+        A_i  are not referenced either,  but are assumed to be  unity.
 
     @param[in]
     lda     [rocblas_int]
@@ -12773,18 +12773,18 @@ ROCBLAS_EXPORT rocblas_status rocblas_ztrmm_batched(rocblas_handle              
             when  side == rocblas_side_left  and
             is  n  when  side == rocblas_side_right.
 
-	    When uplo == rocblas_fill_upper the  leading  k by k
-           upper triangular part of the array  A must contain the upper
-           triangular matrix  and the strictly lower triangular part of
-           A is not referenced.
+        When uplo == rocblas_fill_upper the  leading  k by k
+        upper triangular part of the array  A must contain the upper
+        triangular matrix  and the strictly lower triangular part of
+        A is not referenced.
 
-           When uplo == rocblas_fill_lower the  leading  k by k
-           lower triangular part of the array  A must contain the lower
-           triangular matrix  and the strictly upper triangular part of
-           A is not referenced.
+        When uplo == rocblas_fill_lower the  leading  k by k
+        lower triangular part of the array  A must contain the lower
+        triangular matrix  and the strictly upper triangular part of
+        A is not referenced.
 
-           Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
-           A_i  are not referenced either,  but are assumed to be  unity.
+        Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
+        A_i  are not referenced either,  but are assumed to be  unity.
 
     @param[in]
     lda     [rocblas_int]
@@ -12806,7 +12806,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_ztrmm_batched(rocblas_handle              
     ldb    [rocblas_int]
            ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
 
-	       @param[in]
+           @param[in]
     stride_B  [rocblas_stride]
               stride from the start of one matrix (B_i) and the next one (B_i+1)
     @param[in]
@@ -15625,7 +15625,7 @@ ROCBLAS_EXPORT const char* rocblas_status_to_string(rocblas_status status);
 /* \brief Initialize rocBLAS, to avoid costly startup time at the first call.
 */
 
-ROCBLAS_EXPORT void rocblas_init();
+ROCBLAS_EXPORT void rocblas_init(void);
 
 /*
  * ===========================================================================
@@ -15710,6 +15710,12 @@ ROCBLAS_EXPORT rocblas_status rocblas_set_device_memory_size(rocblas_handle hand
     handle          rocblas handle
  ******************************************************************************/
 ROCBLAS_EXPORT bool rocblas_is_managing_device_memory(rocblas_handle handle);
+
+/*! \brief
+    \details
+    Abort function which safely flushes all IO
+ ******************************************************************************/
+ROCBLAS_EXPORT void rocblas_abort(void) __attribute__((__noreturn__));
 
 #ifdef __cplusplus
 }

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -80,7 +80,7 @@ _rocblas_handle::~_rocblas_handle()
         rocblas_cerr
             << "rocBLAS internal error: Handle object destroyed while device memory still in use."
             << std::endl;
-        abort();
+        rocblas_abort();
     }
     if(device_memory)
         (hipFree)(device_memory);
@@ -96,7 +96,7 @@ void* _rocblas_handle::device_allocator(size_t size)
         rocblas_cerr << "rocBLAS internal error: Cannot allocate device memory while it is already "
                         "allocated."
                      << std::endl;
-        abort();
+        rocblas_abort();
     }
     if(size > device_memory_size)
     {

--- a/library/src/include/rocblas_ostream.hpp
+++ b/library/src/include/rocblas_ostream.hpp
@@ -27,9 +27,6 @@
 #include <unistd.h>
 #include <utility>
 
-// Abort function which safely flushes all IO
-extern "C" void rocblas_abort [[noreturn]] ();
-
 /*****************************************************************************
  * rocBLAS output streams                                                    *
  *****************************************************************************/
@@ -236,7 +233,7 @@ public:
     }
 
     // Abort function which safely flushes all IO
-    friend void rocblas_abort();
+    friend void rocblas_abort_once();
 
     /*************************************************************************
      * Non-member friend functions for formatted output                      *

--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -400,7 +400,7 @@ namespace
             {
                 rocblas_cerr << "\nrocBLAS error: Cannot read " << path << ": " << strerror(errno)
                              << std::endl;
-                abort();
+                rocblas_abort();
             }
 
             library = std::dynamic_pointer_cast<


### PR DESCRIPTION
Adds a 10-minute alarm for every test case (the maximum right now is around 2 minutes on GFX906). If a test takes more than 10 minutes, then all testing is aborted, and a message explaining why is displayed. This should prevent the hangs in the CI when an aborted test is recovered from and everything hangs afterwards, probably because of a deadlock from a still-locked mutex.

Make `catch_signals_and_exceptions_as_failures` nestable, and put it around rocBLAS calls as close as possible, to reduce memory leaks. If a signal occurs in a rocBLAS call, it will be caught and translated into a Google Test failure, but the surrounding vector allocations will still be able to be destructed.

Clean up the implementation to use strict standard-conforming `sigsetjmp` usage, and catch `std::terminate`.

Fix a couple of bugs where Boolean values in macros were defined like:
```
#define NAME false
```
It should be:
```
#define NAME 0
```
... so that it can be used in preprocessor expressions, e.g. `#if NAME`.

Add `rocblas_abort` to the public API,  and fix its implementation to be thread-safe.

Add comments explaining why some of the symbols are "poisoned" in `rocblas-test` and `rocblas-bench`.

Some reformatting caused by `clang-format`.