### PR TITLE
Properly locate libomp.so when installed in clang target subdirectory.

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -75,9 +75,9 @@ find_package(OpenMP)
 
 if (TARGET OpenMP::OpenMP_CXX)
   set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
-  list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
+  get_filename_component(LIBOMP_PATH "${OpenMP_omp_LIBRARY}" PATH)
   if (NOT WIN32)
-    list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+    list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${LIBOMP_PATH}")
   endif()
 endif()
 


### PR DESCRIPTION
An upstream llvm change enables
LLVM_ENABLE_PER_TARGET_RUNTIME_DIR by default for the openmp build. This installs the openmp libraries into
/opt/rocm-ver/llvm/lib/x86_64-unknown-linux-gnu instead of /opt/rocm-ver/llvm/lib. Currenty, rocBLAS only uses /lib.

Since rocBLAS uses hipcc by default, `find_package(OpenMP)` will properly locate the openmp library. Use OpenMP_omp_LIBRARY to extract parent directory from variable for rpath.

Summary of proposed changes:
- Update rpath to use parent directory of `OpenMP_omp_LIBRARY`, which is set by `find_package(OpenMP)`
