### PR TITLE
compress code objects (#2707)

### DIFF
--- a/cmake/build-options.cmake
+++ b/cmake/build-options.cmake
@@ -27,6 +27,8 @@
 # presented in the superbuild GUI, but then passed into the ExternalProject as -D
 # parameters, which would already define them.
 
+include(CheckCXXCompilerFlag)
+
 option( BUILD_VERBOSE "Output additional build information" OFF )
 
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
@@ -45,6 +47,15 @@ endif()
 
 # this file is intended to be loaded by toolchain or early as sets global compiler flags
 # rocm-cmake checks will throw warnings if set later as cmake watchers installed
+
+
+option(BUILD_OFFLOAD_COMPRESS "Build rocBLAS with offload compression" ON)
+if (BUILD_OFFLOAD_COMPRESS)
+  check_cxx_compiler_flag("--offload-compress" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+  if (NOT CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+    message( STATUS "WARNING: BUILD_OFFLOAD_COMPRESS=ON but flag not supported by compiler. Ignoring option." )
+  endif()
+endif()
 
 # FOR OPTIONAL CODE COVERAGE
 option(BUILD_CODE_COVERAGE "Build rocBLAS with code coverage enabled" OFF)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -71,6 +71,10 @@ function( rocblas_library_settings lib_target_ )
   set_target_properties( ${lib_target_} PROPERTIES CXX_EXTENSIONS NO )
   set_target_properties( ${lib_target_} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
 
+  if(BUILD_OFFLOAD_COMPRESS AND CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+    set_target_properties( ${lib_target_} PROPERTIES COMPILE_FLAGS "--offload-compress" )
+  endif()
+
   target_link_libraries( ${lib_target_} INTERFACE hip::host )
   if (WIN32)
     target_link_libraries( ${lib_target_} PRIVATE hip::device )

--- a/rmake.py
+++ b/rmake.py
@@ -133,6 +133,9 @@ def parse_args():
     experimental_opts.add_argument(     '--no-msgpack', dest='tensile_msgpack_backend', required=False, default=True, action='store_false',
                         help='Build Tensile backend not to use MessagePack and so use YAML (optional)')
 
+    general_opts.add_argument( '--no-offload-compress', dest='no_offload_compress', required=False, default=False, action='store_true',
+                        help='Do not apply offload compression.')
+
     general_opts.add_argument( '-r', '--relocatable', required=False, default=False, action='store_true',
                         help='Linux only: Add RUNPATH (based on ROCM_RPATH) and remove ldconf entry.')
 
@@ -398,6 +401,9 @@ def config_cmd():
 
     if args.address_sanitizer:
         cmake_options.append(f"-DBUILD_ADDRESS_SANITIZER=ON")
+
+    if args.no_offload_compress:
+        cmake_options.append(f"-DBUILD_OFFLOAD_COMPRESS=OFF")
 
     # clean
     delete_dir(build_path)


### PR DESCRIPTION
* compress code objects by default
* adds CMake option to control and tests compiler support

(cherry picked from commit bb81a8337ddd3ecc20f252eb0135cb8d58e2eabd)


