### PR TITLE
Rot fixes

### DIFF
--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -22,6 +22,9 @@ Definitions:
     - { incx:  1, incy: -1 }
     - { incx: -1, incy:  1 }
     - { incx: -1, incy: -1 }
+    # - { incx:  0, incy:  1 }
+    # - { incx:  0, incy:  0 }
+    # - { incx:  1, incy:  0 }
 
   - &incx_incy_range_small
     - { incx: 2, incy: 2 }

--- a/clients/gtest/blas1_gtest.yaml
+++ b/clients/gtest/blas1_gtest.yaml
@@ -22,9 +22,6 @@ Definitions:
     - { incx:  1, incy: -1 }
     - { incx: -1, incy:  1 }
     - { incx: -1, incy: -1 }
-    # - { incx:  0, incy:  1 }
-    # - { incx:  0, incy:  0 }
-    # - { incx:  1, incy:  0 }
 
   - &incx_incy_range_small
     - { incx: 2, incy: 2 }

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -69,10 +69,6 @@ void testing_rot(const Arguments& arg)
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
     size_t      size_x   = N * size_t(abs_incx);
     size_t      size_y   = N * size_t(abs_incy);
-    if(!size_x)
-        size_x = 1;
-    if(!size_y)
-        size_y = 1;
 
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -93,8 +93,8 @@ void testing_rot_batched(const Arguments& arg)
     size_t      size_x   = N * size_t(abs_incx);
     size_t      size_y   = N * size_t(abs_incy);
 
-    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
     device_vector<U>       dc(1);
     device_vector<V>       ds(1);
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
@@ -103,8 +103,8 @@ void testing_rot_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(ds.memcheck());
 
     // Initial Data on CPU
-    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
     host_vector<U>       hc(1);
     host_vector<V>       hs(1);
 

--- a/clients/include/testing_rot_strided_batched.hpp
+++ b/clients/include/testing_rot_strided_batched.hpp
@@ -95,10 +95,6 @@ void testing_rot_strided_batched(const Arguments& arg)
     rocblas_int abs_incy = incy >= 0 ? incy : -incy;
     size_t      size_x   = N * size_t(abs_incx) + size_t(stride_x) * size_t(batch_count - 1);
     size_t      size_y   = N * size_t(abs_incy) + size_t(stride_y) * size_t(batch_count - 1);
-    if(!size_x)
-        size_x = 1;
-    if(!size_y)
-        size_y = 1;
 
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);

--- a/clients/include/testing_rot_strided_batched.hpp
+++ b/clients/include/testing_rot_strided_batched.hpp
@@ -73,37 +73,32 @@ void testing_rot_strided_batched(const Arguments& arg)
     const U rel_error          = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || incy <= 0 || batch_count <= 0)
+    if(N <= 0 || batch_count <= 0)
     {
-        static const size_t safe_size = 100; // arbitrarily set to 100
-        device_vector<T>    dx(safe_size);
-        device_vector<T>    dy(safe_size);
-        device_vector<U>    dc(1);
-        device_vector<V>    ds(1);
-        CHECK_DEVICE_ALLOCATION(dx.memcheck());
-        CHECK_DEVICE_ALLOCATION(dy.memcheck());
-        CHECK_DEVICE_ALLOCATION(dc.memcheck());
-        CHECK_DEVICE_ALLOCATION(ds.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS((rocblas_rot_strided_batched<T, U, V>)(handle,
                                                                      N,
-                                                                     dx,
+                                                                     nullptr,
                                                                      incx,
                                                                      stride_x,
-                                                                     dy,
+                                                                     nullptr,
                                                                      incy,
                                                                      stride_y,
-                                                                     dc,
-                                                                     ds,
+                                                                     nullptr,
+                                                                     nullptr,
                                                                      batch_count),
-                              batch_count < 0 ? rocblas_status_invalid_size
-                                              : rocblas_status_success);
+                              rocblas_status_success);
         return;
     }
 
-    size_t size_x = N * size_t(incx) + size_t(stride_x) * size_t(batch_count - 1);
-    size_t size_y = N * size_t(incy) + size_t(stride_y) * size_t(batch_count - 1);
+    rocblas_int abs_incx = incx >= 0 ? incx : -incx;
+    rocblas_int abs_incy = incy >= 0 ? incy : -incy;
+    size_t      size_x   = N * size_t(abs_incx) + size_t(stride_x) * size_t(batch_count - 1);
+    size_t      size_y   = N * size_t(abs_incy) + size_t(stride_y) * size_t(batch_count - 1);
+    if(!size_x)
+        size_x = 1;
+    if(!size_y)
+        size_y = 1;
 
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
@@ -120,8 +115,8 @@ void testing_rot_strided_batched(const Arguments& arg)
     host_vector<U> hc(1);
     host_vector<V> hs(1);
     rocblas_seedrand();
-    rocblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
-    rocblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
+    rocblas_init<T>(hx, 1, N, abs_incx, stride_x, batch_count);
+    rocblas_init<T>(hy, 1, N, abs_incy, stride_y, batch_count);
 
     // Random alpha (0 - 10)
     host_vector<rocblas_int> alpha(1);
@@ -159,15 +154,15 @@ void testing_rot_strided_batched(const Arguments& arg)
             CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
             if(arg.unit_check)
             {
-                near_check_general<T>(1, N, incx, stride_x, cx, rx, batch_count, rel_error);
-                near_check_general<T>(1, N, incy, stride_y, cy, ry, batch_count, rel_error);
+                near_check_general<T>(1, N, abs_incx, stride_x, cx, rx, batch_count, rel_error);
+                near_check_general<T>(1, N, abs_incy, stride_y, cy, ry, batch_count, rel_error);
             }
             if(arg.norm_check)
             {
                 norm_error_host_x
-                    = norm_check_general<T>('F', 1, N, incx, stride_x, cx, rx, batch_count);
+                    = norm_check_general<T>('F', 1, N, abs_incx, stride_x, cx, rx, batch_count);
                 norm_error_host_y
-                    = norm_check_general<T>('F', 1, N, incy, stride_x, cy, ry, batch_count);
+                    = norm_check_general<T>('F', 1, N, abs_incy, stride_x, cy, ry, batch_count);
             }
         }
 
@@ -186,15 +181,15 @@ void testing_rot_strided_batched(const Arguments& arg)
             CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
             if(arg.unit_check)
             {
-                near_check_general<T>(1, N, incx, stride_x, cx, rx, batch_count, rel_error);
-                near_check_general<T>(1, N, incy, stride_y, cy, ry, batch_count, rel_error);
+                near_check_general<T>(1, N, abs_incx, stride_x, cx, rx, batch_count, rel_error);
+                near_check_general<T>(1, N, abs_incy, stride_y, cy, ry, batch_count, rel_error);
             }
             if(arg.norm_check)
             {
                 norm_error_device_x
-                    = norm_check_general<T>('F', 1, N, incx, stride_x, cx, rx, batch_count);
+                    = norm_check_general<T>('F', 1, N, abs_incx, stride_x, cx, rx, batch_count);
                 norm_error_device_y
-                    = norm_check_general<T>('F', 1, N, incy, stride_y, cy, ry, batch_count);
+                    = norm_check_general<T>('F', 1, N, abs_incy, stride_y, cy, ry, batch_count);
             }
         }
     }

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -80,24 +80,10 @@ void testing_rotg_batched(const Arguments& arg)
     // check to prevent undefined memory allocation error
     if(batch_count <= 0)
     {
-        device_batch_vector<T> da(1, 1, 1);
-        device_batch_vector<T> db(1, 1, 1);
-        device_batch_vector<U> dc(1, 1, 1);
-        device_batch_vector<T> ds(1, 1, 1);
-        CHECK_DEVICE_ALLOCATION(da.memcheck());
-        CHECK_DEVICE_ALLOCATION(db.memcheck());
-        CHECK_DEVICE_ALLOCATION(dc.memcheck());
-        CHECK_DEVICE_ALLOCATION(ds.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS((rocblas_rotg_batched<T, U>)(handle,
-                                                           da.ptr_on_device(),
-                                                           db.ptr_on_device(),
-                                                           dc.ptr_on_device(),
-                                                           ds.ptr_on_device(),
-                                                           batch_count),
-                              batch_count < 0 ? rocblas_status_invalid_size
-                                              : rocblas_status_success);
+        EXPECT_ROCBLAS_STATUS(
+            (rocblas_rotg_batched<T, U>)(handle, nullptr, nullptr, nullptr, nullptr, batch_count),
+            rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -73,21 +73,18 @@ void testing_rotg_strided_batched(const Arguments& arg)
     // check to prevent undefined memory allocation error
     if(batch_count <= 0)
     {
-        static const size_t safe_size = 1; // arbitrarily set to 100
-        device_vector<T>    da(safe_size);
-        device_vector<T>    db(safe_size);
-        device_vector<U>    dc(safe_size);
-        device_vector<T>    ds(safe_size);
-        CHECK_DEVICE_ALLOCATION(da.memcheck());
-        CHECK_DEVICE_ALLOCATION(db.memcheck());
-        CHECK_DEVICE_ALLOCATION(dc.memcheck());
-        CHECK_DEVICE_ALLOCATION(ds.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS(
-            (rocblas_rotg_strided_batched<T, U>(
-                handle, da, stride_a, db, stride_b, dc, stride_c, ds, stride_s, batch_count)),
-            batch_count < 0 ? rocblas_status_invalid_size : rocblas_status_success);
+        EXPECT_ROCBLAS_STATUS((rocblas_rotg_strided_batched<T, U>(handle,
+                                                                  nullptr,
+                                                                  stride_a,
+                                                                  nullptr,
+                                                                  stride_b,
+                                                                  nullptr,
+                                                                  stride_c,
+                                                                  nullptr,
+                                                                  stride_s,
+                                                                  batch_count)),
+                              rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_rotmg_batched.hpp
+++ b/clients/include/testing_rotmg_batched.hpp
@@ -95,28 +95,10 @@ void testing_rotmg_batched(const Arguments& arg)
     // check to prevent undefined memory allocation error
     if(batch_count <= 0)
     {
-        size_t                 safe_size = 100;
-        device_batch_vector<T> d1(safe_size, 1, 1);
-        device_batch_vector<T> d2(safe_size, 1, 1);
-        device_batch_vector<T> x1(safe_size, 1, 1);
-        device_batch_vector<T> y1(safe_size, 1, 1);
-        device_batch_vector<T> param(safe_size, 1, 1);
-        CHECK_DEVICE_ALLOCATION(d1.memcheck());
-        CHECK_DEVICE_ALLOCATION(d2.memcheck());
-        CHECK_DEVICE_ALLOCATION(x1.memcheck());
-        CHECK_DEVICE_ALLOCATION(y1.memcheck());
-        CHECK_DEVICE_ALLOCATION(param.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
-        EXPECT_ROCBLAS_STATUS(rocblas_rotmg_batched<T>(handle,
-                                                       d1.ptr_on_device(),
-                                                       d2.ptr_on_device(),
-                                                       x1.ptr_on_device(),
-                                                       y1.ptr_on_device(),
-                                                       param.ptr_on_device(),
-                                                       batch_count),
-                              batch_count < 0 ? rocblas_status_invalid_size
-                                              : rocblas_status_success);
+        EXPECT_ROCBLAS_STATUS(rocblas_rotmg_batched<T>(
+                                  handle, nullptr, nullptr, nullptr, nullptr, nullptr, batch_count),
+                              rocblas_status_success);
         return;
     }
 

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -70,33 +70,20 @@ void testing_rotmg_strided_batched(const Arguments& arg)
     // check to prevent undefined memory allocation error
     if(batch_count <= 0)
     {
-        size_t           safe_size = 1;
-        device_vector<T> d1(safe_size);
-        device_vector<T> d2(safe_size);
-        device_vector<T> x1(safe_size);
-        device_vector<T> y1(safe_size);
-        device_vector<T> params(safe_size);
-        CHECK_DEVICE_ALLOCATION(d1.memcheck());
-        CHECK_DEVICE_ALLOCATION(d2.memcheck());
-        CHECK_DEVICE_ALLOCATION(x1.memcheck());
-        CHECK_DEVICE_ALLOCATION(y1.memcheck());
-        CHECK_DEVICE_ALLOCATION(params.memcheck());
-
         CHECK_ROCBLAS_ERROR(rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device));
         EXPECT_ROCBLAS_STATUS((rocblas_rotmg_strided_batched<T>(handle,
-                                                                d1,
+                                                                nullptr,
                                                                 stride_d1,
-                                                                d2,
+                                                                nullptr,
                                                                 stride_d2,
-                                                                x1,
+                                                                nullptr,
                                                                 stride_x1,
-                                                                y1,
+                                                                nullptr,
                                                                 stride_y1,
-                                                                params,
+                                                                nullptr,
                                                                 stride_param,
                                                                 batch_count)),
-                              batch_count < 0 ? rocblas_status_invalid_size
-                                              : rocblas_status_success);
+                              rocblas_status_success);
         return;
     }
 

--- a/library/src/blas1/rocblas_rot.cpp
+++ b/library/src/blas1/rocblas_rot.cpp
@@ -39,6 +39,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rot_name<T, V>, n, x, incx, y, incy, c, s);
@@ -59,10 +61,11 @@ namespace
         if(layer_mode & rocblas_layer_mode_log_profile)
             log_profile(handle, rocblas_rot_name<T, V>, "N", n, "incx", incx, "incy", incy);
 
+        if(n <= 0)
+            return rocblas_status_success;
+
         if(!x || !y || !c || !s)
             return rocblas_status_invalid_pointer;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rot_template<NB, T>(handle, n, x, 0, incx, 0, y, 0, incy, 0, c, 0, s, 0, 1);
     }

--- a/library/src/blas1/rocblas_rot.hpp
+++ b/library/src/blas1/rocblas_rot.hpp
@@ -88,8 +88,11 @@ rocblas_status rocblas_rot_template(rocblas_handle handle,
                                     rocblas_int    batch_count)
 {
     // Quick return if possible
-    if(n <= 0 || incx <= 0 || incy <= 0 || batch_count == 0)
+    if(n <= 0 || batch_count <= 0)
         return rocblas_status_success;
+
+    auto shiftx = incx < 0 ? offset_x - ptrdiff_t(incx) * (n - 1) : offset_x;
+    auto shifty = incy < 0 ? offset_y - ptrdiff_t(incy) * (n - 1) : offset_y;
 
     dim3        blocks((n - 1) / NB + 1, batch_count);
     dim3        threads(NB);
@@ -103,11 +106,11 @@ rocblas_status rocblas_rot_template(rocblas_handle handle,
                            rocblas_stream,
                            n,
                            x,
-                           offset_x,
+                           shiftx,
                            incx,
                            stride_x,
                            y,
-                           offset_y,
+                           shifty,
                            incy,
                            stride_y,
                            c,
@@ -122,11 +125,11 @@ rocblas_status rocblas_rot_template(rocblas_handle handle,
                            rocblas_stream,
                            n,
                            x,
-                           offset_x,
+                           shiftx,
                            incx,
                            stride_x,
                            y,
-                           offset_y,
+                           shifty,
                            incy,
                            stride_y,
                            *c,

--- a/library/src/blas1/rocblas_rot_batched.cpp
+++ b/library/src/blas1/rocblas_rot_batched.cpp
@@ -40,6 +40,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rot_name<T, V>, n, x, incx, y, incy, c, s, batch_count);
@@ -71,12 +73,10 @@ namespace
                         "batch_count",
                         batch_count);
 
+        if(n <= 0 || batch_count <= 0)
+            return rocblas_status_success;
         if(!x || !y || !c || !s)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rot_template<NB, T>(
             handle, n, x, 0, incx, 0, y, 0, incy, 0, c, 0, s, 0, batch_count);

--- a/library/src/blas1/rocblas_rot_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rot_strided_batched.cpp
@@ -44,6 +44,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle,
@@ -94,12 +96,11 @@ namespace
                         "batch_count",
                         batch_count);
 
+        if(n <= 0 || batch_count <= 0)
+            return rocblas_status_success;
+
         if(!x || !y || !c || !s)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rot_template<NB, T>(
             handle, n, x, 0, incx, stride_x, y, 0, incy, stride_y, c, 0, s, 0, batch_count);

--- a/library/src/blas1/rocblas_rotg.cpp
+++ b/library/src/blas1/rocblas_rotg.cpp
@@ -26,6 +26,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rotg_name<T>, a, b, c, s);
@@ -40,8 +42,6 @@ namespace
 
         if(!a || !b || !c || !s)
             return rocblas_status_invalid_pointer;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rotg_template(handle, a, 0, 0, b, 0, 0, c, 0, 0, s, 0, 0, 1);
     }

--- a/library/src/blas1/rocblas_rotg_batched.cpp
+++ b/library/src/blas1/rocblas_rotg_batched.cpp
@@ -31,6 +31,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rotg_name<T>, a, b, c, s, batch_count);
@@ -45,12 +47,11 @@ namespace
         if(layer_mode & rocblas_layer_mode_log_profile)
             log_profile(handle, rocblas_rotg_name<T>, "batch_count", batch_count);
 
+        if(batch_count <= 0)
+            return rocblas_status_success;
+
         if(!a || !b || !c || !s)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rotg_template(handle, a, 0, 0, b, 0, 0, c, 0, 0, s, 0, 0, batch_count);
     }

--- a/library/src/blas1/rocblas_rotg_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rotg_strided_batched.cpp
@@ -35,6 +35,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle,
@@ -78,12 +80,11 @@ namespace
                         "batch_count",
                         batch_count);
 
+        if(batch_count <= 0)
+            return rocblas_status_success;
+
         if(!a || !b || !c || !s)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rotg_template(
             handle, a, 0, stride_a, b, 0, stride_b, c, 0, stride_c, s, 0, stride_s, batch_count);

--- a/library/src/blas1/rocblas_rotm.cpp
+++ b/library/src/blas1/rocblas_rotm.cpp
@@ -30,6 +30,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rotm_name<T>, n, x, incx, y, incy, param);
@@ -46,10 +48,17 @@ namespace
         if(layer_mode & rocblas_layer_mode_log_profile)
             log_profile(handle, rocblas_rotm_name<T>, "N", n, "incx", incx, "incy", incy);
 
-        if(!x || !y || !param)
+        if(n <= 0)
+            return rocblas_status_success;
+
+        if(!param)
             return rocblas_status_invalid_pointer;
 
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+        if(quick_return_param(handle, param, 0))
+            return rocblas_status_success;
+
+        if(!x || !y)
+            return rocblas_status_invalid_pointer;
 
         return rocblas_rotm_template<NB, false>(
             handle, n, x, 0, incx, 0, y, 0, incy, 0, param, 0, 0, 1);

--- a/library/src/blas1/rocblas_rotm.hpp
+++ b/library/src/blas1/rocblas_rotm.hpp
@@ -150,11 +150,14 @@ rocblas_status rocblas_rotm_template(rocblas_handle handle,
                                      rocblas_int    batch_count)
 {
     // Quick return if possible
-    if(n <= 0 || incx <= 0 || incy <= 0 || batch_count <= 0)
+    if(n <= 0 /*|| incx <= 0 || incy <= 0 */ || batch_count <= 0)
         return rocblas_status_success;
 
     if(quick_return_param(handle, param, stride_param))
         return rocblas_status_success;
+
+    auto shiftx = incx < 0 ? offset_x - ptrdiff_t(incx) * (n - 1) : offset_x;
+    auto shifty = incy < 0 ? offset_y - ptrdiff_t(incy) * (n - 1) : offset_y;
 
     dim3        blocks((n - 1) / NB + 1, batch_count);
     dim3        threads(NB);
@@ -168,11 +171,11 @@ rocblas_status rocblas_rotm_template(rocblas_handle handle,
                            rocblas_stream,
                            n,
                            x,
-                           offset_x,
+                           shiftx,
                            incx,
                            stride_x,
                            y,
-                           offset_y,
+                           shifty,
                            incy,
                            stride_y,
                            param,
@@ -186,11 +189,11 @@ rocblas_status rocblas_rotm_template(rocblas_handle handle,
                            rocblas_stream,
                            n,
                            x,
-                           offset_x,
+                           shiftx,
                            incx,
                            stride_x,
                            y,
-                           offset_y,
+                           shifty,
                            incy,
                            stride_y,
                            param[0],

--- a/library/src/blas1/rocblas_rotm.hpp
+++ b/library/src/blas1/rocblas_rotm.hpp
@@ -150,7 +150,7 @@ rocblas_status rocblas_rotm_template(rocblas_handle handle,
                                      rocblas_int    batch_count)
 {
     // Quick return if possible
-    if(n <= 0 /*|| incx <= 0 || incy <= 0 */ || batch_count <= 0)
+    if(n <= 0 || batch_count <= 0)
         return rocblas_status_success;
 
     if(quick_return_param(handle, param, stride_param))

--- a/library/src/blas1/rocblas_rotm_batched.cpp
+++ b/library/src/blas1/rocblas_rotm_batched.cpp
@@ -31,6 +31,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rotm_name<T>, n, x, incx, y, incy, param, batch_count);
@@ -58,12 +60,17 @@ namespace
                         "batch_count",
                         batch_count);
 
-        if(!x || !y || !param)
-            return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
+        if(n <= 0 || batch_count <= 0)
+            return rocblas_status_success;
 
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+        if(!param)
+            return rocblas_status_invalid_pointer;
+
+        if(quick_return_param(handle, param, 0))
+            return rocblas_status_success;
+
+        if(!x || !y)
+            return rocblas_status_invalid_pointer;
 
         return rocblas_rotm_template<NB, true>(
             handle, n, x, 0, incx, 0, y, 0, incy, 0, param, 0, 0, batch_count);

--- a/library/src/blas1/rocblas_rotm_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rotm_strided_batched.cpp
@@ -34,6 +34,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle,
@@ -79,12 +81,17 @@ namespace
                         "batch_count",
                         batch_count);
 
-        if(!x || !y || !param)
-            return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
+        if(n <= 0 || batch_count <= 0)
+            return rocblas_status_success;
 
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+        if(!param)
+            return rocblas_status_invalid_pointer;
+
+        if(quick_return_param(handle, param, stride_param))
+            return rocblas_status_success;
+
+        if(!x || !y)
+            return rocblas_status_invalid_pointer;
 
         return rocblas_rotm_template<NB, true>(handle,
                                                n,

--- a/library/src/blas1/rocblas_rotmg.cpp
+++ b/library/src/blas1/rocblas_rotmg.cpp
@@ -23,6 +23,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rotmg_name<T>, d1, d2, x1, y1, param);
@@ -33,8 +35,6 @@ namespace
 
         if(!d1 || !d2 || !x1 || !y1 || !param)
             return rocblas_status_invalid_pointer;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rotmg_template(
             handle, d1, 0, 0, d2, 0, 0, x1, 0, 0, y1, 0, 0, param, 0, 0, 1);

--- a/library/src/blas1/rocblas_rotmg.hpp
+++ b/library/src/blas1/rocblas_rotmg.hpp
@@ -191,7 +191,7 @@ rocblas_status rocblas_rotmg_template(rocblas_handle handle,
                                       rocblas_stride stride_param,
                                       rocblas_int    batch_count)
 {
-    if(!batch_count)
+    if(batch_count <= 0)
         return rocblas_status_success;
 
     hipStream_t rocblas_stream = handle->rocblas_stream;

--- a/library/src/blas1/rocblas_rotmg_batched.cpp
+++ b/library/src/blas1/rocblas_rotmg_batched.cpp
@@ -28,6 +28,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle, rocblas_rotmg_name<T>, d1, d2, x1, y1, param, batch_count);
@@ -40,12 +42,10 @@ namespace
         if(layer_mode & rocblas_layer_mode_log_profile)
             log_profile(handle, rocblas_rotmg_name<T>, "batch_count", batch_count);
 
+        if(batch_count <= 0)
+            return rocblas_status_success;
         if(!d1 || !d2 || !x1 || !y1 || !param)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rotmg_template(
             handle, d1, 0, 0, d2, 0, 0, x1, 0, 0, y1, 0, 0, param, 0, 0, batch_count);

--- a/library/src/blas1/rocblas_rotmg_strided_batched.cpp
+++ b/library/src/blas1/rocblas_rotmg_strided_batched.cpp
@@ -33,6 +33,8 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
+
         auto layer_mode = handle->layer_mode;
         if(layer_mode & rocblas_layer_mode_log_trace)
             log_trace(handle,
@@ -80,12 +82,10 @@ namespace
                         "batch_count",
                         batch_count);
 
+        if(batch_count <= 0)
+            return rocblas_status_success;
         if(!d1 || !d2 || !x1 || !y1 || !param)
             return rocblas_status_invalid_pointer;
-        if(batch_count < 0)
-            return rocblas_status_invalid_size;
-
-        RETURN_ZERO_DEVICE_MEMORY_SIZE_IF_QUERIED(handle);
 
         return rocblas_rotmg_template(handle,
                                       d1,


### PR DESCRIPTION
Changes to rot, rotm, rotg, and rotmg.

- Fixes error-checking and quick-return order
- Allows negative incx and incy for rot and rotm
- Does not test for incx == 0 || incy == 0 for rot or rotm as both x and y are outputs.
