### PR TITLE
Update 'packaging' in pip venv to stabilize setuptools.

### DIFF
--- a/cmake/virtualenv.cmake
+++ b/cmake/virtualenv.cmake
@@ -59,6 +59,15 @@ function(virtualenv_install)
         endif()
     endif()
 
+    message("${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging")
+    execute_process(
+        RESULT_VARIABLE rc
+        COMMAND ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging
+    )
+    if(rc)
+        message(FATAL_ERROR ${rc})
+    endif()
+
     message("${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install ${ARGN}")
     execute_process(
       RESULT_VARIABLE rc

--- a/cmake/virtualenv.cmake
+++ b/cmake/virtualenv.cmake
@@ -57,15 +57,15 @@ function(virtualenv_install)
         if(rc)
             message(FATAL_ERROR ${rc})
         endif()
-    endif()
 
-    message("${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging")
-    execute_process(
-        RESULT_VARIABLE rc
-        COMMAND ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging
-    )
-    if(rc)
-        message(FATAL_ERROR ${rc})
+        message("${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging")
+        execute_process(
+            RESULT_VARIABLE rc
+            COMMAND ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging
+        )
+        if(rc)
+            message(FATAL_ERROR ${rc})
+        endif()
     endif()
 
     message("${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install ${ARGN}")


### PR DESCRIPTION
When using setuptools>=71.0.0 and packaging<22.0, setuptools may fail with `TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'`.
