### PR TITLE
Adapt ifdefs to generic architectures

### DIFF
--- a/library/src/blas1/rocblas_dot_kernels.hpp
+++ b/library/src/blas1/rocblas_dot_kernels.hpp
@@ -237,7 +237,7 @@ rocblas_dot_kernel_gfx942_gfx950_float_double(rocblas_int n,
                                               V* __restrict__ workspace,
                                               T* __restrict__ out)
 {
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__)
     int         i = blockIdx.x * NB + threadIdx.x;
     const auto* x = load_ptr_batch(xa, blockIdx.z, shiftx, stridex);
     const auto* y = load_ptr_batch(ya, blockIdx.z, shifty, stridey);

--- a/library/src/blas2/gemv_device.hpp
+++ b/library/src/blas2/gemv_device.hpp
@@ -1385,7 +1385,7 @@ rocblas_gemvn_sm_mn_batched_kernel(rocblas_int    m,
                                    rocblas_stride stridey,
                                    rocblas_int    batch_count)
 {
-#if defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__)
 
     const int b = blockIdx.x * blockDim.y + threadIdx.y;
     if(b >= batch_count)

--- a/library/src/blas2/rocblas_ger_kernels.hpp
+++ b/library/src/blas2/rocblas_ger_kernels.hpp
@@ -139,7 +139,7 @@ rocblas_sger_gfx942_gfx950_kernel(rocblas_int    m,
                                   int64_t        lda,
                                   rocblas_stride strideA)
 {
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__)
 
     rocblas_int tx  = (blockIdx.x * DIM_X + threadIdx.x) * 2;
     rocblas_int col = blockIdx.y;

--- a/library/src/blas3/rocblas_dgmm_kernels.cpp
+++ b/library/src/blas3/rocblas_dgmm_kernels.cpp
@@ -91,7 +91,7 @@ rocblas_dgmm_gfx942_gfx950_kernel(rocblas_int    m,
                                   int64_t        ldc,
                                   rocblas_stride stride_C)
 {
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__)
 
     rocblas_int tx = (blockIdx.x * DIM_X + threadIdx.x) * 2;
     rocblas_int ty = blockIdx.y * DIM_Y + threadIdx.y;


### PR DESCRIPTION
I was thinking about building with e.g. `GPU_TARGETS="gfx9-4-generic;gfx11-generic"` (see https://rocm.docs.amd.com/projects/llvm-project/en/develop/conceptual/code-portability.html#generic-code-objects) to reduce compile time and binary size while still being able to run on all architectures relevant to me. This led me to a few `#ifdef`s that explicitly checked for specific architecture, which this pull request adapts to also support generic architectures.