### PR TITLE
debug format compressed vs old split-dwarf (#2100)

### DIFF
--- a/cmake/toolchain-options.cmake
+++ b/cmake/toolchain-options.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -80,7 +80,7 @@ if( CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_HCC_COMPAT_MODE__=1" )
 
   if ( CMAKE_BUILD_TYPE MATCHES "Debug" AND NOT WIN32 )
-    set ( CMAKE_CXX_FLAGS_DEBUG "-O1 ${CMAKE_CXX_FLAGS_DEBUG} -gsplit-dwarf -ggdb" )
+    set ( CMAKE_CXX_FLAGS_DEBUG "-O1 ${CMAKE_CXX_FLAGS_DEBUG} -gz -ggdb" )
   endif()
 
 elseif( CXX_VERSION_STRING MATCHES "nvcc" )


### PR DESCRIPTION
* avoid split dwarf debug format for now
