### PR TITLE
restrict gemm_ex3 and tests to gfx942 (#2900)

### DIFF
--- a/clients/gtest/gemm_batched_gtest.yaml
+++ b/clients/gtest/gemm_batched_gtest.yaml
@@ -224,6 +224,15 @@ Tests:
   transB: N
   api: [ C, FORTRAN ]
 
+- name: gemm_ex3_xx_batched_bad_arg
+  category: quick
+  function:
+    - gemm_batched_ex3_bad_arg: *float8_float8_float8
+  transA: N
+  transB: N
+  api: [ C, FORTRAN ]
+  gpu_arch: '942'
+
 - name: gemm_batched_algorithm_complex_coverage
   category: pre_checkin
   function:

--- a/clients/gtest/gemm_gtest.yaml
+++ b/clients/gtest/gemm_gtest.yaml
@@ -2426,6 +2426,7 @@ Tests:
   transA: N
   transB: N
   api: [ C, FORTRAN ]
+  gpu_arch: '942'
 
 # Tests confirm no NaN propagation when alpha = 0, 2 and beta = 0. Value .NaN is converted into zero
 - {name: alpha_beta_zero_NaN, category: pre_checkin, precision: *single_precision,

--- a/clients/gtest/gemm_strided_batched_gtest.yaml
+++ b/clients/gtest/gemm_strided_batched_gtest.yaml
@@ -252,10 +252,18 @@ Tests:
   function:
     - gemm_strided_batched_ex_bad_arg: *real_precisions
     - gemm_strided_batched_ex_bad_arg: *complex_precisions
+  transA: N
+  transB: N
+  api: [ C, FORTRAN ]
+
+- name: gemm_strided_batched_ex3_xx_bad_arg
+  category: quick
+  function:
     - gemm_strided_batched_ex3_bad_arg: *float8_float8_float8
   transA: N
   transB: N
   api: [ C, FORTRAN ]
+  gpu_arch: '942'
 
 # Tests confirm no NaN propagation when alpha = 0, 2 and beta = 0. Value .NaN is converted into zero
 - {name: alpha_beta_zero_NaN, category: pre_checkin, precision: *single_precision, batch_count: 1,

--- a/library/src/blas_ex/rocblas_gemm_ex3.cpp
+++ b/library/src/blas_ex/rocblas_gemm_ex3.cpp
@@ -57,7 +57,7 @@ namespace
             return rocblas_status_invalid_handle;
 
         rocblas_internal_logger logger;
-        if(handle->getArch() >= 942 && handle->getArch() < 1000)
+        if(handle->getArch() == 942)
         {
             // Copy alpha and beta to host if on device
             rocblas_union_t alpha_h, beta_h;


### PR DESCRIPTION
resolves gfx950 bad arg tests failures and restricts gemm_ex3 to gfx942 usage.