### PR TITLE
Define the Tensile_LIBRARY_FORMAT variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if( BUILD_WITH_TENSILE )
   set( Tensile_ARCHITECTURE "all" CACHE STRING "Tensile to use which architecture?")
   set( Tensile_CODE_OBJECT_VERSION "V2" CACHE STRING "Tensile code_object_version")
   set( Tensile_COMPILER "hcc" CACHE STRING "Tensile compiler")
+  set( Tensile_LIBRARY_FORMAT "msgpack" CACHE STRING "Tensile library format")
 
   option( Tensile_MERGE_FILES "Tensile to merge kernels and solutions files?" ON )
   option( Tensile_SHORT_FILENAMES "Tensile to use short file names? Use if compiler complains they're too long." OFF )


### PR DESCRIPTION
Fixes:

```
CMake Error at CMakeLists.txt:180 (set_property):
  set_property could not find CACHE variable Tensile_LIBRARY_FORMAT.  Perhaps
  it has not yet been created.
```