### PR TITLE
Update clients.rst for external rocBLAS github link

### DIFF
--- a/docs/source/clients.rst
+++ b/docs/source/clients.rst
@@ -8,7 +8,7 @@ There are two client executables that can be used with rocBLAS. They are,
 
 2. rocblas-test
 
-These two clients can be built by following the instructions at `Building and Installing rocBLAS github page <https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/blob/develop/docs/source/install.rst>`_. After building the rocBLAS clients, they can be found in the directory ``rocBLAS/build/release/clients/staging``.
+These two clients can be built by following the instructions at `Building and Installing rocBLAS github page <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/docs/source/install.rst>`_. After building the rocBLAS clients, they can be found in the directory ``rocBLAS/build/release/clients/staging``.
 
 The next two sections will cover a brief explanation and the usage of each rocBLAS client.
 


### PR DESCRIPTION
externally facing doc, so change the link from:
https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/blob/develop/docs/source/install.rst
to:
https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/docs/source/install.rst

resolves #___

Summary of proposed changes:
-
-
-
