### PR TITLE
Batched memcheck fixes

### DIFF
--- a/clients/include/norm.hpp
+++ b/clients/include/norm.hpp
@@ -239,14 +239,15 @@ double norm_check_general(char           norm_type,
 }
 
 /* ============== Norm Check for batched case ============= */
+
 template <typename T, typename T_hpa>
-double norm_check_general(char               norm_type,
-                          rocblas_int        M,
-                          rocblas_int        N,
-                          rocblas_int        lda,
-                          host_vector<T_hpa> hCPU[],
-                          host_vector<T>     hGPU[],
-                          rocblas_int        batch_count)
+double norm_check_general(char                      norm_type,
+                          rocblas_int               M,
+                          rocblas_int               N,
+                          rocblas_int               lda,
+                          host_batch_vector<T_hpa>& hCPU,
+                          host_batch_vector<T>&     hGPU,
+                          rocblas_int               batch_count)
 {
     // norm type can be O', 'I', 'F', 'o', 'i', 'f' for one, infinity or Frobenius norm
     // one norm is max column sum

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -197,10 +197,6 @@ void rocblas_init_nan(
     std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)
 {
     rocblas_init_nan(A.data(), M, N, lda, stride, batch_count);
-    // for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
-    //     for(size_t i = 0; i < M; ++i)
-    //         for(size_t j = 0; j < N; ++j)
-    //             A[i + j * lda + i_batch * stride] = T(rocblas_nan_rng());
 }
 
 /* ============================================================================================ */

--- a/clients/include/rocblas_init.hpp
+++ b/clients/include/rocblas_init.hpp
@@ -184,7 +184,7 @@ void rocblas_init_nan(T* A, size_t N)
 
 template <typename T>
 void rocblas_init_nan(
-    std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)
+    T* A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)
 {
     for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
         for(size_t i = 0; i < M; ++i)
@@ -192,8 +192,31 @@ void rocblas_init_nan(
                 A[i + j * lda + i_batch * stride] = T(rocblas_nan_rng());
 }
 
+template <typename T>
+void rocblas_init_nan(
+    std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride = 0, size_t batch_count = 1)
+{
+    rocblas_init_nan(A.data(), M, N, lda, stride, batch_count);
+    // for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
+    //     for(size_t i = 0; i < M; ++i)
+    //         for(size_t j = 0; j < N; ++j)
+    //             A[i + j * lda + i_batch * stride] = T(rocblas_nan_rng());
+}
+
 /* ============================================================================================ */
 /*! \brief  Packs strided_batched matricies into groups of 4 in N */
+
+template <typename T>
+void rocblas_packInt8(T* A, const T* temp, size_t M, size_t N, size_t lda)
+{
+    if(N % 4 != 0)
+        rocblas_cerr << "ERROR: dimension must be a multiple of 4 in order to pack" << std::endl;
+
+    for(size_t colBase = 0; colBase < N; colBase += 4)
+        for(size_t row = 0; row < lda; row++)
+            for(size_t colOffset = 0; colOffset < 4; colOffset++)
+                A[(colBase * lda + 4 * row) + colOffset] = temp[(colBase + colOffset) * lda + row];
+}
 
 template <typename T>
 void rocblas_packInt8(

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -26,7 +26,7 @@ void testing_asum_batched_bad_arg(const Arguments& arg)
     rocblas_local_handle handle;
 
     device_batch_vector<T> dx(N, 1, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
@@ -57,9 +57,9 @@ void testing_asum_batched(const Arguments& arg)
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         device_batch_vector<T> dx(3, 1, 2);
-        CHECK_HIP_ERROR(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
         device_vector<real_t<T>> dr(std::max(2, std::abs(batch_count)));
-        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_DEVICE_ALLOCATION(dr.memcheck());
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS(
             rocblas_asum_batched<T>(handle, N, dx.ptr_on_device(), incx, batch_count, dr),
@@ -79,10 +79,10 @@ void testing_asum_batched(const Arguments& arg)
     host_vector<real_t<T>>   hr1(batch_count);
     host_vector<real_t<T>>   hr(batch_count);
 
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(hx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(hx.memcheck());
 
-    CHECK_HIP_ERROR(dr.memcheck());
+    CHECK_DEVICE_ALLOCATION(dr.memcheck());
     CHECK_HIP_ERROR(hr1.memcheck());
     CHECK_HIP_ERROR(hr.memcheck());
 

--- a/clients/include/testing_axpy_batched.hpp
+++ b/clients/include/testing_axpy_batched.hpp
@@ -24,9 +24,9 @@ void testing_axpy_batched_bad_arg(const Arguments& arg)
 
     T                      alpha = 0.6;
     device_batch_vector<T> dx(10, 1, 2);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
     device_batch_vector<T> dy(10, 1, 2);
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_axpy_batched<T>(
@@ -59,9 +59,9 @@ void testing_axpy_batched(const Arguments& arg)
     if(N <= 0 || batch_count <= 0)
     {
         device_batch_vector<T> dx(10, 1, 3);
-        CHECK_HIP_ERROR(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
         device_batch_vector<T> dy(10, 1, 3);
-        CHECK_HIP_ERROR(dy.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
         EXPECT_ROCBLAS_STATUS(rocblas_axpy_batched<T>(handle,
@@ -98,9 +98,9 @@ void testing_axpy_batched(const Arguments& arg)
     device_batch_vector<T> dx(N, incx, batch_count), dy(N, incy, batch_count);
     device_vector<T>       dalpha(1);
 
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dalpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dalpha.memcheck());
 
     //
     // Assign host alpha.

--- a/clients/include/testing_gbmv_batched.hpp
+++ b/clients/include/testing_gbmv_batched.hpp
@@ -39,9 +39,9 @@ void testing_gbmv_batched_bad_arg(const Arguments& arg)
     device_batch_vector<T> dA(batch_count, safe_size);
     device_batch_vector<T> dx(batch_count, safe_size);
     device_batch_vector<T> dy(batch_count, safe_size);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     auto dA_dev = dA.ptr_on_device();
     auto dx_dev = dx.ptr_on_device();
@@ -239,12 +239,12 @@ void testing_gbmv_batched(const Arguments& arg)
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
 
-    CHECK_HIP_ERROR(AA.memcheck());
-    CHECK_HIP_ERROR(xA.memcheck());
-    CHECK_HIP_ERROR(y_1A.memcheck());
-    CHECK_HIP_ERROR(y_2A.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(AA.memcheck());
+    CHECK_DEVICE_ALLOCATION(xA.memcheck());
+    CHECK_DEVICE_ALLOCATION(y_1A.memcheck());
+    CHECK_DEVICE_ALLOCATION(y_2A.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     rocblas_init(hA, true);
     rocblas_init(hxA);

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -308,9 +308,9 @@ void testing_gemm_batched_bad_arg(const Arguments& arg)
     device_batch_vector<T> dA(safe_size, 1, batch_count);
     device_batch_vector<T> dB(safe_size, 1, batch_count);
     device_batch_vector<T> dC(safe_size, 1, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dB.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dB.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_gemm_batched<T>(handle,
                                                   transA,

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -374,7 +374,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
     hD_2.copy_from(hD_1);
     for(int b = 0; b < batch_count; b++)
     {
-        for(int i = 0; i < size_d; i++)
+        for(size_t i = 0; i < size_d; i++)
         {
             hD_gold[b][i] = hD_1[b][i];
         }

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -370,8 +370,8 @@ void testing_gemm_batched_ex(const Arguments& arg)
             rocblas_init<To>(hC[b], M, N, ldc);
         rocblas_init<To>(hD_1[b], M, N, ldd);
     }
-    hD_2.copy_from(hD_1);
 
+    hD_2.copy_from(hD_1);
     for(int b = 0; b < batch_count; b++)
     {
         for(int i = 0; i < size_d; i++)
@@ -379,7 +379,6 @@ void testing_gemm_batched_ex(const Arguments& arg)
             hD_gold[b][i] = hD_1[b][i];
         }
     }
-    // hD_gold.copy_from(hD_1);
 
 #if 0 // Copied from testing_gemm_ex.hpp
     if(std::is_same<To, rocblas_half>{} && std::is_same<Tc, float>{})

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -284,16 +284,15 @@ void testing_gemm_batched_ex(const Arguments& arg)
        || (std::is_same<Ti, int8_t>{}
            && (K % 4 != 0 || (transA != rocblas_operation_none && lda % 4 != 0))))
     {
-        static const size_t       safe_size = 100;
-        device_vector<Ti*, 0, Ti> dA(1);
-        device_vector<Ti*, 0, Ti> dB(1);
-        device_vector<To*, 0, To> dC(1);
-        device_vector<To*, 0, To> dD(1);
-        if(!dA || !dB || !dC || !dD)
-        {
-            CHECK_HIP_ERROR(hipErrorOutOfMemory);
-            return;
-        }
+        // TODO: Fix argument checking to check nullptrs after invalid_size
+        device_batch_vector<Ti> dA(1, 1, 1);
+        device_batch_vector<Ti> dB(1, 1, 1);
+        device_batch_vector<To> dC(1, 1, 1);
+        device_batch_vector<To> dD(1, 1, 1);
+        CHECK_DEVICE_ALLOCATION(dA.memcheck());
+        CHECK_DEVICE_ALLOCATION(dB.memcheck());
+        CHECK_DEVICE_ALLOCATION(dC.memcheck());
+        CHECK_DEVICE_ALLOCATION(dD.memcheck());
 
         EXPECT_ROCBLAS_STATUS(rocblas_gemm_batched_ex(handle,
                                                       transA,
@@ -302,17 +301,17 @@ void testing_gemm_batched_ex(const Arguments& arg)
                                                       N,
                                                       K,
                                                       &h_alpha_Tc,
-                                                      dA,
+                                                      dA.ptr_on_device(),
                                                       arg.a_type,
                                                       lda,
-                                                      dB,
+                                                      dB.ptr_on_device(),
                                                       arg.b_type,
                                                       ldb,
                                                       &h_beta_Tc,
-                                                      dC,
+                                                      dC.ptr_on_device(),
                                                       arg.c_type,
                                                       ldc,
-                                                      dD,
+                                                      dD.ptr_on_device(),
                                                       arg.d_type,
                                                       ldd,
                                                       batch_count,
@@ -337,48 +336,27 @@ void testing_gemm_batched_ex(const Arguments& arg)
     size_t size_d     = size_one_d;
 
     // allocate memory on device
-    device_vector<Ti*, 0, Ti> dA(batch_count);
-    device_vector<Ti*, 0, Ti> dB(batch_count);
-    device_vector<To*, 0, To> dC(batch_count);
-    device_vector<To*, 0, To> dD(batch_count);
-    device_vector<Tc>         d_alpha_Tc(1);
-    device_vector<Tc>         d_beta_Tc(1);
-    if(!dA || !dB || !dC || !dD)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    device_batch_vector<Ti> dA(size_a, 1, batch_count);
+    device_batch_vector<Ti> dB(size_b, 1, batch_count);
+    device_batch_vector<To> dC(size_c, 1, batch_count);
+    device_batch_vector<To> dD(size_d, 1, batch_count);
+    device_vector<Tc>       d_alpha_Tc(1);
+    device_vector<Tc>       d_beta_Tc(1);
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dB.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dD.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha_Tc.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta_Tc.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<Ti> hA[batch_count];
-    host_vector<Ti> hB[batch_count];
-    host_vector<To> hC[batch_count];
-    host_vector<To> hD_1[batch_count];
-    host_vector<To> hD_2[batch_count];
     using To_hpa = std::conditional_t<std::is_same<To, rocblas_bfloat16>{}, float, To>;
-    host_vector<To_hpa> hD_gold[batch_count];
-    for(rocblas_int b = 0; b < batch_count; b++)
-    {
-        hA[b]      = host_vector<Ti>(size_a);
-        hB[b]      = host_vector<Ti>(size_b);
-        hC[b]      = host_vector<To>(size_c);
-        hD_1[b]    = host_vector<To>(size_d);
-        hD_2[b]    = host_vector<To>(size_d);
-        hD_gold[b] = host_vector<To_hpa>(size_d);
-    }
-
-    device_batch_vector<Ti> bA(batch_count, size_a);
-    device_batch_vector<Ti> bB(batch_count, size_b);
-    device_batch_vector<To> bC(batch_count, size_c);
-    device_batch_vector<To> bD(batch_count, size_d);
-
-    int last = batch_count - 1;
-    if((!bA[last] && size_a) || (!bB[last] && size_b) || (!bC[last] && size_c)
-       || (!bD[last] && size_d) || !d_alpha_Tc || !d_beta_Tc)
-    {
-        CHECK_HIP_ERROR(hipErrorOutOfMemory);
-        return;
-    }
+    host_batch_vector<Ti>     hA(size_a, 1, batch_count);
+    host_batch_vector<Ti>     hB(size_b, 1, batch_count);
+    host_batch_vector<To>     hC(size_c, 1, batch_count);
+    host_batch_vector<To>     hD_1(size_d, 1, batch_count);
+    host_batch_vector<To>     hD_2(size_d, 1, batch_count);
+    host_batch_vector<To_hpa> hD_gold(size_d, 1, batch_count);
 
     // Initial Data on CPU
     rocblas_seedrand();
@@ -391,9 +369,17 @@ void testing_gemm_batched_ex(const Arguments& arg)
         else
             rocblas_init<To>(hC[b], M, N, ldc);
         rocblas_init<To>(hD_1[b], M, N, ldd);
-        hD_2[b]    = hD_1[b];
-        hD_gold[b] = hD_1[b];
     }
+    hD_2.copy_from(hD_1);
+
+    for(int b = 0; b < batch_count; b++)
+    {
+        for(int i = 0; i < size_d; i++)
+        {
+            hD_gold[b][i] = hD_1[b][i];
+        }
+    }
+    // hD_gold.copy_from(hD_1);
 
 #if 0 // Copied from testing_gemm_ex.hpp
     if(std::is_same<To, rocblas_half>{} && std::is_same<Tc, float>{})
@@ -427,52 +413,42 @@ void testing_gemm_batched_ex(const Arguments& arg)
 #endif
 
     // copy data from CPU to device
-    // 1. Use intermediate arrays to access device memory from host
-    for(int b = 0; b < batch_count; b++)
+    if(std::is_same<Ti, int8_t>{} && transA == rocblas_operation_none)
     {
-        // Packing stuff
-        if(std::is_same<Ti, int8_t>{} && transA == rocblas_operation_none)
-        {
-            host_vector<Ti> hA_packed(hA[b]);
-            rocblas_packInt8(hA_packed, M, K, lda);
-            CHECK_HIP_ERROR(
-                hipMemcpy(bA[b], hA_packed, sizeof(Ti) * size_a, hipMemcpyHostToDevice));
-        }
-        else
-        {
-            CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b], sizeof(Ti) * size_a, hipMemcpyHostToDevice));
-        }
+        host_batch_vector<Ti> hA_packed(size_a, 1, batch_count);
+        hA_packed.copy_from(hA);
 
-        if(std::is_same<Ti, int8_t>{} && transB != rocblas_operation_none)
-        {
-            host_vector<Ti> hB_packed(hB[b]);
+        for(int b = 0; b < batch_count; b++)
+            rocblas_packInt8(hA_packed[b], hA[b], M, K, lda);
 
-            rocblas_packInt8(hB_packed, N, K, ldb);
-            CHECK_HIP_ERROR(
-                hipMemcpy(bB[b], hB_packed, sizeof(Ti) * size_b, hipMemcpyHostToDevice));
-        }
-        else
-        {
-            CHECK_HIP_ERROR(hipMemcpy(bB[b], hB[b], sizeof(Ti) * size_b, hipMemcpyHostToDevice));
-        }
-
-        CHECK_HIP_ERROR(hipMemcpy(bC[b], hC[b], sizeof(To) * size_c, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(dA.transfer_from(hA_packed));
     }
-    // 2. Copy intermediate arrays into device arrays
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(Ti*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, bB, sizeof(Ti*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, bC, sizeof(To*) * batch_count, hipMemcpyHostToDevice));
+    else
+    {
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+
+    if(std::is_same<Ti, int8_t>{} && transB != rocblas_operation_none)
+    {
+        host_batch_vector<Ti> hB_packed(size_b, 1, batch_count);
+        hB_packed.copy_from(hB);
+
+        for(int b = 0; b < batch_count; b++)
+            rocblas_packInt8(hB_packed[b], hB[b], N, K, ldb);
+
+        CHECK_HIP_ERROR(dB.transfer_from(hB_packed));
+    }
+    else
+    {
+        CHECK_HIP_ERROR(dB.transfer_from(hB));
+    }
+    CHECK_HIP_ERROR(dC.transfer_from(hC));
 
     if(arg.unit_check || arg.norm_check)
     {
         // ROCBLAS rocblas_pointer_mode_host
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(hipMemcpy(bD[b], hD_1[b], sizeof(To) * size_d, hipMemcpyHostToDevice));
-        }
-        CHECK_HIP_ERROR(hipMemcpy(dD, bD, sizeof(To*) * batch_count, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(dD.transfer_from(hD_1));
 
         CHECK_ROCBLAS_ERROR(rocblas_gemm_batched_ex(handle,
                                                     transA,
@@ -481,17 +457,17 @@ void testing_gemm_batched_ex(const Arguments& arg)
                                                     N,
                                                     K,
                                                     &h_alpha_Tc,
-                                                    dA,
+                                                    dA.ptr_on_device(),
                                                     arg.a_type,
                                                     lda,
-                                                    dB,
+                                                    dB.ptr_on_device(),
                                                     arg.b_type,
                                                     ldb,
                                                     &h_beta_Tc,
-                                                    dC,
+                                                    dC.ptr_on_device(),
                                                     arg.c_type,
                                                     ldc,
-                                                    dD,
+                                                    dD.ptr_on_device(),
                                                     arg.d_type,
                                                     ldd,
                                                     batch_count,
@@ -501,20 +477,12 @@ void testing_gemm_batched_ex(const Arguments& arg)
                                                     flags));
 
         // copy output from device to CPU
-        // Use intermediate arrays to access device memory from host
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(hipMemcpy(hD_1[b], bD[b], sizeof(To) * size_d, hipMemcpyDeviceToHost));
-        }
+        CHECK_HIP_ERROR(hD_1.transfer_from(dD));
 
         // ROCBLAS rocblas_pointer_mode_device
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
 
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(hipMemcpy(bD[b], hD_2[b], sizeof(To) * size_d, hipMemcpyHostToDevice));
-        }
-        CHECK_HIP_ERROR(hipMemcpy(dD, bD, sizeof(To*) * batch_count, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(dD.transfer_from(hD_2));
 
         CHECK_HIP_ERROR(hipMemcpy(d_alpha_Tc, &h_alpha_Tc, sizeof(Tc), hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(d_beta_Tc, &h_beta_Tc, sizeof(Tc), hipMemcpyHostToDevice));
@@ -526,17 +494,17 @@ void testing_gemm_batched_ex(const Arguments& arg)
                                                     N,
                                                     K,
                                                     d_alpha_Tc,
-                                                    dA,
+                                                    dA.ptr_on_device(),
                                                     arg.a_type,
                                                     lda,
-                                                    dB,
+                                                    dB.ptr_on_device(),
                                                     arg.b_type,
                                                     ldb,
                                                     d_beta_Tc,
-                                                    dC,
+                                                    dC.ptr_on_device(),
                                                     arg.c_type,
                                                     ldc,
-                                                    dD,
+                                                    dD.ptr_on_device(),
                                                     arg.d_type,
                                                     ldd,
                                                     batch_count,
@@ -546,11 +514,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
                                                     flags));
 
         // copy output from device to CPU
-        // Use intermediate arrays to access device memory from host
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(hipMemcpy(hD_2[b], bD[b], sizeof(To) * size_d, hipMemcpyDeviceToHost));
-        }
+        CHECK_HIP_ERROR(hD_2.transfer_from(dD));
 
         // CPU BLAS
         // copy C matrix into D matrix
@@ -615,38 +579,36 @@ void testing_gemm_batched_ex(const Arguments& arg)
         int number_cold_calls = arg.cold_iters;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(hipMemcpy(bD[b], hD_1[b], sizeof(To) * size_d, hipMemcpyHostToDevice));
-        }
-        CHECK_HIP_ERROR(hipMemcpy(dD, bD, sizeof(To*) * batch_count, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(dD.transfer_from(hD_1));
+
         for(int i = 0; i < number_cold_calls; i++)
         {
-            CHECK_ROCBLAS_ERROR(rocblas_gemm_batched_ex(handle,
-                                                        transA,
-                                                        transB,
-                                                        M,
-                                                        N,
-                                                        K,
-                                                        &h_alpha_Tc,
-                                                        dA,
-                                                        arg.a_type,
-                                                        lda,
-                                                        dB,
-                                                        arg.b_type,
-                                                        ldb,
-                                                        &h_beta_Tc,
-                                                        dC,
-                                                        arg.c_type,
-                                                        ldc,
-                                                        arg.c_noalias_d ? dD : dC,
-                                                        arg.c_noalias_d ? arg.d_type : arg.c_type,
-                                                        arg.c_noalias_d ? ldd : ldc,
-                                                        batch_count,
-                                                        arg.compute_type,
-                                                        algo,
-                                                        solution_index,
-                                                        flags));
+            CHECK_ROCBLAS_ERROR(
+                rocblas_gemm_batched_ex(handle,
+                                        transA,
+                                        transB,
+                                        M,
+                                        N,
+                                        K,
+                                        &h_alpha_Tc,
+                                        dA.ptr_on_device(),
+                                        arg.a_type,
+                                        lda,
+                                        dB.ptr_on_device(),
+                                        arg.b_type,
+                                        ldb,
+                                        &h_beta_Tc,
+                                        dC.ptr_on_device(),
+                                        arg.c_type,
+                                        ldc,
+                                        arg.c_noalias_d ? dD.ptr_on_device() : dC.ptr_on_device(),
+                                        arg.c_noalias_d ? arg.d_type : arg.c_type,
+                                        arg.c_noalias_d ? ldd : ldc,
+                                        batch_count,
+                                        arg.compute_type,
+                                        algo,
+                                        solution_index,
+                                        flags));
         }
 
         int number_hot_calls = arg.iters;
@@ -660,17 +622,17 @@ void testing_gemm_batched_ex(const Arguments& arg)
                                     N,
                                     K,
                                     &h_alpha_Tc,
-                                    dA,
+                                    dA.ptr_on_device(),
                                     arg.a_type,
                                     lda,
-                                    dB,
+                                    dB.ptr_on_device(),
                                     arg.b_type,
                                     ldb,
                                     &h_beta_Tc,
-                                    dC,
+                                    dC.ptr_on_device(),
                                     arg.c_type,
                                     ldc,
-                                    arg.c_noalias_d ? dD : dC,
+                                    arg.c_noalias_d ? dD.ptr_on_device() : dC.ptr_on_device(),
                                     arg.c_noalias_d ? arg.d_type : arg.c_type,
                                     arg.c_noalias_d ? ldd : ldc,
                                     batch_count,

--- a/clients/include/testing_hbmv_batched.hpp
+++ b/clients/include/testing_hbmv_batched.hpp
@@ -41,9 +41,9 @@ void testing_hbmv_batched_bad_arg(const Arguments& arg)
     device_batch_vector<T> dA(size_A, 1, batch_count);
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_hbmv_batched<T>(handle,
                                                   uplo,
@@ -209,12 +209,12 @@ void testing_hbmv_batched(const Arguments& arg)
     device_batch_vector<T> dy_2(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy_1.memcheck());
-    CHECK_HIP_ERROR(dy_2.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     rocblas_init(hA, true);
     rocblas_init(hx, false);

--- a/clients/include/testing_hemv_batched.hpp
+++ b/clients/include/testing_hemv_batched.hpp
@@ -40,9 +40,9 @@ void testing_hemv_batched_bad_arg(const Arguments& arg)
     device_batch_vector<T> dA(size_A, 1, batch_count);
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_hemv_batched<T>(handle,
                                                   uplo,
@@ -200,12 +200,12 @@ void testing_hemv_batched(const Arguments& arg)
     device_batch_vector<T> dy_2(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy_1.memcheck());
-    CHECK_HIP_ERROR(dy_2.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     rocblas_init(hA, true);
     rocblas_init(hx, false);

--- a/clients/include/testing_her2_batched.hpp
+++ b/clients/include/testing_her2_batched.hpp
@@ -34,8 +34,8 @@ void testing_her2_batched_bad_arg()
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         (rocblas_her2_batched<
@@ -118,11 +118,11 @@ void testing_her2_batched(const Arguments& arg)
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_her_batched.hpp
+++ b/clients/include/testing_her_batched.hpp
@@ -32,8 +32,8 @@ void testing_her_batched_bad_arg()
     // allocate memory on device
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_her_batched<T>(
@@ -96,10 +96,10 @@ void testing_her_batched(const Arguments& arg)
     device_batch_vector<T>   dA_2(size_A, 1, batch_count);
     device_batch_vector<T>   dx(N, incx, batch_count);
     device_vector<real_t<T>> d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_herk_batched.hpp
+++ b/clients/include/testing_herk_batched.hpp
@@ -35,8 +35,8 @@ void testing_herk_batched_bad_arg(const Arguments& arg)
     // allocate memory on device
     device_batch_vector<T> dA(safe_size, 1, batch_count);
     device_batch_vector<T> dC(safe_size, 1, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         (rocblas_herk_batched<
@@ -157,10 +157,10 @@ void testing_herk_batched(const Arguments& arg)
     device_batch_vector<T> dC(size_C, 1, batch_count);
     device_vector<U>       d_alpha(1);
     device_vector<U>       d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<U>       h_alpha(1);

--- a/clients/include/testing_herk_strided_batched.hpp
+++ b/clients/include/testing_herk_strided_batched.hpp
@@ -37,8 +37,8 @@ void testing_herk_strided_batched_bad_arg(const Arguments& arg)
     // allocate memory on device
     device_vector<T> dA(batch_count);
     device_vector<T> dC(batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
     EXPECT_ROCBLAS_STATUS((rocblas_herk_strided_batched<T>)(nullptr,
                                                             uplo,
@@ -228,10 +228,10 @@ void testing_herk_strided_batched(const Arguments& arg)
     device_vector<T> dC(size_C);
     device_vector<U> d_alpha(1);
     device_vector<U> d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<U> h_alpha(1);

--- a/clients/include/testing_hpmv_batched.hpp
+++ b/clients/include/testing_hpmv_batched.hpp
@@ -39,9 +39,9 @@ void testing_hpmv_batched_bad_arg(const Arguments& arg)
     device_batch_vector<T> dA(size_A, 1, batch_count);
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_hpmv_batched<T>(handle,
                                                   uplo,
@@ -191,12 +191,12 @@ void testing_hpmv_batched(const Arguments& arg)
     device_batch_vector<T> dy_2(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy_1.memcheck());
-    CHECK_HIP_ERROR(dy_2.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     rocblas_init(hA, true);
     rocblas_init(hx, false);

--- a/clients/include/testing_hpr2_batched.hpp
+++ b/clients/include/testing_hpr2_batched.hpp
@@ -33,9 +33,9 @@ void testing_hpr2_batched_bad_arg()
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         (rocblas_hpr2_batched<
@@ -109,11 +109,11 @@ void testing_hpr2_batched(const Arguments& arg)
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_hpr_batched.hpp
+++ b/clients/include/testing_hpr_batched.hpp
@@ -31,8 +31,8 @@ void testing_hpr_batched_bad_arg()
     // allocate memory on device
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_hpr_batched<T>(handle, rocblas_fill_full, N, &alpha, dx, incx, dA_1, batch_count),
@@ -93,10 +93,10 @@ void testing_hpr_batched(const Arguments& arg)
     device_batch_vector<T>   dA_2(size_A, 1, batch_count);
     device_batch_vector<T>   dx(N, incx, batch_count);
     device_vector<real_t<T>> d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_hpr_strided_batched.hpp
+++ b/clients/include/testing_hpr_strided_batched.hpp
@@ -34,8 +34,8 @@ void testing_hpr_strided_batched_bad_arg()
     // allocate memory on device
     device_strided_batch_vector<T> dA_1(size_A, 1, stride_A, batch_count);
     device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_hpr_strided_batched<T>(

--- a/clients/include/testing_reduction_batched.hpp
+++ b/clients/include/testing_reduction_batched.hpp
@@ -33,7 +33,7 @@ void template_testing_reduction_batched_bad_arg(const Arguments&                
     // allocate memory on device
     //
     device_batch_vector<T> dx(N, incx, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     R h_rocblas_result;
 
@@ -61,9 +61,9 @@ void template_testing_reduction_batched(
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         device_batch_vector<T> dx(3, 1, 2);
-        CHECK_HIP_ERROR(dx.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx.memcheck());
         device_vector<R> dr(std::max(2, std::abs(batch_count)));
-        CHECK_HIP_ERROR(dr.memcheck());
+        CHECK_DEVICE_ALLOCATION(dr.memcheck());
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS(func(handle, N, dx.ptr_on_device(), incx, batch_count, dr),
                               (N > 0 && incx > 0 && batch_count < 0) ? rocblas_status_invalid_size
@@ -78,12 +78,12 @@ void template_testing_reduction_batched(
     host_vector<R> cpu_result(batch_count);
     CHECK_HIP_ERROR(cpu_result.memcheck());
     device_vector<R> dr(batch_count);
-    CHECK_HIP_ERROR(dr.memcheck());
+    CHECK_DEVICE_ALLOCATION(dr.memcheck());
 
     host_batch_vector<T> hx(N, incx, batch_count);
     CHECK_HIP_ERROR(hx.memcheck());
     device_batch_vector<T> dx(N, incx, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     //
     // Initialize.

--- a/clients/include/testing_rotmg_batched.hpp
+++ b/clients/include/testing_rotmg_batched.hpp
@@ -264,11 +264,11 @@ void testing_rotmg_batched(const Arguments& arg)
         device_batch_vector<T> dx1(1, 1, batch_count);
         device_batch_vector<T> dy1(1, 1, batch_count);
         device_batch_vector<T> dparams(5, 1, batch_count);
-        CHECK_HIP_ERROR(dd1.memcheck());
-        CHECK_HIP_ERROR(dd2.memcheck());
-        CHECK_HIP_ERROR(dx1.memcheck());
-        CHECK_HIP_ERROR(dy1.memcheck());
-        CHECK_HIP_ERROR(dparams.memcheck());
+        CHECK_DEVICE_ALLOCATION(dd1.memcheck());
+        CHECK_DEVICE_ALLOCATION(dd2.memcheck());
+        CHECK_DEVICE_ALLOCATION(dx1.memcheck());
+        CHECK_DEVICE_ALLOCATION(dy1.memcheck());
+        CHECK_DEVICE_ALLOCATION(dparams.memcheck());
 
         CHECK_HIP_ERROR(dd1.transfer_from(hd1));
         CHECK_HIP_ERROR(dd2.transfer_from(hd2));

--- a/clients/include/testing_spmv_batched.hpp
+++ b/clients/include/testing_spmv_batched.hpp
@@ -201,9 +201,9 @@ void testing_spmv_batched(const Arguments& arg)
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
 
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
 
     // Initial Data on CPU
     rocblas_seedrand();

--- a/clients/include/testing_spr2_batched.hpp
+++ b/clients/include/testing_spr2_batched.hpp
@@ -32,9 +32,9 @@ void testing_spr2_batched_bad_arg()
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_spr2_batched<T>(
@@ -105,11 +105,11 @@ void testing_spr2_batched(const Arguments& arg)
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dy.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dy.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_spr_batched.hpp
+++ b/clients/include/testing_spr_batched.hpp
@@ -30,8 +30,8 @@ void testing_spr_batched_bad_arg()
     // allocate memory on device
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dA_1(size_A, 1, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_spr_batched<T>(handle, rocblas_fill_full, N, &alpha, dx, incx, dA_1, batch_count),
@@ -92,10 +92,10 @@ void testing_spr_batched(const Arguments& arg)
     device_batch_vector<T> dA_2(size_A, 1, batch_count);
     device_batch_vector<T> dx(N, incx, batch_count);
     device_vector<T>       d_alpha(1);
-    CHECK_HIP_ERROR(dA_1.memcheck());
-    CHECK_HIP_ERROR(dA_2.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_1.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA_2.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
     double gpu_time_used, cpu_time_used;
     double rocblas_gflops, cblas_gflops, rocblas_bandwidth;

--- a/clients/include/testing_syrk_batched.hpp
+++ b/clients/include/testing_syrk_batched.hpp
@@ -34,8 +34,8 @@ void testing_syrk_batched_bad_arg(const Arguments& arg)
     // allocate memory on device
     device_batch_vector<T> dA(safe_size, 1, batch_count);
     device_batch_vector<T> dC(safe_size, 1, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_syrk_batched<T>(
@@ -138,10 +138,10 @@ void testing_syrk_batched(const Arguments& arg)
     device_batch_vector<T> dC(size_C, 1, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T>       h_alpha(1);

--- a/clients/include/testing_syrk_strided_batched.hpp
+++ b/clients/include/testing_syrk_strided_batched.hpp
@@ -36,8 +36,8 @@ void testing_syrk_strided_batched_bad_arg(const Arguments& arg)
     // allocate memory on device
     device_vector<T> dA(batch_count);
     device_vector<T> dC(batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
     EXPECT_ROCBLAS_STATUS(rocblas_syrk_strided_batched<T>(nullptr,
                                                           uplo,
@@ -226,10 +226,10 @@ void testing_syrk_strided_batched(const Arguments& arg)
     device_vector<T> dC(size_C);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dC.memcheck());
-    CHECK_HIP_ERROR(d_alpha.memcheck());
-    CHECK_HIP_ERROR(d_beta.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dC.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
+    CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> h_alpha(1);

--- a/clients/include/testing_tbmv_batched.hpp
+++ b/clients/include/testing_tbmv_batched.hpp
@@ -38,8 +38,8 @@ void testing_tbmv_batched_bad_arg(const Arguments& arg)
     // allocate memory on device
     device_batch_vector<T> dA(size_A, 1, batch_count);
     device_batch_vector<T> dx(M, incx, batch_count);
-    CHECK_HIP_ERROR(dA.memcheck());
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     EXPECT_ROCBLAS_STATUS(
         rocblas_tbmv_batched<T>(
@@ -116,8 +116,8 @@ void testing_tbmv_batched(const Arguments& arg)
 
     device_batch_vector<T> dA(size_A, 1, batch_count);
     device_batch_vector<T> dx(M, incx, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
     rocblas_init(hA, true);
     rocblas_init(hx, false);

--- a/clients/include/testing_tpmv_batched.hpp
+++ b/clients/include/testing_tpmv_batched.hpp
@@ -36,9 +36,9 @@ void testing_tpmv_batched_bad_arg(const Arguments& arg)
     CHECK_HIP_ERROR(hx.memcheck());
 
     device_batch_vector<T> dA(batch_count, size_A);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
     device_batch_vector<T> dx(M, incx, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     //
     // Checks.
@@ -102,10 +102,10 @@ void testing_tpmv_batched(const Arguments& arg)
     CHECK_HIP_ERROR(hres.memcheck());
 
     device_batch_vector<T> dA(batch_count, size_A);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
     device_batch_vector<T> dx(M, incx, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     auto dA_on_device = dA.ptr_on_device();
     auto dx_on_device = dx.ptr_on_device();

--- a/clients/include/testing_trmv_batched.hpp
+++ b/clients/include/testing_trmv_batched.hpp
@@ -40,9 +40,9 @@ void testing_trmv_batched_bad_arg(const Arguments& arg)
     CHECK_HIP_ERROR(hx.memcheck());
 
     device_batch_vector<T> dA(batch_count, M * lda);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
     device_batch_vector<T> dx(M, incx, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     //
     // Checks.
@@ -107,10 +107,10 @@ void testing_trmv_batched(const Arguments& arg)
     CHECK_HIP_ERROR(hres.memcheck());
 
     device_batch_vector<T> dA(batch_count, size_A);
-    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_DEVICE_ALLOCATION(dA.memcheck());
 
     device_batch_vector<T> dx(M, incx, batch_count);
-    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
     auto dA_on_device = dA.ptr_on_device();
     auto dx_on_device = dx.ptr_on_device();


### PR DESCRIPTION
Should resolve [SWDEV-220984](http://ontrack-internal.amd.com/browse/SWDEV-220984). Apparently I missed updating a bunch of batched tests to the new memory checking scheme. This should use `CHECK_DEVICE_ALLOCATION` instead of `CHECK_HIP_ERROR` when calling `memcheck` on all device vectors now.

Also updates gemm_batched_ex test to use new batch_vectors as these tests were segfaulting apparently.