### PR TITLE
Update CONTRIBUTING.rst in docs/6.0.2

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -536,7 +536,7 @@ Coding Guidelines
     for an example, and how it's handled there.
 
 18. For reduction operations, the file
-    `reduction.h <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/library/src/blas1/reduction.h>`__
+    `reduction.hpp <https://github.com/ROCm/rocBLAS/blob/develop/library/src/blas1/reduction.hpp>`__
     has been created to systematize reductions and perform their device
     kernels in one place. This works for ``amax``, ``amin``, ``asum``,
     ``nrm2``, and (partially) ``dot`` and ``gemv``.


### PR DESCRIPTION
To fix broken link in live docs

Change in rocBLAS-internal was already submitted yesterday, this is to address live broken link in docs branch only.
