### PR TITLE
Fix host-pointer-mode reductions for nonblocking streams

### DIFF
--- a/library/src/blas1/rocblas_reduction_kernels.cpp
+++ b/library/src/blas1/rocblas_reduction_kernels.cpp
@@ -237,16 +237,20 @@ rocblas_status rocblas_reduction_template(rocblas_handle handle,
             // If FINALIZE is trivial or kernel part2 was called, result is in the
             // beginning of workspace[0]+offset, and can be copied directly.
             size_t offset = reduceKernel ? size_t(batch_count) * blocks : 0;
-            RETURN_IF_HIP_ERROR(hipMemcpy(
-                result, workspace + offset, batch_count * sizeof(Tr), hipMemcpyDeviceToHost));
+            RETURN_IF_HIP_ERROR(hipMemcpyAsync(
+                result, workspace + offset, batch_count * sizeof(Tr), hipMemcpyDeviceToHost,
+                handle->get_stream()));
+            RETURN_IF_HIP_ERROR(hipStreamSynchronize(handle->get_stream()));
         }
         else
         {
             // If FINALIZE is not trivial and kernel part2 was not called, then
             // workspace[0] needs to be finalized on host.
             auto res = std::make_unique<To[]>(batch_count);
-            RETURN_IF_HIP_ERROR(
-                hipMemcpy(&res[0], workspace, batch_count * sizeof(To), hipMemcpyDeviceToHost));
+            RETURN_IF_HIP_ERROR(hipMemcpyAsync(
+                &res[0], workspace, batch_count * sizeof(To), hipMemcpyDeviceToHost,
+                handle->get_stream()));
+            RETURN_IF_HIP_ERROR(hipStreamSynchronize(handle->get_stream()));
             for(rocblas_int i = 0; i < batch_count; i++)
                 result[i] = Tr(FINALIZE{}(res[i]));
         }


### PR DESCRIPTION
Reductions (e.g. asum) with host-pointer mode enabled would use `hipMemcpy` to copy back the results. When using a nonblocking stream, the copy would execute out of order. This PR addresses this by calling `hipMemcpyAsync` followed by a stream synchronization, which will guarantee that the value is available on the host.