### PR TITLE
Fix link to device memory allocation in contributing doc 6.2 version

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,8 +60,8 @@ Coding Guidelines
     that this is allocated workspace memory, such as ``workspace`` or using a ``w_`` prefix.
 
     Details are in the `Device Memory
-    Allocation <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/docs/Device_Memory_Allocation.pdf>`__
-    design document. Examples of how to use the device memory allocator
+    Allocation <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/how-to/Programmers_Guide.html#device-memory-allocation>`__
+    documentation. Examples of how to use the device memory allocator
     are in
     `TRSV <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/library/src/blas2/rocblas_trsv.cpp>`__
     and


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- This is a rework of https://github.com/ROCm/rocBLAS/pull/1493, which fixed three links in the contributing document
- The base document is different and in a different location in 6.2, so I could not backport the fix as a cherry pick.
- Only one link is affected this time.
- This fix is extremely minor, so I did not add it to the Changelog. If you feel it needs to be added, please let me know.
- I will backport this to the docs/6.2.x branches after approval, but no further back than that.
