### PR TITLE
Remove all instances of hcc in rocBLAS

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@ export PATH=/usr/bin:/bin
 
 set -x
 
-format=/opt/rocm/hcc/bin/clang-format
+format=/opt/rocm/llvm/bin/clang-format
 
 # Redirect stdout to stderr.
 exec >&2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if( BUILD_WITH_TENSILE )
   set( Tensile_TEST_LOCAL_PATH "" CACHE PATH "Use local Tensile directory instead of fetching a GitHub branch" )
   set_property( CACHE Tensile_ARCHITECTURE PROPERTY STRINGS all gfx803 gfx900 gfx906 gfx908)
   set_property( CACHE Tensile_LOGIC PROPERTY STRINGS asm_full asm_lite asm_miopen hip_lite other )
-  set_property( CACHE Tensile_CODE_OBJECT_VERSION PROPERTY STRINGS V3 )
+  set_property( CACHE Tensile_CODE_OBJECT_VERSION PROPERTY STRINGS V2 V3 )
   set_property( CACHE Tensile_COMPILER PROPERTY STRINGS hipcc)
 
   include(virtualenv)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,15 +55,15 @@ find_package(Threads REQUIRED)
 
 # Hopefully, cost #2 is already paid.  All in all, I want to get rid of the
 # need for hipcc, and hope that at some point of time in the future we
-# can use the export config files from hip & hcc for both ROCm & nvcc backends.
+# can use the export config files from hip-clang for both ROCm & nvcc backends.
 # ########################################################################
 
 # ########################################################################
 # Main
 # ########################################################################
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hcc$")
-  # Determine if CXX Compiler is hcc, hip-clang or nvcc
+if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+  # Determine if CXX Compiler is hip-clang or nvcc
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
                   OUTPUT_STRIP_TRAILING_WHITESPACE
                   ERROR_STRIP_TRAILING_WHITESPACE)
@@ -92,9 +92,6 @@ elseif( CXX_VERSION_STRING MATCHES "nvcc" )
   set( CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY "-Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY}" )
   set( CMAKE_C_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN "-Xcompiler ${CMAKE_C_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}" )
   set( CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN "-Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}" )
-elseif( CXX_VERSION_STRING MATCHES "HCC" )
-  message( STATUS "HCC compiler set; ROCm backend selected [ CXX=/opt/rocm-<ver>/bin/hcc cmake ... ]" )
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -hc")
 endif( )
 
 # This finds the rocm-cmake project, and installs it if not found
@@ -144,8 +141,8 @@ rocm_setup_version( VERSION ${VERSION_STRING} )
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
-# NOTE:  workaround until hcc & hip cmake modules fixes symlink logic in their config files; remove when fixed
-list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hcc ${ROCM_PATH}/hip /opt/rocm/hcc /opt/rocm/hip )
+# NOTE:  workaround until hip cmake modules fixes symlink logic in their config files; remove when fixed
+list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip /opt/rocm/hip )
 
 option( BUILD_VERBOSE "Output additional build information" OFF )
 
@@ -164,8 +161,8 @@ option( BUILD_WITH_TENSILE_HOST "Use the new tensile client for gemm?" ON )
 if( BUILD_WITH_TENSILE )
   set( Tensile_LOGIC "asm_full" CACHE STRING "Tensile to use which logic?")
   set( Tensile_ARCHITECTURE "all" CACHE STRING "Tensile to use which architecture?")
-  set( Tensile_CODE_OBJECT_VERSION "V2" CACHE STRING "Tensile code_object_version")
-  set( Tensile_COMPILER "hcc" CACHE STRING "Tensile compiler")
+  set( Tensile_CODE_OBJECT_VERSION "V3" CACHE STRING "Tensile code_object_version")
+  set( Tensile_COMPILER "hipcc" CACHE STRING "Tensile compiler")
 
   option( Tensile_MERGE_FILES "Tensile to merge kernels and solutions files?" ON )
   option( Tensile_SHORT_FILENAMES "Tensile to use short file names? Use if compiler complains they're too long." OFF )
@@ -174,8 +171,8 @@ if( BUILD_WITH_TENSILE )
   set( Tensile_TEST_LOCAL_PATH "" CACHE PATH "Use local Tensile directory instead of fetching a GitHub branch" )
   set_property( CACHE Tensile_ARCHITECTURE PROPERTY STRINGS all gfx803 gfx900 gfx906 gfx908)
   set_property( CACHE Tensile_LOGIC PROPERTY STRINGS asm_full asm_lite asm_miopen hip_lite other )
-  set_property( CACHE Tensile_CODE_OBJECT_VERSION PROPERTY STRINGS V2 V3 )
-  set_property( CACHE Tensile_COMPILER PROPERTY STRINGS hcc hipcc)
+  set_property( CACHE Tensile_CODE_OBJECT_VERSION PROPERTY STRINGS V3 )
+  set_property( CACHE Tensile_COMPILER PROPERTY STRINGS hipcc)
 
   include(virtualenv)
   if (Tensile_TEST_LOCAL_PATH)
@@ -197,12 +194,6 @@ if( BUILD_WITH_TENSILE )
     find_package(Tensile 4.19.0 EXACT REQUIRED HIP LLVM OpenMP PATHS "${INSTALLED_TENSILE_PATH}")
   endif()
 endif()
-
-# Find HCC/HIP dependencies
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-  find_package( hcc REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-  find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-endif( )
 
 # CMake list of machine targets
 if( Tensile_ARCHITECTURE STREQUAL "all" )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -93,12 +93,8 @@ if( OS_ID_rhel OR OS_ID_sles OR OS_ID_centos)
     endif()
 
     message(STATUS "RocmPath: ${ROCM_PATH}")
-    if(EXISTS ${ROCM_PATH}/llvm/lib/clang/11.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
+    if(EXISTS ${ROCM_PATH}/llvm/lib/clang/11.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
         set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/11.0.0/include )
-    elseif (EXISTS ${ROCM_PATH}/hcc/lib/clang/10.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/hcc/lib/clang/10.0.0/include )
-    elseif (EXISTS ${ROCM_PATH}/hcc/lib/clang/9.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$")
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/hcc/lib/clang/9.0.0/include )
     else()
         set( CLANG_INCLUDE_DIR )
     endif()
@@ -152,12 +148,7 @@ else( )
   target_link_libraries( rocblas-bench PRIVATE hip::device )
 endif( )
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-  # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-  # "clang-5.0: warning: argument unused during compilation: '-isystem ${ROCM_PATH}/include'"
-  target_compile_options( rocblas-bench PRIVATE -Wno-unused-command-line-argument -mf16c )
-  target_include_directories( rocblas-bench PRIVATE ${ROCM_PATH}/hsa/include)
-elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
+if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
   # GCC or hip-clang needs specific flags to turn on f16c intrinsics
   target_compile_options( rocblas-bench PRIVATE -mf16c )
 endif( )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -167,12 +167,8 @@ if( OS_ID_rhel OR OS_ID_sles OR OS_ID_centos)
     endif()
 
     message(STATUS "RocmPath: ${ROCM_PATH}")
-    if(EXISTS ${ROCM_PATH}/llvm/lib/clang/11.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
+    if(EXISTS ${ROCM_PATH}/llvm/lib/clang/11.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
         set( CLANG_INCLUDE_DIR ${ROCM_PATH}/llvm/lib/clang/11.0.0/include )
-    elseif (EXISTS ${ROCM_PATH}/hcc/lib/clang/10.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/hcc/lib/clang/10.0.0/include )
-    elseif (EXISTS ${ROCM_PATH}/hcc/lib/clang/9.0.0/include/immintrin.h AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-        set( CLANG_INCLUDE_DIR ${ROCM_PATH}/hcc/lib/clang/9.0.0/include )
     else()
         set( CLANG_INCLUDE_DIR )
     endif()
@@ -237,12 +233,7 @@ add_custom_target( rocblas-test-data
 
 add_dependencies( rocblas-test rocblas-test-data rocblas-common )
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-  # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-  # "clang-5.0: warning: argument unused during compilation: '-isystem ${ROCM_PATH}/include'"
-  target_compile_options( rocblas-test PRIVATE -Wno-unused-command-line-argument -mf16c )
-  target_include_directories( rocblas-test PRIVATE ${ROCM_PATH}/hsa/include)
-elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
+if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
   # GCC or hip-clang needs specific flag to turn on f16c intrinsics
   target_compile_options( rocblas-test PRIVATE -mf16c )
 endif( )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -53,20 +53,8 @@ foreach( exe ${sample_list} )
     target_link_libraries( ${exe} PRIVATE hip::device )
   endif( )
 
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-    # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-    # "clang-5.0: warning: argument unused during compilation: '-isystem ${ROCM_PATH}/include'"
-    # include order workaround to force /opt/rocm/include later in order to ignore installed rocblas
-    set(CMAKE_CXX_FLAGS "-isystem /opt/rocm/include ${CMAKE_CXX_FLAGS}")
-    target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument )
-    target_include_directories( ${exe} PRIVATE ${ROCM_PATH}/hsa/include)
-  elseif( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
+  if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
     # GCC or hip-clang needs specific flags to turn on f16c intrinsics
     target_compile_options( ${exe} PRIVATE -mf16c )
   endif( )
 endforeach( )
-
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-  # include order workaround to force /opt/rocm/include later in order to ignore installed rocblas
-  set(CMAKE_CXX_FLAGS "-isystem /opt/rocm/include ${CMAKE_CXX_FLAGS}")
-endif()

--- a/install.sh
+++ b/install.sh
@@ -275,7 +275,7 @@ install_dependencies=false
 install_prefix=rocblas-install
 tensile_logic=asm_full
 tensile_architecture=all
-tensile_cov=
+tensile_cov=V3
 tensile_fork=
 tensile_merge_files=
 tensile_tag=
@@ -401,14 +401,6 @@ while true; do
         ;;
   esac
 done
-
-if [[ -z $tensile_cov ]]; then
-    if [[ $build_hip_clang == true ]]; then
-        tensile_cov=V3
-    else
-        tensile_cov=V2
-    fi
-fi
 
 set -x
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -143,7 +143,7 @@ endif( )
 set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib" )
 
 # Give rocblas compiled for CUDA backend a different name
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CXX_VERSION_STRING MATCHES "clang" )
+if( CXX_VERSION_STRING MATCHES "clang" )
     set( package_name rocblas )
 else( )
     set( package_name rocblas-alt )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -80,20 +80,11 @@ if( BUILD_WITH_TENSILE )
     target_link_libraries( Tensile PRIVATE hip::device )
   endif()
 
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-    # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-    # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    # target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc -Wno-deprecated-declarations)
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
     foreach( target ${AMDGPU_TARGETS} )
       if( BUILD_WITH_TENSILE_HOST )
-          # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-          # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-          target_compile_options( TensileHost PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc -Wno-deprecated-declarations)
           target_compile_options( TensileHost PRIVATE --amdgpu-target=${target} )
       else()
-          # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-          # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-          target_compile_options( Tensile PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc -Wno-deprecated-declarations)
           target_compile_options( Tensile PRIVATE --amdgpu-target=${target} )
       endif()
     endforeach( )
@@ -322,10 +313,7 @@ target_link_libraries( rocblas PRIVATE hip::device )
 
 set_target_properties( rocblas PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-  # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-  # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-  target_compile_options( rocblas PRIVATE -Wno-unused-command-line-argument -fno-gpu-rdc )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
   foreach( target ${AMDGPU_TARGETS} )
     target_compile_options( rocblas PRIVATE --amdgpu-target=${target} )
   endforeach( )


### PR DESCRIPTION
- Removes hcc in pre-commit and header_compilation tests
- Removes hcc from install script
- Sets default TENSILE_CODE_OBJECT_VERSION to V3 and TENSILE_COMPILER to hipcc
- Removes all paths with hcc in the CMake files
- Only will be done in master-rocm-3.5 branch, thus the direct PR to main rocBLAS repo