### PR TITLE
hotfix: swdev-458330 reduce test stress level check_numerics (#2497)

### DIFF
--- a/clients/gtest/general_gtest.yaml
+++ b/clients/gtest/general_gtest.yaml
@@ -60,7 +60,7 @@ Tests:
   function : check_numerics_vector
   N : [ 1 ]
   incx : [ 1 ]
-  batch_count : [ -1, 666666 ]
+  batch_count : [ -1, *c_grid_yz_require_passes ]
   stride_x : [ 0 ]
   precision : *half_precision
   os_flags: [ LINUX ]
@@ -82,9 +82,9 @@ Tests:
 - name : check_numerics_matrix_64
   category : stress
   function : check_numerics_matrix
-  M : [ 2147486720 ]
+  M : [ *c_grid_x_require_passes ]
   N : [ 1 ]
-  lda: 2147486720
+  lda: *c_grid_x_require_passes
   batch_count : [ 1 ]
   stride_x : [ 0 ]
   uplo: [ U ]
@@ -98,7 +98,7 @@ Tests:
   M : [ 3 ]
   N : [ 3 ]
   lda: 3
-  batch_count : [ 666666 ]
+  batch_count : [ *c_grid_yz_require_passes ]
   stride_x : [ 0 ]
   uplo: [ U ]
   transA: [ T ]

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -508,6 +508,9 @@ Definitions:
   - &c_grid_yz_require_passes
     - [65539] # force looping over y/z chunks 65536.  TODO track constant c_i64_grid_YZ_chunk in int64_helpers.hpp
 
+  - &c_grid_x_require_passes
+    - [268435459] # force looping over x chunks 268435456.  TODO track constant c_i64_grid_X_chunk in int64_helpers.hpp
+
 # The Arguments struct passed directly to C++. See rocblas_arguments.hpp.
 # The order of the entries is significant, so it can't simply be a dictionary.
 # The types on the RHS are eval'd for Python-recognized types including ctypes


### PR DESCRIPTION
* test loop rather than large sizes due to long running tests
