### PR TITLE
Hotfix : Update CMakeLists.txt to link libpthread

### DIFF
--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -69,7 +69,7 @@ foreach( exe ${sample_list_fortran} )
 endforeach( )
 
 foreach( exe ${sample_list_all} )
-  target_link_libraries( ${exe} PRIVATE roc::rocblas )
+  target_link_libraries( ${exe} PRIVATE Threads::Threads roc::rocblas )
 
   set_target_properties( ${exe} PROPERTIES
     CXX_STANDARD 14

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -69,7 +69,7 @@ foreach( exe ${sample_list_fortran} )
 endforeach( )
 
 foreach( exe ${sample_list_all} )
-  target_link_libraries( ${exe} PRIVATE Threads::Threads roc::rocblas )
+  target_link_libraries( ${exe} PRIVATE roc::rocblas )
 
   set_target_properties( ${exe} PROPERTIES
     CXX_STANDARD 14

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -406,6 +406,7 @@ if (WIN32)
 else()
   target_link_libraries( rocblas PRIVATE hip::device -lstdc++fs --rtlib=compiler-rt --unwindlib=libgcc )
 endif()
+  target_link_libraries( rocblas PRIVATE Threads::Threads )
 
 #  -fno-gpu-rdc compiler option was used with hcc, so revisit feature at some point
 


### PR DESCRIPTION
Update CMakeLists.txt to link libpthread for all rocblas samples programs to avoid build error.