### PR TITLE
Cherry picks 6.5fc

### DIFF
--- a/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -669,6 +669,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
 
     rocblas_gemm_algo algo = rocblas_gemm_algo(arg.algo);
 
+#ifdef BUILD_WITH_TENSILE // tensile or hipblaslt only for now
     if(compare_solutions && algo == rocblas_gemm_algo_solution_index)
     {
         arguments = &run_arg; // override
@@ -708,6 +709,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
             solutions_that_solve.push_back(0);
         }
     }
+#endif
 
     for(auto sol : solutions_that_solve)
     {

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -812,6 +812,7 @@ void testing_gemm_ex(const Arguments& arg)
 
     rocblas_gemm_algo algo = rocblas_gemm_algo(arg.algo);
 
+#ifdef BUILD_WITH_TENSILE // tensile or hipblaslt only for now
     if(compare_solutions && algo == rocblas_gemm_algo_solution_index)
     {
         arguments = &run_arg; // override
@@ -851,6 +852,7 @@ void testing_gemm_ex(const Arguments& arg)
             solutions_that_solve.push_back(0);
         }
     }
+#endif
 
     for(auto sol : solutions_that_solve)
     {

--- a/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -693,6 +693,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
 
     rocblas_gemm_algo algo = rocblas_gemm_algo(arg.algo);
 
+#ifdef BUILD_WITH_TENSILE // tensile or hipblaslt only for now
     if(compare_solutions && algo == rocblas_gemm_algo_solution_index)
     {
         arguments = &run_arg; // override
@@ -735,6 +736,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
             solutions_that_solve.push_back(0);
         }
     }
+#endif
 
     for(auto sol : solutions_that_solve)
     {

--- a/docs/conceptual/rocblas-design-notes.rst
+++ b/docs/conceptual/rocblas-design-notes.rst
@@ -171,6 +171,9 @@ all ``rocblas_int`` arguments are replaced by the type name
 precision. Function-level documentation is not repeated for these APIs because they are identical in behavior to the LP64 versions.
 However, functions which support this alternate API include the line:
 ``This function supports the 64-bit integer interface (ILP64)``.
+When parameters exceeding the internal maximum supported size are provided
+the functions will return ``rocblas_status_invalid_size``.  This is most often for symmetric matrix dimensions larger than the ``int32_t`` max value,
+for which such large memory allocation is not practical.
 
 Column-major storage and 1-based indexing
 -----------------------------------------

--- a/docs/reference/extension.rst
+++ b/docs/reference/extension.rst
@@ -185,7 +185,8 @@ rocblas_Xgemmt + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zgemmt
 
-The ``gemmt`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``gemmt`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sgemmt_batched
    :outline:
@@ -195,7 +196,8 @@ The ``gemmt`` functions support the ``_64`` interface. See the :ref:`ILP64 API` 
    :outline:
 .. doxygenfunction:: rocblas_zgemmt_batched
 
-The ``gemmt_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``gemmt_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sgemmt_strided_batched
    :outline:
@@ -205,4 +207,5 @@ The ``gemmt_batched`` functions support the ``_64`` interface. See the :ref:`ILP
    :outline:
 .. doxygenfunction:: rocblas_zgemmt_strided_batched
 
-The ``gemmt_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``gemmt_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.

--- a/docs/reference/level-2.rst
+++ b/docs/reference/level-2.rst
@@ -176,19 +176,22 @@ rocblas_Xspmv + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_dspmv
 
-The ``spmv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spmv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sspmv_batched
    :outline:
 .. doxygenfunction:: rocblas_dspmv_batched
 
-The ``spmv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spmv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sspmv_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_dspmv_strided_batched
 
-The ``spmv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spmv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xspr + batched, strided_batched
 ========================================
@@ -201,7 +204,8 @@ rocblas_Xspr + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zspr
 
-The ``spr`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spr`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sspr_batched
    :outline:
@@ -211,7 +215,8 @@ The ``spr`` functions support the ``_64`` interface. See the :ref:`ILP64 API` se
    :outline:
 .. doxygenfunction:: rocblas_zspr_batched
 
-The ``spr_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spr_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sspr_strided_batched
    :outline:
@@ -221,7 +226,8 @@ The ``spr_batched`` functions support the ``_64`` interface. See the :ref:`ILP64
    :outline:
 .. doxygenfunction:: rocblas_zspr_strided_batched
 
-The ``spr_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spr_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xspr2 + batched, strided_batched
 ========================================
@@ -230,19 +236,22 @@ rocblas_Xspr2 + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_dspr2
 
-The ``spr2`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spr2`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sspr2_batched
    :outline:
 .. doxygenfunction:: rocblas_dspr2_batched
 
-The ``spr2_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spr2_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_sspr2_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_dspr2_strided_batched
 
-The ``spr2_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``spr2_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xsymv + batched, strided_batched
 ========================================
@@ -255,7 +264,8 @@ rocblas_Xsymv + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zsymv
 
-The ``symv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``symv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssymv_batched
    :outline:
@@ -265,7 +275,8 @@ The ``symv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_zsymv_batched
 
-The ``symv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``symv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssymv_strided_batched
    :outline:
@@ -275,7 +286,8 @@ The ``symv_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_zsymv_strided_batched
 
-The ``symv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``symv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xsyr + batched, strided_batched
 ========================================
@@ -288,7 +300,8 @@ rocblas_Xsyr + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zsyr
 
-The ``syr`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyr_batched
    :outline:
@@ -298,7 +311,8 @@ The ``syr`` functions support the ``_64`` interface. See the :ref:`ILP64 API` se
    :outline:
 .. doxygenfunction:: rocblas_zsyr_batched
 
-The ``syr_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyr_strided_batched
    :outline:
@@ -308,7 +322,8 @@ The ``syr_batched`` functions support the ``_64`` interface. See the :ref:`ILP64
    :outline:
 .. doxygenfunction:: rocblas_zsyr_strided_batched
 
-The ``syr_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xsyr2 + batched, strided_batched
 ========================================
@@ -321,7 +336,8 @@ rocblas_Xsyr2 + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zsyr2
 
-The ``syr2`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr2`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyr2_batched
    :outline:
@@ -331,7 +347,8 @@ The ``syr2`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_zsyr2_batched
 
-The ``syr2_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr2_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyr2_strided_batched
    :outline:
@@ -341,7 +358,8 @@ The ``syr2_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_zsyr2_strided_batched
 
-The ``syr2_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr2_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xtbmv + batched, strided_batched
 ========================================
@@ -426,7 +444,8 @@ rocblas_Xtpmv + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_ztpmv
 
-The ``tpmv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``tpmv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_stpmv_batched
    :outline:
@@ -436,7 +455,8 @@ The ``tpmv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_ztpmv_batched
 
-The ``tpmv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``tpmv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_stpmv_strided_batched
    :outline:
@@ -446,7 +466,8 @@ The ``tpmv_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_ztpmv_strided_batched
 
-The ``tpmv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``tpmv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xtpsv + batched, strided_batched
 ========================================
@@ -460,7 +481,8 @@ rocblas_Xtpsv + batched, strided_batched
 .. doxygenfunction:: rocblas_ztpsv
 
 
-The ``tpsv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``tpsv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_stpsv_batched
    :outline:
@@ -470,7 +492,8 @@ The ``tpsv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_ztpsv_batched
 
-The ``tpsv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``tpsv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_stpsv_strided_batched
    :outline:
@@ -480,7 +503,8 @@ The ``tpsv_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_ztpsv_strided_batched
 
-The ``tpsv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``tpsv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xtrmv + batched, strided_batched
 ========================================
@@ -493,7 +517,8 @@ rocblas_Xtrmv + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_ztrmv
 
-The ``trmv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trmv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strmv_batched
    :outline:
@@ -504,7 +529,8 @@ The ``trmv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
 .. doxygenfunction:: rocblas_ztrmv_batched
 
 
-The ``trmv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trmv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strmv_strided_batched
    :outline:
@@ -514,7 +540,8 @@ The ``trmv_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_ztrmv_strided_batched
 
-The ``trmv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trmv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xtrsv + batched, strided_batched
 ========================================
@@ -528,7 +555,8 @@ rocblas_Xtrsv + batched, strided_batched
 .. doxygenfunction:: rocblas_ztrsv
 
 
-The ``trsv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trsv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strsv_batched
    :outline:
@@ -538,7 +566,8 @@ The ``trsv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_ztrsv_batched
 
-The ``trsv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trsv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strsv_strided_batched
    :outline:
@@ -548,7 +577,8 @@ The ``trsv_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_ztrsv_strided_batched
 
-The ``trsv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trsv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xhemv + batched, strided_batched
 ========================================
@@ -557,19 +587,22 @@ rocblas_Xhemv + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhemv
 
-The ``hemv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hemv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chemv_batched
    :outline:
 .. doxygenfunction:: rocblas_zhemv_batched
 
-The ``hemv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hemv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chemv_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhemv_strided_batched
 
-The ``hemv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hemv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xhbmv + batched, strided_batched
 ========================================
@@ -602,19 +635,22 @@ rocblas_Xhpmv + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhpmv
 
-The ``hpmv`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hpmv`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chpmv_batched
    :outline:
 .. doxygenfunction:: rocblas_zhpmv_batched
 
-The ``hpmv_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hpmv_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chpmv_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhpmv_strided_batched
 
-The ``hpmv_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hpmv_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xher + batched, strided_batched
 ========================================
@@ -623,19 +659,22 @@ rocblas_Xher + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zher
 
-The ``her`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cher_batched
    :outline:
 .. doxygenfunction:: rocblas_zher_batched
 
-The ``her_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cher_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zher_strided_batched
 
-The ``her_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xher2 + batched, strided_batched
 ========================================
@@ -644,19 +683,22 @@ rocblas_Xher2 + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zher2
 
-The ``her2`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her2`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cher2_batched
    :outline:
 .. doxygenfunction:: rocblas_zher2_batched
 
-The ``her2_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her2_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cher2_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zher2_strided_batched
 
-The ``her2_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her2_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xhpr + batched, strided_batched
 ========================================
@@ -665,19 +707,22 @@ rocblas_Xhpr + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhpr
 
-The ``hpr`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hpr`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chpr_batched
    :outline:
 .. doxygenfunction:: rocblas_zhpr_batched
 
-The ``hpr_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hpr_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chpr_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhpr_strided_batched
 
-The ``hpr_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hpr_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xhpr2 + batched, strided_batched
 ========================================

--- a/docs/reference/level-3.rst
+++ b/docs/reference/level-3.rst
@@ -65,7 +65,8 @@ rocblas_Xsymm + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zsymm
 
-The ``symm`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``symm`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssymm_batched
    :outline:
@@ -75,7 +76,8 @@ The ``symm`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_zsymm_batched
 
-The ``symm_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``symm_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssymm_strided_batched
    :outline:
@@ -85,7 +87,8 @@ The ``symm_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_zsymm_strided_batched
 
-The ``symm_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``symm_strided_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xsyrk + batched, strided_batched
 =========================================
@@ -98,7 +101,8 @@ rocblas_Xsyrk + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zsyrk
 
-The ``syrk`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syrk`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyrk_batched
    :outline:
@@ -108,7 +112,8 @@ The ``syrk`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_zsyrk_batched
 
-The ``syrk_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syrk_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyrk_strided_batched
    :outline:
@@ -118,7 +123,8 @@ The ``syrk_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_zsyrk_strided_batched
 
-The ``syrk_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syrk_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xsyr2k + batched, strided_batched
 =========================================
@@ -131,7 +137,8 @@ rocblas_Xsyr2k + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zsyr2k
 
-The ``syr2k`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr2k`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyr2k_batched
    :outline:
@@ -141,7 +148,8 @@ The ``syr2k`` functions support the ``_64`` interface. See the :ref:`ILP64 API` 
    :outline:
 .. doxygenfunction:: rocblas_zsyr2k_batched
 
-The ``syr2k_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr2k_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyr2k_strided_batched
    :outline:
@@ -151,7 +159,8 @@ The ``syr2k_batched`` functions support the ``_64`` interface. See the :ref:`ILP
    :outline:
 .. doxygenfunction:: rocblas_zsyr2k_strided_batched
 
-The ``syr2k_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syr2k_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xsyrkx + batched, strided_batched
 =========================================
@@ -164,7 +173,8 @@ rocblas_Xsyrkx + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zsyrkx
 
-The ``syrkx`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syrkx`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyrkx_batched
    :outline:
@@ -174,7 +184,8 @@ The ``syrkx`` functions support the ``_64`` interface. See the :ref:`ILP64 API` 
    :outline:
 .. doxygenfunction:: rocblas_zsyrkx_batched
 
-The ``syrkx_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syrkx_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_ssyrkx_strided_batched
    :outline:
@@ -184,7 +195,8 @@ The ``syrkx_batched`` functions support the ``_64`` interface. See the :ref:`ILP
    :outline:
 .. doxygenfunction:: rocblas_zsyrkx_strided_batched
 
-The ``syrkx_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``syrkx_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xtrmm + batched, strided_batched
 =========================================
@@ -197,7 +209,8 @@ rocblas_Xtrmm + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_ztrmm
 
-The ``trmm`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trmm`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``2^28`` not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strmm_batched
    :outline:
@@ -207,7 +220,8 @@ The ``trmm`` functions support the ``_64`` interface. See the :ref:`ILP64 API` s
    :outline:
 .. doxygenfunction:: rocblas_ztrmm_batched
 
-The ``trmm_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trmm_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``2^28`` are not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strmm_strided_batched
    :outline:
@@ -217,7 +231,8 @@ The ``trmm_batched`` functions support the ``_64`` interface. See the :ref:`ILP6
    :outline:
 .. doxygenfunction:: rocblas_ztrmm_strided_batched
 
-The ``trmm_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``trmm_strided_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``2^28`` are not currently supported.
+See the :ref:`ILP64 API` section.
 
 
 rocblas_Xtrsm + batched, strided_batched
@@ -231,7 +246,8 @@ rocblas_Xtrsm + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_ztrsm
 
-The ``trsm`` functions support the ``_64`` interface. Parameters larger than ``int32_t`` max value are not currently supported. Refer to section :ref:`ILP64 API`.See the :ref:`ILP64 API` section.
+The ``trsm`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strsm_batched
    :outline:
@@ -241,7 +257,8 @@ The ``trsm`` functions support the ``_64`` interface. Parameters larger than ``i
    :outline:
 .. doxygenfunction:: rocblas_ztrsm_batched
 
-The ``trsm_batched`` functions support the ``_64`` interface. Parameters larger than ``int32_t`` max value are not currently supported. See the :ref:`ILP64 API` section.
+The ``trsm_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_strsm_strided_batched
    :outline:
@@ -251,7 +268,8 @@ The ``trsm_batched`` functions support the ``_64`` interface. Parameters larger 
    :outline:
 .. doxygenfunction:: rocblas_ztrsm_strided_batched
 
-The ``trsm_strided_batched`` functions support the ``_64`` interface. Parameters larger than ``int32_t`` max value are not currently supported. See the :ref:`ILP64 API` section.
+The ``trsm_strided_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xhemm + batched, strided_batched
 =========================================
@@ -260,19 +278,22 @@ rocblas_Xhemm + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhemm
 
-The ``hemm`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hemm`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chemm_batched
    :outline:
 .. doxygenfunction:: rocblas_zhemm_batched
 
-The ``hemm_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hemm_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_chemm_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zhemm_strided_batched
 
-The ``hemm_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``hemm_strided_batched`` functions support the ``_64`` interface. Parameter ``m`` for left side, or ``n`` with right side, larger than ``int32_t`` max value are not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xherk + batched, strided_batched
 =========================================
@@ -281,19 +302,22 @@ rocblas_Xherk + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zherk
 
-The ``herk`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``herk`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cherk_batched
    :outline:
 .. doxygenfunction:: rocblas_zherk_batched
 
-The ``herk_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``herk_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cherk_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zherk_strided_batched
 
-The ``herk_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``herk_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xher2k + batched, strided_batched
 =========================================
@@ -302,19 +326,22 @@ rocblas_Xher2k + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zher2k
 
-The ``her2k`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her2k`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cher2k_batched
    :outline:
 .. doxygenfunction:: rocblas_zher2k_batched
 
-The ``her2k_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her2k_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cher2k_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zher2k_strided_batched
 
-The ``her2k_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``her2k_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xherkx + batched, strided_batched
 =========================================
@@ -323,19 +350,22 @@ rocblas_Xherkx + batched, strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zherkx
 
-The ``herkx`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``herkx`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cherkx_batched
    :outline:
 .. doxygenfunction:: rocblas_zherkx_batched
 
-The ``herkx_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``herkx_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 .. doxygenfunction:: rocblas_cherkx_strided_batched
    :outline:
 .. doxygenfunction:: rocblas_zherkx_strided_batched
 
-The ``herkx_strided_batched`` functions support the ``_64`` interface. See the :ref:`ILP64 API` section.
+The ``herkx_strided_batched`` functions support the ``_64`` interface. Parameter ``n`` larger than ``int32_t`` max value is not currently supported.
+See the :ref:`ILP64 API` section.
 
 rocblas_Xtrtri + batched, strided_batched
 =========================================

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -31,7 +31,7 @@
 #include <hipblaslt/hipblaslt.h>
 #endif
 
-#if BUILD_WITH_TENSILE
+#ifdef BUILD_WITH_TENSILE
 #else
 // see TensileHost.cpp for normal rocblas_initialize definition
 // it isn't compiled if not BUILD_WITH_TENSILE so defining here

--- a/library/src/src64/blas3/rocblas_symm_hemm_kernels_64.cpp
+++ b/library/src/src64/blas3/rocblas_symm_hemm_kernels_64.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,13 @@ rocblas_status rocblas_internal_symm_hemm_launcher_64(rocblas_handle handle,
 {
     if(!m_64 || !n_64 || !batch_count_64)
         return rocblas_status_success;
+
+    if((m_64 > c_i32_max && side == rocblas_side_left)
+       || (n_64 > c_i32_max && side == rocblas_side_right))
+    {
+        // exceeds practical memory
+        return rocblas_status_invalid_size;
+    }
 
     if(n_64 <= c_ILP64_i32_max && m_64 < c_ILP64_i32_max && lda_64 < c_ILP64_i32_max
        && ldb_64 < c_ILP64_i32_max && ldc_64 < c_ILP64_i32_max


### PR DESCRIPTION
    clarify ILP64 limitations in documentation for large data (#2888)
    
    * fix quick return symm/hemm and update doc
    
    (cherry picked from commit e8cf3037bdf19ab5e9a4f8047f4e8917b9f9fbd5)
    
     noTensile fixes (#2887)
    
    * removes new tests for solutions with noTensile build
    
    (cherry picked from commit 2ba9a12d62d3de877c75cbd8dff73c50d54b6a98)
    