### PR TITLE
ex3 duplicate test removal

### DIFF
--- a/clients/gtest/gemm_batched_gtest.yaml
+++ b/clients/gtest/gemm_batched_gtest.yaml
@@ -219,7 +219,6 @@ Tests:
   function:
     - gemm_batched_ex_bad_arg: *real_precisions
     - gemm_batched_ex_bad_arg: *complex_precisions
-    - gemm_batched_ex3_bad_arg: *float8_float8_float8
   transA: N
   transB: N
   api: [ C, FORTRAN ]


### PR DESCRIPTION
(cherry picked from commit 6086a73dadd70c6d2d6a9e316ca055b8883c62f6)

* removes incorrect test which is gfx942 only