### PR TITLE
Move gemm repeatability test to stress category (#2800)

### DIFF
--- a/clients/gtest/gemm_gtest.yaml
+++ b/clients/gtest/gemm_gtest.yaml
@@ -3947,7 +3947,7 @@ Tests:
   os_flags: LINUX
 
 - name: gemm_repeatability_check
-  category: pre_checkin
+  category: stress
   function:
     - gemm: *half_single_double_precisions
   matrix_size:


### PR DESCRIPTION
Move gemm repeatability test to stress category.

(cherry picked from commit 7658bc568460f0fd6c818abfbc88da3d6fb251c7)

