### PR TITLE
Duplicate file in rocBLAS package.\n \n Removing LICENSE file install…

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -531,11 +531,6 @@ rocm_install(FILES "../include/rocblas_module.f90"
         DESTINATION "rocblas/include"
 )
 
-# Force installation of LICENSE.md
-install(FILES "../../LICENSE.md"
-	DESTINATION "share/doc/rocBLAS"
-)
-
 rocm_install_targets(
   TARGETS ${package_targets}
   INCLUDE


### PR DESCRIPTION
Duplicate license file in rocBLAS package. 

Removing the LICENSE file install from rocBLAS as its already handled in rocm_cmake

resolves #SWDEV-322589

Summary of proposed changes:
- Removing the LICENSE file install from rocBLAS as its already handled in rocm_cmake
-
-
