### PR TITLE
Hotfix reference lib 6.1

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -718,7 +718,7 @@ void cblas_geam(rocblas_operation       transa,
 }
 
 // legacy BLAS implementation
-// gemm for dim and leading dims < 130 so no int64 multiplies
+// gemm for dim and leading dims <= 256 so no int64 multiplies
 void small_sgemm(rocblas_operation transA,
                  rocblas_operation transB,
                  int               m,
@@ -915,7 +915,7 @@ void ref_gemm(rocblas_operation                    transA,
 {
     // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
 
-    static constexpr int64_t small = 129;
+    static constexpr int64_t small = 256; // seeing random NaNs with blis on some small sizes
     if(m > small || n > small || k > small || lda > small || ldb > small || ldc > small)
     {
         // just directly cast, since transA, transB enum values match CBLAS

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -1098,20 +1098,20 @@ void cast_from_buffer(int64_t m, int64_t n, int64_t ldc, const host_vector<T>& C
 
 // gemm
 template <>
-void cblas_gemm<rocblas_bfloat16, float, float>(rocblas_operation                    transA,
-                                                rocblas_operation                    transB,
-                                                int64_t                              m,
-                                                int64_t                              n,
-                                                int64_t                              k,
-                                                float                                alpha,
-                                                const rocblas_bfloat16*              A,
-                                                int64_t                              lda,
-                                                const rocblas_bfloat16*              B,
-                                                int64_t                              ldb,
-                                                float                                beta,
-                                                float*                               C,
-                                                int64_t                              ldc,
-                                                rocblas_bfloat16::rocblas_truncate_t round)
+void ref_gemm<rocblas_bfloat16, float, float>(rocblas_operation                    transA,
+                                              rocblas_operation                    transB,
+                                              int64_t                              m,
+                                              int64_t                              n,
+                                              int64_t                              k,
+                                              float                                alpha,
+                                              const rocblas_bfloat16*              A,
+                                              int64_t                              lda,
+                                              const rocblas_bfloat16*              B,
+                                              int64_t                              ldb,
+                                              float                                beta,
+                                              float*                               C,
+                                              int64_t                              ldc,
+                                              rocblas_bfloat16::rocblas_truncate_t round)
 {
     // cblas does not support rocblas_bfloat16, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -1148,21 +1148,20 @@ void cblas_gemm<rocblas_bfloat16, float, float>(rocblas_operation               
 }
 
 template <>
-void cblas_gemm<rocblas_bfloat16, rocblas_bfloat16, float>(
-    rocblas_operation                    transA,
-    rocblas_operation                    transB,
-    int64_t                              m,
-    int64_t                              n,
-    int64_t                              k,
-    float                                alpha,
-    const rocblas_bfloat16*              A,
-    int64_t                              lda,
-    const rocblas_bfloat16*              B,
-    int64_t                              ldb,
-    float                                beta,
-    rocblas_bfloat16*                    C,
-    int64_t                              ldc,
-    rocblas_bfloat16::rocblas_truncate_t round)
+void ref_gemm<rocblas_bfloat16, rocblas_bfloat16, float>(rocblas_operation       transA,
+                                                         rocblas_operation       transB,
+                                                         int64_t                 m,
+                                                         int64_t                 n,
+                                                         int64_t                 k,
+                                                         float                   alpha,
+                                                         const rocblas_bfloat16* A,
+                                                         int64_t                 lda,
+                                                         const rocblas_bfloat16* B,
+                                                         int64_t                 ldb,
+                                                         float                   beta,
+                                                         rocblas_bfloat16*       C,
+                                                         int64_t                 ldc,
+                                                         rocblas_bfloat16::rocblas_truncate_t round)
 {
     // cblas does not support rocblas_bfloat16, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -1216,20 +1215,20 @@ void cblas_gemm<rocblas_bfloat16, rocblas_bfloat16, float>(
 }
 
 template <>
-void cblas_gemm<rocblas_half, float, float>(rocblas_operation                    transA,
-                                            rocblas_operation                    transB,
-                                            int64_t                              m,
-                                            int64_t                              n,
-                                            int64_t                              k,
-                                            float                                alpha,
-                                            const rocblas_half*                  A,
-                                            int64_t                              lda,
-                                            const rocblas_half*                  B,
-                                            int64_t                              ldb,
-                                            float                                beta,
-                                            float*                               C,
-                                            int64_t                              ldc,
-                                            rocblas_bfloat16::rocblas_truncate_t round)
+void ref_gemm<rocblas_half, float, float>(rocblas_operation                    transA,
+                                          rocblas_operation                    transB,
+                                          int64_t                              m,
+                                          int64_t                              n,
+                                          int64_t                              k,
+                                          float                                alpha,
+                                          const rocblas_half*                  A,
+                                          int64_t                              lda,
+                                          const rocblas_half*                  B,
+                                          int64_t                              ldb,
+                                          float                                beta,
+                                          float*                               C,
+                                          int64_t                              ldc,
+                                          rocblas_bfloat16::rocblas_truncate_t round)
 {
     // cblas does not support rocblas_half, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -1266,20 +1265,20 @@ void cblas_gemm<rocblas_half, float, float>(rocblas_operation                   
 }
 
 template <>
-void cblas_gemm<rocblas_half, rocblas_half, float>(rocblas_operation                    transA,
-                                                   rocblas_operation                    transB,
-                                                   int64_t                              m,
-                                                   int64_t                              n,
-                                                   int64_t                              k,
-                                                   float                                alpha,
-                                                   const rocblas_half*                  A,
-                                                   int64_t                              lda,
-                                                   const rocblas_half*                  B,
-                                                   int64_t                              ldb,
-                                                   float                                beta,
-                                                   rocblas_half*                        C,
-                                                   int64_t                              ldc,
-                                                   rocblas_bfloat16::rocblas_truncate_t round)
+void ref_gemm<rocblas_half, rocblas_half, float>(rocblas_operation                    transA,
+                                                 rocblas_operation                    transB,
+                                                 int64_t                              m,
+                                                 int64_t                              n,
+                                                 int64_t                              k,
+                                                 float                                alpha,
+                                                 const rocblas_half*                  A,
+                                                 int64_t                              lda,
+                                                 const rocblas_half*                  B,
+                                                 int64_t                              ldb,
+                                                 float                                beta,
+                                                 rocblas_half*                        C,
+                                                 int64_t                              ldc,
+                                                 rocblas_bfloat16::rocblas_truncate_t round)
 {
     // cblas does not support rocblas_half, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -1345,21 +1344,20 @@ void cblas_gemm<rocblas_half, rocblas_half, float>(rocblas_operation            
 }
 
 template <>
-void cblas_gemm<rocblas_half, rocblas_half, rocblas_half>(
-    rocblas_operation                    transA,
-    rocblas_operation                    transB,
-    int64_t                              m,
-    int64_t                              n,
-    int64_t                              k,
-    rocblas_half                         alpha,
-    const rocblas_half*                  A,
-    int64_t                              lda,
-    const rocblas_half*                  B,
-    int64_t                              ldb,
-    rocblas_half                         beta,
-    rocblas_half*                        C,
-    int64_t                              ldc,
-    rocblas_bfloat16::rocblas_truncate_t round)
+void ref_gemm<rocblas_half, rocblas_half, rocblas_half>(rocblas_operation                    transA,
+                                                        rocblas_operation                    transB,
+                                                        int64_t                              m,
+                                                        int64_t                              n,
+                                                        int64_t                              k,
+                                                        rocblas_half                         alpha,
+                                                        const rocblas_half*                  A,
+                                                        int64_t                              lda,
+                                                        const rocblas_half*                  B,
+                                                        int64_t                              ldb,
+                                                        rocblas_half                         beta,
+                                                        rocblas_half*                        C,
+                                                        int64_t                              ldc,
+                                                        rocblas_bfloat16::rocblas_truncate_t round)
 {
     // cblas does not support rocblas_half, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -1415,20 +1413,20 @@ void cblas_gemm<rocblas_half, rocblas_half, rocblas_half>(
 }
 
 template <>
-void cblas_gemm<int8_t, int32_t, int32_t>(rocblas_operation                    transA,
-                                          rocblas_operation                    transB,
-                                          int64_t                              m,
-                                          int64_t                              n,
-                                          int64_t                              k,
-                                          int32_t                              alpha,
-                                          const int8_t*                        A,
-                                          int64_t                              lda,
-                                          const int8_t*                        B,
-                                          int64_t                              ldb,
-                                          int32_t                              beta,
-                                          int32_t*                             C,
-                                          int64_t                              ldc,
-                                          rocblas_bfloat16::rocblas_truncate_t round)
+void ref_gemm<int8_t, int32_t, int32_t>(rocblas_operation                    transA,
+                                        rocblas_operation                    transB,
+                                        int64_t                              m,
+                                        int64_t                              n,
+                                        int64_t                              k,
+                                        int32_t                              alpha,
+                                        const int8_t*                        A,
+                                        int64_t                              lda,
+                                        const int8_t*                        B,
+                                        int64_t                              ldb,
+                                        int32_t                              beta,
+                                        int32_t*                             C,
+                                        int64_t                              ldc,
+                                        rocblas_bfloat16::rocblas_truncate_t round)
 {
     // cblas does not support int8_t input / int32_t output, however non-overflowing
     // 32-bit integer operations can be represented accurately with double-precision

--- a/clients/include/blas3/testing_gemm.hpp
+++ b/clients/include/blas3/testing_gemm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -356,7 +356,7 @@ void testing_gemm(const Arguments& arg)
             cpu_time_used = get_time_us_no_sync();
         }
 
-        cblas_gemm<T>(transA, transB, M, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
+        ref_gemm<T>(transA, transB, M, N, K, h_alpha, hA, lda, hB, ldb, h_beta, (T*)hC_gold, ldc);
 
         if(arg.timing)
         {

--- a/clients/include/blas3/testing_gemm_batched.hpp
+++ b/clients/include/blas3/testing_gemm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -438,7 +438,7 @@ void testing_gemm_batched(const Arguments& arg)
         cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < batch_count; b++)
         {
-            cblas_gemm<T>(
+            ref_gemm<T>(
                 transA, transB, M, N, K, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
         cpu_time_used = get_time_us_no_sync() - cpu_time_used;

--- a/clients/include/blas3/testing_gemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_gemm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -442,7 +442,7 @@ void testing_gemm_strided_batched(const Arguments& arg)
         cpu_time_used = get_time_us_no_sync();
         for(rocblas_int b = 0; b < batch_count; b++)
         {
-            cblas_gemm<T>(
+            ref_gemm<T>(
                 transA, transB, M, N, K, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
         cpu_time_used = get_time_us_no_sync() - cpu_time_used;

--- a/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -533,19 +533,19 @@ void testing_gemm_batched_ex(const Arguments& arg)
 
         for(rocblas_int b = 0; b < batch_count; b++)
         {
-            cblas_gemm<Ti, To_hpa>(transA,
-                                   transB,
-                                   M,
-                                   N,
-                                   K,
-                                   h_alpha_Tc,
-                                   hA[b],
-                                   lda,
-                                   hB[b],
-                                   ldb,
-                                   h_beta_Tc,
-                                   hD_gold[b],
-                                   ldd);
+            ref_gemm<Ti, To_hpa>(transA,
+                                 transB,
+                                 M,
+                                 N,
+                                 K,
+                                 h_alpha_Tc,
+                                 hA[b],
+                                 lda,
+                                 hB[b],
+                                 ldb,
+                                 h_beta_Tc,
+                                 hD_gold[b],
+                                 ldd);
         }
 
         cpu_time_used = get_time_us_no_sync() - cpu_time_used;

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -493,7 +493,7 @@ void testing_gemm_ex(const Arguments& arg)
         // CPU BLAS
         cpu_time_used = get_time_us_no_sync();
 
-        cblas_gemm<Ti, To_hpa, Tc>(
+        ref_gemm<Ti, To_hpa, Tc>(
             transA,
             transB,
             M,

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -505,7 +505,7 @@ void testing_gemm_ex(const Arguments& arg)
             hB,
             ldb,
             h_beta_Tc,
-            hD_gold,
+            (To_hpa*)hD_gold,
             ldd,
             alt ? (alt_round ? rocblas_bfloat16::rocblas_truncate_t::rocblas_round_near_zero
                              : rocblas_bfloat16::rocblas_truncate_t::rocblas_truncate)

--- a/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -553,7 +553,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
         // CPU BLAS
         for(rocblas_int b = 0; b < batch_count; b++)
         {
-            cblas_gemm<Ti, To_hpa>(
+            ref_gemm<Ti, To_hpa>(
                 transA,
                 transB,
                 M,

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1820,6 +1820,7 @@ void cblas_geam(rocblas_operation transa,
                 int64_t           ldc);
 
 // gemm
+
 template <typename TiA,
           typename TiB,
           typename To,
@@ -1928,187 +1929,22 @@ inline void f8_to_cblas_sgemm(rocblas_operation transA,
         C[i] = To(C_float[i]);
 }
 
-template <typename Ti, typename To = Ti, typename Tc>
-void cblas_gemm(rocblas_operation                    transA,
-                rocblas_operation                    transB,
-                int64_t                              m,
-                int64_t                              n,
-                int64_t                              k,
-                Tc                                   alpha,
-                const Ti*                            A,
-                int64_t                              lda,
-                const Ti*                            B,
-                int64_t                              ldb,
-                Tc                                   beta,
-                std::add_pointer_t<To>               C,
-                int64_t                              ldc,
-                rocblas_bfloat16::rocblas_truncate_t round
-                = rocblas_bfloat16::rocblas_truncate_t::rocblas_round_near_even);
-
-template <>
-inline void cblas_gemm(rocblas_operation                    transA,
-                       rocblas_operation                    transB,
-                       int64_t                              m,
-                       int64_t                              n,
-                       int64_t                              k,
-                       float                                alpha,
-                       const float*                         A,
-                       int64_t                              lda,
-                       const float*                         B,
-                       int64_t                              ldb,
-                       float                                beta,
-                       float*                               C,
-                       int64_t                              ldc,
-                       rocblas_bfloat16::rocblas_truncate_t round)
-{
-    // just directly cast, since transA, transB are integers in the enum
-    // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
-    cblas_sgemm(CblasColMajor,
-                CBLAS_TRANSPOSE(transA),
-                CBLAS_TRANSPOSE(transB),
-                m,
-                n,
-                k,
-                alpha,
-                A,
-                lda,
-                B,
-                ldb,
-                beta,
-                C,
-                ldc);
-}
-
-template <>
-inline void cblas_gemm(rocblas_operation                    transA,
-                       rocblas_operation                    transB,
-                       int64_t                              m,
-                       int64_t                              n,
-                       int64_t                              k,
-                       double                               alpha,
-                       const float*                         A,
-                       int64_t                              lda,
-                       const float*                         B,
-                       int64_t                              ldb,
-                       double                               beta,
-                       float*                               C,
-                       int64_t                              ldc,
-                       rocblas_bfloat16::rocblas_truncate_t round)
-{
-    // just directly cast, since transA, transB are integers in the enum
-    // printf("transA: rocblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
-    cblas_sgemm(CblasColMajor,
-                CBLAS_TRANSPOSE(transA),
-                CBLAS_TRANSPOSE(transB),
-                m,
-                n,
-                k,
-                float(alpha),
-                A,
-                lda,
-                B,
-                ldb,
-                float(beta),
-                C,
-                ldc);
-}
-
-template <>
-inline void cblas_gemm(rocblas_operation                    transA,
-                       rocblas_operation                    transB,
-                       int64_t                              m,
-                       int64_t                              n,
-                       int64_t                              k,
-                       double                               alpha,
-                       const double*                        A,
-                       int64_t                              lda,
-                       const double*                        B,
-                       int64_t                              ldb,
-                       double                               beta,
-                       double*                              C,
-                       int64_t                              ldc,
-                       rocblas_bfloat16::rocblas_truncate_t round)
-{
-    cblas_dgemm(CblasColMajor,
-                CBLAS_TRANSPOSE(transA),
-                CBLAS_TRANSPOSE(transB),
-                m,
-                n,
-                k,
-                alpha,
-                A,
-                lda,
-                B,
-                ldb,
-                beta,
-                C,
-                ldc);
-}
-
-template <>
-inline void cblas_gemm(rocblas_operation                    transA,
-                       rocblas_operation                    transB,
-                       int64_t                              m,
-                       int64_t                              n,
-                       int64_t                              k,
-                       rocblas_float_complex                alpha,
-                       const rocblas_float_complex*         A,
-                       int64_t                              lda,
-                       const rocblas_float_complex*         B,
-                       int64_t                              ldb,
-                       rocblas_float_complex                beta,
-                       rocblas_float_complex*               C,
-                       int64_t                              ldc,
-                       rocblas_bfloat16::rocblas_truncate_t round)
-{
-    // just directly cast, since transA, transB are integers in the enum
-    cblas_cgemm(CblasColMajor,
-                CBLAS_TRANSPOSE(transA),
-                CBLAS_TRANSPOSE(transB),
-                m,
-                n,
-                k,
-                &alpha,
-                A,
-                lda,
-                B,
-                ldb,
-                &beta,
-                C,
-                ldc);
-}
-
-template <>
-inline void cblas_gemm(rocblas_operation                    transA,
-                       rocblas_operation                    transB,
-                       int64_t                              m,
-                       int64_t                              n,
-                       int64_t                              k,
-                       rocblas_double_complex               alpha,
-                       const rocblas_double_complex*        A,
-                       int64_t                              lda,
-                       const rocblas_double_complex*        B,
-                       int64_t                              ldb,
-                       rocblas_double_complex               beta,
-                       rocblas_double_complex*              C,
-                       int64_t                              ldc,
-                       rocblas_bfloat16::rocblas_truncate_t round)
-{
-    cblas_zgemm(CblasColMajor,
-                CBLAS_TRANSPOSE(transA),
-                CBLAS_TRANSPOSE(transB),
-                m,
-                n,
-                k,
-                &alpha,
-                A,
-                lda,
-                B,
-                ldb,
-                &beta,
-                C,
-                ldc);
-}
+template <typename Ti, typename To, typename Tc>
+void ref_gemm(rocblas_operation                    transA,
+              rocblas_operation                    transB,
+              int64_t                              m,
+              int64_t                              n,
+              int64_t                              k,
+              Tc                                   alpha,
+              const Ti*                            A,
+              int64_t                              lda,
+              const Ti*                            B,
+              int64_t                              ldb,
+              Tc                                   beta,
+              To*                                  C,
+              int64_t                              ldc,
+              rocblas_bfloat16::rocblas_truncate_t round
+              = rocblas_bfloat16::rocblas_truncate_t::rocblas_round_near_even);
 
 //GEMMT
 template <typename T>


### PR DESCRIPTION
* avoids reference code rare and random host ONLY NaNs on some gemms resulting in test failures:
Value of: rocblas_isnan(hGPU[i + idx])
  Actual: false
Expected: true
* no change to library