### PR TITLE
Hotfix: Remove passing the device set to lazy load API

### DIFF
--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -799,7 +799,7 @@ namespace
                     auto deviceArch = getLazyLoadingArch(devId);
                     if(tensileDeviceSet.find(deviceArch) == tensileDeviceSet.end())
                     {
-                        //populate the arch list for lazy loading
+                        //future work: populate the arch list for heterogeneous support
                         tensileDeviceSet.insert(deviceArch);
                         //populate device property map, used in finding solutions based on arch
                         HIP_CHECK_EXC(hipGetDeviceProperties(&prop, devId));
@@ -900,8 +900,7 @@ namespace
                         = std::async(std::launch::async,
                                      Tensile::LoadLibraryFilePreload<Tensile::ContractionProblem>,
                                      tensileLibraryPath,
-                                     std::vector<Tensile::LazyLoadingInit>{tensileDeviceSet.begin(),
-                                                                           tensileDeviceSet.end()});
+                                     std::vector<Tensile::LazyLoadingInit>{});
                     return 0;
                 }();
             }


### PR DESCRIPTION
Remove passing the list of devices to Lazy Loading API, due to following reasons,

 - Increases the initilaization time.
 - Resolves [SWDEV-438929](https://ontrack-internal.amd.com/browse/SWDEV-438929) - hipModuleNotFound error ( this is a workaround and root cause is still unknown)

Reverting this change might affect heterogeneous GPU support.