### PR TITLE
update CHANGELOG.md for ROCm 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocBLAS is available at [rocblas.readthedocs.io](https://rocblas.readthedocs.io/en/latest/).
 
-## (Unreleased) rocBLAS 2.42.0
+## rocBLAS 2.42.0 for ROCm 5.0.0
 ### Added
 - Added rocblas_get_version_string_size convenience function
 - Added rocblas_xtrmm_outofplace, an out-of-place version of rocblas_xtrmm


### PR DESCRIPTION
- This PR is to rocBLAS:release/rocm-rel-5.0. It will be merged back into rocBLAS-internal:develop in a future PR