### PR TITLE
SWDEV-246520-hide-symbols

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -377,6 +377,7 @@ if( BUILD_WITH_TENSILE )
       #target_link_libraries( rocblas PRIVATE Tensile TensileHost )
       if( BUILD_SHARED_LIBS )
         target_link_libraries( rocblas PRIVATE TensileHost )
+        target_link_libraries( rocblas PRIVATE "-Xlinker --exclude-lib=ALL" ) # HIDE symbols
       else()
         target_compile_definitions( rocblas PRIVATE ROCBLAS_STATIC_LIB )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -377,7 +377,7 @@ if( BUILD_WITH_TENSILE )
       #target_link_libraries( rocblas PRIVATE Tensile TensileHost )
       if( BUILD_SHARED_LIBS )
         target_link_libraries( rocblas PRIVATE TensileHost )
-        target_link_libraries( rocblas PRIVATE "-Xlinker --exclude-lib=ALL" ) # HIDE symbols
+        target_link_libraries( rocblas PRIVATE "-Xlinker --exclude-libs=ALL" ) # HIDE symbols
       else()
         target_compile_definitions( rocblas PRIVATE ROCBLAS_STATIC_LIB )
 


### PR DESCRIPTION
* hides llvm symbols used by embedded rocblas-tensile library