### PR TITLE
adapt test coverage for no atomics defaults (#1612)

### DIFF
--- a/clients/gtest/gemv_gtest.yaml
+++ b/clients/gtest/gemv_gtest.yaml
@@ -328,7 +328,7 @@ Tests:
   matrix_size: *size_t_non_transpose_90a
   alpha_beta: *alpha_beta_range_size_t
   pointer_mode_host: false
-  atomics_mode: [1]
+  atomics_mode: [0, 1]
   os_flags: LINUX
   gpu_arch: ['90a']
 

--- a/clients/include/rocblas_common.yaml
+++ b/clients/include/rocblas_common.yaml
@@ -635,7 +635,7 @@ Defaults:
   solution_index: 0
   geam_op: rocblas_geam_ex_operation_min_plus
   flags: none
-  atomics_mode: atomics_allowed
+  atomics_mode: atomics_not_allowed
   initialization: rand_int
   category: nightly
   known_bug_platforms: ''

--- a/clients/include/rocblas_extras.yaml
+++ b/clients/include/rocblas_extras.yaml
@@ -460,7 +460,7 @@ Tests:
 
   - name: atomics_mode_L3_quick
     category: quick
-    atomics_mode: atomics_not_allowed
+    atomics_mode: [0, 1]
     function:
       - gemm: *single_double_precisions_complex
       - gemm_ex: *single_double_precisions_complex

--- a/scripts/yaml/min_coverage.yaml
+++ b/scripts/yaml/min_coverage.yaml
@@ -433,7 +433,7 @@ Tests:
 
   - name: atomics_mode_L3_quick
     category: quick
-    atomics_mode: atomics_not_allowed
+    atomics_mode: [0, 1]
     function:
       gemm: *single_double_precisions_complex
       gemm_ex: *single_double_precisions_complex


### PR DESCRIPTION
(cherry picked from commit 35217b2a4ad3ef6823184f61c11022320f03e800)

