### PR TITLE
Add missing symbols for hipblas with no-tensile build

### DIFF
--- a/library/include/internal/rocblas-types.h
+++ b/library/include/internal/rocblas-types.h
@@ -217,6 +217,8 @@ typedef enum rocblas_status_
     rocblas_status_continue            = 12, /**< Nothing preventing function to proceed */
     rocblas_status_check_numerics_fail
     = 13, /**< Will be set if the vector/matrix has a NaN/Infinity/denormal value */
+    rocblas_status_excluded_from_build
+    = 14, /**< Function is not available in build, likely a function requiring Tensile built without Tensile */
 } rocblas_status;
 
 /*! \brief Indicates if scalar pointers are on host or device. This is used for

--- a/library/include/rocblas_module.f90
+++ b/library/include/rocblas_module.f90
@@ -64,6 +64,8 @@ module rocblas_enums
         enumerator :: rocblas_status_size_unchanged = 10
         enumerator :: rocblas_status_invalid_value = 11
         enumerator :: rocblas_status_continue = 12
+        enumerator :: rocblas_status_check_numerics_fail = 13
+        enumerator :: rocblas_status_excluded_from_build = 14
     end enum
 
     enum, bind(c)

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -123,15 +123,9 @@ if( BUILD_WITH_TENSILE )
     tensile_host.cpp
   )
 
-  #rocblas gemm_ex, gemm_ext2 and trsv require tensile
+  # gemm_ext2 requires tensile and doesn't need stub
   set( rocblas_ex_source
-    blas_ex/rocblas_gemm_ex.cpp
-    blas_ex/rocblas_gemm_batched_ex.cpp
-    blas_ex/rocblas_gemm_strided_batched_ex.cpp
     blas_ex/rocblas_gemm_ext2.cpp
-    blas_ex/rocblas_trsv_ex.cpp
-    blas_ex/rocblas_trsv_strided_batched_ex.cpp
-    blas_ex/rocblas_trsv_batched_ex.cpp
     ${Tensile_SRC}
   )
 
@@ -168,6 +162,14 @@ set(rocblas_ex_source_no_tensile
     blas_ex/rocblas_trmm_outofplace_strided_batched.cpp
     blas_ex/rocblas_geam_ex.cpp
     blas_ex/rocblas_geam_ex_kernels.cpp
+
+    # these require tensile but export no-op symbols to build downstream components
+    blas_ex/rocblas_gemm_ex.cpp
+    blas_ex/rocblas_gemm_batched_ex.cpp
+    blas_ex/rocblas_gemm_strided_batched_ex.cpp
+    blas_ex/rocblas_trsv_ex.cpp
+    blas_ex/rocblas_trsv_strided_batched_ex.cpp
+    blas_ex/rocblas_trsv_batched_ex.cpp
 )
 
 set( rocblas_blas3_source_no_tensile

--- a/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
@@ -21,11 +21,16 @@
  * ************************************************************************ */
 
 #include "handle.hpp"
-#include "logging.hpp"
 #include "rocblas.h"
+
+#ifdef BUILD_WITH_TENSILE
+
+#include "logging.hpp"
 #include "rocblas_gemm_ex.hpp"
 #include "rocblas_gemm_ex_get_solutions.hpp"
 #include "utility.hpp"
+
+#endif
 
 extern "C" rocblas_status rocblas_gemm_batched_ex(rocblas_handle    handle,
                                                   rocblas_operation trans_a,
@@ -54,6 +59,7 @@ extern "C" rocblas_status rocblas_gemm_batched_ex(rocblas_handle    handle,
                                                   uint32_t          flags)
 try
 {
+#ifdef BUILD_WITH_TENSILE
     if(!handle)
         return rocblas_status_invalid_handle;
 
@@ -288,6 +294,9 @@ try
                                           algo,
                                           solution_index,
                                           flags);
+#else
+    return rocblas_status_excluded_from_build;
+#endif
 }
 catch(...)
 {
@@ -323,6 +332,7 @@ extern "C" rocblas_status rocblas_gemm_batched_ex_get_solutions(rocblas_handle  
 {
     try
     {
+#ifdef BUILD_WITH_TENSILE
         if(!handle)
             return rocblas_status_invalid_handle;
 
@@ -399,6 +409,9 @@ extern "C" rocblas_status rocblas_gemm_batched_ex_get_solutions(rocblas_handle  
                                                             CAN_SOLVE,
                                                             list_array,
                                                             list_size);
+#else
+        return rocblas_status_not_implemented;
+#endif
     }
     catch(...)
     {
@@ -415,6 +428,7 @@ ROCBLAS_EXPORT rocblas_status
                                                   rocblas_int*     list_array,
                                                   rocblas_int*     list_size)
 {
+#ifdef BUILD_WITH_TENSILE
     // Create dummy GEMM problem to take advantage of problem templating
     // Most parameters are ignored, just needs to be valid for all types
     float          alpha = 0.0f;
@@ -454,4 +468,7 @@ ROCBLAS_EXPORT rocblas_status
                                                         MATCHES_TYPE,
                                                         list_array,
                                                         list_size);
+#else
+    return rocblas_status_not_implemented;
+#endif
 }

--- a/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
@@ -410,7 +410,7 @@ extern "C" rocblas_status rocblas_gemm_batched_ex_get_solutions(rocblas_handle  
                                                             list_array,
                                                             list_size);
 #else
-        return rocblas_status_not_implemented;
+        return rocblas_status_excluded_from_build;
 #endif
     }
     catch(...)
@@ -469,6 +469,6 @@ ROCBLAS_EXPORT rocblas_status
                                                         list_array,
                                                         list_size);
 #else
-    return rocblas_status_not_implemented;
+    return rocblas_status_excluded_from_build;
 #endif
 }

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -464,7 +464,7 @@ extern "C" rocblas_status rocblas_gemm_ex_get_solutions(rocblas_handle    handle
                                                              list_array,
                                                              list_size);
 #else
-        return rocblas_status_not_implemented;
+        return rocblas_status_excluded_from_build;
 #endif
     }
     catch(...)
@@ -522,6 +522,6 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex_get_solutions_by_type(rocblas_hand
                                                          list_array,
                                                          list_size);
 #else
-    return rocblas_status_not_implemented;
+    return rocblas_status_excluded_from_build;
 #endif
 }

--- a/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -20,10 +20,13 @@
  *
  * ************************************************************************ */
 
-#include "rocblas_gemm_ex.hpp"
 #include "handle.hpp"
-#include "logging.hpp"
 #include "rocblas.h"
+
+#ifdef BUILD_WITH_TENSILE
+
+#include "logging.hpp"
+#include "rocblas_gemm_ex.hpp"
 #include "rocblas_gemm_ex_get_solutions.hpp"
 #include "utility.hpp"
 
@@ -294,6 +297,8 @@ namespace
 }
 // namespace
 
+#endif // BUILD_WITH_TENSILE
+
 extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle    handle,
                                           rocblas_operation trans_a,
                                           rocblas_operation trans_b,
@@ -320,6 +325,7 @@ extern "C" rocblas_status rocblas_gemm_ex(rocblas_handle    handle,
                                           uint32_t          flags)
 try
 {
+#ifdef BUILD_WITH_TENSILE
     return rocblas_gemm_ex_impl(handle,
                                 trans_a,
                                 trans_b,
@@ -344,6 +350,9 @@ try
                                 algo,
                                 solution_index,
                                 flags);
+#else
+    return rocblas_status_excluded_from_build;
+#endif
 }
 catch(...)
 {
@@ -378,6 +387,7 @@ extern "C" rocblas_status rocblas_gemm_ex_get_solutions(rocblas_handle    handle
 {
     try
     {
+#ifdef BUILD_WITH_TENSILE
         if(!handle)
             return rocblas_status_invalid_handle;
 
@@ -453,6 +463,9 @@ extern "C" rocblas_status rocblas_gemm_ex_get_solutions(rocblas_handle    handle
                                                              CAN_SOLVE,
                                                              list_array,
                                                              list_size);
+#else
+        return rocblas_status_not_implemented;
+#endif
     }
     catch(...)
     {
@@ -468,6 +481,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex_get_solutions_by_type(rocblas_hand
                                                                     rocblas_int*     list_array,
                                                                     rocblas_int*     list_size)
 {
+#ifdef BUILD_WITH_TENSILE
     // Create dummy GEMM problem to take advantage of problem templating
     // Most parameters are ignored, just needs to be valid for all types
     float          alpha = 0.0f;
@@ -507,4 +521,7 @@ ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex_get_solutions_by_type(rocblas_hand
                                                          MATCHES_TYPE,
                                                          list_array,
                                                          list_size);
+#else
+    return rocblas_status_not_implemented;
+#endif
 }

--- a/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
@@ -434,7 +434,7 @@ extern "C" rocblas_status
                                                              list_array,
                                                              list_size);
 #else
-        return rocblas_status_not_implemented;
+        return rocblas_status_excluded_from_build;
 #endif
     }
     catch(...)

--- a/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
@@ -20,11 +20,16 @@
  *
  * ************************************************************************ */
 #include "handle.hpp"
-#include "logging.hpp"
 #include "rocblas.h"
+
+#ifdef BUILD_WITH_TENSILE
+
+#include "logging.hpp"
 #include "rocblas_gemm_ex.hpp"
 #include "rocblas_gemm_ex_get_solutions.hpp"
 #include "utility.hpp"
+
+#endif
 
 extern "C" rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle    handle,
                                                           rocblas_operation trans_a,
@@ -57,6 +62,7 @@ extern "C" rocblas_status rocblas_gemm_strided_batched_ex(rocblas_handle    hand
                                                           uint32_t          flags)
 try
 {
+#ifdef BUILD_WITH_TENSILE
     if(!handle)
         return rocblas_status_invalid_handle;
 
@@ -312,6 +318,9 @@ try
                                            algo,
                                            solution_index,
                                            flags);
+#else
+    return rocblas_status_excluded_from_build;
+#endif
 }
 catch(...)
 {
@@ -352,6 +361,7 @@ extern "C" rocblas_status
 {
     try
     {
+#ifdef BUILD_WITH_TENSILE
         if(!handle)
             return rocblas_status_invalid_handle;
 
@@ -423,6 +433,9 @@ extern "C" rocblas_status
                                                              CAN_SOLVE,
                                                              list_array,
                                                              list_size);
+#else
+        return rocblas_status_not_implemented;
+#endif
     }
     catch(...)
     {

--- a/library/src/blas_ex/rocblas_trsv_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_trsv_batched_ex.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,11 @@
  *
  * ************************************************************************ */
 #include "handle.hpp"
-#include "logging.hpp"
 #include "rocblas.h"
+
+#ifdef BUILD_WITH_TENSILE
+
+#include "logging.hpp"
 #include "rocblas_block_sizes.h"
 #include "rocblas_trsv_inverse.hpp"
 #include "utility.hpp"
@@ -223,6 +226,8 @@ namespace
 
 } // namespace
 
+#endif // BUILD_WITH_TENSILE
+
 /*
  * ===========================================================================
  *    C wrapper
@@ -246,6 +251,7 @@ rocblas_status rocblas_trsv_batched_ex(rocblas_handle    handle,
                                        rocblas_datatype  compute_type)
 try
 {
+#ifdef BUILD_WITH_TENSILE
     switch(compute_type)
     {
     case rocblas_datatype_f64_r:
@@ -309,6 +315,9 @@ try
     default:
         return rocblas_status_not_implemented;
     }
+#else
+    return rocblas_status_excluded_from_build;
+#endif
 }
 catch(...)
 {

--- a/library/src/blas_ex/rocblas_trsv_ex.cpp
+++ b/library/src/blas_ex/rocblas_trsv_ex.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,11 @@
  *
  * ************************************************************************ */
 #include "handle.hpp"
-#include "logging.hpp"
 #include "rocblas.h"
+
+#ifdef BUILD_WITH_TENSILE
+
+#include "logging.hpp"
 #include "rocblas_block_sizes.h"
 #include "rocblas_trsv_inverse.hpp"
 #include "utility.hpp"
@@ -208,6 +211,8 @@ namespace
 
 } // namespace
 
+#endif // BUILD_WITH_TENSILE
+
 /*
  * ===========================================================================
  *    C wrapper
@@ -230,6 +235,7 @@ rocblas_status rocblas_trsv_ex(rocblas_handle    handle,
                                rocblas_datatype  compute_type)
 try
 {
+#ifdef BUILD_WITH_TENSILE
     switch(compute_type)
     {
     case rocblas_datatype_f64_r:
@@ -289,6 +295,9 @@ try
     default:
         return rocblas_status_not_implemented;
     }
+#else
+    return rocblas_status_excluded_from_build;
+#endif
 }
 catch(...)
 {

--- a/library/src/blas_ex/rocblas_trsv_strided_batched_ex.cpp
+++ b/library/src/blas_ex/rocblas_trsv_strided_batched_ex.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,11 @@
  *
  * ************************************************************************ */
 #include "handle.hpp"
-#include "logging.hpp"
 #include "rocblas.h"
+
+#ifdef BUILD_WITH_TENSILE
+
+#include "logging.hpp"
 #include "rocblas_block_sizes.h"
 #include "rocblas_trsv_inverse.hpp"
 #include "utility.hpp"
@@ -237,6 +240,8 @@ namespace
 
 } // namespace
 
+#endif // BUILD_WITH_TENSILE
+
 /*
  * ===========================================================================
  *    C wrapper
@@ -262,6 +267,7 @@ rocblas_status rocblas_trsv_strided_batched_ex(rocblas_handle    handle,
                                                rocblas_datatype  compute_type)
 try
 {
+#ifdef BUILD_WITH_TENSILE
     switch(compute_type)
     {
     case rocblas_datatype_f64_r:
@@ -335,6 +341,9 @@ try
     default:
         return rocblas_status_not_implemented;
     }
+#else
+    return rocblas_status_excluded_from_build;
+#endif
 }
 catch(...)
 {

--- a/library/src/rocblas_auxiliary.cpp
+++ b/library/src/rocblas_auxiliary.cpp
@@ -1117,6 +1117,7 @@ extern "C" const char* rocblas_status_to_string(rocblas_status status)
         CASE(rocblas_status_invalid_value);
         CASE(rocblas_status_continue);
         CASE(rocblas_status_check_numerics_fail);
+        CASE(rocblas_status_excluded_from_build);
     }
 #undef CASE
     // We don't use default: so that the compiler warns us if any valid enums are missing


### PR DESCRIPTION
cherry-pick https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/commit/9eacbb249f64aaef0bf789c2ccad4336d9234295 and https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/commit/06b51585aef2356e2bc3cc6ffc13d41f3b8555d7 and merge conflict fixes into 5.7.