### PR TITLE
Reuse device memory in testing_gemm_ex

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -1283,13 +1283,201 @@ int run_bench_test(bool               init,
     return 0;
 }
 
+template <typename data_type, bool altInit>
+void* setup_shared_matrix(size_t         row,
+                          size_t         col,
+                          size_t         ld,
+                          rocblas_stride stride,
+                          Arguments      arg,
+                          size_t         a_b_c_cached_size,
+                          bool           seedReset,
+                          bool           alternate_sign)
+{
+    size_t flush_batch_count = calculate_flush_batch_count(
+        arg.flush_batch_count, arg.flush_memory_size, a_b_c_cached_size);
+
+    rocblas_stride aligned_stride = align_stride<data_type>(stride);
+
+    device_strided_batch_matrix<data_type> dA(
+        row, col, ld, aligned_stride, flush_batch_count, false, false);
+    // HOST_MEMCHECK(host_matrix<data_type>, hA, (row, col, ld));
+    host_matrix<data_type> hA(row, col, ld);
+    rocblas_init_matrix<data_type, altInit>(hA,
+                                            arg,
+                                            rocblas_client_alpha_sets_nan,
+                                            rocblas_client_general_matrix,
+                                            seedReset,
+                                            alternate_sign);
+    //CHECK_HIP_ERROR(
+    dA.broadcast_one_matrix_from(hA);
+    //    );
+    return dA.data();
+}
+
+template <bool altInit = false>
+void* setup_shared_matrix(size_t           row,
+                          size_t           col,
+                          size_t           ld,
+                          rocblas_stride   stride,
+                          rocblas_datatype type,
+                          Arguments        arg,
+                          size_t           a_b_c_cached_size,
+                          bool             seedReset      = false,
+                          bool             alternate_sign = false)
+{
+    switch(type)
+    {
+    case rocblas_datatype_f16_r:
+    {
+        return setup_shared_matrix<rocblas_half, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_f32_r:
+    {
+        return setup_shared_matrix<rocblas_float, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_f8_r:
+    {
+        return setup_shared_matrix<rocblas_f8, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_bf8_r:
+    {
+        return setup_shared_matrix<rocblas_bf8, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_f64_r:
+    {
+        return setup_shared_matrix<rocblas_double, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_f32_c:
+    {
+        return setup_shared_matrix<rocblas_float_complex, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_f64_c:
+    {
+        return setup_shared_matrix<rocblas_double_complex, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_i8_r:
+    {
+        return setup_shared_matrix<int8_t, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_u8_r:
+    {
+        return setup_shared_matrix<uint8_t, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_i32_r:
+    {
+        return setup_shared_matrix<int32_t, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_u32_r:
+    {
+        return setup_shared_matrix<uint32_t, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    case rocblas_datatype_bf16_r:
+    {
+        return setup_shared_matrix<rocblas_bfloat16, altInit>(
+            row, col, ld, stride, arg, a_b_c_cached_size, seedReset, alternate_sign);
+    }
+    default:
+        return nullptr;
+    }
+}
+
+void setup_shared_memory(std::vector<Arguments>& args)
+{
+    if(args.empty())
+    {
+        return;
+    }
+    Arguments arg0   = args.front();
+    size_t    maxA_n = 0, maxB_n = 0, maxC_n = 0, maxD_n = 0;
+    size_t    maxA_ld = 1, maxB_ld = 1, maxC_ld = 1, maxD_ld = 1;
+
+    // Check if shared memory can be used
+    for(const Arguments& arg : args)
+    {
+        auto A_cols = arg.transA == 'N' ? arg.K : arg.M;
+        auto B_cols = arg.transB == 'N' ? arg.N : arg.K;
+
+        if(arg.lda * A_cols > maxA_ld * maxA_n)
+        {
+            maxA_n  = A_cols;
+            maxA_ld = arg.lda;
+        }
+        if(arg.ldb * B_cols > maxB_ld * maxB_n)
+        {
+            maxB_n  = B_cols;
+            maxB_ld = arg.ldb;
+        }
+        if(arg.ldc * arg.N > maxC_ld * maxC_n)
+        {
+            maxC_n  = arg.N;
+            maxC_ld = arg.ldc;
+        }
+        if(arg.ldd * arg.N > maxD_ld * maxD_n)
+        {
+            maxD_n  = arg.N;
+            maxD_ld = arg.ldd;
+        }
+        if(arg.a_type != arg0.a_type || arg.b_type != arg0.b_type || arg.c_type != arg0.c_type
+           || arg.d_type != arg0.d_type || arg.initialization != arg0.initialization
+           || arg.outofplace != arg0.outofplace || strcmp(arg.function, "gemm_ex"))
+        {
+            return;
+        }
+    }
+
+    rocblas_stride stride_a = maxA_ld * maxA_n;
+    rocblas_stride stride_b = maxB_ld * maxB_n;
+    rocblas_stride stride_c = maxC_ld * maxC_n;
+    rocblas_stride stride_d = arg0.outofplace ? maxD_ld * maxD_n : 0;
+
+    size_t a_b_c_cached_size = maxA_ld * maxA_n * rocblas_sizeof_datatype(arg0.a_type)
+                               + maxB_ld * maxB_n * rocblas_sizeof_datatype(arg0.b_type)
+                               + maxC_ld * maxC_n * rocblas_sizeof_datatype(arg0.c_type);
+
+    void* dA = setup_shared_matrix(
+        maxA_ld, maxA_n, maxA_ld, stride_a, arg0.a_type, arg0, a_b_c_cached_size, true);
+    void* dB = setup_shared_matrix<true>(
+        maxB_ld, maxB_n, maxB_ld, stride_b, arg0.b_type, arg0, a_b_c_cached_size, false, true);
+    void* dC = setup_shared_matrix<true>(
+        maxC_ld, maxC_n, maxC_ld, stride_c, arg0.c_type, arg0, a_b_c_cached_size);
+    void* dD = (arg0.outofplace) ? setup_shared_matrix<true>(
+                   maxD_ld, maxD_n, maxD_ld, stride_d, arg0.d_type, arg0, a_b_c_cached_size)
+                                 : dC;
+
+    for(Arguments& arg : args)
+    {
+        arg.dA = dA;
+        arg.dB = dB;
+        arg.dC = dC;
+        arg.dD = dD;
+    }
+}
+
 int rocblas_bench_datafile(const std::string& filter,
                            const std::string& name_filter,
                            bool               any_stride)
 {
-    int ret = 0;
-    for(Arguments arg : RocBLAS_TestData())
+    int                    ret      = 0;
+    auto                   arg_iter = RocBLAS_TestData();
+    std::vector<Arguments> args{arg_iter.begin(), arg_iter.end()};
+
+    setup_shared_memory(args);
+
+    for(Arguments arg : args)
+    {
         ret |= run_bench_test(true, arg, filter, name_filter, any_stride, true);
+    }
     test_cleanup::cleanup();
     return ret;
 }

--- a/clients/common/rocblas_arguments.cpp
+++ b/clients/common/rocblas_arguments.cpp
@@ -153,6 +153,11 @@ void Arguments::init()
     repeatability_check = false;
 
     use_hipblaslt = -1;
+
+    dA = nullptr;
+    dB = nullptr;
+    dC = nullptr;
+    dD = nullptr;
 }
 
 bool Arguments::validate()

--- a/clients/common/rocblas_arguments.cpp
+++ b/clients/common/rocblas_arguments.cpp
@@ -154,10 +154,17 @@ void Arguments::init()
 
     use_hipblaslt = -1;
 
-    dA = nullptr;
-    dB = nullptr;
-    dC = nullptr;
-    dD = nullptr;
+    max_a_ld = 0;
+    max_b_ld = 0;
+    max_c_ld = 0;
+    max_d_ld = 0;
+
+    max_a_n = 0;
+    max_b_n = 0;
+    max_c_n = 0;
+    max_d_n = 0;
+
+    cleanup = true;
 }
 
 bool Arguments::validate()

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -685,7 +685,7 @@ void testing_gemm_ex(const Arguments& arg)
         }
         if(arg.outofplace)
         {
-            if(!dC_alloc || !dD_alloc->resize(M, N, ldd, aligned_stride_d, flush_batch_count))
+            if(!dD_alloc || !dD_alloc->resize(M, N, ldd, aligned_stride_d, flush_batch_count))
             {
                 dD_alloc = std::make_unique<device_strided_batch_matrix<To>>(
                     M, N, ldd, aligned_stride_d, flush_batch_count);

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -184,10 +184,17 @@ struct Arguments
 
     int use_hipblaslt;
 
-    void* dA;
-    void* dB;
-    void* dC;
-    void* dD;
+    int64_t max_a_ld;
+    int64_t max_b_ld;
+    int64_t max_c_ld;
+    int64_t max_d_ld;
+
+    int64_t max_a_n;
+    int64_t max_b_n;
+    int64_t max_c_n;
+    int64_t max_d_n;
+
+    bool cleanup;
 
     /*************************************************************************
      *                     End Of Arguments                                  *
@@ -275,10 +282,15 @@ struct Arguments
     OPER(graph_test) SEP             \
     OPER(repeatability_check) SEP    \
     OPER(use_hipblaslt) SEP          \
-    OPER(dA) SEP                     \
-    OPER(dB) SEP                     \
-    OPER(dC) SEP                     \
-    OPER(dD)
+    OPER(max_a_ld) SEP               \
+    OPER(max_b_ld) SEP               \
+    OPER(max_c_ld) SEP               \
+    OPER(max_d_ld) SEP               \
+    OPER(max_a_n) SEP                \
+    OPER(max_b_n) SEP                \
+    OPER(max_c_n) SEP                \
+    OPER(max_d_n) SEP                \
+    OPER(cleanup)
     // clang-format on
 
     // Validate input format.

--- a/clients/include/rocblas_arguments.hpp
+++ b/clients/include/rocblas_arguments.hpp
@@ -184,6 +184,11 @@ struct Arguments
 
     int use_hipblaslt;
 
+    void* dA;
+    void* dB;
+    void* dC;
+    void* dD;
+
     /*************************************************************************
      *                     End Of Arguments                                  *
      *************************************************************************/
@@ -269,7 +274,11 @@ struct Arguments
     OPER(HMM) SEP                    \
     OPER(graph_test) SEP             \
     OPER(repeatability_check) SEP    \
-    OPER(use_hipblaslt)
+    OPER(use_hipblaslt) SEP          \
+    OPER(dA) SEP                     \
+    OPER(dB) SEP                     \
+    OPER(dC) SEP                     \
+    OPER(dD)
     // clang-format on
 
     // Validate input format.

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -587,10 +587,15 @@ Arguments:
   - graph_test: c_bool
   - repeatability_check: c_bool
   - use_hipblaslt: c_int32
-  - dA: c_uint64
-  - dB: c_uint64
-  - dC: c_uint64
-  - dD: c_uint64
+  - max_a_ld: c_int64
+  - max_b_ld: c_int64
+  - max_c_ld: c_int64
+  - max_d_ld: c_int64
+  - max_a_n: c_int64
+  - max_b_n: c_int64
+  - max_c_n: c_int64
+  - max_d_n: c_int64
+  - cleanup: c_bool
 
 
 # These named dictionary lists [ {dict1}, {dict2}, etc. ] supply subsets of
@@ -685,7 +690,12 @@ Defaults:
   composite_compute_type: -1
   compute_type: -1
   use_hipblaslt: -1
-  dA: 0
-  dB: 0
-  dC: 0
-  dD: 0
+  max_a_ld: 0
+  max_b_ld: 0
+  max_c_ld: 0
+  max_d_ld: 0
+  max_a_n: 0
+  max_b_n: 0
+  max_c_n: 0
+  max_d_n: 0
+  cleanup: true

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -587,6 +587,11 @@ Arguments:
   - graph_test: c_bool
   - repeatability_check: c_bool
   - use_hipblaslt: c_int32
+  - dA: c_uint64
+  - dB: c_uint64
+  - dC: c_uint64
+  - dD: c_uint64
+
 
 # These named dictionary lists [ {dict1}, {dict2}, etc. ] supply subsets of
 # test arguments in a structured way. The dictionaries are applied to the test
@@ -680,3 +685,7 @@ Defaults:
   composite_compute_type: -1
   compute_type: -1
   use_hipblaslt: -1
+  dA: 0
+  dB: 0
+  dC: 0
+  dD: 0


### PR DESCRIPTION
Reuse device memory allocation in testing_gemm_ex. 
Based on code originally by @bethune-bryant 

This drastically speeds up testing of many consecutive calls to gemm_ex.
For a run with 50K different gemms, I observed a ~23x speedup.


