### PR TITLE
Hotfix: rocBLAS failure during stream capture

### DIFF
--- a/library/src/rocblas_auxiliary.cpp
+++ b/library/src/rocblas_auxiliary.cpp
@@ -246,9 +246,14 @@ try
     if(stream == handle->stream)
         return rocblas_status_success;
 
-    // The new stream must be valid
-    if(stream != 0 && hipStreamQuery(stream) == hipErrorInvalidResourceHandle)
-        return rocblas_status_invalid_value;
+    // Stream capture does not allow use of hipStreamQuery
+    // If the current stream is in capture mode, skip use of hipStreamQuery()
+    if(!handle->is_stream_in_capture_mode())
+    {
+        // The new stream must be valid
+        if(stream != 0 && hipStreamQuery(stream) == hipErrorInvalidHandle)
+            return rocblas_status_invalid_value;
+    }
 
     // Set the new stream
     handle->stream = stream;


### PR DESCRIPTION
resolves #SWDEV-454629

Summary of proposed changes:
Fix error during graph capture. A recent change in HIP runtime to not support hipStreamQuery() during stream capture ( matches CUDA behavior) causes rocblas_set_stream() to return error 'hipErrorStreamCaptureUnsupported' during stream capture.

- This PR checks if the current stream is in capture mode, and skips the use of hipStreamQuery().
- Fixed return of hipStreamQuery()