### PR TITLE
fix(tensile_host): fix solutions for gfx103x not able to load

### DIFF
--- a/library/src/tensile_host.cpp
+++ b/library/src/tensile_host.cpp
@@ -257,6 +257,22 @@ namespace
         {
             return Tensile::LazyLoadingInit::gfx1030;
         }
+        else if(deviceString.find("gfx1031") != std::string::npos)
+        {
+            return Tensile::LazyLoadingInit::gfx1031;
+        }
+        else if(deviceString.find("gfx1032") != std::string::npos)
+        {
+            return Tensile::LazyLoadingInit::gfx1032;
+        }
+        else if(deviceString.find("gfx1034") != std::string::npos)
+        {
+            return Tensile::LazyLoadingInit::gfx1034;
+        }
+        else if(deviceString.find("gfx1035") != std::string::npos)
+        {
+            return Tensile::LazyLoadingInit::gfx1035;
+        }
         else if(deviceString.find("gfx1100") != std::string::npos)
         {
             return Tensile::LazyLoadingInit::gfx1100;


### PR DESCRIPTION
This patch possibly will fix the problem where the added map broke gfx1031-gfx1035, causing any Tensile solutions for these archs unable to load, forcing them to drop to fallback. 

Related log:
```
ProblemMap Searching for Contraction_l_Alik_Bljk_Cijk_Dijk found Problem library (1 rows)
Object key: 768, 77, 768
Key: 768, 77, 768
Starting point: 17179869184, 1, 2937652110784
Rightward search...
Leftward search...

129, 129, 65: 905234 < 1.79769e+308 <-- Best distance, but no matching solution
129, 129, 65: 905234 == 905234
129, 129, 65: 905234 == 905234
129, 129, 65: 905234 == 905234
129, 129, 65: 905234 == 905234
129, 129, 64: 906641 > 905234
129, 129, 64: 906641 > 905234

......

Considered 100% of entries.
Solution index selected: 69
Running kernel: Cijk_Alik_Bljk_HHS_BH_MT64x32x8_SN_AF0EM1_AMAS2_ASEM1_BL1_BS1_EPS0_FL0_GLVWA2_GLVWB1_GRVW2_GSU1_GSUASB_ISA000_IU1_K1_KLS_LPB0_LDL1_LRVW2_MMFSC_NLCA1_NLCB1_PGR0_PLR1_RK0_SIA1_SU32_SUM0_SUS256_SVW4_TT4_2_USFGROn1_VAW1_VSn1_VW2_VWB2_WS64_WG16_16_1_WGM8
```

Could you please backport this to HIP SDK 6.1.2 for Windows if possible?