### PR TITLE
Fallback to rocBLAS GEMM for complex types when others fail.

### DIFF
--- a/library/src/blas3/Tensile/gemm_templates.cpp
+++ b/library/src/blas3/Tensile/gemm_templates.cpp
@@ -135,8 +135,7 @@ rocblas_status rocblas_internal_gemm(rocblas_handle    handle,
     // Return the current status if a solution was not found
     // by other libraries(hipBLASLt or Tensile) or if the data is not both complex.
     // Otherwise, fall through to rocblas source GEMM.
-    if(status != rocblas_status_not_implemented
-       && !(rocblas_is_complex<TConstPtr> && rocblas_is_complex<TPtr>))
+    if(status != rocblas_status_not_implemented && !rocblas_is_complex<TScal>)
     {
         return status;
     }

--- a/library/src/blas3/Tensile/gemm_templates.cpp
+++ b/library/src/blas3/Tensile/gemm_templates.cpp
@@ -135,7 +135,7 @@ rocblas_status rocblas_internal_gemm(rocblas_handle    handle,
     // Return the current status if a solution was not found
     // by other libraries(hipBLASLt or Tensile) or if the data is not both complex.
     // Otherwise, fall through to rocblas source GEMM.
-    if(status != rocblas_status_not_implemented && !rocblas_is_complex<TScal>)
+    if(status != rocblas_status_not_implemented || !rocblas_is_complex<TScal>)
     {
         return status;
     }

--- a/library/src/blas3/Tensile/gemm_templates.cpp
+++ b/library/src/blas3/Tensile/gemm_templates.cpp
@@ -132,10 +132,10 @@ rocblas_status rocblas_internal_gemm(rocblas_handle    handle,
                                       batch_count);
     }
 
-    // Return the current status if a solution was not found
-    // by other libraries(hipBLASLt or Tensile) or if the data is not both complex.
-    // Otherwise, fall through to rocblas source GEMM.
-    if(status != rocblas_status_not_implemented || !rocblas_is_complex<TScal>)
+    // Return the current status if an exception is thrown
+    // by other libraries(hipBLASLt or Tensile).
+    // Otherwise, fall through to the rocBLAS source GEMM implementation.
+    if(status != rocblas_status_not_implemented)
     {
         return status;
     }

--- a/library/src/blas3/Tensile/gemm_templates.cpp
+++ b/library/src/blas3/Tensile/gemm_templates.cpp
@@ -24,9 +24,8 @@
 
 #ifdef BUILD_WITH_TENSILE
 #include "gemm_tensile.hpp"
-#else
-#include "blas3/rocblas_gemm_source.hpp"
 #endif
+#include "blas3/rocblas_gemm_source.hpp"
 
 #include "blas3/rocblas_gemm.hpp"
 
@@ -62,10 +61,12 @@ rocblas_status rocblas_internal_gemm(rocblas_handle    handle,
                                      rocblas_stride    stride_c,
                                      rocblas_int       batch_count)
 {
+    rocblas_status status = rocblas_status_success;
+
     // quick return 0 is valid in BLAS
     // Note: k==0 is not a quick return, because C must still be multiplied by beta
     if(!m || !n || !batch_count)
-        return rocblas_status_success;
+        return status;
 
     TScal alpha_h, beta_h;
     RETURN_IF_ROCBLAS_ERROR(
@@ -76,61 +77,71 @@ rocblas_status rocblas_internal_gemm(rocblas_handle    handle,
 
     if(BATCHED)
     {
-        return rocblas_call_tensile(handle,
-                                    alpha,
-                                    beta,
-                                    A,
-                                    B,
-                                    C,
-                                    C, // gemm uses C matrix for output D
-                                    trans_a,
-                                    trans_b,
-                                    ldc, // gemm uses C matrix for output D
-                                    stride_c,
-                                    offset_c,
-                                    ldc,
-                                    stride_c,
-                                    offset_c,
-                                    lda,
-                                    stride_a,
-                                    offset_a,
-                                    ldb,
-                                    stride_b,
-                                    offset_b,
-                                    m,
-                                    n,
-                                    k,
-                                    batch_count);
+        status = rocblas_call_tensile(handle,
+                                      alpha,
+                                      beta,
+                                      A,
+                                      B,
+                                      C,
+                                      C, // gemm uses C matrix for output D
+                                      trans_a,
+                                      trans_b,
+                                      ldc, // gemm uses C matrix for output D
+                                      stride_c,
+                                      offset_c,
+                                      ldc,
+                                      stride_c,
+                                      offset_c,
+                                      lda,
+                                      stride_a,
+                                      offset_a,
+                                      ldb,
+                                      stride_b,
+                                      offset_b,
+                                      m,
+                                      n,
+                                      k,
+                                      batch_count);
     }
     else
     {
-        return rocblas_call_tensile(handle,
-                                    alpha,
-                                    beta,
-                                    A + offset_a,
-                                    B + offset_b,
-                                    C + offset_c,
-                                    C + offset_c,
-                                    trans_a,
-                                    trans_b,
-                                    ldc,
-                                    stride_c,
-                                    0,
-                                    ldc,
-                                    stride_c,
-                                    0,
-                                    lda,
-                                    stride_a,
-                                    0,
-                                    ldb,
-                                    stride_b,
-                                    0,
-                                    m,
-                                    n,
-                                    k,
-                                    batch_count);
+        status = rocblas_call_tensile(handle,
+                                      alpha,
+                                      beta,
+                                      A + offset_a,
+                                      B + offset_b,
+                                      C + offset_c,
+                                      C + offset_c,
+                                      trans_a,
+                                      trans_b,
+                                      ldc,
+                                      stride_c,
+                                      0,
+                                      ldc,
+                                      stride_c,
+                                      0,
+                                      lda,
+                                      stride_a,
+                                      0,
+                                      ldb,
+                                      stride_b,
+                                      0,
+                                      m,
+                                      n,
+                                      k,
+                                      batch_count);
     }
-#else // BUILD_WITH_TENSILE
+
+    // Return the current status if a solution was not found
+    // by other libraries(hipBLASLt or Tensile) or if the data is not both complex.
+    // Otherwise, fall through to rocblas source GEMM.
+    if(status != rocblas_status_not_implemented
+       && !(rocblas_is_complex<TConstPtr> && rocblas_is_complex<TPtr>))
+    {
+        return status;
+    }
+
+#endif // BUILD_WITH_TENSILE
 
     bool backend_logging = handle->layer_mode & rocblas_layer_mode_log_internal;
     if(backend_logging)
@@ -160,7 +171,7 @@ rocblas_status rocblas_internal_gemm(rocblas_handle    handle,
             handle, m, n, *beta, C, offset_c, ldc, stride_c, batch_count);
     }
 
-    rocblas_status status = rocblas_status_success;
+    status = rocblas_status_success;
     for(int64_t n_base = 0; n_base < n; n_base += c_i64_grid_YZ_chunk)
     {
         // don't need to block through M as it's 32 bit and can use full 32-bits in X-dim of grid
@@ -198,8 +209,6 @@ rocblas_status rocblas_internal_gemm(rocblas_handle    handle,
     }
 
     return status;
-
-#endif // BUILD_WITH_TENSILE
 }
 
 template <typename T>


### PR DESCRIPTION
resolves # LWPMLSE-844

Summary of proposed changes:
- Fallback to rocBLAS GEMM for complex types when other libraries (hipBLASLt or Tensile) fail. 
