### PR TITLE
Use build directory instead of source directory for generated files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -498,3 +498,6 @@ public:
 
 
 23. Automatically-generated files should always go into `build/` directories, and should not go into source directories (even if marked `.gitignore`). The CMake philosophy is such that you can create any `build/` directory, run `cmake` from there, and then have a self-contained build environment which will not touch any files outside of it.
+
+
+24. The `library/include` subdirectory of rocBLAS, to be distinguished from the `library/src/include` subdirectory, shall consist only of C-compatible header files for public rocBLAS APIs. It should not include internal APIs, even if they are used in other projects, e.g., rocSOLVER, and the headers must be compilable with a C compiler, and must use `.h` extensions.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,11 +60,16 @@ To format a file, use:
 /opt/rocm/hcc/bin/clang-format -style=file -i <path-to-source-file>
 ```
 
-To format all files, run the following script in rocBLAS directory:
+To format all files, run the following command in rocBLAS directory:
 
 ```
-#!/bin/bash
 git ls-files -z *.cc *.cpp *.h *.hpp *.cl *.h.in *.hpp.in *.cpp.in | xargs -0 /opt/rocm/hcc/bin/clang-format  -style=file -i
+```
+
+For More extensive reformatting, such as removing redundant whitespace, run:
+```
+./.githooks/pre-commit --reformat
+
 ```
 
 Also, githooks can be installed to format the code per-commit:
@@ -490,3 +495,6 @@ public:
 ```
 
     The former denotes the rocBLAS arguments as a list which is passed as a variadic template argument, and whose properties are known and can be optimized at compile-time, and which can be passed on as arguments to other templates, while the latter requires creating a dynamically-allocated runtime object which must be interpreted at runtime, such as by using `switch` statements on the arguments. The `switch` statement will need to list out and handle every possible argument, while the template solution simply passes the argument as another template argument, and hence can be resolved at compile-time.
+
+
+23. Automatically-generated files should always go into `build/` directories, and should not go into source directories (even if marked `.gitignore`). The CMake philosophy is such that you can create any `build/` directory, run `cmake` from there, and then have a self-contained build environment which will not touch any files outside of it.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -803,3 +803,6 @@ Coding Guidelines
         model.func();
 
   The former denotes the rocBLAS arguments as a list which is passed as a variadic template argument, and whose properties are known and can be optimized at compile-time, and which can be passed on as arguments to other templates, while the latter requires creating a dynamically-allocated runtime object which must be interpreted at runtime, such as by using ``switch`` statements on the arguments. The ``switch`` statement will need to list out and handle every possible argument, while the template solution simply passes the argument as another template argument, and hence can be resolved at compile-time.
+
+
+23. Automatically-generated files should always go into ``build/`` directories, and should not go into source directories (even if marked ``.gitignore``). The CMake philosophy is such that you can create any ``build/`` directory, run ``cmake`` from there, and then have a self-contained build environment which will not touch any files outside of it.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -806,3 +806,6 @@ Coding Guidelines
 
 
 23. Automatically-generated files should always go into ``build/`` directories, and should not go into source directories (even if marked ``.gitignore``). The CMake philosophy is such that you can create any ``build/`` directory, run ``cmake`` from there, and then have a self-contained build environment which will not touch any files outside of it.
+
+
+24. The ``library/include`` subdirectory of rocBLAS, to be distinguished from the ``library/src/include`` subdirectory, shall consist only of C-compatible header files for public rocBLAS APIs. It should not include internal APIs, even if they are used in other projects, e.g., rocSOLVER, and the headers must be compilable with a C compiler, and must use ``.h`` extensions.

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -372,12 +372,11 @@ set_target_properties( rocblas PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIBIL
 generate_export_header( rocblas EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/rocblas-export.h )
 
 # generate header with prototypes for export reuse
-set( SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}" )
-set( ROCBLAS_PROTO_TEMPLATES "${SRC_DIR}/../include/rocblas-exported-proto.hpp" )
+set( ROCBLAS_PROTO_TEMPLATES "${PROJECT_BINARY_DIR}/include/rocblas-exported-proto.hpp" )
 add_custom_command( TARGET rocblas PRE_BUILD
-  COMMAND python template-proto.py ${SRC_DIR}/blas3/Tensile/*.hpp ${SRC_DIR}/blas3/*.hpp ${SRC_DIR}/blas2/*.hpp ${SRC_DIR}/blas1/*.hpp > ${ROCBLAS_PROTO_TEMPLATES}
-  DEPENDS ${SRC_DIR}
-  COMMENT "Generating prototypes from ${SRC_DIR}."
+  COMMAND python template-proto.py ${CMAKE_CURRENT_SOURCE_DIR}/blas3/Tensile/*.hpp ${CMAKE_CURRENT_SOURCE_DIR}/blas3/*.hpp ${CMAKE_CURRENT_SOURCE_DIR}/blas2/*.hpp ${CMAKE_CURRENT_SOURCE_DIR}/blas1/*.hpp > ${ROCBLAS_PROTO_TEMPLATES}
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Generating prototypes from ${CMAKE_CURRENT_SOURCE_DIR}."
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 


### PR DESCRIPTION
The `build` directory should be used to store files generated automatically during builds, rather than the source directory.

Also, rocBLAS files should not go into the `library/include` directory unless they are **public C-compatible** header files which are documented and supported. This does not apply to internal C++ headers.

This PR:

1. Keeps the source directory clean (`git status`) after builds, without requiring `.gitignore`.

2. Preserves the invariant that `library/include` consists only of C-compatible public header files.

3. Documents these best practices in `CONTRIBUTING.md` and `contributing.rst`.

4. Is in keeping with the CMake philosophy that a build directory is self-contained, and if the `cmake` command is run from a build _working directory_, then all of the files generated by `cmake` and the `make` build it creates, **stay confined to that build directory**.
