### PR TITLE
Find BLAS with `find_package()`

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -185,7 +185,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     set( BLIS_CPP ../common/blis_interface.cpp )
   endif()
 
-  message(STATUS "Linking BLAS LIB: ${BLAS_LIBRARY}")
+  message(STATUS "Linking reference BLAS LIB: ${BLAS_LIBRARY}")
 
   if ( WARN_NOT_ILP64_PREFERRED )
     message( WARNING "Using ${BLAS_LIBRARY} as reference library, 64-bit tests may fail. Test suite should be run with --gtest_filter=-*stress*")

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -157,7 +157,8 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
         endif()
       endif()
     else()
-      set( BLAS_LIBRARY "blas" )
+      find_package( BLAS REQUIRED )
+      set( BLAS_LIBRARY "${BLAS_LIBRARIES}" )
     endif()
   else() # WIN32
     file(TO_CMAKE_PATH "C:/Program\ Files/AMD/AOCL-Windows/amd-blis/lib/ILP64/AOCL-LibBlis-Win-MT.lib" AOCL_BLAS_LIBRARY)
@@ -184,7 +185,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     set( BLIS_CPP ../common/blis_interface.cpp )
   endif()
 
-  message(STATUS "Linking Reference BLAS LIB: ${BLAS_LIBRARY}")
+  message(STATUS "Linking BLAS LIB: ${BLAS_LIBRARY}")
 
   if ( WARN_NOT_ILP64_PREFERRED )
     message( WARNING "Using ${BLAS_LIBRARY} as reference library, 64-bit tests may fail. Test suite should be run with --gtest_filter=-*stress*")


### PR DESCRIPTION
Switches to `find_package()` instead of assuming that the reference BLAS is available without any check. This also allows to use OpenBLAS.