### PR TITLE
Docs: cherry-pick contributing link fix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ The rocBLAS documentation is structured as follows:
 
     * :ref:`api-reference-guide`
 
-To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/index.html>`_.
+To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
 You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.
 


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Add fixed link from `develop` into 6.1.0
-
-
