### PR TITLE
Revert "Stream Order Allocation as default  (#1608)"

### DIFF
--- a/clients/common/client_utility.cpp
+++ b/clients/common/client_utility.cpp
@@ -474,6 +474,8 @@ void rocblas_local_handle::rocblas_stream_begin_capture()
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(m_handle, &m_old_stream));
     CHECK_HIP_ERROR(hipStreamSynchronize(m_old_stream));
 
+    m_handle->set_stream_order_memory_allocation(true);
+
     CHECK_HIP_ERROR(hipStreamCreate(&m_graph_stream));
     CHECK_ROCBLAS_ERROR(rocblas_set_stream(m_handle, m_graph_stream));
 
@@ -498,6 +500,8 @@ void rocblas_local_handle::rocblas_stream_end_capture()
     CHECK_ROCBLAS_ERROR(rocblas_set_stream(m_handle, m_old_stream));
     CHECK_HIP_ERROR(hipStreamDestroy(m_graph_stream));
     m_graph_stream = nullptr;
+
+    m_handle->set_stream_order_memory_allocation(false);
 }
 
 void rocblas_parallel_initialize_thread(int id, size_t& memory_used)

--- a/clients/include/blas2/testing_trsv.hpp
+++ b/clients/include/blas2/testing_trsv.hpp
@@ -155,6 +155,18 @@ void testing_trsv(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocblas_trsv_fn(handle, uplo, transA, diag, N, dA, lda, dx_or_b, incx));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/clients/include/blas2/testing_trsv_batched.hpp
+++ b/clients/include/blas2/testing_trsv_batched.hpp
@@ -175,6 +175,28 @@ void testing_trsv_batched(const Arguments& arg)
     double error_eps_multiplier    = ERROR_EPS_MULTIPLIER;
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trsv_batched_fn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  diag,
+                                                  N,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dx_or_b.ptr_on_device(),
+                                                  incx,
+                                                  batch_count));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
 
     if(arg.unit_check || arg.norm_check)
     {

--- a/clients/include/blas2/testing_trsv_strided_batched.hpp
+++ b/clients/include/blas2/testing_trsv_strided_batched.hpp
@@ -189,6 +189,30 @@ void testing_trsv_strided_batched(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trsv_strided_batched_fn(handle,
+                                                          uplo,
+                                                          transA,
+                                                          diag,
+                                                          N,
+                                                          dA,
+                                                          lda,
+                                                          stride_a,
+                                                          dx_or_b,
+                                                          incx,
+                                                          stride_x,
+                                                          batch_count));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/clients/include/blas3/testing_trsm.hpp
+++ b/clients/include/blas3/testing_trsm.hpp
@@ -324,6 +324,21 @@ void testing_trsm(const Arguments& arg)
     double err_host                = 0.0;
     double err_device              = 0.0;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        DAPI_CHECK_ALLOC_QUERY(
+            rocblas_trsm_fn,
+            (handle, side, uplo, transA, diag, M, N, &alpha_h, dA, lda, dXorB, ldb));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/clients/include/blas3/testing_trsm_batched.hpp
+++ b/clients/include/blas3/testing_trsm_batched.hpp
@@ -455,6 +455,31 @@ void testing_trsm_batched(const Arguments& arg)
     double err_host                = 0.0;
     double err_device              = 0.0;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        DAPI_CHECK_ALLOC_QUERY(rocblas_trsm_batched_fn,
+                               (handle,
+                                side,
+                                uplo,
+                                transA,
+                                diag,
+                                M,
+                                N,
+                                &alpha_h,
+                                dA.ptr_on_device(),
+                                lda,
+                                dXorB.ptr_on_device(),
+                                ldb,
+                                batch_count));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/clients/include/blas3/testing_trsm_strided_batched.hpp
+++ b/clients/include/blas3/testing_trsm_strided_batched.hpp
@@ -522,6 +522,34 @@ void testing_trsm_strided_batched(const Arguments& arg)
     double err_host   = 0.0;
     double err_device = 0.0;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        DAPI_CHECK_ALLOC_QUERY(rocblas_trsm_strided_batched_fn,
+                               (handle,
+                                side,
+                                uplo,
+                                transA,
+                                diag,
+                                M,
+                                N,
+                                &alpha_h,
+                                dA,
+                                lda,
+                                stride_A,
+                                dXorB,
+                                ldb,
+                                stride_B,
+                                batch_count));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/clients/include/blas3/testing_trtri.hpp
+++ b/clients/include/blas3/testing_trtri.hpp
@@ -163,6 +163,20 @@ void testing_trtri(const Arguments& arg)
     gpu_time_used = cpu_time_used = 0.0;
     double rocblas_error_out, rocblas_error_in;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trtri_fn(handle, uplo, diag, N, dA, lda, dinvA, ldinvA));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     /* =====================================================================
            ROCBLAS
     =================================================================== */

--- a/clients/include/blas3/testing_trtri_batched.hpp
+++ b/clients/include/blas3/testing_trtri_batched.hpp
@@ -234,6 +234,32 @@ void testing_trtri_batched(const Arguments& arg)
     gpu_time_used = cpu_time_used = 0.0;
     double rocblas_error_out, rocblas_error_in;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trtri_batched_fn(handle,
+                                                   uplo,
+                                                   diag,
+                                                   N,
+                                                   dA.ptr_on_device(),
+                                                   lda,
+                                                   dinvA.ptr_on_device(),
+                                                   lda,
+                                                   batch_count));
+
+        // Test in place
+        CHECK_ALLOC_QUERY(rocblas_trtri_batched_fn(
+            handle, uplo, diag, N, dA.ptr_on_device(), lda, dA.ptr_on_device(), lda, batch_count));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     /* =====================================================================
            ROCBLAS
     =================================================================== */

--- a/clients/include/blas3/testing_trtri_strided_batched.hpp
+++ b/clients/include/blas3/testing_trtri_strided_batched.hpp
@@ -214,6 +214,25 @@ void testing_trtri_strided_batched(const Arguments& arg)
     gpu_time_used = cpu_time_used = 0.0;
     double rocblas_error_out, rocblas_error_in;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched_fn(
+            handle, uplo, diag, N, dA, lda, stride_A, dinvA, lda, stride_A, batch_count));
+
+        // Test in place
+        CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched_fn(
+            handle, uplo, diag, N, dA, lda, stride_A, dA, lda, stride_A, batch_count));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     /* =====================================================================
            ROCBLAS
     =================================================================== */

--- a/clients/include/blas_ex/testing_trsm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_batched_ex.hpp
@@ -365,6 +365,72 @@ void testing_trsm_batched_ex(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        if(arg.unit_check || arg.norm_check)
+        {
+            for(int b = 0; b < batch_count; b++)
+            {
+                if(blocks > 0)
+                {
+                    CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                                       uplo,
+                                                                       diag,
+                                                                       TRSM_BLOCK,
+                                                                       dA[b],
+                                                                       lda,
+                                                                       stride_A,
+                                                                       dinvA[b],
+                                                                       TRSM_BLOCK,
+                                                                       stride_invA,
+                                                                       blocks));
+                }
+
+                if(K % TRSM_BLOCK != 0 || blocks == 0)
+                {
+                    CHECK_ALLOC_QUERY(
+                        rocblas_trtri_strided_batched<T>(handle,
+                                                         uplo,
+                                                         diag,
+                                                         K - TRSM_BLOCK * blocks,
+                                                         dA[b] + stride_A * blocks,
+                                                         lda,
+                                                         stride_A,
+                                                         dinvA[b] + stride_invA * blocks,
+                                                         TRSM_BLOCK,
+                                                         stride_invA,
+                                                         1));
+                }
+            }
+        }
+
+        CHECK_ALLOC_QUERY(rocblas_trsm_batched_ex_fn(handle,
+                                                     side,
+                                                     uplo,
+                                                     transA,
+                                                     diag,
+                                                     M,
+                                                     N,
+                                                     &alpha_h,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     dXorB.ptr_on_device(),
+                                                     ldb,
+                                                     batch_count,
+                                                     dinvA.ptr_on_device(),
+                                                     TRSM_BLOCK * K,
+                                                     arg.compute_type));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         // calculate dXorB <- A^(-1) B   rocblas_device_pointer_host

--- a/clients/include/blas_ex/testing_trsm_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_ex.hpp
@@ -339,6 +339,64 @@ void testing_trsm_ex(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        if(blocks > 0)
+        {
+            CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                               uplo,
+                                                               diag,
+                                                               TRSM_BLOCK,
+                                                               dA,
+                                                               lda,
+                                                               stride_A,
+                                                               dinvA,
+                                                               TRSM_BLOCK,
+                                                               stride_invA,
+                                                               blocks));
+        }
+
+        if(K % TRSM_BLOCK != 0 || blocks == 0)
+        {
+            CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                               uplo,
+                                                               diag,
+                                                               K - TRSM_BLOCK * blocks,
+                                                               dA + stride_A * blocks,
+                                                               lda,
+                                                               stride_A,
+                                                               dinvA + stride_invA * blocks,
+                                                               TRSM_BLOCK,
+                                                               stride_invA,
+                                                               1));
+        }
+
+        CHECK_ALLOC_QUERY(rocblas_trsm_ex_fn(handle,
+                                             side,
+                                             uplo,
+                                             transA,
+                                             diag,
+                                             M,
+                                             N,
+                                             &alpha_h,
+                                             dA,
+                                             lda,
+                                             dXorB,
+                                             ldb,
+                                             dinvA,
+                                             TRSM_BLOCK * K,
+                                             arg.compute_type));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         // calculate dXorB <- A^(-1) B   rocblas_device_pointer_host

--- a/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
@@ -415,6 +415,75 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        if(arg.unit_check || arg.norm_check)
+        {
+            for(int b = 0; b < batch_count; b++)
+            {
+                if(blocks > 0)
+                {
+                    CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                                       uplo,
+                                                                       diag,
+                                                                       TRSM_BLOCK,
+                                                                       dA[b],
+                                                                       lda,
+                                                                       sub_stride_A,
+                                                                       dinvA[b],
+                                                                       TRSM_BLOCK,
+                                                                       sub_stride_invA,
+                                                                       blocks));
+                }
+
+                if(K % TRSM_BLOCK != 0 || blocks == 0)
+                {
+                    CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(
+                        handle,
+                        uplo,
+                        diag,
+                        K - TRSM_BLOCK * blocks,
+                        (T*)dA + sub_stride_A * blocks + b * stride_A,
+                        lda,
+                        sub_stride_A,
+                        (T*)dinvA + sub_stride_invA * blocks + b * stride_invA,
+                        TRSM_BLOCK,
+                        sub_stride_invA,
+                        1));
+                }
+            }
+
+            CHECK_ALLOC_QUERY(rocblas_trsm_strided_batched_ex_fn(handle,
+                                                                 side,
+                                                                 uplo,
+                                                                 transA,
+                                                                 diag,
+                                                                 M,
+                                                                 N,
+                                                                 &alpha_h,
+                                                                 dA,
+                                                                 lda,
+                                                                 stride_A,
+                                                                 dXorB,
+                                                                 ldb,
+                                                                 stride_B,
+                                                                 batch_count,
+                                                                 dinvA,
+                                                                 size_invA,
+                                                                 stride_invA,
+                                                                 arg.compute_type));
+        }
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
 

--- a/clients/samples/example_solver_rocblas.cpp
+++ b/clients/samples/example_solver_rocblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,9 @@ int main()
     rocblas_handle handle;
     CHECK_ROCBLAS_ERROR(rocblas_create_handle(&handle));
 
+    // Free all memory in the handle
+    CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, 0));
+
     size_t sizes[] = {512, 1025, 10 * 1024 * 1024};
 
     if(rocblas_is_device_memory_size_query(handle))
@@ -47,6 +50,11 @@ int main()
     }
 
     CHECK_ALLOC_QUERY(rocblas_set_optimal_device_memory_size(handle, sizes[0], sizes[1], sizes[2]));
+
+    size_t max;
+    CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &max));
+
+    CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, max));
 
     for(size_t size : sizes)
     {

--- a/docs/how-to/Programmers_Guide.rst
+++ b/docs/how-to/Programmers_Guide.rst
@@ -46,7 +46,7 @@ This includes source code for Level 1, 2, and 3 BLAS functions in ``.cpp`` and `
       call functions with a ``_template`` extension.
 
 *  The ``*_imp.hpp`` files contain:
-
+ 
    *  ``_template`` functions that can be exported to rocSOLVER. They usually call the ``_launcher`` functions.
    *  API implementations that can be instantiated for the original APIs with integer arguments using ``rocblas_int`` and
       again for the ILP64 API with integer arguments as ``int64_t``.
@@ -224,7 +224,7 @@ the ``hipStreamSynchronize(old_stream)`` API before setting the new stream.
 
 .. code-block:: cpp
 
-    // Synchronize the old stream (optional)
+    // Synchronize the old stream
     if(hipStreamSynchronize(old_stream) != hipSuccess) return EXIT_FAILURE;
 
     // Create a new stream (this step can be done before the steps above)
@@ -236,8 +236,8 @@ the ``hipStreamSynchronize(old_stream)`` API before setting the new stream.
     // Destroy the old stream (this step is optional but must come after synchronization)
     if(hipStreamDestroy(old_stream) != hipSuccess) return EXIT_FAILURE;
 
-The call to ``hipStreamSynchronize`` above is necessary for user_owned allocation scheme because the ``rocBLAS_handle`` contains allocated device
-memory provided by the user that must not be shared by multiple asynchronous streams at the same time.
+The call to ``hipStreamSynchronize`` above is necessary because the ``rocBLAS_handle`` contains allocated device
+memory that must not be shared by multiple asynchronous streams at the same time.
 
 If either the old or new stream is the default or ``NULL`` stream, it is not necessary to
 synchronize the old stream before destroying it, or before setting the new stream,
@@ -245,8 +245,8 @@ because the synchronization is implicit.
 
 .. note::
 
-   You can switch from one non-default stream to another without calling ``hipStreamSynchronize()`` as the default memory allocation scheme (rocBLAS_managed) uses stream order allocation.
-   For more information, see :ref:`Device Memory Allocation Usage`.
+   You can switch from one non-default stream to another without calling ``hipStreamSynchronize()`` by enabling stream-order memory allocation.
+   For more information, see :ref:`stream order alloc`.
 
 Creating the handle incurs a startup cost. There is an additional startup cost for
 GEMM functions to load GEMM kernels for a specific device. You can shift the
@@ -298,7 +298,7 @@ HIP has two important device management functions:
 *  ``hipSetDevice()``: Sets the default device to be used for subsequent HIP API calls from the thread.
 *  ``hipGetDevice()``: Returns the default device ID for the calling host thread.
 
-The device which was set using ``hipSetDevice()`` when ``hipStreamCreate()`` was called
+The device which was set using ``hipSetDevice()`` when ``hipStreamCreate()`` was called 
 is the one that is associated with a stream. If the device was not set using ``hipSetDevice()``, then the default device is used.
 
 You cannot switch the device in a stream between ``hipStreamCreate()`` and ``hipStreamDestroy()``.
@@ -674,7 +674,7 @@ rocBLAS has the following differences from legacy BLAS:
    In legacy BLAS, the following functions return a scalar result: ``dot``, ``nrm2``, ``asum``, ``amax``, and ``amin``.
 *  The first argument is a ``rocblas_handle`` argument. This is an opaque pointer to rocBLAS resources,
    corresponding to a single HIP stream.
-*  Scalar arguments like alpha and beta are pointers on either the host or device, controlled by the pointer mode of the rocBLAS handle.
+*  Scalar arguments like alpha and beta are pointers on either the host or device, controlled by the pointer mode of the rocBLAS handle. 
    In cases where the other arguments do not dictate an early return, if the alpha and beta pointers are ``NULL``,
    the function returns ``rocblas_status_invalid_pointer``.
 *  Vector and matrix arguments are always pointers to device memory.
@@ -685,7 +685,7 @@ rocBLAS has the following differences from legacy BLAS:
    This is to avoid slowing down execution to fetch and inspect alpha and beta values.
 *  The ``ROCBLAS_LAYER`` environment variable controls the option to log argument values.
 *  rocBLAS has added functionality, including the following:
-
+  
    *  batched
    *  strided_batched
    *  mixed precision in ``gemm_ex``, ``gemm_batched_ex``, and ``gemm_strided_batched_ex``
@@ -696,7 +696,7 @@ The following changes were made to accommodate the new features:
 *  For batched and strided_batched L2 and L3 functions, there is a quick-return-success for ``batch_count == 0``
    and an invalid-size error for ``batch_count < 0``.
 *  For batched and strided_batched L1 functions, there is a quick-return-success for ``batch_count <= 0``.
-*  When ``rocblas_pointer_mode == rocblas_pointer_mode_device``, alpha and beta are not copied
+*  When ``rocblas_pointer_mode == rocblas_pointer_mode_device``, alpha and beta are not copied 
    from the device to host for quick-return-success checks. In this case, the quick-return-success checks are omitted.
    This still provides a correct result, but the operation is slower.
 *  For strided_batched functions, there is no argument checking for the stride.
@@ -753,7 +753,7 @@ rocBLAS control flow
 
    *  If there is no return value, return ``rocblas_status_success``.
    *  If there is a return value:
-
+  
       * If the return value pointer argument is a ``NULL`` pointer, return ``rocblas_status_invalid_pointer``.
       * Otherwise, return ``rocblas_status_success``
 
@@ -2047,7 +2047,7 @@ To add new data-driven tests to the rocBLAS GoogleTest Framework, follow these s
    .. csv-table::
       :header: "Level","quick","pre_checkin","nightly"
       :widths: 20, 30, 30, 30
-
+   
       "Level 1", "2 - 12 sec", "20 - 36 sec", "70 - 200 sec"
       "Level 2", "6 - 36 sec", "35 - 100 sec", "200 - 650 sec"
       "Level 3", "20 sec - 2 min", "2 - 6 min", "12 - 24 min"

--- a/docs/reference/beta-features.rst
+++ b/docs/reference/beta-features.rst
@@ -46,8 +46,8 @@ The captured graph can be launched as shown below:
       CHECK_HIP_ERROR(hipGraphInstantiate(&instance, graph, NULL, NULL, 0));
       CHECK_HIP_ERROR(hipGraphLaunch(instance, stream));
 
-Graph support requires asynchronous HIP APIs, so users must use rocBLAS_managed (default) which uses stream-order memory allocation.
-For more details, see :ref:`Device Memory Allocation Usage`.
+Graph support requires asynchronous HIP APIs, so users must enable stream-order memory allocation.
+For more details, see :ref:`stream order alloc`.
 
 During stream capture, rocBLAS stores the allocated host and device memory in the handle.
 The allocated memory is freed when the handle is destroyed.

--- a/docs/reference/deprecations.rst
+++ b/docs/reference/deprecations.rst
@@ -23,11 +23,6 @@ rocblas_Xgemm_kernel_name removed
 
 ``rocblas_Xgemm_kernel_name`` API functions were removed in 5.0.
 
-
-rocblas_is_user_managing_device_memory and rocblas_set_device_memory_size removed
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-``rocblas_is_user_managing_device_memory`` and ``rocblas_set_device_memory_size`` API functions are removed in 5.0
-
 Announced in rocBLAS 4.3
 ==========================
 

--- a/library/include/internal/rocblas-functions.h
+++ b/library/include/internal/rocblas-functions.h
@@ -25024,7 +25024,25 @@ ROCBLAS_EXPORT rocblas_status rocblas_get_device_memory_size(rocblas_handle hand
 
 /*! \brief
     \details
-    Allows user to set the device memory for the handle to use as a workspace (user-owned scheme).
+    Changes the size of allocated device memory at runtime.
+
+    Any previously allocated device memory managed by the handle is freed.
+
+    If size > 0 sets the device memory size to the specified size (in bytes).
+    If size == 0, frees the memory allocated so far, and lets rocBLAS manage device memory in the future, expanding it when necessary.
+    Returns rocblas_status_invalid_handle if handle is nullptr; rocblas_status_invalid_pointer if size is nullptr; rocblas_status_success otherwise
+    @param[in]
+    handle          rocblas handle
+    @param[in]
+    size            size of allocated device memory
+ ******************************************************************************/
+ROCBLAS_DEPRECATED_MSG("rocblas_set_device_memory_size will be removed in a future release and "
+                       "supported modes will be rocblas_managed & user_owned")
+ROCBLAS_EXPORT rocblas_status rocblas_set_device_memory_size(rocblas_handle handle, size_t size);
+
+/*! \brief
+    \details
+    Sets the device workspace for the handle to use.
 
     Any previously allocated device memory managed by the handle is freed.
 
@@ -25046,6 +25064,16 @@ ROCBLAS_EXPORT rocblas_status rocblas_set_workspace(rocblas_handle handle, void*
     handle          rocblas handle
  ******************************************************************************/
 ROCBLAS_EXPORT bool rocblas_is_managing_device_memory(rocblas_handle handle);
+
+/*! \brief
+    \details
+    Returns true when device memory in handle is managed by the user
+    @param[in]
+    handle          rocblas handle
+ ******************************************************************************/
+ROCBLAS_DEPRECATED_MSG("rocblas_is_user_managing_device_memory will be removed in a future release "
+                       "and supported modes will be rocblas_managed and user_owned")
+ROCBLAS_EXPORT bool rocblas_is_user_managing_device_memory(rocblas_handle handle);
 
 /*! \brief
     \details

--- a/library/src/blas2/rocblas_trsv_imp.hpp
+++ b/library/src/blas2/rocblas_trsv_imp.hpp
@@ -143,6 +143,7 @@ namespace
             if(trsv_check_numerics_status != rocblas_status_success)
                 return trsv_check_numerics_status;
         }
+
         rocblas_status status
             = ROCBLAS_API(rocblas_internal_trsv_template)(handle,
                                                           uplo,


### PR DESCRIPTION
This reverts commit ac0268898afd653eed8e7a52d197723a1e4579e6.

resolves # SWDEV-537363

Revert the stream order allocation as default.
