### PR TITLE
Hotfix: Remove hipStreamSynchronize from rotg

### DIFF
--- a/library/include/internal/rocblas-functions.h
+++ b/library/include/internal/rocblas-functions.h
@@ -2194,9 +2194,6 @@ ROCBLAS_EXPORT rocblas_status rocblas_zdrot_strided_batched(rocblas_handle      
     rotg creates the Givens rotation matrix for the vector (a b).
     Scalars c and s and arrays a and b may be stored in either host or device memory, location is specified by calling rocblas_set_pointer_mode:
 
-    - If the pointer mode is set to rocblas_pointer_mode_host, then this function blocks the CPU until the GPU has finished and the results are available in host memory.
-    - If the pointer mode is set to rocblas_pointer_mode_device, then this function returns immediately and synchronization is required to read the results.
-
     @param[in]
     handle  [rocblas_handle]
             handle to the rocblas library context queue.
@@ -2576,9 +2573,6 @@ ROCBLAS_EXPORT rocblas_status rocblas_drotm_strided_batched(rocblas_handle handl
     \details
     rotmg creates the modified Givens rotation matrix for the vector (d1 * x1, d2 * y1).
           Parameters may be stored in either host or device memory. Location is specified by calling rocblas_set_pointer_mode:
-
-    - If the pointer mode is set to rocblas_pointer_mode_host, then this function blocks the CPU until the GPU has finished and the results are available in host memory.
-    - If the pointer mode is set to rocblas_pointer_mode_device, then this function returns immediately and synchronization is required to read the results.
 
     @param[in]
     handle  [rocblas_handle]

--- a/library/src/blas1/rocblas_rotg_kernels.cpp
+++ b/library/src/blas1/rocblas_rotg_kernels.cpp
@@ -142,7 +142,6 @@ rocblas_status rocblas_rotg_template(rocblas_handle handle,
     }
     else
     {
-        RETURN_IF_HIP_ERROR(hipStreamSynchronize(rocblas_stream));
         // TODO: make this faster for a large number of batches.
         for(int i = 0; i < batch_count; i++)
         {

--- a/library/src/blas1/rocblas_rotmg_kernels.cpp
+++ b/library/src/blas1/rocblas_rotmg_kernels.cpp
@@ -241,7 +241,6 @@ rocblas_status rocblas_rotmg_template(rocblas_handle handle,
     }
     else
     {
-        RETURN_IF_HIP_ERROR(hipStreamSynchronize(rocblas_stream));
         // TODO: make this faster for a large number of batches.
         for(int i = 0; i < batch_count; i++)
         {


### PR DESCRIPTION
- Remove hipStreamSynchronize from rotg functions as they are not needed. 
- Resolves HIP graph capture pre_checkin test failures. 