### PR TITLE
Rocblas initialize

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -634,6 +634,8 @@ struct perf_blas_rotg<
 
 int run_bench_test(Arguments& arg)
 {
+    rocblas_initialize(); // Initialize rocBLAS
+
     // disable unit_check in client benchmark, it is only used in gtest unit test
     arg.unit_check = 0;
 
@@ -836,6 +838,11 @@ using namespace boost::program_options;
 int main(int argc, char* argv[])
 try
 {
+    // Initialize rocBLAS; TODO: Remove this after it is determined why rocblas-bench
+    // returns lower performance if this is executed after Boost parse_command_line().
+    // Right now this causes 5-10 seconds of delay before processing the CLI arguments.
+    rocblas_initialize();
+
     fix_batch(argc, argv);
     Arguments   arg;
     std::string function;

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -49,18 +49,18 @@ std::string rocblas_exepath()
 double get_time_us(void)
 {
     hipDeviceSynchronize();
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (tv.tv_sec * 1000 * 1000) + tv.tv_usec;
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
 };
 
 /*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
 double get_time_us_sync(hipStream_t stream)
 {
     hipStreamSynchronize(stream);
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (tv.tv_sec * 1000 * 1000) + tv.tv_usec;
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
 };
 
 /* ============================================================================================ */

--- a/clients/gtest/rocblas_gtest_main.cpp
+++ b/clients/gtest/rocblas_gtest_main.cpp
@@ -204,7 +204,7 @@ int main(int argc, char** argv)
     rocblas_set_listener();
 
     // Initialize rocBLAS (not explicitly needed; just included for testing)
-    rocblas_init();
+    rocblas_initialize();
 
     // Run the tests
     int status = RUN_ALL_TESTS();

--- a/library/include/rocblas-functions.h
+++ b/library/include/rocblas-functions.h
@@ -15625,7 +15625,7 @@ ROCBLAS_EXPORT const char* rocblas_status_to_string(rocblas_status status);
 /* \brief Initialize rocBLAS, to avoid costly startup time at the first call.
 */
 
-ROCBLAS_EXPORT void rocblas_init(void);
+ROCBLAS_EXPORT void rocblas_initialize(void);
 
 /*
  * ===========================================================================

--- a/library/src/rocblas_auxiliary.cpp
+++ b/library/src/rocblas_auxiliary.cpp
@@ -12,11 +12,13 @@
 /*******************************************************************************
  * ! \brief  Initialize rocBLAS, to avoid costly startup time at the first call.
  ******************************************************************************/
-
-extern "C" void rocblas_init()
+extern "C" void rocblas_initialize()
 {
+    // Static resources are initialized only once, by creating and destroying a handle
     static rocblas_handle handle;
-    static int            dummy = (rocblas_create_handle(&handle), 0);
+    static int            dummy
+        = rocblas_create_handle(&handle) == rocblas_status_success ? rocblas_destroy_handle(handle),
+        0 : 0;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Renames `rocblas_init` to `rocblas_initialize`.

Changes `rocblas-bench` timing functions to use `clock_gettime` instead of `gettimeofday`.

Calls `rocblas_initialize` _before_ Boost `parse_command_line()`. This causes 5-10 seconds of initialization time before the command returns, even if it can return immediately, like `rocblas-bench --help`. It is uncertain why initialization of rocBLAS has to occur before running Boost `parse_command_line()` in order to get good performance results.
