### PR TITLE
remove division by number_hot_calls when using ArgumentModel

### DIFF
--- a/clients/include/blas2/testing_syr_strided_batched.hpp
+++ b/clients/include/blas2/testing_syr_strided_batched.hpp
@@ -225,7 +225,7 @@ void testing_syr_strided_batched(const Arguments& arg)
                 handle, uplo, N, &h_alpha, dx, incx, stridex, dA_1, lda, strideA, batch_count);
         }
 
-        gpu_time_used = (get_time_us_sync(stream) - gpu_time_used) / number_hot_calls;
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
         Arguments targ(arg);
         targ.stride_a = strideA;

--- a/clients/include/blas3/testing_gemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_gemm_strided_batched.hpp
@@ -329,7 +329,7 @@ void testing_gemm_strided_batched(const Arguments& arg)
                                             batch_count);
         }
 
-        gpu_time_used = (get_time_us_sync(stream) - gpu_time_used) / number_hot_calls;
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
         ArgumentModel<e_transA,
                       e_transB,

--- a/clients/include/blas_ex/testing_rot_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_rot_strided_batched_ex.hpp
@@ -353,7 +353,7 @@ void testing_rot_strided_batched_ex(const Arguments& arg)
                                               batch_count,
                                               execution_type);
         }
-        gpu_time_used = (get_time_us_sync(stream) - gpu_time_used) / number_hot_calls;
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
         ArgumentModel<e_N, e_incx, e_stride_x, e_incy, e_stride_y, e_batch_count>{}.log_args<Tx>(
             rocblas_cout,


### PR DESCRIPTION
- resolves SWDEV-280617
- The function ArgumentModel divides gpu_time by number_hot_calls so the calling code should not do this division.
- This fix is for the three functions: syr_strided_batched, gemm_strided_batched, rot_strided_batched
