### PR TITLE
Bitwise Reproducibility documentation (#2658)

### DIFF
--- a/docs/how-to/what-is-rocblas.rst
+++ b/docs/how-to/what-is-rocblas.rst
@@ -324,7 +324,7 @@ Bitwise reproducible results in rocBLAS can be obtained under the following cond
 * Identical GFX target ISA
 * Single HIP stream active per rocBLAS handle
 * Identical ROCm versions
-* Disable atomic operations ( for more infromation, see :ref:`Atomic Operations`)
+* Disabled atomic operations ( for more infromation, see :ref:`Atomic Operations`)
 
 
 By default rocBLAS may use atomic operations to achieve better performance in some functions.

--- a/docs/how-to/what-is-rocblas.rst
+++ b/docs/how-to/what-is-rocblas.rst
@@ -319,6 +319,14 @@ In addition to the above API, rocBLAS also provides an environment variable ``RO
 Bitwise Reproducibility
 -----------------------
 
+Bitwise reproducible results in rocBLAS can be obtained under the following conditions:
+
+ - Identical GFX target ISA
+ - Single HIP stream active per rocBLAS handle
+ - Identical ROCm versions
+ - Disable atomic operations ( Refer section :ref:`Atomic Operations`)
+
+
 By default rocBLAS may use atomic operations to achieve better performance in some functions.
 To ensure bitwise reproducible results, where users require identical results across multiple runs, the following functions require atomics to be disabled
 

--- a/docs/how-to/what-is-rocblas.rst
+++ b/docs/how-to/what-is-rocblas.rst
@@ -321,10 +321,10 @@ Bitwise Reproducibility
 
 Bitwise reproducible results in rocBLAS can be obtained under the following conditions:
 
- - Identical GFX target ISA
- - Single HIP stream active per rocBLAS handle
- - Identical ROCm versions
- - Disable atomic operations ( Refer section :ref:`Atomic Operations`)
+* Identical GFX target ISA
+* Single HIP stream active per rocBLAS handle
+* Identical ROCm versions
+* Disable atomic operations ( for more infromation, see :ref:`Atomic Operations`)
 
 
 By default rocBLAS may use atomic operations to achieve better performance in some functions.


### PR DESCRIPTION
Documentation has been added to clearly specify the conditions under which rocBLAS provides bitwise reproducible results.

