### PR TITLE
Hotfix for rocblas initialization time issues

### DIFF
--- a/clients/gtest/multiheaded_gtest.cpp
+++ b/clients/gtest/multiheaded_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,9 +65,6 @@ namespace
     void thread_function(int id, const Arguments& arg)
     {
         CHECK_HIP_ERROR(hipSetDevice(id));
-
-        //Initialize rocblas
-        rocblas_client_initialize();
 
         rocblas_operation transa = rocblas_operation_none, transb = rocblas_operation_transpose;
         float             alpha = 1.1, beta = 0.9;
@@ -191,6 +188,9 @@ namespace
                    << std::endl;
             return;
         }
+
+        rocblas_parallel_initialize(count);
+
         auto thread = std::make_unique<std::thread[]>(count);
 
         for(int id = 0; id < count; ++id)

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -96,12 +96,15 @@
 #define NOOP (void)0
 
 /*!
- * Initialize rocBLAS for the current HIP device and report
- * the time taken to complete the initialization. This is used to
- * avoid costly startup time at the first call on that device.
- * Internal use for benchmark & testing.
+ * Initialize rocBLAS for the requested number of  HIP devices
+ * and report the time taken to complete the initialization.
+ * This is to avoid costly startup time at the first call on
+ * that device. Internal use for benchmark & testing.
+ * Initializes devices indexed from 0 to parallel_devices-1.
+ * If parallel_devices is 1, hipSetDevice should be called
+ * before calling this function.
  */
-void rocblas_client_initialize();
+void rocblas_parallel_initialize(int parallel_devices);
 
 /* ============================================================================================ */
 /*! \brief  local handle which is automatically created and destroyed  */

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -80,7 +80,7 @@ foreach( exe ${sample_list_fortran} )
 endforeach( )
 
 foreach( exe ${sample_list_all} )
-  target_link_libraries( ${exe} PRIVATE roc::rocblas )
+  target_link_libraries( ${exe} PRIVATE roc::rocblas Threads::Threads )
 
   set_target_properties( ${exe} PROPERTIES
     CXX_STANDARD 14

--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -701,14 +701,12 @@ namespace
                 int    g = glob(dir.c_str(), GLOB_NOSORT, nullptr, &glob_result);
                 if(!g)
                 {
-                    const char* experimental = getenv("ROCBLAS_TENSILE_EXPERIMENTAL_SELECTION");
                     for(size_t i = 0; i < glob_result.gl_pathc; ++i)
                     {
                         std::string cofile = glob_result.gl_pathv[i];
                         if(!skip_xnack.empty() && cofile.find(skip_xnack) != std::string::npos)
                             continue;
-                        if((experimental == nullptr || experimental[0] == '\0')
-                           && cofile.find("Experimental") != std::string::npos)
+                        if(cofile.find("Experimental") != std::string::npos)
                             continue;
                         adapter.loadCodeObjectFile(cofile);
                     }

--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -685,6 +685,9 @@ namespace
                         if(!skip_xnack.empty()
                            && codeObjectFile.find(skip_xnack) != std::string::npos)
                             continue;
+                        // Skip experimental libraries
+                        if(codeObjectFile.find("Experimental") != std::string::npos)
+                            continue;
                         adapter.loadCodeObjectFile(codeObjectFile.c_str());
                     } while(FindNextFileA(hfine, &finddata));
                 }
@@ -698,10 +701,14 @@ namespace
                 int    g = glob(dir.c_str(), GLOB_NOSORT, nullptr, &glob_result);
                 if(!g)
                 {
+                    const char* experimental = getenv("ROCBLAS_TENSILE_EXPERIMENTAL_SELECTION");
                     for(size_t i = 0; i < glob_result.gl_pathc; ++i)
                     {
                         std::string cofile = glob_result.gl_pathv[i];
                         if(!skip_xnack.empty() && cofile.find(skip_xnack) != std::string::npos)
+                            continue;
+                        if((experimental == nullptr || experimental[0] == '\0')
+                           && cofile.find("Experimental") != std::string::npos)
                             continue;
                         adapter.loadCodeObjectFile(cofile);
                     }


### PR DESCRIPTION
resolves SWDEV-386410

Summary of proposed changes:
- Refactor initialization time reporting for clarity
- Skip experimental code objects in rocblas_initialize
- Output only maximum memory per device
