### PR TITLE
don't pad memory for rocblas-bench (#2670)

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -980,6 +980,9 @@ int run_bench_test(bool               init,
     // enable timing check,otherwise no performance data collected
     arg.timing = 1;
 
+    // defeat memory padding for benchmarks
+    arg.pad = 0;
+
     // One stream and one thread (0 indicates to use default behavior)
     arg.streams = 0;
     arg.threads = 0;


### PR DESCRIPTION
* maintain old behaviour where pad was not supported in bench