### PR TITLE
Enable Origin header file dump option for wrapper

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -511,6 +511,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     internal/rocblas-version.h internal/rocblas-export.h internal/rocblas-exported-proto.hpp internal/rocblas_device_malloc.hpp
     GUARDS SYMLINK WRAPPER
     WRAPPER_LOCATIONS include rocblas/include
+    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/rocblas/internal/rocblas-version.h
   )
 endif( )
 


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Original Header File Dump enabled for version header wrapper to support backward Compatibility for PT/TF
- Use rocm-cmake updated version https://github.com/RadeonOpenCompute/rocm-cmake/commit/d108dbf05e029996d5d7bcbe258abb1166547a30