### PR TITLE
Fix casing on OpenBLAS package for Windows compatibility

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -172,7 +172,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
                     NO_DEFAULT_PATH
                   )
       if (NOT BLAS_LIBRARY)
-        find_package( OPENBLAS CONFIG REQUIRED )
+        find_package( OpenBLAS CONFIG REQUIRED )
         set( BLAS_LIBRARY OpenBLAS::OpenBLAS )
         set( BLAS_INCLUDE_DIR "" )
       endif()


### PR DESCRIPTION
rocBLAS configure is failing to find OPENBLAS on Windows with -DBUILD_TESTING=ON, which is fixed with this patch. See https://github.com/ROCm/TheRock/issues/482 for further details.