### PR TITLE
Use CMAKE_CXX_COMPILER_ID to detect Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
   string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
 endif()
 
-if( CXX_VERSION_STRING MATCHES "clang" )
+if( CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   message( STATUS "Use hip-clang to build for amdgpu backend" )
 # set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fallow-half-arguments-and-returns" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_HCC_COMPAT_MODE__=1" )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -68,7 +68,7 @@ else( )
   target_link_libraries( rocblas-bench PRIVATE hip::host hip::device )
 endif( )
 
-if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang")
+if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # GCC or hip-clang needs specific flags to turn on f16c intrinsics
   target_compile_options( rocblas-bench PRIVATE -mf16c )
 endif( )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -159,7 +159,7 @@ add_custom_target( rocblas-test-data
 
 add_dependencies( rocblas-test rocblas-test-data rocblas-common )
 
-if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
+if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # GCC or hip-clang needs specific flag to turn on f16c intrinsics
   target_compile_options( rocblas-test PRIVATE -mf16c )
 endif( )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -70,7 +70,7 @@ foreach( exe ${sample_list_all} )
     #target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
   endif( )
 
-  if( CMAKE_COMPILER_IS_GNUCXX OR CXX_VERSION_STRING MATCHES "clang" )
+  if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # GCC or hip-clang needs specific flags to turn on f16c intrinsics
     target_compile_options( ${exe} PRIVATE -mf16c )
   endif( )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc.
+# Copyright 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
 # The following helper functions wrap common cmake functions.  They are
@@ -154,7 +154,7 @@ endif( )
 set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib" )
 
 # Give rocblas compiled for CUDA backend a different name
-if( CXX_VERSION_STRING MATCHES "clang" )
+if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     set( package_name rocblas )
 else( )
     set( package_name rocblas-alt )


### PR DESCRIPTION
We are adding the vendor string "AMD" to ROCm's hip-clang as a consequence, the regex to detect clang from its version string would be broken.  Instead of doing that, check whether the cmake's built-in CMAKE_CXX_COMPILER_ID variable is defined as Clang.