### PR TITLE
Improve docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -503,9 +503,9 @@ public:
 24. The `library/include` subdirectory of rocBLAS, to be distinguished from the `library/src/include` subdirectory, shall consist only of C-compatible header files for public rocBLAS APIs. It should not include internal APIs, even if they are used in other projects, e.g., rocSOLVER, and the headers must be compilable with a C compiler, and must use `.h` extensions.
 
 
-25. Macro parameters should only be evaluated once when practical, and should be parenthesized if there is a chance of ambiguous precedence. They should stored in a local temporary variable if needed more than once.
+25. Macro parameters should only be evaluated once when practical, and should be parenthesized if there is a chance of ambiguous precedence. They should be stored in a local temporary variable if needed more than once.
 
-Macros which expand to code with local variables, should use double-underscore suffixes in the local variable names, to prevent their conflict with variables passed in macro parameters. However, if they are in a completely separate block scope than the macro parameter is expanded in, then they do not need to use trailing underscores.
+Macros which expand to code with local variables, should use double-underscore suffixes in the local variable names, to prevent their conflict with variables passed in macro parameters. However, if they are in a completely separate block scope than the macro parameter is expanded in, or if they are only passed to another macro/function, then they do not need to use trailing underscores.
 ```
         #define CHECK_DEVICE_ALLOCATION(ERROR)                   \
             do                                                   \

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -501,3 +501,29 @@ public:
 
 
 24. The `library/include` subdirectory of rocBLAS, to be distinguished from the `library/src/include` subdirectory, shall consist only of C-compatible header files for public rocBLAS APIs. It should not include internal APIs, even if they are used in other projects, e.g., rocSOLVER, and the headers must be compilable with a C compiler, and must use `.h` extensions.
+
+
+25. Macro parameters should only be evaluated once when practical, and should be parenthesized if there is a chance of ambiguous precedence. They should stored in a local temporary variable if needed more than once.
+
+Macros which expand to code with local variables, should use double-underscore suffixes in the local variable names, to prevent their conflict with variables passed in macro parameters. However, if they are in a completely separate block scope than the macro parameter is expanded in, then they do not need to use trailing underscores.
+```
+        #define CHECK_DEVICE_ALLOCATION(ERROR)                   \
+            do                                                   \
+            {                                                    \
+                /* Use error__ in case ERROR contains "error" */ \
+                hipError_t error__ = (ERROR);                    \
+                if(error__ != hipSuccess)                        \
+                {                                                \
+                    if(error__ == hipErrorOutOfMemory)           \
+                        SUCCEED() << LIMITED_MEMORY_STRING;      \
+                    else                                         \
+                        FAIL() << hipGetErrorString(error__);    \
+                    return;                                      \
+                }                                                \
+            } while(0)
+```
+The `ERROR` macro parameter is evaluated only once, and is stored in the temporary variable `error__`, for use multiple times later.
+
+The `ERROR` macro parameter is parenthesized when initializing `error__`, to avoid ambiguous precedence, such as if ``ERROR`` contains a comma expression.
+
+The `error__` variable name is used, to prevent it from conflicting with variables passed in the `ERROR` macro parameter, such as `error`.

--- a/docs/cleanup_text.sh
+++ b/docs/cleanup_text.sh
@@ -113,7 +113,7 @@ while(<>)
       print ICONV;
       close ICONV;
     } else {
-      ($code, $code_indent) = (1, $indent) if /::\s*$/;
+      ($code, $code_indent) = (1, $indent) if /::(\s+\S+)?\s*$/;
       print;
     }
 }

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -809,3 +809,31 @@ Coding Guidelines
 
 
 24. The ``library/include`` subdirectory of rocBLAS, to be distinguished from the ``library/src/include`` subdirectory, shall consist only of C-compatible header files for public rocBLAS APIs. It should not include internal APIs, even if they are used in other projects, e.g., rocSOLVER, and the headers must be compilable with a C compiler, and must use ``.h`` extensions.
+
+
+25. Macro parameters should only be evaluated once when practical, and should be parenthesized if there is a chance of ambiguous precedence. They should stored in a local temporary variable if needed more than once.
+
+Macros which expand to code with local variables, should use double-underscore suffixes in the local variable names, to prevent their conflict with variables passed in macro parameters. However, if they are in a completely separate block scope than the macro parameter is expanded in, then they do not need to use trailing underscores.
+
+    ..code:: cpp
+
+        #define CHECK_DEVICE_ALLOCATION(ERROR)                   \
+            do                                                   \
+            {                                                    \
+                /* Use error__ in case ERROR contains "error" */ \
+                hipError_t error__ = (ERROR);                    \
+                if(error__ != hipSuccess)                        \
+                {                                                \
+                    if(error__ == hipErrorOutOfMemory)           \
+                        SUCCEED() << LIMITED_MEMORY_STRING;      \
+                    else                                         \
+                        FAIL() << hipGetErrorString(error__);    \
+                    return;                                      \
+                }                                                \
+            } while(0)
+
+The ``ERROR`` macro parameter is evaluated only once, and is stored in the temporary variable ``error__``, for use multiple times later.
+
+The ``ERROR`` macro parameter is parenthesized when initializing ``error__``, to avoid ambiguous precedence, such as if ``ERROR`` contains a comma expression.
+
+The ``error__`` variable name is used, to prevent it from conflicting with variables passed in the ``ERROR`` macro parameter, such as ``error``.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -811,9 +811,9 @@ Coding Guidelines
 24. The ``library/include`` subdirectory of rocBLAS, to be distinguished from the ``library/src/include`` subdirectory, shall consist only of C-compatible header files for public rocBLAS APIs. It should not include internal APIs, even if they are used in other projects, e.g., rocSOLVER, and the headers must be compilable with a C compiler, and must use ``.h`` extensions.
 
 
-25. Macro parameters should only be evaluated once when practical, and should be parenthesized if there is a chance of ambiguous precedence. They should stored in a local temporary variable if needed more than once.
+25. Macro parameters should only be evaluated once when practical, and should be parenthesized if there is a chance of ambiguous precedence. They should be stored in a local temporary variable if needed more than once.
 
-Macros which expand to code with local variables, should use double-underscore suffixes in the local variable names, to prevent their conflict with variables passed in macro parameters. However, if they are in a completely separate block scope than the macro parameter is expanded in, then they do not need to use trailing underscores.
+Macros which expand to code with local variables, should use double-underscore suffixes in the local variable names, to prevent their conflict with variables passed in macro parameters. However, if they are in a completely separate block scope than the macro parameter is expanded in, or if they are only passed to another macro/function, then they do not need to use trailing underscores.
 
     ..code:: cpp
 


### PR DESCRIPTION
Add another guideline for macros (motivated by a recent bug caused by a macro expansion's local variable `status` conflicting with a macro caller's `status` without any compile-time error, just a strange runtime failure), and enhance `cleanup_text.sh` to handle quoted code segments in restructuredtext with a language specified.


