### PR TITLE
Cleanup macros and #include file ordering

### DIFF
--- a/clients/include/rocblas_test.hpp
+++ b/clients/include/rocblas_test.hpp
@@ -5,6 +5,10 @@
 #ifndef ROCBLAS_TEST_H_
 #define ROCBLAS_TEST_H_
 
+#ifdef GOOGLE_TEST
+#include <gtest/gtest.h>
+#endif
+
 #include "argument_model.hpp"
 #include "rocblas.h"
 #include "rocblas_arguments.hpp"
@@ -20,38 +24,27 @@
 #include <unordered_map>
 #include <utility>
 
-// Suppress warnings about hipMalloc(), hipFree() except in rocblas-test and rocblas-bench
-#if !defined(GOOGLE_TEST) && !defined(ROCBLAS_BENCH)
-#undef hipMalloc
-#undef hipFree
-#endif
-
 #ifdef GOOGLE_TEST
-#include <gtest/gtest.h>
 
 // Extra macro so that macro arguments get expanded before calling Google Test
 #define CHECK_HIP_ERROR2(ERROR) ASSERT_EQ(ERROR, hipSuccess)
 #define CHECK_HIP_ERROR(ERROR) CHECK_HIP_ERROR2(ERROR)
 
-#define CHECK_DEVICE_ALLOCATION(ERROR)            \
-    do                                            \
-    {                                             \
-        auto error = ERROR;                       \
-        if(error == hipErrorOutOfMemory)          \
-        {                                         \
-            SUCCEED() << LIMITED_MEMORY_STRING;   \
-            return;                               \
-        }                                         \
-        else if(error != hipSuccess)              \
-        {                                         \
-            fprintf(stderr,                       \
-                    "error: '%s'(%d) at %s:%d\n", \
-                    hipGetErrorString(error),     \
-                    error,                        \
-                    __FILE__,                     \
-                    __LINE__);                    \
-            return;                               \
-        }                                         \
+#define CHECK_DEVICE_ALLOCATION(ERROR)                                              \
+    do                                                                              \
+    {                                                                               \
+        auto error = ERROR;                                                         \
+        if(error == hipErrorOutOfMemory)                                            \
+        {                                                                           \
+            SUCCEED() << LIMITED_MEMORY_STRING;                                     \
+            return;                                                                 \
+        }                                                                           \
+        else if(error != hipSuccess)                                                \
+        {                                                                           \
+            rocblas_cerr << "error: '" << hipGetErrorString(error) << "'(" << error \
+                         << ") at " __FILE__ ":" << __LINE__ << std::endl;          \
+            return;                                                                 \
+        }                                                                           \
     } while(0)
 
 #define EXPECT_ROCBLAS_STATUS ASSERT_EQ

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -35,7 +35,7 @@
 #undef stderr
 #pragma GCC poison cout cerr clog stdout stderr gets puts putchar fputs fprintf printf sprintf    \
     vfprintf vprintf vsprintf perror strerror strtok gmtime ctime asctime localtime tmpnam putenv \
-        clearenv fcloseall ecvt fcvt sleep abort
+        clearenv fcloseall ecvt fcvt
 #else
 // Suppress warnings about hipMalloc(), hipFree() except in rocblas-test and rocblas-bench
 #undef hipMalloc

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -8,7 +8,6 @@
 #include "cblas_interface.hpp"
 #include "logging.h"
 #include "rocblas.h"
-#include "rocblas_test.hpp"
 #include "rocblas_vector.hpp"
 #include "utility.h"
 #include <cstdio>
@@ -36,7 +35,11 @@
 #undef stderr
 #pragma GCC poison cout cerr clog stdout stderr gets puts putchar fputs fprintf printf sprintf    \
     vfprintf vprintf vsprintf perror strerror strtok gmtime ctime asctime localtime tmpnam putenv \
-        clearenv fcloseall ecvt fcvt
+        clearenv fcloseall ecvt fcvt sleep abort
+#else
+// Suppress warnings about hipMalloc(), hipFree() except in rocblas-test and rocblas-bench
+#undef hipMalloc
+#undef hipFree
 #endif
 
 static constexpr char LIMITED_MEMORY_STRING[]


### PR DESCRIPTION
This fixes an undefined macro for `CHECK_HIP_ERROR`, fixes poisoned identifiers by `#include`ing `gtest/gtest.h` first, and puts the `hipMalloc/hipFree` code next to the poisoned identifiers `#ifdef` test.