### PR TITLE
disable dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,1 +1,12 @@
-
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/docs/sphinx" # Location of package manifests
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+    target-branch: "develop_deprecated"
+    labels:
+      - "documentation"
+      - "dependencies"
+      - "ci:docs-only"


### PR DESCRIPTION
disable dependabot.yml

Summary of proposed changes:
- stops dependabot prs for docs
- dependabot.yml is separate from the settings/advanced security config, but still has to be valid. example: https://github.com/ROCm/rocBLAS/pull/1669 was still opened despite having invalid dependabot.yml