### PR TITLE
Hotfix: Use hipStreamQuery only if the stream capture status is `hipStreamCaptureStatusNone`  

### DIFF
--- a/library/src/include/handle.hpp
+++ b/library/src/include/handle.hpp
@@ -366,19 +366,18 @@ public:
         //default stream will not be in capture mode
         if(stream != 0)
         {
-            bool status = hipStreamIsCapturing(stream, &capture_status) == hipSuccess;
-
-            if(!status)
+            hipError_t status = hipStreamIsCapturing(stream, &capture_status);
+            if(status != hipSuccess)
             {
-                rocblas_cerr << "Stream capture check failed" << std::endl;
+                PRINT_IF_HIP_ERROR(status);
                 return false;
             }
         }
 
-        if(capture_status == hipStreamCaptureStatusActive)
-            return true;
-        else
+        if(capture_status == hipStreamCaptureStatusNone)
             return false;
+        else
+            return true; // returns true for both hipStreamCaptureStatusActive & hipStreamCaptureStatusInvalidated
     }
 
 private:

--- a/library/src/rocblas_auxiliary.cpp
+++ b/library/src/rocblas_auxiliary.cpp
@@ -259,7 +259,7 @@ try
     // Stream capture does not allow use of hipStreamQuery
     // If the current stream or new stream is in capture mode, skip use of hipStreamQuery()
     if((handle->stream == 0 || !handle->is_stream_in_capture_mode())
-       && stream_status != hipStreamCaptureStatusActive)
+       && stream_status == hipStreamCaptureStatusNone)
     {
         // The new stream must be valid
         if(stream != 0 && hipStreamQuery(stream) == hipErrorInvalidHandle)


### PR DESCRIPTION
resolves # [SWDEV-466097](https://ontrack-internal.amd.com/browse/SWDEV-466097) & [SWDEV-464655](https://ontrack-internal.amd.com/browse/SWDEV-464655)

Checking whether Stream capture is active ( hipStreamCaptureStatusActive ) might not be enough, as there could be a status hipStreamCaptureStatusInvalidated which indicates the stream capture is invalidated but not terminated. This PR addresses this issue by calling hipStreamQuery() only if the stream capture status is `hipStreamCaptureStatusNone`  

