### PR TITLE
Move `blas_ex/common_gemm_ex3` to different target

### DIFF
--- a/clients/common/CMakeLists.txt
+++ b/clients/common/CMakeLists.txt
@@ -140,11 +140,11 @@ set(rocblas_testing_common_source
     blas_ex/common_geam_ex.cpp
 )
 
-add_library(rocblas_clients_common OBJECT ${rocblas_testing_common_tensile_source} ${rocblas_common_source})
+add_library(rocblas_clients_common OBJECT ${rocblas_common_source})
 
 rocblas_client_library_settings( rocblas_clients_common )
 
-add_library(rocblas_clients_testing_common OBJECT ${rocblas_testing_common_source})
+add_library(rocblas_clients_testing_common OBJECT ${rocblas_testing_common_tensile_source}  ${rocblas_testing_common_source})
 
 rocblas_client_library_settings( rocblas_clients_testing_common )
 


### PR DESCRIPTION
resolves https://github.com/ROCm/TheRock/issues/273

`clients/common/blas_ex/common_gemm_ex3.cpp` pulls in cblas via `clients/common/common_helpers.hpp` -> `clients/common/testing_common.hpp` -> `clients/include/testing_common.hpp` -> `clients/include/cblas_interface.hpp` -> `cblas.h`

While the `rocblas_clients_testing_common` target depends on BLAS, `rocblas_clients_common` does not. This therefore moves the source file to the former target. Both libraries get linked into one common executable in a later step.
