### PR TITLE
Fix rmake for windows

### DIFF
--- a/rmake.py
+++ b/rmake.py
@@ -208,7 +208,7 @@ def fatal(msg, code=1):
 def deps_cmd():
     if os.name == "nt":
         exe = f"python3 rdeps.py"
-        cmdline_args = ""
+        all_args = ""
     else:
         exe = f"./install.sh --rmake_invoked -d"
         all_args = ' '.join(sys.argv[1:])


### PR DESCRIPTION
It previously crashed with:
UnboundLocalError: local variable 'all_args' referenced before assignment

