### PR TITLE
Make logging handle-specific

### DIFF
--- a/clients/include/testing_logging.hpp
+++ b/clients/include/testing_logging.hpp
@@ -80,8 +80,6 @@ void testing_logging()
     ASSERT_EQ(setenv_status, 0);
 #endif
 
-    rocblas::reinit_logs(); // reinitialize logging with newly set environment
-
     //
     // call rocBLAS functions with log_trace and log_bench to output log_trace and log_bench files
     //
@@ -329,8 +327,6 @@ void testing_logging()
 #ifdef GOOGLE_TEST
     ASSERT_EQ(setenv_status, 0);
 #endif
-
-    rocblas::reinit_logs(); // reinitialize logging, flushing old data to files
 
     //
     // write "golden file"

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -66,6 +66,9 @@ _rocblas_handle::_rocblas_handle()
 
     // Allocate device memory
     THROW_IF_HIP_ERROR((hipMalloc)(&device_memory, device_memory_size));
+
+    // Initialize logging
+    init_logging();
 }
 
 /*******************************************************************************
@@ -82,6 +85,10 @@ _rocblas_handle::~_rocblas_handle()
     }
     if(device_memory)
         (hipFree)(device_memory);
+
+    delete log_trace_os;
+    delete log_bench_os;
+    delete log_profile_os;
 }
 
 /*******************************************************************************
@@ -221,15 +228,6 @@ extern "C" bool rocblas_is_managing_device_memory(rocblas_handle handle)
     return handle && handle->device_memory_is_rocblas_managed;
 }
 
-/*******************************************************************************
- * Static handle data
- ******************************************************************************/
-rocblas_layer_mode    _rocblas_handle::layer_mode = rocblas_layer_mode_none;
-rocblas_ostream*      _rocblas_handle::log_trace_os;
-rocblas_ostream*      _rocblas_handle::log_bench_os;
-rocblas_ostream*      _rocblas_handle::log_profile_os;
-_rocblas_handle::init _rocblas_handle::handle_init;
-
 /**
  *  @brief Logging function
  *
@@ -244,61 +242,39 @@ _rocblas_handle::init _rocblas_handle::handle_init;
  *  environment_variable_name   const char*
  *                              Name of environment variable that contains
  *                              the full logfile path.
- *
- *  @parm[out]
- *  log_os      rocblas_ostream*&
- *              Output stream. Stream to filename in environment_variable_name
- *              if set, else set to standard error
  */
 
-static void open_log_stream(const char* environment_variable_name, rocblas_ostream*& log_os)
+static rocblas_ostream* open_log_stream(const char* environment_variable_name)
 {
     // if environment variable is set, open file at logfile_pathname contained in the
     // environment variable; else use standard error
     const char* logfile_pathname = getenv(environment_variable_name);
 
-    log_os = logfile_pathname ? new rocblas_ostream(logfile_pathname)
-                              : new rocblas_ostream(STDERR_FILENO);
+    return logfile_pathname ? new rocblas_ostream(logfile_pathname)
+                            : new rocblas_ostream(STDERR_FILENO);
 }
 
 /*******************************************************************************
- * Static runtime initialization
+ * Logging initialization
  ******************************************************************************/
-_rocblas_handle::init::init()
+void _rocblas_handle::init_logging()
 {
-    // nullify output stream pointers
-    log_trace_os = log_bench_os = log_profile_os = nullptr;
-
     // set layer_mode from value of environment variable ROCBLAS_LAYER
-    auto str_layer_mode = getenv("ROCBLAS_LAYER");
+    const char* str_layer_mode = getenv("ROCBLAS_LAYER");
     if(str_layer_mode)
     {
         layer_mode = static_cast<rocblas_layer_mode>(strtol(str_layer_mode, 0, 0));
 
         // open log_trace file
         if(layer_mode & rocblas_layer_mode_log_trace)
-            open_log_stream("ROCBLAS_LOG_TRACE_PATH", log_trace_os);
+            log_trace_os = open_log_stream("ROCBLAS_LOG_TRACE_PATH");
 
         // open log_bench file
         if(layer_mode & rocblas_layer_mode_log_bench)
-            open_log_stream("ROCBLAS_LOG_BENCH_PATH", log_bench_os);
+            log_bench_os = open_log_stream("ROCBLAS_LOG_BENCH_PATH");
 
         // open log_profile file
         if(layer_mode & rocblas_layer_mode_log_profile)
-            open_log_stream("ROCBLAS_LOG_PROFILE_PATH", log_profile_os);
+            log_profile_os = open_log_stream("ROCBLAS_LOG_PROFILE_PATH");
     }
 }
-
-/*******************************************************************************
- * Static reinitialization (for testing only)
- ******************************************************************************/
-namespace rocblas
-{
-    void reinit_logs()
-    {
-        delete _rocblas_handle::log_trace_os;
-        delete _rocblas_handle::log_bench_os;
-        delete _rocblas_handle::log_profile_os;
-        new(&_rocblas_handle::handle_init) _rocblas_handle::init;
-    }
-} // namespace rocblas

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -85,10 +85,6 @@ _rocblas_handle::~_rocblas_handle()
     }
     if(device_memory)
         (hipFree)(device_memory);
-
-    delete log_trace_os;
-    delete log_bench_os;
-    delete log_profile_os;
 }
 
 /*******************************************************************************
@@ -244,14 +240,14 @@ extern "C" bool rocblas_is_managing_device_memory(rocblas_handle handle)
  *                              the full logfile path.
  */
 
-static rocblas_ostream* open_log_stream(const char* environment_variable_name)
+static auto open_log_stream(const char* environment_variable_name)
 {
     // if environment variable is set, open file at logfile_pathname contained in the
     // environment variable; else use standard error
     const char* logfile_pathname = getenv(environment_variable_name);
 
-    return logfile_pathname ? new rocblas_ostream(logfile_pathname)
-                            : new rocblas_ostream(STDERR_FILENO);
+    return logfile_pathname ? std::make_unique<rocblas_ostream>(logfile_pathname)
+                            : std::make_unique<rocblas_ostream>(STDERR_FILENO);
 }
 
 /*******************************************************************************
@@ -265,27 +261,16 @@ void _rocblas_handle::init_logging()
     {
         layer_mode = static_cast<rocblas_layer_mode>(strtol(str_layer_mode, 0, 0));
 
-        try
-        {
-            // open log_trace file
-            if(layer_mode & rocblas_layer_mode_log_trace)
-                log_trace_os = open_log_stream("ROCBLAS_LOG_TRACE_PATH");
+        // open log_trace file
+        if(layer_mode & rocblas_layer_mode_log_trace)
+            log_trace_os = open_log_stream("ROCBLAS_LOG_TRACE_PATH");
 
-            // open log_bench file
-            if(layer_mode & rocblas_layer_mode_log_bench)
-                log_bench_os = open_log_stream("ROCBLAS_LOG_BENCH_PATH");
+        // open log_bench file
+        if(layer_mode & rocblas_layer_mode_log_bench)
+            log_bench_os = open_log_stream("ROCBLAS_LOG_BENCH_PATH");
 
-            // open log_profile file
-            if(layer_mode & rocblas_layer_mode_log_profile)
-                log_profile_os = open_log_stream("ROCBLAS_LOG_PROFILE_PATH");
-        }
-        catch(...)
-        {
-            delete log_trace_os;
-            delete log_bench_os;
-            delete log_profile_os;
-            log_trace_os = log_bench_os = log_profile_os = nullptr;
-            throw;
-        }
+        // open log_profile file
+        if(layer_mode & rocblas_layer_mode_log_profile)
+            log_profile_os = open_log_stream("ROCBLAS_LOG_PROFILE_PATH");
     }
 }

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -265,16 +265,27 @@ void _rocblas_handle::init_logging()
     {
         layer_mode = static_cast<rocblas_layer_mode>(strtol(str_layer_mode, 0, 0));
 
-        // open log_trace file
-        if(layer_mode & rocblas_layer_mode_log_trace)
-            log_trace_os = open_log_stream("ROCBLAS_LOG_TRACE_PATH");
+        try
+        {
+            // open log_trace file
+            if(layer_mode & rocblas_layer_mode_log_trace)
+                log_trace_os = open_log_stream("ROCBLAS_LOG_TRACE_PATH");
 
-        // open log_bench file
-        if(layer_mode & rocblas_layer_mode_log_bench)
-            log_bench_os = open_log_stream("ROCBLAS_LOG_BENCH_PATH");
+            // open log_bench file
+            if(layer_mode & rocblas_layer_mode_log_bench)
+                log_bench_os = open_log_stream("ROCBLAS_LOG_BENCH_PATH");
 
-        // open log_profile file
-        if(layer_mode & rocblas_layer_mode_log_profile)
-            log_profile_os = open_log_stream("ROCBLAS_LOG_PROFILE_PATH");
+            // open log_profile file
+            if(layer_mode & rocblas_layer_mode_log_profile)
+                log_profile_os = open_log_stream("ROCBLAS_LOG_PROFILE_PATH");
+        }
+        catch(...)
+        {
+            delete log_trace_os;
+            delete log_bench_os;
+            delete log_profile_os;
+            log_trace_os = log_bench_os = log_profile_os = nullptr;
+            throw;
+        }
     }
 }

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -11,6 +11,7 @@
 #include <array>
 #include <cstddef>
 #include <hip/hip_runtime.h>
+#include <memory>
 #include <tuple>
 #include <type_traits>
 #include <unistd.h>
@@ -80,10 +81,10 @@ public:
     rocblas_layer_mode layer_mode = rocblas_layer_mode_none;
 
     // logging streams
-    rocblas_ostream* log_trace_os   = nullptr;
-    rocblas_ostream* log_bench_os   = nullptr;
-    rocblas_ostream* log_profile_os = nullptr;
-    void             init_logging();
+    std::unique_ptr<rocblas_ostream> log_trace_os;
+    std::unique_ptr<rocblas_ostream> log_bench_os;
+    std::unique_ptr<rocblas_ostream> log_profile_os;
+    void                             init_logging();
 
     static int device_arch_id()
     {

--- a/library/src/include/handle.h
+++ b/library/src/include/handle.h
@@ -77,18 +77,13 @@ public:
     rocblas_pointer_mode pointer_mode = rocblas_pointer_mode_host;
 
     // default logging_mode is no logging
-    static rocblas_layer_mode layer_mode;
+    rocblas_layer_mode layer_mode = rocblas_layer_mode_none;
 
     // logging streams
-    static rocblas_ostream* log_trace_os;
-    static rocblas_ostream* log_bench_os;
-    static rocblas_ostream* log_profile_os;
-
-    // static data for startup initialization
-    static struct init
-    {
-        init();
-    } handle_init;
+    rocblas_ostream* log_trace_os   = nullptr;
+    rocblas_ostream* log_bench_os   = nullptr;
+    rocblas_ostream* log_profile_os = nullptr;
+    void             init_logging();
 
     static int device_arch_id()
     {
@@ -327,10 +322,5 @@ private:
 #define hipFree(ptr)                                                                               \
     _Pragma("GCC warning \"Direct use of hipFree in rocBLAS is deprecated; see CONTRIBUTING.md\"") \
         hipFree(ptr)
-
-namespace rocblas
-{
-    void reinit_logs(); // Reinitialize static data (for testing only)
-}
 
 #endif


### PR DESCRIPTION
This makes the logging handle-specific, which, by rocBLAS rules, is thread-specific. It initializes the handle's logging during handle creation, and uses the `ROCBLAS_LAYER` environment variable's value at the time of handle creation, to determine the logging for that handle. It removes the legacy code which made logging a static member of `rocblas_handle`.

The recent change #922 had mostly to do with making the IO thread-safe in the sense of not interleaving output from multiple threads writing to the same file/device, while remaining as lock-free as possible. This change, and #1129 _make the actual data structures thread-local_, **which is an orthogonal and much simpler issue** than #922.