### PR TITLE
use appropriate find_package calls for HIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,10 +212,10 @@ endif()
 # Find HCC/HIP dependencies
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   find_package( hcc REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-  find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
+  find_package( HIP REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
 endif( )
 if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-  find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
+  find_package( HIP REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
 endif( )
 
 # CMake list of machine targets

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -54,7 +54,7 @@ endif( )
 
 # Hip headers required of all clients; clients use hip to allocate device memory
 list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} /opt/rocm )
-find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} )
+find_package( HIP REQUIRED CONFIG PATHS ${ROCM_PATH} )
 
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -500,7 +500,7 @@ if( BUILD_SHARED_LIBS )
   rocm_export_targets(
     TARGETS roc::rocblas
     PREFIX rocblas
-    DEPENDS PACKAGE hip
+    DEPENDS PACKAGE HIP
     NAMESPACE roc::
     )
 else()
@@ -508,7 +508,7 @@ else()
     rocm_export_targets(
       TARGETS roc::rocblas
       PREFIX rocblas
-      DEPENDS PACKAGE hip
+      DEPENDS PACKAGE HIP
       STATIC_DEPENDS PACKAGE msgpack
       NAMESPACE roc::
       )
@@ -516,7 +516,7 @@ else()
     rocm_export_targets(
       TARGETS roc::rocblas
       PREFIX rocblas
-      DEPENDS PACKAGE hip
+      DEPENDS PACKAGE HIP
       STATIC_DEPENDS PACKAGE LLVM
       NAMESPACE roc::
       )


### PR DESCRIPTION
resolves #1156 

Summary of proposed changes:
- change `find_package( hip ...` calls to `find_package( HIP ...` to match the `FindHIP.cmake` file as installed by `hip-base`.
-  change export dep from hip to HIP