### PR TITLE
ROCm 6.1 CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocBLAS is available at
 [https://rocm.docs.amd.com/projects/rocBLAS/en/latest/index.html](https://rocm.docs.amd.com/projects/rocBLAS/en/latest/index.html).
 
-## (Unreleased) rocBLAS 4.1.0
+## rocBLAS 4.1.0 for ROCm 6.1
 
 ## Additions
 


### PR DESCRIPTION
- remove "Unreleased" from CHANGELOG.md after release/rocm-rel-6.1 branch created