### PR TITLE
Fix link to device memory allocation in contributing doc 6.2 version …

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,8 +64,8 @@ Coding Guidelines
     that this is allocated workspace memory, such as ``workspace`` or using a ``w_`` prefix.
 
     Details are in the `Device Memory
-    Allocation <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/docs/Device_Memory_Allocation.pdf>`__
-    design document. Examples of how to use the device memory allocator
+    Allocation <https://rocm.docs.amd.com/projects/rocBLAS/en/latest/how-to/Programmers_Guide.html#device-memory-allocation>`__
+    documentation. Examples of how to use the device memory allocator
     are in
     `TRSV <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/library/src/blas2/rocblas_trsv.cpp>`__
     and


### PR DESCRIPTION
…(#1494)

* This is a rework of Cherry-pick to release-staging/rocm-rel-6.3: Update three links to point to official ROCm docs rather than the com… #1493, which fixed three links in the contributing document

resolves #___

Summary of proposed changes:
- Backport fix from release/rocm-rel-6.2
-
-
